### PR TITLE
Add font collection (ttc) support

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -33,6 +33,9 @@ pub use tag::{InvalidTag, Tag};
 pub use uint24::Uint24;
 pub use version::{Compatible, MajorMinor, Version16Dot16};
 
+/// The header tag for a font collection file.
+pub const TTC_HEADER_TAG: Tag = Tag::new(b"ttcf");
+
 /// The SFNT version for fonts containing TrueType outlines.
 pub const TT_SFNT_VERSION: u32 = 0x00010000;
 /// The SFNT version for fonts containing CFF outlines.

--- a/font-types/src/version.rs
+++ b/font-types/src/version.rs
@@ -80,6 +80,8 @@ impl MajorMinor {
     pub const VERSION_1_2: MajorMinor = MajorMinor::new(1, 2);
     /// Version 1.3
     pub const VERSION_1_3: MajorMinor = MajorMinor::new(1, 3);
+    /// Version 2.0
+    pub const VERSION_2_0: MajorMinor = MajorMinor::new(2, 0);
 
     /// Create a new version with major and minor parts.
     #[inline]

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, str::FromStr};
 
 use font_types::Tag;
-use read_fonts::{traversal::SomeTable, FontData, FontRef, ReadError, TableProvider};
+use read_fonts::{traversal::SomeTable, FontData, FontFileRef, FontRef, ReadError, TableProvider};
 
 mod print;
 mod query;
@@ -16,9 +16,10 @@ use query::Query;
 
 fn main() -> Result<(), Error> {
     let args = flags::Args::from_env().map_err(|e| Error(e.to_string()))?;
+    let index = args.index.unwrap_or(0);
     let bytes = std::fs::read(&args.input).unwrap();
     let data = FontData::new(&bytes);
-    let font = FontRef::new(data).unwrap();
+    let font = FontFileRef::new(data).get_font(index).unwrap(); //FontRef::new(data).unwrap();
     if args.list {
         list_tables(&font);
         return Ok(());
@@ -196,6 +197,7 @@ mod flags {
         cmd args
             required input: PathBuf
             {
+                optional -i, --index index: u32
                 optional -l, --list
                 optional -q, --query query: Query
                 optional -t, --tables include: String

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Error> {
     let index = args.index.unwrap_or(0);
     let bytes = std::fs::read(&args.input).unwrap();
     let data = FontData::new(&bytes);
-    let font = FontFileRef::new(data).get_font(index).unwrap(); //FontRef::new(data).unwrap();
+    let font = FontFileRef::new(data).get_font(index).unwrap();
     if args.list {
         list_tables(&font);
         return Ok(());

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, str::FromStr};
 
 use font_types::Tag;
-use read_fonts::{traversal::SomeTable, FontData, FontFileRef, FontRef, ReadError, TableProvider};
+use read_fonts::{traversal::SomeTable, FileRef, FontData, FontRef, ReadError, TableProvider};
 
 mod print;
 mod query;
@@ -16,10 +16,15 @@ use query::Query;
 
 fn main() -> Result<(), Error> {
     let args = flags::Args::from_env().map_err(|e| Error(e.to_string()))?;
-    let index = args.index.unwrap_or(0);
     let bytes = std::fs::read(&args.input).unwrap();
     let data = FontData::new(&bytes);
-    let font = FontFileRef::new(data).get_font(index).unwrap();
+    let font = FileRef::new(data)
+        .unwrap()
+        .fonts()
+        .skip(args.index.unwrap_or(0) as usize)
+        .next()
+        .unwrap()
+        .unwrap();
     if args.list {
         list_tables(&font);
         return Ok(());

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -21,8 +21,7 @@ fn main() -> Result<(), Error> {
     let font = FileRef::new(data)
         .unwrap()
         .fonts()
-        .skip(args.index.unwrap_or(0) as usize)
-        .next()
+        .nth(args.index.unwrap_or(0) as usize)
         .unwrap()
         .unwrap();
     if args.list {

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -4,6 +4,7 @@
 
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
+
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -56,29 +57,35 @@ impl<'a> FontRead<'a> for TableDirectory<'a> {
 
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 pub type TableDirectory<'a> = TableRef<'a, TableDirectoryMarker>;
+
 impl<'a> TableDirectory<'a> {
     /// 0x00010000 or 0x4F54544F
     pub fn sfnt_version(&self) -> u32 {
         let range = self.shape.sfnt_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     /// Number of tables.
     pub fn num_tables(&self) -> u16 {
         let range = self.shape.num_tables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     /// Table records array—one for each top-level table in the font
     pub fn table_records(&self) -> &'a [TableRecord] {
         let range = self.shape.table_records_byte_range();
@@ -138,14 +145,17 @@ impl TableRecord {
     pub fn tag(&self) -> Tag {
         self.tag.get()
     }
+
     /// Checksum for the table.
     pub fn checksum(&self) -> u32 {
         self.checksum.get()
     }
+
     /// Offset from the beginning of the font data.
     pub fn offset(&self) -> Offset32 {
         self.offset.get()
     }
+
     /// Length of the table.
     pub fn length(&self) -> u32 {
         self.length.get()
@@ -258,31 +268,38 @@ impl<'a> FontRead<'a> for TTCHeader<'a> {
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 pub type TTCHeader<'a> = TableRef<'a, TTCHeaderMarker>;
+
 impl<'a> TTCHeader<'a> {
     pub fn ttc_tag(&self) -> Tag {
         let range = self.shape.ttc_tag_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     pub fn version(&self) -> Version16Dot16 {
         let range = self.shape.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     pub fn num_fonts(&self) -> u32 {
         let range = self.shape.num_fonts_byte_range();
         self.data.read_at(range.start).unwrap()
     }
+
     pub fn table_directory_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.table_directory_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
+
     pub fn dsig_tag(&self) -> Option<u32> {
         let range = self.shape.dsig_tag_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
+
     pub fn dsig_length(&self) -> Option<u32> {
         let range = self.shape.dsig_length_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
+
     pub fn dsig_offset(&self) -> Option<u32> {
         let range = self.shape.dsig_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
@@ -292,7 +309,7 @@ impl<'a> TTCHeader<'a> {
 #[cfg(feature = "traversal")]
 impl<'a> SomeTable<'a> for TTCHeader<'a> {
     fn type_name(&self) -> &str {
-        "TtcHeader"
+        "TTCHeader"
     }
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         let version = self.version();

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -180,14 +180,14 @@ impl<'a> SomeRecord<'a> for TableRecord {
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct TtcHeaderMarker {
+pub struct TTCHeaderMarker {
     table_directory_offsets_byte_len: usize,
     dsig_tag_byte_start: Option<usize>,
     dsig_length_byte_start: Option<usize>,
     dsig_offset_byte_start: Option<usize>,
 }
 
-impl TtcHeaderMarker {
+impl TTCHeaderMarker {
     fn ttc_tag_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Tag::RAW_BYTE_LEN
@@ -218,7 +218,7 @@ impl TtcHeaderMarker {
     }
 }
 
-impl<'a> FontRead<'a> for TtcHeader<'a> {
+impl<'a> FontRead<'a> for TTCHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<Tag>();
@@ -247,7 +247,7 @@ impl<'a> FontRead<'a> for TtcHeader<'a> {
         version
             .compatible(Version16Dot16::VERSION_2_0)
             .then(|| cursor.advance::<u32>());
-        cursor.finish(TtcHeaderMarker {
+        cursor.finish(TTCHeaderMarker {
             table_directory_offsets_byte_len,
             dsig_tag_byte_start,
             dsig_length_byte_start,
@@ -257,8 +257,8 @@ impl<'a> FontRead<'a> for TtcHeader<'a> {
 }
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
-pub type TtcHeader<'a> = TableRef<'a, TtcHeaderMarker>;
-impl<'a> TtcHeader<'a> {
+pub type TTCHeader<'a> = TableRef<'a, TTCHeaderMarker>;
+impl<'a> TTCHeader<'a> {
     pub fn ttc_tag(&self) -> Tag {
         let range = self.shape.ttc_tag_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -290,7 +290,7 @@ impl<'a> TtcHeader<'a> {
 }
 
 #[cfg(feature = "traversal")]
-impl<'a> SomeTable<'a> for TtcHeader<'a> {
+impl<'a> SomeTable<'a> for TTCHeader<'a> {
     fn type_name(&self) -> &str {
         "TtcHeader"
     }
@@ -319,7 +319,7 @@ impl<'a> SomeTable<'a> for TtcHeader<'a> {
 }
 
 #[cfg(feature = "traversal")]
-impl<'a> std::fmt::Debug for TtcHeader<'a> {
+impl<'a> std::fmt::Debug for TTCHeader<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -4,7 +4,6 @@
 
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
-
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -57,35 +56,29 @@ impl<'a> FontRead<'a> for TableDirectory<'a> {
 
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 pub type TableDirectory<'a> = TableRef<'a, TableDirectoryMarker>;
-
 impl<'a> TableDirectory<'a> {
     /// 0x00010000 or 0x4F54544F
     pub fn sfnt_version(&self) -> u32 {
         let range = self.shape.sfnt_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
-
     /// Number of tables.
     pub fn num_tables(&self) -> u16 {
         let range = self.shape.num_tables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
-
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
-
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
-
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
-
     /// Table records array—one for each top-level table in the font
     pub fn table_records(&self) -> &'a [TableRecord] {
         let range = self.shape.table_records_byte_range();
@@ -145,17 +138,14 @@ impl TableRecord {
     pub fn tag(&self) -> Tag {
         self.tag.get()
     }
-
     /// Checksum for the table.
     pub fn checksum(&self) -> u32 {
         self.checksum.get()
     }
-
     /// Offset from the beginning of the font data.
     pub fn offset(&self) -> Offset32 {
         self.offset.get()
     }
-
     /// Length of the table.
     pub fn length(&self) -> u32 {
         self.length.get()
@@ -184,5 +174,153 @@ impl<'a> SomeRecord<'a> for TableRecord {
             }),
             data,
         }
+    }
+}
+
+/// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct TtcHeaderMarker {
+    table_directory_offsets_byte_len: usize,
+    dsig_tag_byte_start: Option<usize>,
+    dsig_length_byte_start: Option<usize>,
+    dsig_offset_byte_start: Option<usize>,
+}
+
+impl TtcHeaderMarker {
+    fn ttc_tag_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Tag::RAW_BYTE_LEN
+    }
+    fn version_byte_range(&self) -> Range<usize> {
+        let start = self.ttc_tag_byte_range().end;
+        start..start + Version16Dot16::RAW_BYTE_LEN
+    }
+    fn num_fonts_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+    fn table_directory_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.num_fonts_byte_range().end;
+        start..start + self.table_directory_offsets_byte_len
+    }
+    fn dsig_tag_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.dsig_tag_byte_start?;
+        Some(start..start + u32::RAW_BYTE_LEN)
+    }
+    fn dsig_length_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.dsig_length_byte_start?;
+        Some(start..start + u32::RAW_BYTE_LEN)
+    }
+    fn dsig_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.dsig_offset_byte_start?;
+        Some(start..start + u32::RAW_BYTE_LEN)
+    }
+}
+
+impl<'a> FontRead<'a> for TtcHeader<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<Tag>();
+        let version: Version16Dot16 = cursor.read()?;
+        let num_fonts: u32 = cursor.read()?;
+        let table_directory_offsets_byte_len = num_fonts as usize * u32::RAW_BYTE_LEN;
+        cursor.advance_by(table_directory_offsets_byte_len);
+        let dsig_tag_byte_start = version
+            .compatible(Version16Dot16::VERSION_2_0)
+            .then(|| cursor.position())
+            .transpose()?;
+        version
+            .compatible(Version16Dot16::VERSION_2_0)
+            .then(|| cursor.advance::<u32>());
+        let dsig_length_byte_start = version
+            .compatible(Version16Dot16::VERSION_2_0)
+            .then(|| cursor.position())
+            .transpose()?;
+        version
+            .compatible(Version16Dot16::VERSION_2_0)
+            .then(|| cursor.advance::<u32>());
+        let dsig_offset_byte_start = version
+            .compatible(Version16Dot16::VERSION_2_0)
+            .then(|| cursor.position())
+            .transpose()?;
+        version
+            .compatible(Version16Dot16::VERSION_2_0)
+            .then(|| cursor.advance::<u32>());
+        cursor.finish(TtcHeaderMarker {
+            table_directory_offsets_byte_len,
+            dsig_tag_byte_start,
+            dsig_length_byte_start,
+            dsig_offset_byte_start,
+        })
+    }
+}
+
+/// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
+pub type TtcHeader<'a> = TableRef<'a, TtcHeaderMarker>;
+impl<'a> TtcHeader<'a> {
+    pub fn ttc_tag(&self) -> Tag {
+        let range = self.shape.ttc_tag_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+    pub fn version(&self) -> Version16Dot16 {
+        let range = self.shape.version_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+    pub fn num_fonts(&self) -> u32 {
+        let range = self.shape.num_fonts_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+    pub fn table_directory_offsets(&self) -> &'a [BigEndian<u32>] {
+        let range = self.shape.table_directory_offsets_byte_range();
+        self.data.read_array(range).unwrap()
+    }
+    pub fn dsig_tag(&self) -> Option<u32> {
+        let range = self.shape.dsig_tag_byte_range()?;
+        Some(self.data.read_at(range.start).unwrap())
+    }
+    pub fn dsig_length(&self) -> Option<u32> {
+        let range = self.shape.dsig_length_byte_range()?;
+        Some(self.data.read_at(range.start).unwrap())
+    }
+    pub fn dsig_offset(&self) -> Option<u32> {
+        let range = self.shape.dsig_offset_byte_range()?;
+        Some(self.data.read_at(range.start).unwrap())
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> SomeTable<'a> for TtcHeader<'a> {
+    fn type_name(&self) -> &str {
+        "TtcHeader"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        let version = self.version();
+        match idx {
+            0usize => Some(Field::new("ttc_tag", self.ttc_tag())),
+            1usize => Some(Field::new("version", self.version())),
+            2usize => Some(Field::new("num_fonts", self.num_fonts())),
+            3usize => Some(Field::new(
+                "table_directory_offsets",
+                self.table_directory_offsets(),
+            )),
+            4usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+                Some(Field::new("dsig_tag", self.dsig_tag().unwrap()))
+            }
+            5usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+                Some(Field::new("dsig_length", self.dsig_length().unwrap()))
+            }
+            6usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+                Some(Field::new("dsig_offset", self.dsig_offset().unwrap()))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> std::fmt::Debug for TtcHeader<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
     }
 }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -204,7 +204,7 @@ impl TTCHeaderMarker {
     }
     fn version_byte_range(&self) -> Range<usize> {
         let start = self.ttc_tag_byte_range().end;
-        start..start + Version16Dot16::RAW_BYTE_LEN
+        start..start + MajorMinor::RAW_BYTE_LEN
     }
     fn num_fonts_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
@@ -232,30 +232,30 @@ impl<'a> FontRead<'a> for TTCHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<Tag>();
-        let version: Version16Dot16 = cursor.read()?;
+        let version: MajorMinor = cursor.read()?;
         let num_fonts: u32 = cursor.read()?;
         let table_directory_offsets_byte_len = num_fonts as usize * u32::RAW_BYTE_LEN;
         cursor.advance_by(table_directory_offsets_byte_len);
         let dsig_tag_byte_start = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible(MajorMinor::VERSION_2_0)
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible(MajorMinor::VERSION_2_0)
             .then(|| cursor.advance::<u32>());
         let dsig_length_byte_start = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible(MajorMinor::VERSION_2_0)
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible(MajorMinor::VERSION_2_0)
             .then(|| cursor.advance::<u32>());
         let dsig_offset_byte_start = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible(MajorMinor::VERSION_2_0)
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible(MajorMinor::VERSION_2_0)
             .then(|| cursor.advance::<u32>());
         cursor.finish(TTCHeaderMarker {
             table_directory_offsets_byte_len,
@@ -270,36 +270,43 @@ impl<'a> FontRead<'a> for TTCHeader<'a> {
 pub type TTCHeader<'a> = TableRef<'a, TTCHeaderMarker>;
 
 impl<'a> TTCHeader<'a> {
+    /// Font Collection ID string: \"ttcf\"
     pub fn ttc_tag(&self) -> Tag {
         let range = self.shape.ttc_tag_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
-    pub fn version(&self) -> Version16Dot16 {
+    /// Major/minor version of the TTC Header
+    pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
+    /// Number of fonts in TTC
     pub fn num_fonts(&self) -> u32 {
         let range = self.shape.num_fonts_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
+    /// Array of offsets to the TableDirectory for each font from the beginning of the file
     pub fn table_directory_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.table_directory_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
+    /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
     pub fn dsig_tag(&self) -> Option<u32> {
         let range = self.shape.dsig_tag_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    /// The length (in bytes) of the DSIG table (null if no signature)
     pub fn dsig_length(&self) -> Option<u32> {
         let range = self.shape.dsig_length_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
     pub fn dsig_offset(&self) -> Option<u32> {
         let range = self.shape.dsig_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
@@ -321,13 +328,13 @@ impl<'a> SomeTable<'a> for TTCHeader<'a> {
                 "table_directory_offsets",
                 self.table_directory_offsets(),
             )),
-            4usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+            4usize if version.compatible(MajorMinor::VERSION_2_0) => {
                 Some(Field::new("dsig_tag", self.dsig_tag().unwrap()))
             }
-            5usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+            5usize if version.compatible(MajorMinor::VERSION_2_0) => {
                 Some(Field::new("dsig_length", self.dsig_length().unwrap()))
             }
-            6usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+            6usize if version.compatible(MajorMinor::VERSION_2_0) => {
                 Some(Field::new("dsig_offset", self.dsig_offset().unwrap()))
             }
             _ => None,

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -97,9 +97,6 @@ impl<'a> FontFileRef<'a> {
     }
 
     pub fn get_font(&self, index: u32) -> Option<FontRef<'a>> {
-        if index > self.num_fonts() {
-            return None;
-        }
         if let Some(ttc_header) = self.ttc_header() {
             let offset = ttc_header
                 .table_directory_offsets()

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -71,60 +71,86 @@ pub(crate) mod codegen_prelude {
 
 include!("../generated/font.rs");
 
+#[derive(Clone)]
+/// Reference to the content of a font or font collection file.
+pub enum FileRef<'a> {
+    /// A single font.
+    Font(FontRef<'a>),
+    /// A collection of fonts.
+    Collection(CollectionRef<'a>),
+}
+
+impl<'a> FileRef<'a> {
+    pub fn new(data: FontData<'a>) -> Result<Self, ReadError> {
+        Ok(if let Ok(collection) = CollectionRef::new(data) {
+            Self::Collection(collection)
+        } else {
+            Self::Font(FontRef::new(data)?)
+        })
+    }
+
+    pub fn fonts(&self) -> impl Iterator<Item = Result<FontRef<'a>, ReadError>> + 'a + Clone {
+        let copy = self.clone();
+        let len = match self {
+            Self::Collection(collection) => collection.len(),
+            _ => 1,
+        };
+        (0..len).filter_map(move |ix| match &copy {
+            Self::Font(font) => Some(Ok(font.clone())),
+            Self::Collection(collection) => collection.get(ix),
+        })
+    }
+}
+
 const TTC_HEADER_TAG: Tag = Tag::new(b"ttcf");
 
-pub struct FontFileRef<'a> {
-    pub data: FontData<'a>,
+/// Reference to the content of a font collection file.
+#[derive(Clone)]
+pub struct CollectionRef<'a> {
+    data: FontData<'a>,
+    header: TTCHeader<'a>,
 }
 
-impl<'a> FontFileRef<'a> {
-    pub fn new(data: FontData<'a>) -> Self {
-        Self { data }
-    }
-
-    pub fn is_collection(&self) -> bool {
-        self.ttc_header().is_some()
-    }
-
-    pub fn num_fonts(&self) -> u32 {
-        if let Some(ttc_header) = self.ttc_header() {
-            ttc_header.num_fonts()
-        } else if FontRef::new(self.data).is_ok() {
-            1
+impl<'a> CollectionRef<'a> {
+    pub fn new(data: FontData<'a>) -> Result<Self, ReadError> {
+        let header = TTCHeader::read(data)?;
+        if header.ttc_tag() != TTC_HEADER_TAG {
+            Err(ReadError::InvalidTtc(header.ttc_tag()))
         } else {
-            0
+            Ok(Self { data, header })
         }
     }
 
-    pub fn get_font(&self, index: u32) -> Option<FontRef<'a>> {
-        if let Some(ttc_header) = self.ttc_header() {
-            let offset = ttc_header
-                .table_directory_offsets()
-                .get(index as usize)?
-                .get() as usize;
-            let data = self.data.slice(offset..)?;
-            let table_directory = TableDirectory::read(data).ok()?;
-            Some(FontRef {
-                data: self.data,
-                table_directory,
-            })
-        } else if index == 0 {
-            FontRef::new(self.data).ok()
-        } else {
-            None
+    pub fn len(&self) -> u32 {
+        self.header.num_fonts()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get(&self, index: u32) -> Option<Result<FontRef<'a>, ReadError>> {
+        if index >= self.len() {
+            return None;
+        }
+        let offset = self
+            .header
+            .table_directory_offsets()
+            .get(index as usize)?
+            .get() as usize;
+        match TableDirectory::read(self.data.slice(offset..)?) {
+            Ok(table_directory) => Some(FontRef::with_table_directory(self.data, table_directory)),
+            _ => None,
         }
     }
 
-    fn ttc_header(&self) -> Option<TtcHeader<'a>> {
-        let header = TtcHeader::read(self.data).ok()?;
-        if header.ttc_tag() == TTC_HEADER_TAG {
-            Some(header)
-        } else {
-            None
-        }
+    pub fn iter(&self) -> impl Iterator<Item = Result<FontRef<'a>, ReadError>> + 'a + Clone {
+        let copy = self.clone();
+        (0..self.len()).filter_map(move |ix| copy.get(ix))
     }
 }
 
+#[derive(Clone)]
 /// A temporary type for accessing tables
 pub struct FontRef<'a> {
     data: FontData<'a>,
@@ -133,15 +159,7 @@ pub struct FontRef<'a> {
 
 impl<'a> FontRef<'a> {
     pub fn new(data: FontData<'a>) -> Result<Self, ReadError> {
-        let table_directory = TableDirectory::read(data)?;
-        if [TT_SFNT_VERSION, CFF_SFTN_VERSION].contains(&table_directory.sfnt_version()) {
-            Ok(FontRef {
-                data,
-                table_directory,
-            })
-        } else {
-            Err(ReadError::InvalidSfnt(table_directory.sfnt_version()))
-        }
+        Self::with_table_directory(data, TableDirectory::read(data)?)
     }
 
     pub fn table_data(&self, tag: Tag) -> Option<FontData<'a>> {
@@ -155,6 +173,20 @@ impl<'a> FontRef<'a> {
                 let len = record.length() as usize;
                 self.data.slice(start..start + len)
             })
+    }
+
+    fn with_table_directory(
+        data: FontData<'a>,
+        table_directory: TableDirectory<'a>,
+    ) -> Result<Self, ReadError> {
+        if [TT_SFNT_VERSION, CFF_SFTN_VERSION].contains(&table_directory.sfnt_version()) {
+            Ok(FontRef {
+                data,
+                table_directory,
+            })
+        } else {
+            Err(ReadError::InvalidSfnt(table_directory.sfnt_version()))
+        }
     }
 }
 

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -85,6 +85,7 @@ pub enum ReadError {
     // i64 is flexible enough to store any value we might encounter
     InvalidFormat(i64),
     InvalidSfnt(u32),
+    InvalidTtc(Tag),
     InvalidArrayLen,
     ValidationError,
     NullOffset,
@@ -98,6 +99,7 @@ impl std::fmt::Display for ReadError {
             ReadError::OutOfBounds => write!(f, "An offset was out of bounds"),
             ReadError::InvalidFormat(x) => write!(f, "Invalid format '{x}'"),
             ReadError::InvalidSfnt(ver) => write!(f, "Invalid sfnt version 0x{ver:08X}"),
+            ReadError::InvalidTtc(tag) => write!(f, "Invalid ttc tag {tag}"),
             ReadError::InvalidArrayLen => {
                 write!(f, "Specified array length not a multiple of item size")
             }

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -86,6 +86,7 @@ pub enum ReadError {
     InvalidFormat(i64),
     InvalidSfnt(u32),
     InvalidTtc(Tag),
+    InvalidCollectionIndex(u32),
     InvalidArrayLen,
     ValidationError,
     NullOffset,
@@ -100,6 +101,9 @@ impl std::fmt::Display for ReadError {
             ReadError::InvalidFormat(x) => write!(f, "Invalid format '{x}'"),
             ReadError::InvalidSfnt(ver) => write!(f, "Invalid sfnt version 0x{ver:08X}"),
             ReadError::InvalidTtc(tag) => write!(f, "Invalid ttc tag {tag}"),
+            ReadError::InvalidCollectionIndex(ix) => {
+                write!(f, "Invalid index {ix} for font collection")
+            }
             ReadError::InvalidArrayLen => {
                 write!(f, "Specified array length not a multiple of item size")
             }

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -6,6 +6,7 @@ use crate::{
     offset::{Offset, ResolveOffset},
 };
 
+#[derive(Clone)]
 /// Typed access to raw table data.
 pub struct TableRef<'a, T> {
     pub(crate) shape: T,

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -32,16 +32,24 @@ record TableRecord {
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 table TTCHeader {
+    /// Font Collection ID string: "ttcf"
     ttc_tag: BigEndian<Tag>,
+    /// Major/minor version of the TTC Header
     #[version]
-    version: BigEndian<Version16Dot16>,
+    version: BigEndian<MajorMinor>,
+    /// Number of fonts in TTC
     num_fonts: BigEndian<u32>,
+    /// Array of offsets to the TableDirectory for each font from the beginning of the file
     #[count($num_fonts)]
     table_directory_offsets: [BigEndian<u32>],
-    #[available(Version16Dot16::VERSION_2_0)]
+
+    /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
+    #[available(MajorMinor::VERSION_2_0)]
     dsig_tag: BigEndian<u32>,
-    #[available(Version16Dot16::VERSION_2_0)]
+    /// The length (in bytes) of the DSIG table (null if no signature)
+    #[available(MajorMinor::VERSION_2_0)]
     dsig_length: BigEndian<u32>,
-    #[available(Version16Dot16::VERSION_2_0)]
+    /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
+    #[available(MajorMinor::VERSION_2_0)]
     dsig_offset: BigEndian<u32>,
 }

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -31,7 +31,7 @@ record TableRecord {
 }
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
-table TtcHeader {
+table TTCHeader {
     ttc_tag: BigEndian<Tag>,
     #[version]
     version: BigEndian<Version16Dot16>,

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -29,3 +29,19 @@ record TableRecord {
     /// Length of the table.
     length: BigEndian<u32>,
 }
+
+/// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
+table TtcHeader {
+    ttc_tag: BigEndian<Tag>,
+    #[version]
+    version: BigEndian<Version16Dot16>,
+    num_fonts: BigEndian<u32>,
+    #[count($num_fonts)]
+    table_directory_offsets: [BigEndian<u32>],
+    #[available(Version16Dot16::VERSION_2_0)]
+    dsig_tag: BigEndian<u32>,
+    #[available(Version16Dot16::VERSION_2_0)]
+    dsig_length: BigEndian<u32>,
+    #[available(Version16Dot16::VERSION_2_0)]
+    dsig_offset: BigEndian<u32>,
+}

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -69,7 +69,7 @@ impl Validate for TableRecord {
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 #[derive(Clone, Debug)]
-pub struct TtcHeader {
+pub struct TTCHeader {
     pub ttc_tag: Tag,
     pub version: Version16Dot16,
     pub num_fonts: u32,
@@ -79,7 +79,7 @@ pub struct TtcHeader {
     pub dsig_offset: Option<u32>,
 }
 
-impl FontWrite for TtcHeader {
+impl FontWrite for TTCHeader {
     fn write_into(&self, writer: &mut TableWriter) {
         self.ttc_tag.write_into(writer);
         let version = self.version;
@@ -107,9 +107,9 @@ impl FontWrite for TtcHeader {
     }
 }
 
-impl Validate for TtcHeader {
+impl Validate for TTCHeader {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
-        ctx.in_table("TtcHeader", |ctx| {
+        ctx.in_table("TTCHeader", |ctx| {
             let version = self.version;
             ctx.in_field("table_directory_offsets", |ctx| {
                 if self.table_directory_offsets.len() > (u32::MAX as usize) {
@@ -136,9 +136,9 @@ impl Validate for TtcHeader {
 }
 
 #[cfg(feature = "parsing")]
-impl<'a> FromObjRef<read_fonts::TtcHeader<'a>> for TtcHeader {
-    fn from_obj_ref(obj: &read_fonts::TtcHeader<'a>, _: FontData) -> Self {
-        TtcHeader {
+impl<'a> FromObjRef<read_fonts::TTCHeader<'a>> for TTCHeader {
+    fn from_obj_ref(obj: &read_fonts::TTCHeader<'a>, _: FontData) -> Self {
+        TTCHeader {
             ttc_tag: obj.ttc_tag(),
             version: obj.version(),
             num_fonts: obj.num_fonts(),
@@ -155,10 +155,10 @@ impl<'a> FromObjRef<read_fonts::TtcHeader<'a>> for TtcHeader {
 }
 
 #[cfg(feature = "parsing")]
-impl<'a> FromTableRef<read_fonts::TtcHeader<'a>> for TtcHeader {}
+impl<'a> FromTableRef<read_fonts::TTCHeader<'a>> for TTCHeader {}
 #[cfg(feature = "parsing")]
-impl<'a> FontRead<'a> for TtcHeader {
+impl<'a> FontRead<'a> for TTCHeader {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        <read_fonts::TtcHeader as FontRead>::read(data).map(|x| x.to_owned_table())
+        <read_fonts::TTCHeader as FontRead>::read(data).map(|x| x.to_owned_table())
     }
 }

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -4,6 +4,7 @@
 
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
+
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 #[derive(Clone, Debug)]
 pub struct TableDirectory {
@@ -156,6 +157,7 @@ impl<'a> FromObjRef<read_fonts::TTCHeader<'a>> for TTCHeader {
 
 #[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::TTCHeader<'a>> for TTCHeader {}
+
 #[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for TTCHeader {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -71,12 +71,19 @@ impl Validate for TableRecord {
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 #[derive(Clone, Debug)]
 pub struct TTCHeader {
+    /// Font Collection ID string: \"ttcf\"
     pub ttc_tag: Tag,
-    pub version: Version16Dot16,
+    /// Major/minor version of the TTC Header
+    pub version: MajorMinor,
+    /// Number of fonts in TTC
     pub num_fonts: u32,
+    /// Array of offsets to the TableDirectory for each font from the beginning of the file
     pub table_directory_offsets: Vec<u32>,
+    /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
     pub dsig_tag: Option<u32>,
+    /// The length (in bytes) of the DSIG table (null if no signature)
     pub dsig_length: Option<u32>,
+    /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
     pub dsig_offset: Option<u32>,
 }
 
@@ -87,19 +94,19 @@ impl FontWrite for TTCHeader {
         version.write_into(writer);
         self.num_fonts.write_into(writer);
         self.table_directory_offsets.write_into(writer);
-        version.compatible(Version16Dot16::VERSION_2_0).then(|| {
+        version.compatible(MajorMinor::VERSION_2_0).then(|| {
             self.dsig_tag
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_2_0).then(|| {
+        version.compatible(MajorMinor::VERSION_2_0).then(|| {
             self.dsig_length
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_2_0).then(|| {
+        version.compatible(MajorMinor::VERSION_2_0).then(|| {
             self.dsig_offset
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -118,17 +125,17 @@ impl Validate for TTCHeader {
                 }
             });
             ctx.in_field("dsig_tag", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_2_0) && self.dsig_tag.is_none() {
+                if version.compatible(MajorMinor::VERSION_2_0) && self.dsig_tag.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("dsig_length", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_2_0) && self.dsig_length.is_none() {
+                if version.compatible(MajorMinor::VERSION_2_0) && self.dsig_length.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("dsig_offset", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_2_0) && self.dsig_offset.is_none() {
+                if version.compatible(MajorMinor::VERSION_2_0) && self.dsig_offset.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });


### PR DESCRIPTION
Initial support for reading ttc files. Also adds an index command line flag to otexplorer.

The API probably needs some adjustments. `FontRef::new` should likely take an `index` parameter to make this consistent.