### PR TITLE
Support offsets to arrays

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1,5 +1,7 @@
 //! methods on fields
 
+use std::ops::Deref;
+
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
@@ -960,6 +962,10 @@ impl Field {
         match &self.typ {
             FieldType::Scalar { .. } | FieldType::Other { .. } => false,
             FieldType::Offset { target: None, .. } => false,
+            FieldType::Offset {
+                target: Some(OffsetTarget::Array(elem)),
+                ..
+            } if matches!(elem.deref(), FieldType::Scalar { .. }) => false,
             FieldType::Offset { .. }
             | FieldType::ComputedArray { .. }
             | FieldType::VarLenArray(_) => true,

--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -4,7 +4,8 @@ use std::io::Write;
 
 use ansi_term::{Color, Style};
 use read_fonts::traversal::{
-    FieldType, OffsetType, ResolvedOffset, SomeArray, SomeString, SomeTable, StringOffset,
+    ArrayOffset, FieldType, OffsetType, ResolvedOffset, SomeArray, SomeString, SomeTable,
+    StringOffset,
 };
 
 static MANY_SPACES: [u8; 200] = [0x20; 200];
@@ -200,6 +201,16 @@ impl<'a> PrettyPrinter<'a> {
                     self.print_offset_hex(*offset)?;
                     self.print_newline()?;
                     self.indented(|this| this.print_string(string))?;
+                }
+                Err(e) => write!(self, "Error: '{e}'")?,
+            },
+            FieldType::ArrayOffset(ArrayOffset { offset, target }) => match target {
+                Ok(array) => {
+                    self.print_with_style(Color::Blue.into(), |this| write!(this, "{offset}"))?;
+                    self.print_current_array_pos()?;
+                    self.print_offset_hex(*offset)?;
+                    self.print_newline()?;
+                    self.indented(|this| this.print_array(array))?;
                 }
                 Err(e) => write!(self, "Error: '{e}'")?,
             },

--- a/otexplorer/src/query.rs
+++ b/otexplorer/src/query.rs
@@ -177,7 +177,9 @@ fn field_type_name(field_type: &FieldType) -> Cow<'static, str> {
         FieldType::ResolvedOffset(ResolvedOffset {
             target: Ok(table), ..
         }) => table.type_name().to_string().into(),
-        FieldType::ResolvedOffset(_) | FieldType::BareOffset(_) => "Offset".into(),
+        FieldType::ResolvedOffset(_) | FieldType::BareOffset(_) | FieldType::ArrayOffset(_) => {
+            "Offset".into()
+        }
         FieldType::StringOffset(_) => "String".into(),
     }
 }

--- a/read-fonts/generated/generated_test.rs
+++ b/read-fonts/generated/generated_test.rs
@@ -169,7 +169,7 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
             3usize => Some(Field::new("array_offset_count", self.array_offset_count())),
             4usize => Some(Field::new(
                 "array_offset",
-                FieldType::unknown_offset(self.array_offset()),
+                FieldType::offset_to_array_of_scalars(self.array_offset(), self.array()),
             )),
             5usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
                 "versioned_nonnullable_offset",

--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -1,5 +1,7 @@
 //! Custom array types
 
+use font_types::FixedSize;
+
 use crate::read::{ComputeSize, FontReadWithArgs, ReadArgs, VarSize};
 use crate::{FontData, FontRead, ReadError};
 
@@ -135,5 +137,16 @@ impl<'a, T> FontRead<'a> for VarLenArray<'a, T> {
             data,
             phantom: core::marker::PhantomData,
         })
+    }
+}
+
+impl<'a, T: FixedSize> ReadArgs for &'a [T] {
+    type Args = u16;
+}
+
+impl<'a, T: FixedSize> FontReadWithArgs<'a> for &'a [T] {
+    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
+        let len = *args as usize * T::RAW_BYTE_LEN;
+        data.read_array(0..len)
     }
 }

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -9,3 +9,20 @@
 //! $ cargo run --bin=codegen resources/test_plan.toml && cargo test
 
 include!("../generated/generated_test.rs");
+
+#[test]
+fn array_offsets() {
+    let mut builder = crate::test_helpers::BeBuffer::new();
+    builder.push(MajorMinor::VERSION_1_0);
+    builder.push(12_u16); // offset to 0xdead
+    builder.push(0u16); // nullable
+    builder.push(2u16); // array len
+    builder.push(12u16); // array offset
+    builder.extend([0xdead_u16, 0xbeef]);
+
+    let table = KindsOfOffsets::read(builder.font_data()).unwrap();
+    assert_eq!(table.nonnullable().unwrap().value(), 0xdead);
+
+    let array = table.array().unwrap();
+    assert_eq!(array, &[0xdead, 0xbeef]);
+}

--- a/resources/codegen_inputs/colr.rs
+++ b/resources/codegen_inputs/colr.rs
@@ -11,11 +11,11 @@ table Colr {
     /// Offset to baseGlyphRecords array (may be NULL).
     #[nullable]
     #[read_offset_with($num_base_glyph_records)]
-    base_glyph_records_offset: BigEndian<Offset32<BaseGlyphRecordArray>>,
+    base_glyph_records_offset: BigEndian<Offset32<[BaseGlyph]>>,
     /// Offset to layerRecords array (may be NULL).
     #[nullable]
     #[read_offset_with($num_layer_records)]
-    layer_records_offset: BigEndian<Offset32<LayerRecordArray>>,
+    layer_records_offset: BigEndian<Offset32<[Layer]>>,
     /// Number of Layer records; may be 0 in a version 1 table.
     num_layer_records: BigEndian<u16>,
     /// Offset to BaseGlyphList table.
@@ -40,15 +40,6 @@ table Colr {
     item_variation_store_offset: BigEndian<Offset32>,
 }
 
-/// [BaseGlyphRecordArray](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) table. This
-/// is not present in the specification and is a shim to support reading a raw array of records (i.e. a non-table) through an offset.
-#[read_args(num_base_glyph_records: u16)]
-table BaseGlyphRecordArray {
-    /// Array of BaseGlyph records
-    #[count($num_base_glyph_records)]
-    base_glyph_records: [BaseGlyph],
-}
-
 /// [BaseGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
 record BaseGlyph {
     /// Glyph ID of the base glyph.
@@ -57,15 +48,6 @@ record BaseGlyph {
     first_layer_index: BigEndian<u16>,
     /// Number of color layers associated with this glyph.
     num_layers: BigEndian<u16>,
-}
-
-/// [LayerRecordArray](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) table. This
-/// is not present in the specification and is a shim to support reading a raw array of records (i.e. a non-table) through an offset.
-#[read_args(num_layer_records: u16)]
-table LayerRecordArray {
-    /// Array of Layer records
-    #[count($num_layer_records)]
-    layer_record: [Layer],
 }
 
 /// [Layer](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record

--- a/resources/codegen_inputs/test.rs
+++ b/resources/codegen_inputs/test.rs
@@ -9,6 +9,11 @@ table KindsOfOffsets {
     /// An offset that is nullable, but always present
     #[nullable]
     nullable_offset: BigEndian<Offset16<Dummy>>,
+    /// count of the array at array_offset
+    array_offset_count: BigEndian<u16>,
+    /// An offset to an array:
+    #[read_offset_with($array_offset_count)]
+    array_offset: BigEndian<Offset16<[BigEndian<u16>]>>,
     /// A normal offset that is versioned
     #[available(MajorMinor::VERSION_1_1)]
     versioned_nonnullable_offset: BigEndian<Offset16<Dummy>>,

--- a/write-fonts/generated/generated_test.rs
+++ b/write-fonts/generated/generated_test.rs
@@ -13,6 +13,10 @@ pub struct KindsOfOffsets {
     pub nonnullable_offset: OffsetMarker<Dummy>,
     /// An offset that is nullable, but always present
     pub nullable_offset: NullableOffsetMarker<Dummy>,
+    /// count of the array at array_offset
+    pub array_offset_count: u16,
+    /// An offset to an array:
+    pub array_offset: OffsetMarker<Vec<u16>>,
     /// A normal offset that is versioned
     pub versioned_nonnullable_offset: Option<OffsetMarker<Dummy>>,
     /// An offset that is nullable and versioned
@@ -25,6 +29,8 @@ impl FontWrite for KindsOfOffsets {
         version.write_into(writer);
         self.nonnullable_offset.write_into(writer);
         self.nullable_offset.write_into(writer);
+        self.array_offset_count.write_into(writer);
+        self.array_offset.write_into(writer);
         version.compatible(MajorMinor::VERSION_1_1).then(|| {
             self.versioned_nonnullable_offset
                 .as_ref()
@@ -69,6 +75,8 @@ impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfOffsets<'a>> for KindsOfOff
             version: obj.version(),
             nonnullable_offset: obj.nonnullable().into(),
             nullable_offset: obj.nullable().into(),
+            array_offset_count: obj.array_offset_count(),
+            array_offset: obj.array().into(),
             versioned_nonnullable_offset: obj.versioned_nonnullable().map(|obj| obj.into()),
             versioned_nullable_offset: obj.versioned_nullable().into(),
         }

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -271,3 +271,9 @@ impl<T: FontWrite> FontWrite for BTreeSet<T> {
         self.iter().for_each(|item| item.write_into(writer))
     }
 }
+
+impl<T: FontWrite> FontWrite for Vec<T> {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.iter().for_each(|item| item.write_into(writer))
+    }
+}


### PR DESCRIPTION
With this change, you can now have an offset where the inner type is either a) a scalar (`BigEndian<T>`) type, or a record. I believe this covers all the existing cases?

I've updated COLR to use the new syntax.

I've also added support in traversal and `otexplorer`, although I haven't played around much to see what the formatting looks like; we may want to tweak it.

This required some fairly deep changes in our parsing code since we need to distinguish between whether an offset's inner type is an array or not, and then if it *is* we also need to know if it's a scalar. Anyway, it wasn't so bad.

- closes #74 
- relevant to #68 