### PR TITLE
[traversal] Rename offset_array -> array_of_offsets

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -293,7 +293,7 @@ fn traversal_arm_for_field(
                     #maybe_data
                     #args_if_needed
                     Field::new(#name_str,
-                        FieldType::offset_array(
+                        FieldType::array_of_offsets(
                             better_type_name::<#target>(),
                             self.#name()#maybe_unwrap,
                             move |off| {

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -555,7 +555,7 @@ impl<'a> SomeTable<'a> for LayerList<'a> {
                 let data = self.data;
                 Field::new(
                     "paint_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Paint>(),
                         self.paint_offsets(),
                         move |off| {

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -349,7 +349,7 @@ impl<'a> SomeTable<'a> for AttachList<'a> {
                 let data = self.data;
                 Field::new(
                     "attach_point_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<AttachPoint>(),
                         self.attach_point_offsets(),
                         move |off| {
@@ -528,7 +528,7 @@ impl<'a> SomeTable<'a> for LigCaretList<'a> {
                 let data = self.data;
                 Field::new(
                     "lig_glyph_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<LigGlyph>(),
                         self.lig_glyph_offsets(),
                         move |off| {
@@ -618,7 +618,7 @@ impl<'a> SomeTable<'a> for LigGlyph<'a> {
                 let data = self.data;
                 Field::new(
                     "caret_value_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CaretValue>(),
                         self.caret_value_offsets(),
                         move |off| {
@@ -1001,7 +1001,7 @@ impl<'a> SomeTable<'a> for MarkGlyphSets<'a> {
                 let data = self.data;
                 Field::new(
                     "coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.coverage_offsets(),
                         move |off| {

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1159,7 +1159,7 @@ impl<'a> SomeTable<'a> for PairPosFormat1<'a> {
                 let args = (self.value_format1(), self.value_format2());
                 Field::new(
                     "pair_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<PairSet>(),
                         self.pair_set_offsets(),
                         move |off| {
@@ -2168,7 +2168,7 @@ impl<'a> SomeRecord<'a> for BaseRecord<'a> {
                 0usize => Some({
                     Field::new(
                         "base_anchor_offsets",
-                        FieldType::offset_array(
+                        FieldType::array_of_offsets(
                             better_type_name::<AnchorTable>(),
                             self.base_anchor_offsets(),
                             move |off| {
@@ -2425,7 +2425,7 @@ impl<'a> SomeTable<'a> for LigatureArray<'a> {
                 let args = self.mark_class_count();
                 Field::new(
                     "ligature_attach_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<LigatureAttach>(),
                         self.ligature_attach_offsets(),
                         move |off| {
@@ -2594,7 +2594,7 @@ impl<'a> SomeRecord<'a> for ComponentRecord<'a> {
                 0usize => Some({
                     Field::new(
                         "ligature_anchor_offsets",
-                        FieldType::offset_array(
+                        FieldType::array_of_offsets(
                             better_type_name::<AnchorTable>(),
                             self.ligature_anchor_offsets(),
                             move |off| {
@@ -2914,7 +2914,7 @@ impl<'a> SomeRecord<'a> for Mark2Record<'a> {
                 0usize => Some({
                     Field::new(
                         "mark2_anchor_offsets",
-                        FieldType::offset_array(
+                        FieldType::array_of_offsets(
                             better_type_name::<AnchorTable>(),
                             self.mark2_anchor_offsets(),
                             move |off| {

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -558,7 +558,7 @@ impl<'a> SomeTable<'a> for MultipleSubstFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "sequence_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Sequence>(),
                         self.sequence_offsets(),
                         move |off| {
@@ -761,7 +761,7 @@ impl<'a> SomeTable<'a> for AlternateSubstFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "alternate_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<AlternateSet>(),
                         self.alternate_set_offsets(),
                         move |off| {
@@ -960,7 +960,7 @@ impl<'a> SomeTable<'a> for LigatureSubstFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "ligature_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<LigatureSet>(),
                         self.ligature_set_offsets(),
                         move |off| {
@@ -1050,7 +1050,7 @@ impl<'a> SomeTable<'a> for LigatureSet<'a> {
                 let data = self.data;
                 Field::new(
                     "ligature_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Ligature>(),
                         self.ligature_offsets(),
                         move |off| {
@@ -1506,7 +1506,7 @@ impl<'a> SomeTable<'a> for ReverseChainSingleSubstFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "backtrack_coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.backtrack_coverage_offsets(),
                         move |off| {
@@ -1524,7 +1524,7 @@ impl<'a> SomeTable<'a> for ReverseChainSingleSubstFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "lookahead_coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.lookahead_coverage_offsets(),
                         move |off| {

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -700,7 +700,7 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, 
                 let data = self.data;
                 Field::new(
                     "lookup_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<T>(),
                         self.lookup_offsets(),
                         move |off| {
@@ -857,7 +857,7 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
                 let data = self.data;
                 Field::new(
                     "subtable_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<T>(),
                         self.subtable_offsets(),
                         move |off| {
@@ -1584,7 +1584,7 @@ impl<'a> SomeTable<'a> for SequenceContextFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "seq_rule_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<SequenceRuleSet>(),
                         self.seq_rule_set_offsets(),
                         move |off| {
@@ -1674,7 +1674,7 @@ impl<'a> SomeTable<'a> for SequenceRuleSet<'a> {
                 let data = self.data;
                 Field::new(
                     "seq_rule_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<SequenceRule>(),
                         self.seq_rule_offsets(),
                         move |off| {
@@ -1933,7 +1933,7 @@ impl<'a> SomeTable<'a> for SequenceContextFormat2<'a> {
                 let data = self.data;
                 Field::new(
                     "class_seq_rule_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ClassSequenceRuleSet>(),
                         self.class_seq_rule_set_offsets(),
                         move |off| {
@@ -2029,7 +2029,7 @@ impl<'a> SomeTable<'a> for ClassSequenceRuleSet<'a> {
                 let data = self.data;
                 Field::new(
                     "class_seq_rule_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ClassSequenceRule>(),
                         self.class_seq_rule_offsets(),
                         move |off| {
@@ -2266,7 +2266,7 @@ impl<'a> SomeTable<'a> for SequenceContextFormat3<'a> {
                 let data = self.data;
                 Field::new(
                     "coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.coverage_offsets(),
                         move |off| {
@@ -2454,7 +2454,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat1<'a> {
                 let data = self.data;
                 Field::new(
                     "chained_seq_rule_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ChainedSequenceRuleSet>(),
                         self.chained_seq_rule_set_offsets(),
                         move |off| {
@@ -2550,7 +2550,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceRuleSet<'a> {
                 let data = self.data;
                 Field::new(
                     "chained_seq_rule_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ChainedSequenceRule>(),
                         self.chained_seq_rule_offsets(),
                         move |off| {
@@ -2919,7 +2919,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat2<'a> {
                 let data = self.data;
                 Field::new(
                     "chained_class_seq_rule_set_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ChainedClassSequenceRuleSet>(),
                         self.chained_class_seq_rule_set_offsets(),
                         move |off| {
@@ -3015,7 +3015,7 @@ impl<'a> SomeTable<'a> for ChainedClassSequenceRuleSet<'a> {
                 let data = self.data;
                 Field::new(
                     "chained_class_seq_rule_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ChainedClassSequenceRule>(),
                         self.chained_class_seq_rule_offsets(),
                         move |off| {
@@ -3387,7 +3387,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat3<'a> {
                 let data = self.data;
                 Field::new(
                     "backtrack_coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.backtrack_coverage_offsets(),
                         move |off| {
@@ -3402,7 +3402,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat3<'a> {
                 let data = self.data;
                 Field::new(
                     "input_coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.input_coverage_offsets(),
                         move |off| {
@@ -3420,7 +3420,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat3<'a> {
                 let data = self.data;
                 Field::new(
                     "lookahead_coverage_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<CoverageTable>(),
                         self.lookahead_coverage_offsets(),
                         move |off| {
@@ -3948,7 +3948,7 @@ impl<'a> SomeTable<'a> for ConditionSet<'a> {
                 let data = self.data;
                 Field::new(
                     "condition_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<ConditionFormat1>(),
                         self.condition_offsets(),
                         move |off| {

--- a/read-fonts/generated/generated_test.rs
+++ b/read-fonts/generated/generated_test.rs
@@ -363,7 +363,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                 let data = self.data;
                 Field::new(
                     "nonnullable_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Dummy>(),
                         self.nonnullable_offsets(),
                         move |off| {
@@ -377,7 +377,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                 let data = self.data;
                 Field::new(
                     "nullable_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Dummy>(),
                         self.nullable_offsets(),
                         move |off| {
@@ -391,7 +391,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                 let data = self.data;
                 Field::new(
                     "versioned_nonnullable_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Dummy>(),
                         self.versioned_nonnullable_offsets().unwrap(),
                         move |off| {
@@ -405,7 +405,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                 let data = self.data;
                 Field::new(
                     "versioned_nullable_offsets",
-                    FieldType::offset_array(
+                    FieldType::array_of_offsets(
                         better_type_name::<Dummy>(),
                         self.versioned_nullable_offsets().unwrap(),
                         move |off| {

--- a/read-fonts/src/traversal.rs
+++ b/read-fonts/src/traversal.rs
@@ -153,12 +153,11 @@ impl<'a> FieldType<'a> {
         .into()
     }
 
-    /// Convenience method for creating a `FieldType` from an array of offests.
+    /// Convenience method for creating a `FieldType` from an array of offsets.
     ///
     /// The `resolver` argument is a function that takes an offset and resolves
     /// it.
-    //TODO: rename this to array_of_offsets?
-    pub fn offset_array<O>(
+    pub fn array_of_offsets<O>(
         type_name: &'static str,
         offsets: &'a [O],
         resolver: impl Fn(&O) -> FieldType<'a> + 'a,


### PR DESCRIPTION
This becomes confusing once we also support offsets _to_ arrays.