### PR TITLE
Drop BigEndian from codegen input

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -21,3 +21,5 @@ quote = "1.0"
 toml = "0.5"
 serde = {version = "1.0", features = ["derive"] }
 xflags = "0.2.4"
+log = "0.4"
+env_logger = "0.9.0"

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -3,6 +3,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
+use crate::parsing::Phase;
+
 use super::parsing::{CustomCompile, Field, Fields, Record, TableAttrs};
 
 pub(crate) fn generate(item: &Record) -> syn::Result<TokenStream> {
@@ -244,8 +246,8 @@ fn generate_from_obj_impl(item: &Record, parse_module: &syn::Path) -> syn::Resul
 }
 
 impl Record {
-    pub(crate) fn sanity_check(&self) -> syn::Result<()> {
-        self.fields.sanity_check()?;
+    pub(crate) fn sanity_check(&self, phase: Phase) -> syn::Result<()> {
+        self.fields.sanity_check(phase)?;
         let field_needs_lifetime = self
             .fields
             .iter()

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -3,7 +3,7 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 
-use crate::parsing::{Attr, GenericGroup};
+use crate::parsing::{Attr, GenericGroup, Phase};
 
 use super::parsing::{Field, ReferencedFields, Table, TableFormat, TableReadArg, TableReadArgs};
 
@@ -574,8 +574,8 @@ pub(crate) fn generate_format_group(item: &TableFormat) -> syn::Result<TokenStre
 }
 
 impl Table {
-    pub(crate) fn sanity_check(&self) -> syn::Result<()> {
-        self.fields.sanity_check()
+    pub(crate) fn sanity_check(&self, phase: Phase) -> syn::Result<()> {
+        self.fields.sanity_check(phase)
     }
 
     fn marker_name(&self) -> syn::Ident {

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -331,7 +331,7 @@ impl<'a> Cmap0<'a> {
     }
 
     /// An array that maps character codes to glyph index values.
-    pub fn glyph_id_array(&self) -> &'a [BigEndian<u8>] {
+    pub fn glyph_id_array(&self) -> &'a [u8] {
         let range = self.shape.glyph_id_array_byte_range();
         self.data.read_array(range).unwrap()
     }
@@ -940,7 +940,7 @@ impl<'a> Cmap8<'a> {
     /// Tightly packed array of bits (8K bytes total) indicating
     /// whether the particular 16-bit (index) value is the start of a
     /// 32-bit character code
-    pub fn is32(&self) -> &'a [BigEndian<u8>] {
+    pub fn is32(&self) -> &'a [u8] {
         let range = self.shape.is32_byte_range();
         self.data.read_array(range).unwrap()
     }
@@ -1758,7 +1758,7 @@ pub struct UnicodeRange {
     /// First value in this range
     pub start_unicode_value: BigEndian<Uint24>,
     /// Number of additional values in this range
-    pub additional_count: BigEndian<u8>,
+    pub additional_count: u8,
 }
 
 impl UnicodeRange {
@@ -1769,7 +1769,7 @@ impl UnicodeRange {
 
     /// Number of additional values in this range
     pub fn additional_count(&self) -> u8 {
-        self.additional_count.get()
+        self.additional_count
     }
 }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -266,34 +266,34 @@ impl<'a> std::fmt::Debug for Cpal<'a> {
 #[repr(packed)]
 pub struct ColorRecord {
     /// Blue value (B0).
-    pub blue: BigEndian<u8>,
+    pub blue: u8,
     /// Green value (B1).
-    pub green: BigEndian<u8>,
+    pub green: u8,
     ///     Red value (B2).
-    pub red: BigEndian<u8>,
+    pub red: u8,
     /// Alpha value (B3).
-    pub alpha: BigEndian<u8>,
+    pub alpha: u8,
 }
 
 impl ColorRecord {
     /// Blue value (B0).
     pub fn blue(&self) -> u8 {
-        self.blue.get()
+        self.blue
     }
 
     /// Green value (B1).
     pub fn green(&self) -> u8 {
-        self.green.get()
+        self.green
     }
 
     ///     Red value (B2).
     pub fn red(&self) -> u8 {
-        self.red.get()
+        self.red
     }
 
     /// Alpha value (B3).
     pub fn alpha(&self) -> u8 {
-        self.alpha.get()
+        self.alpha
     }
 }
 

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -169,7 +169,7 @@ impl<'a> SimpleGlyph<'a> {
     }
 
     /// Array of instruction byte code for the glyph.
-    pub fn instructions(&self) -> &'a [BigEndian<u8>] {
+    pub fn instructions(&self) -> &'a [u8] {
         let range = self.shape.instructions_byte_range();
         self.data.read_array(range).unwrap()
     }

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -3,10 +3,10 @@
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
 table Cmap {
     /// Table version number (0).
-    version: BigEndian<u16>,
+    version: u16,
     /// Number of encoding tables that follow.
     #[compile(array_len($encoding_records))]
-    num_tables: BigEndian<u16>,
+    num_tables: u16,
     #[count($num_tables)]
     encoding_records: [EncodingRecord],
 }
@@ -14,12 +14,12 @@ table Cmap {
 /// [Encoding Record](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings)
 record EncodingRecord {
     /// Platform ID.
-    platform_id: BigEndian<PlatformId>,
+    platform_id: PlatformId,
     /// Platform-specific encoding ID.
-    encoding_id: BigEndian<u16>,
+    encoding_id: u16,
     /// Byte offset from beginning of table to the subtable for this
     /// encoding.
-    subtable_offset: BigEndian<Offset32<CmapSubtable>>,
+    subtable_offset: Offset32<CmapSubtable>,
 }
 
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#platform-ids>
@@ -48,33 +48,33 @@ format u16 CmapSubtable {
 table Cmap0 {
     /// Format number is set to 0.
     #[format = 0]
-    format: BigEndian<u16>,
+    format: u16,
     /// This is the length in bytes of the subtable.
     #[compile(256 + 6)]
-    length: BigEndian<u16>,
+    length: u16,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u16>,
+    language: u16,
     /// An array that maps character codes to glyph index values.
     #[count(256)]
-    glyph_id_array: [BigEndian<u8>],
+    glyph_id_array: [u8],
 }
 
     /// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
 table Cmap2 {
     /// Format number is set to 2.
     #[format = 2]
-    format: BigEndian<u16>,
+    format: u16,
     /// This is the length in bytes of the subtable.
     #[compile(panic!("not implemented"))]
-    length: BigEndian<u16>,
+    length: u16,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u16>,
+    language: u16,
     /// Array that maps high bytes to subHeaders: value is subHeader
     /// index × 8.
     #[count(256)]
-    sub_header_keys: [BigEndian<u16>],
+    sub_header_keys: [u16],
 
     //FIXME: these two fields will require some custom handling
     ///// Variable-length array of SubHeader records.
@@ -83,103 +83,103 @@ table Cmap2 {
     ///// Variable-length array containing subarrays used for mapping the
     ///// low byte of 2-byte characters.
     //#[count( )]
-    //glyph_id_array: [BigEndian<u16>],
+    //glyph_id_array: [u16],
 }
 
 
 /// Part of [Cmap2]
 record SubHeader {
     /// First valid low byte for this SubHeader.
-    first_code: BigEndian<u16>,
+    first_code: u16,
     /// Number of valid low bytes for this SubHeader.
-    entry_count: BigEndian<u16>,
+    entry_count: u16,
     /// See text below.
-    id_delta: BigEndian<i16>,
+    id_delta: i16,
     /// See text below.
-    id_range_offset: BigEndian<u16>,
+    id_range_offset: u16,
 }
 
 /// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
 table Cmap4 {
     /// Format number is set to 4.
     #[format = 4]
-    format: BigEndian<u16>,
+    format: u16,
     /// This is the length in bytes of the subtable.
-    length: BigEndian<u16>,
+    length: u16,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u16>,
+    language: u16,
     /// 2 × segCount.
-    seg_count_x2: BigEndian<u16>,
+    seg_count_x2: u16,
     /// Maximum power of 2 less than or equal to segCount, times 2
     /// ((2**floor(log2(segCount))) * 2, where “**” is an
     /// exponentiation operator)
-    search_range: BigEndian<u16>,
+    search_range: u16,
     /// Log2 of the maximum power of 2 less than or equal to numTables
     /// (log2(searchRange/2), which is equal to floor(log2(segCount)))
-    entry_selector: BigEndian<u16>,
+    entry_selector: u16,
     /// segCount times 2, minus searchRange ((segCount * 2) -
     /// searchRange)
-    range_shift: BigEndian<u16>,
+    range_shift: u16,
     /// End characterCode for each segment, last=0xFFFF.
     #[count($seg_count_x2 as usize / 2)]
-    end_code: [BigEndian<u16>],
+    end_code: [u16],
     /// Set to 0.
     #[skip_getter]
-    reserved_pad: BigEndian<u16>,
+    reserved_pad: u16,
     /// Start character code for each segment.
     #[count($seg_count_x2 as usize / 2)]
-    start_code: [BigEndian<u16>],
+    start_code: [u16],
     /// Delta for all character codes in segment.
     #[count($seg_count_x2 as usize / 2)]
-    id_delta: [BigEndian<i16>],
+    id_delta: [i16],
     /// Offsets into glyphIdArray or 0
     #[count($seg_count_x2 as usize / 2)]
-    id_range_offsets: [BigEndian<u16>],
+    id_range_offsets: [u16],
     /// Glyph index array (arbitrary length)
     #[count(..)]
-    glyph_id_array: [BigEndian<u16>],
+    glyph_id_array: [u16],
 }
 
 /// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
 table Cmap6 {
     /// Format number is set to 6.
     #[format = 6]
-    format: BigEndian<u16>,
+    format: u16,
     /// This is the length in bytes of the subtable.
-    length: BigEndian<u16>,
+    length: u16,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u16>,
+    language: u16,
     /// First character code of subrange.
-    first_code: BigEndian<u16>,
+    first_code: u16,
     /// Number of character codes in subrange.
-    entry_count: BigEndian<u16>,
+    entry_count: u16,
     /// Array of glyph index values for character codes in the range.
     #[count($entry_count)]
-    glyph_id_array: [BigEndian<u16>],
+    glyph_id_array: [u16],
 }
 
 /// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
 table Cmap8 {
     /// Subtable format; set to 8.
     #[format = 8]
-    format: BigEndian<u16>,
+    format: u16,
     /// Reserved; set to 0
     #[skip_getter]
-    reserved: BigEndian<u16>,
+    reserved: u16,
     /// Byte length of this subtable (including the header)
-    length: BigEndian<u32>,
+    length: u32,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u32>,
+    language: u32,
     /// Tightly packed array of bits (8K bytes total) indicating
     /// whether the particular 16-bit (index) value is the start of a
     /// 32-bit character code
     #[count(8192)]
-    is32: [BigEndian<u8>],
+    is32: [u8],
     /// Number of groupings which follow
-    num_groups: BigEndian<u32>,
+    num_groups: u32,
     /// Array of SequentialMapGroup records.
     #[count($num_groups)]
     groups: [SequentialMapGroup],
@@ -191,51 +191,51 @@ record SequentialMapGroup {
     /// for one or more 16-bit character codes (which is determined
     /// from the is32 array), this 32-bit value will have the high
     /// 16-bits set to zero
-    start_char_code: BigEndian<u32>,
+    start_char_code: u32,
     /// Last character code in this group; same condition as listed
     /// above for the startCharCode
-    end_char_code: BigEndian<u32>,
+    end_char_code: u32,
     /// Glyph index corresponding to the starting character code
-    start_glyph_id: BigEndian<u32>,
+    start_glyph_id: u32,
 }
 
     /// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
 table Cmap10 {
     /// Subtable format; set to 10.
     #[format = 10]
-    format: BigEndian<u16>,
+    format: u16,
     /// Reserved; set to 0
     #[skip_getter]
-    reserved: BigEndian<u16>,
+    reserved: u16,
     /// Byte length of this subtable (including the header)
-    length: BigEndian<u32>,
+    length: u32,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u32>,
+    language: u32,
     /// First character code covered
-    start_char_code: BigEndian<u32>,
+    start_char_code: u32,
     /// Number of character codes covered
-    num_chars: BigEndian<u32>,
+    num_chars: u32,
     /// Array of glyph indices for the character codes covered
     #[count(..)]
-    glyph_id_array: [BigEndian<u16>],
+    glyph_id_array: [u16],
 }
 
 /// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
 table Cmap12 {
     /// Subtable format; set to 12.
     #[format = 12]
-    format: BigEndian<u16>,
+    format: u16,
     /// Reserved; set to 0
     #[skip_getter]
-    reserved: BigEndian<u16>,
+    reserved: u16,
     /// Byte length of this subtable (including the header)
-    length: BigEndian<u32>,
+    length: u32,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u32>,
+    language: u32,
     /// Number of groupings which follow
-    num_groups: BigEndian<u32>,
+    num_groups: u32,
     /// Array of SequentialMapGroup records.
     #[count($num_groups)]
     groups: [SequentialMapGroup],
@@ -245,17 +245,17 @@ table Cmap12 {
 table Cmap13 {
     /// Subtable format; set to 13.
     #[format = 13]
-    format: BigEndian<u16>,
+    format: u16,
     /// Reserved; set to 0
     #[skip_getter]
-    reserved: BigEndian<u16>,
+    reserved: u16,
     /// Byte length of this subtable (including the header)
-    length: BigEndian<u32>,
+    length: u32,
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
-    language: BigEndian<u32>,
+    language: u32,
     /// Number of groupings which follow
-    num_groups: BigEndian<u32>,
+    num_groups: u32,
     /// Array of ConstantMapGroup records.
     #[count($num_groups)]
     groups: [ConstantMapGroup],
@@ -264,23 +264,23 @@ table Cmap13 {
 /// Part of [Cmap13]
 record ConstantMapGroup {
     /// First character code in this group
-    start_char_code: BigEndian<u32>,
+    start_char_code: u32,
     /// Last character code in this group
-    end_char_code: BigEndian<u32>,
+    end_char_code: u32,
     /// Glyph index to be used for all the characters in the group’s
     /// range.
-    glyph_id: BigEndian<u32>,
+    glyph_id: u32,
 }
 
 /// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
 table Cmap14 {
     /// Subtable format. Set to 14.
     #[format = 14]
-    format: BigEndian<u16>,
+    format: u16,
     /// Byte length of this subtable (including this header)
-    length: BigEndian<u32>,
+    length: u32,
     /// Number of variation Selector Records
-    num_var_selector_records: BigEndian<u32>,
+    num_var_selector_records: u32,
     /// Array of VariationSelector records.
     #[count($num_var_selector_records)]
     var_selector: [VariationSelector],
@@ -289,19 +289,19 @@ table Cmap14 {
 /// Part of [Cmap14]
 record VariationSelector {
     /// Variation selector
-    var_selector: BigEndian<Uint24>,
+    var_selector: Uint24,
     /// Offset from the start of the format 14 subtable to Default UVS
     /// Table. May be 0.
-    default_uvs_offset: BigEndian<Offset32>,
+    default_uvs_offset: Offset32,
     /// Offset from the start of the format 14 subtable to Non-Default
     /// UVS Table. May be 0.
-    non_default_uvs_offset: BigEndian<Offset32>,
+    non_default_uvs_offset: Offset32,
 }
 
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
 table DefaultUvs {
     /// Number of Unicode character ranges.
-    num_unicode_value_ranges: BigEndian<u32>,
+    num_unicode_value_ranges: u32,
     /// Array of UnicodeRange records.
     #[count($num_unicode_value_ranges)]
     ranges: [UnicodeRange],
@@ -310,15 +310,15 @@ table DefaultUvs {
 /// Part of [Cmap14]
 record UVSMapping {
     /// Base Unicode value of the UVS
-    unicode_value: BigEndian<Uint24>,
+    unicode_value: Uint24,
     /// Glyph ID of the UVS
-    glyph_id: BigEndian<u16>,
+    glyph_id: u16,
 }
 
 /// Part of [Cmap14]
 record UnicodeRange {
     /// First value in this range
-    start_unicode_value: BigEndian<Uint24>,
+    start_unicode_value: Uint24,
     /// Number of additional values in this range
-    additional_count: BigEndian<u8>,
+    additional_count: u8,
 }

--- a/resources/codegen_inputs/colr.rs
+++ b/resources/codegen_inputs/colr.rs
@@ -5,62 +5,62 @@
 table Colr {
     /// Table version number - set to 0 or 1.
     #[version]
-    version: BigEndian<u16>,
+    version: u16,
     /// Number of BaseGlyph records; may be 0 in a version 1 table.
-    num_base_glyph_records: BigEndian<u16>,
+    num_base_glyph_records: u16,
     /// Offset to baseGlyphRecords array (may be NULL).
     #[nullable]
     #[read_offset_with($num_base_glyph_records)]
-    base_glyph_records_offset: BigEndian<Offset32<[BaseGlyph]>>,
+    base_glyph_records_offset: Offset32<[BaseGlyph]>,
     /// Offset to layerRecords array (may be NULL).
     #[nullable]
     #[read_offset_with($num_layer_records)]
-    layer_records_offset: BigEndian<Offset32<[Layer]>>,
+    layer_records_offset: Offset32<[Layer]>,
     /// Number of Layer records; may be 0 in a version 1 table.
-    num_layer_records: BigEndian<u16>,
+    num_layer_records: u16,
     /// Offset to BaseGlyphList table.
     #[available(1)]
     #[nullable]
-    base_glyph_list_offset: BigEndian<Offset32<BaseGlyphList>>,
+    base_glyph_list_offset: Offset32<BaseGlyphList>,
     /// Offset to LayerList table (may be NULL).
     #[available(1)]
     #[nullable]
-    layer_list_offset: BigEndian<Offset32<LayerList>>,
+    layer_list_offset: Offset32<LayerList>,
     /// Offset to ClipList table (may be NULL).
     #[available(1)]
     #[nullable]
-    clip_list_offset: BigEndian<Offset32<ClipList>>,
+    clip_list_offset: Offset32<ClipList>,
     /// Offset to DeltaSetIndexMap table (may be NULL).
     #[available(1)]
     #[nullable]
-    var_index_map_offset: BigEndian<Offset32>,
+    var_index_map_offset: Offset32,
     /// Offset to ItemVariationStore (may be NULL).
     #[available(1)]
     #[nullable]
-    item_variation_store_offset: BigEndian<Offset32>,
+    item_variation_store_offset: Offset32,
 }
 
 /// [BaseGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
 record BaseGlyph {
     /// Glyph ID of the base glyph.
-    glyph_id: BigEndian<GlyphId>,
+    glyph_id: GlyphId,
     /// Index (base 0) into the layerRecords array.
-    first_layer_index: BigEndian<u16>,
+    first_layer_index: u16,
     /// Number of color layers associated with this glyph.
-    num_layers: BigEndian<u16>,
+    num_layers: u16,
 }
 
 /// [Layer](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
 record Layer {
     /// Glyph ID of the glyph used for a given layer.
-    glyph_id: BigEndian<GlyphId>,
+    glyph_id: GlyphId,
     /// Index (base 0) for a palette entry in the CPAL table.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
 }
 
 /// [BaseGlyphList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 table BaseGlyphList {
-    num_base_glyph_paint_records: BigEndian<u32>,
+    num_base_glyph_paint_records: u32,
     #[count($num_base_glyph_paint_records)]
     base_glyph_paint_records: [BaseGlyphPaint],
 }
@@ -68,25 +68,25 @@ table BaseGlyphList {
 /// [BaseGlyphPaint](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
 record BaseGlyphPaint {
     /// Glyph ID of the base glyph.
-    glyph_id: BigEndian<GlyphId>,
+    glyph_id: GlyphId,
     /// Offset to a Paint table.
-    paint_offset: BigEndian<Offset32<Paint>>,
+    paint_offset: Offset32<Paint>,
 }
 
 /// [LayerList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 table LayerList {
-    num_layers: BigEndian<u32>,
+    num_layers: u32,
     /// Offsets to Paint tables.
     #[count($num_layers)]
-    paint_offsets: [BigEndian<Offset32<Paint>>],
+    paint_offsets: [Offset32<Paint>],
 }
 
 /// [ClipList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 table ClipList {
     /// Set to 1.
-    format: BigEndian<u8>,
+    format: u8,
     /// Number of Clip records.
-    num_clips: BigEndian<u32>,
+    num_clips: u32,
     /// Clip records. Sorted by startGlyphID.
     #[count($num_clips)]
     clips: [Clip],
@@ -95,11 +95,11 @@ table ClipList {
 /// [Clip](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
 record Clip {
     /// First glyph ID in the range.
-    start_glyph_id: BigEndian<GlyphId>,
+    start_glyph_id: GlyphId,
     /// Last glyph ID in the range.
-    end_glyph_id: BigEndian<GlyphId>,
+    end_glyph_id: GlyphId,
     /// Offset to a ClipBox table.
-    clip_box_offset: BigEndian<Offset24<ClipBox>>,
+    clip_box_offset: Offset24<ClipBox>,
 }
 
 /// [ClipBox](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
@@ -112,80 +112,80 @@ format u8 ClipBox {
 table ClipBoxFormat1 {
     /// Set to 1.
     #[format = 1]
-    format: BigEndian<u8>,
+    format: u8,
     /// Minimum x of clip box.
-    x_min: BigEndian<FWord>,
+    x_min: FWord,
     /// Minimum y of clip box.
-    y_min: BigEndian<FWord>,
+    y_min: FWord,
     /// Maximum x of clip box.
-    x_max: BigEndian<FWord>,
+    x_max: FWord,
     /// Maximum y of clip box.
-    y_max: BigEndian<FWord>,
+    y_max: FWord,
 }
 
 /// [ClipBoxFormat2](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
 table ClipBoxFormat2 {
     /// Set to 2.
     #[format = 2]
-    format: BigEndian<u8>,
+    format: u8,
     /// Minimum x of clip box. For variation, use varIndexBase + 0.
-    x_min: BigEndian<FWord>,
+    x_min: FWord,
     /// Minimum y of clip box. For variation, use varIndexBase + 1.
-    y_min: BigEndian<FWord>,
+    y_min: FWord,
     /// Maximum x of clip box. For variation, use varIndexBase + 2.
-    x_max: BigEndian<FWord>,
+    x_max: FWord,
     /// Maximum y of clip box. For variation, use varIndexBase + 3.
-    y_max: BigEndian<FWord>,
+    y_max: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [ColorIndex](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
 record ColorIndex {
     /// Index for a CPAL palette entry.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
     /// Alpha value.
-    alpha: BigEndian<F2Dot14>,
+    alpha: F2Dot14,
 }
 
 /// [VarColorIndex](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
 record VarColorIndex {
     /// Index for a CPAL palette entry.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
     /// Alpha value. For variation, use varIndexBase + 0.
-    alpha: BigEndian<F2Dot14>,
+    alpha: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [ColorStop](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
 record ColorStop {
     /// Position on a color line.
-    stop_offset: BigEndian<F2Dot14>,
+    stop_offset: F2Dot14,
     /// Index for a CPAL palette entry.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
     /// Alpha value.
-    alpha: BigEndian<F2Dot14>,
+    alpha: F2Dot14,
 }
 
 /// [VarColorStop](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
 record VarColorStop {
     /// Position on a color line. For variation, use varIndexBase + 0.
-    stop_offset: BigEndian<F2Dot14>,
+    stop_offset: F2Dot14,
     /// Index for a CPAL palette entry.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
     /// Alpha value. For variation, use varIndexBase + 1.
-    alpha: BigEndian<F2Dot14>,
+    alpha: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [ColorLine](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) table
 table ColorLine {
     /// An Extend enum value.
-    extend: BigEndian<Extend>,
+    extend: Extend,
     /// Number of ColorStop records.
-    num_stops: BigEndian<u16>,
+    num_stops: u16,
     #[count($num_stops)]
     color_stops: [ColorStop],
 }
@@ -193,9 +193,9 @@ table ColorLine {
 /// [VarColorLine](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) table
 table VarColorLine {
     /// An Extend enum value.
-    extend: BigEndian<Extend>,
+    extend: Extend,
     /// Number of ColorStop records.
-    num_stops: BigEndian<u16>,
+    num_stops: u16,
     /// Allows for variations.
     #[count($num_stops)]
     color_stops: [VarColorStop],
@@ -248,566 +248,566 @@ format u8 Paint {
 table PaintColrLayers {
     /// Set to 1.
     #[format = 1]
-    format: BigEndian<u8>,
+    format: u8,
     /// Number of offsets to paint tables to read from LayerList.
-    num_layers: BigEndian<u8>,
+    num_layers: u8,
     /// Index (base 0) into the LayerList.
-    first_layer_index: BigEndian<u32>,
+    first_layer_index: u32,
 }
 
 /// [PaintSolid](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-2-and-3-paintsolid-paintvarsolid) table
 table PaintSolid {
     /// Set to 2.
     #[format = 2]
-    format: BigEndian<u8>,
+    format: u8,
     /// Index for a CPAL palette entry.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
     /// Alpha value.
-    alpha: BigEndian<F2Dot14>,
+    alpha: F2Dot14,
 }
 
 /// [PaintVarSolid](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-2-and-3-paintsolid-paintvarsolid) table
 table PaintVarSolid {
     /// Set to 3.
     #[format = 3]
-    format: BigEndian<u8>,
+    format: u8,
     /// Index for a CPAL palette entry.
-    palette_index: BigEndian<u16>,
+    palette_index: u16,
     /// Alpha value. For variation, use varIndexBase + 0.
-    alpha: BigEndian<F2Dot14>,
+    alpha: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintLinearGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-4-and-5-paintlineargradient-paintvarlineargradient) table
 table PaintLinearGradient {
     /// Set to 4.
     #[format = 4]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to ColorLine table.
-    color_line_offset: BigEndian<Offset24<ColorLine>>,
+    color_line_offset: Offset24<ColorLine>,
     /// Start point (p₀) x coordinate.
-    x0: BigEndian<FWord>,
+    x0: FWord,
     /// Start point (p₀) y coordinate.
-    y0: BigEndian<FWord>,
+    y0: FWord,
     /// End point (p₁) x coordinate.
-    x1: BigEndian<FWord>,
+    x1: FWord,
     /// End point (p₁) y coordinate.
-    y1: BigEndian<FWord>,
+    y1: FWord,
     /// Rotation point (p₂) x coordinate.
-    x2: BigEndian<FWord>,
+    x2: FWord,
     /// Rotation point (p₂) y coordinate.
-    y2: BigEndian<FWord>,
+    y2: FWord,
 }
 
 /// [PaintVarLinearGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-4-and-5-paintlineargradient-paintvarlineargradient) table
 table PaintVarLinearGradient {
     /// Set to 5.
     #[format = 5]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to VarColorLine table.
-    color_line_offset: BigEndian<Offset24<VarColorLine>>,
+    color_line_offset: Offset24<VarColorLine>,
     /// Start point (p₀) x coordinate. For variation, use
     /// varIndexBase + 0.
-    x0: BigEndian<FWord>,
+    x0: FWord,
     /// Start point (p₀) y coordinate. For variation, use
     /// varIndexBase + 1.
-    y0: BigEndian<FWord>,
+    y0: FWord,
     /// End point (p₁) x coordinate. For variation, use varIndexBase
     /// + 2.
-    x1: BigEndian<FWord>,
+    x1: FWord,
     /// End point (p₁) y coordinate. For variation, use varIndexBase
     /// + 3.
-    y1: BigEndian<FWord>,
+    y1: FWord,
     /// Rotation point (p₂) x coordinate. For variation, use
     /// varIndexBase + 4.
-    x2: BigEndian<FWord>,
+    x2: FWord,
     /// Rotation point (p₂) y coordinate. For variation, use
     /// varIndexBase + 5.
-    y2: BigEndian<FWord>,
+    y2: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintRadialGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-6-and-7-paintradialgradient-paintvarradialgradient) table
 table PaintRadialGradient {
     /// Set to 6.
     #[format = 6]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to ColorLine table.
-    color_line_offset: BigEndian<Offset24<ColorLine>>,
+    color_line_offset: Offset24<ColorLine>,
     /// Start circle center x coordinate.
-    x0: BigEndian<FWord>,
+    x0: FWord,
     /// Start circle center y coordinate.
-    y0: BigEndian<FWord>,
+    y0: FWord,
     /// Start circle radius.
-    radius0: BigEndian<UfWord>,
+    radius0: UfWord,
     /// End circle center x coordinate.
-    x1: BigEndian<FWord>,
+    x1: FWord,
     /// End circle center y coordinate.
-    y1: BigEndian<FWord>,
+    y1: FWord,
     /// End circle radius.
-    radius1: BigEndian<UfWord>,
+    radius1: UfWord,
 }
 
 /// [PaintVarRadialGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-6-and-7-paintradialgradient-paintvarradialgradient) table
 table PaintVarRadialGradient {
     /// Set to 7.
     #[format = 7]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to VarColorLine table.
-    color_line_offset: BigEndian<Offset24<VarColorLine>>,
+    color_line_offset: Offset24<VarColorLine>,
     /// Start circle center x coordinate. For variation, use
     /// varIndexBase + 0.
-    x0: BigEndian<FWord>,
+    x0: FWord,
     /// Start circle center y coordinate. For variation, use
     /// varIndexBase + 1.
-    y0: BigEndian<FWord>,
+    y0: FWord,
     /// Start circle radius. For variation, use varIndexBase + 2.
-    radius0: BigEndian<UfWord>,
+    radius0: UfWord,
     /// End circle center x coordinate. For variation, use varIndexBase
     /// + 3.
-    x1: BigEndian<FWord>,
+    x1: FWord,
     /// End circle center y coordinate. For variation, use varIndexBase
     /// + 4.
-    y1: BigEndian<FWord>,
+    y1: FWord,
     /// End circle radius. For variation, use varIndexBase + 5.
-    radius1: BigEndian<UfWord>,
+    radius1: UfWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintSweepGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-8-and-9-paintsweepgradient-paintvarsweepgradient) table
 table PaintSweepGradient {
     /// Set to 8.
     #[format = 8]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to ColorLine table.
-    color_line_offset: BigEndian<Offset24<ColorLine>>,
+    color_line_offset: Offset24<ColorLine>,
     /// Center x coordinate.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// Center y coordinate.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
     /// Start of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
-    start_angle: BigEndian<F2Dot14>,
+    start_angle: F2Dot14,
     /// End of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
-    end_angle: BigEndian<F2Dot14>,
+    end_angle: F2Dot14,
 }
 
 /// [PaintVarSweepGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-8-and-9-paintsweepgradient-paintvarsweepgradient) table
 table PaintVarSweepGradient {
     /// Set to 9.
     #[format = 9]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to VarColorLine table.
-    color_line_offset: BigEndian<Offset24<VarColorLine>>,
+    color_line_offset: Offset24<VarColorLine>,
     /// Center x coordinate. For variation, use varIndexBase + 0.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// Center y coordinate. For variation, use varIndexBase + 1.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
     /// Start of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 2.
-    start_angle: BigEndian<F2Dot14>,
+    start_angle: F2Dot14,
     /// End of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 3.
-    end_angle: BigEndian<F2Dot14>,
+    end_angle: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-10-paintglyph) table
 table PaintGlyph {
     /// Set to 10.
     #[format = 10]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint table.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Glyph ID for the source outline.
-    glyph_id: BigEndian<GlyphId>,
+    glyph_id: GlyphId,
 }
 
 /// [PaintColrGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-11-paintcolrglyph) table
 table PaintColrGlyph {
     /// Set to 11.
     #[format = 11]
-    format: BigEndian<u8>,
+    format: u8,
     /// Glyph ID for a BaseGlyphList base glyph.
-    glyph_id: BigEndian<GlyphId>,
+    glyph_id: GlyphId,
 }
 
 /// [PaintTransform](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) table
 table PaintTransform {
     /// Set to 12.
     #[format = 12]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Offset to an Affine2x3 table.
-    transform_offset: BigEndian<Offset24<Affine2x3>>,
+    transform_offset: Offset24<Affine2x3>,
 }
 
 /// [PaintVarTransform](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) table
 table PaintVarTransform {
     /// Set to 13.
     #[format = 13]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Offset to a VarAffine2x3 table.
-    transform_offset: BigEndian<Offset24<VarAffine2x3>>,
+    transform_offset: Offset24<VarAffine2x3>,
 }
 
 /// [Affine2x3](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) record
 table Affine2x3 {
     /// x-component of transformed x-basis vector.
-    xx: BigEndian<Fixed>,
+    xx: Fixed,
     /// y-component of transformed x-basis vector.
-    yx: BigEndian<Fixed>,
+    yx: Fixed,
     /// x-component of transformed y-basis vector.
-    xy: BigEndian<Fixed>,
+    xy: Fixed,
     /// y-component of transformed y-basis vector.
-    yy: BigEndian<Fixed>,
+    yy: Fixed,
     /// Translation in x direction.
-    dx: BigEndian<Fixed>,
+    dx: Fixed,
     /// Translation in y direction.
-    dy: BigEndian<Fixed>,
+    dy: Fixed,
 }
 
 /// [VarAffine2x3](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) record
 table VarAffine2x3 {
     /// x-component of transformed x-basis vector. For variation, use
     /// varIndexBase + 0.
-    xx: BigEndian<Fixed>,
+    xx: Fixed,
     /// y-component of transformed x-basis vector. For variation, use
     /// varIndexBase + 1.
-    yx: BigEndian<Fixed>,
+    yx: Fixed,
     /// x-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 2.
-    xy: BigEndian<Fixed>,
+    xy: Fixed,
     /// y-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 3.
-    yy: BigEndian<Fixed>,
+    yy: Fixed,
     /// Translation in x direction. For variation, use varIndexBase + 4.
-    dx: BigEndian<Fixed>,
+    dx: Fixed,
     /// Translation in y direction. For variation, use varIndexBase + 5.
-    dy: BigEndian<Fixed>,
+    dy: Fixed,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintTranslate](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-14-and-15-painttranslate-paintvartranslate) table
 table PaintTranslate {
     /// Set to 14.
     #[format = 14]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Translation in x direction.
-    dx: BigEndian<FWord>,
+    dx: FWord,
     /// Translation in y direction.
-    dy: BigEndian<FWord>,
+    dy: FWord,
 }
 
 /// [PaintVarTranslate](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-14-and-15-painttranslate-paintvartranslate) table
 table PaintVarTranslate {
     /// Set to 15.
     #[format = 15]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Translation in x direction. For variation, use varIndexBase + 0.
-    dx: BigEndian<FWord>,
+    dx: FWord,
     /// Translation in y direction. For variation, use varIndexBase + 1.
-    dy: BigEndian<FWord>,
+    dy: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintScale](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintScale {
     /// Set to 16.
     #[format = 16]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x direction.
-    scale_x: BigEndian<F2Dot14>,
+    scale_x: F2Dot14,
     /// Scale factor in y direction.
-    scale_y: BigEndian<F2Dot14>,
+    scale_y: F2Dot14,
 }
 
 /// [PaintVarScale](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintVarScale {
     /// Set to 17.
     #[format = 17]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x direction. For variation, use varIndexBase +
     /// 0.
-    scale_x: BigEndian<F2Dot14>,
+    scale_x: F2Dot14,
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
-    scale_y: BigEndian<F2Dot14>,
+    scale_y: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintScaleAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintScaleAroundCenter {
     /// Set to 18.
     #[format = 18]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x direction.
-    scale_x: BigEndian<F2Dot14>,
+    scale_x: F2Dot14,
     /// Scale factor in y direction.
-    scale_y: BigEndian<F2Dot14>,
+    scale_y: F2Dot14,
     /// x coordinate for the center of scaling.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of scaling.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
 }
 
 /// [PaintVarScaleAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintVarScaleAroundCenter {
     /// Set to 19.
     #[format = 19]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x direction. For variation, use varIndexBase +
     /// 0.
-    scale_x: BigEndian<F2Dot14>,
+    scale_x: F2Dot14,
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
-    scale_y: BigEndian<F2Dot14>,
+    scale_y: F2Dot14,
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 3.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintScaleUniform](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintScaleUniform {
     /// Set to 20.
     #[format = 20]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x and y directions.
-    scale: BigEndian<F2Dot14>,
+    scale: F2Dot14,
 }
 
 /// [PaintVarScaleUniform](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintVarScaleUniform {
     /// Set to 21.
     #[format = 21]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x and y directions. For variation, use
     /// varIndexBase + 0.
-    scale: BigEndian<F2Dot14>,
+    scale: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintScaleUniformAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintScaleUniformAroundCenter {
     /// Set to 22.
     #[format = 22]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x and y directions.
-    scale: BigEndian<F2Dot14>,
+    scale: F2Dot14,
     /// x coordinate for the center of scaling.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of scaling.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
 }
 
 /// [PaintVarScaleUniformAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
 table PaintVarScaleUniformAroundCenter {
     /// Set to 23.
     #[format = 23]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Scale factor in x and y directions. For variation, use
     /// varIndexBase + 0.
-    scale: BigEndian<F2Dot14>,
+    scale: F2Dot14,
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 1.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintRotate](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
 table PaintRotate {
     /// Set to 24.
     #[format = 24]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value.
-    angle: BigEndian<F2Dot14>,
+    angle: F2Dot14,
 }
 
 /// [PaintVarRotate](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
 table PaintVarRotate {
     /// Set to 25.
     #[format = 25]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value. For variation, use varIndexBase + 0.
-    angle: BigEndian<F2Dot14>,
+    angle: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintRotateAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
 table PaintRotateAroundCenter {
     /// Set to 26.
     #[format = 26]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value.
-    angle: BigEndian<F2Dot14>,
+    angle: F2Dot14,
     /// x coordinate for the center of rotation.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of rotation.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
 }
 
 /// [PaintVarRotateAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
 table PaintVarRotateAroundCenter {
     /// Set to 27.
     #[format = 27]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value. For variation, use varIndexBase + 0.
-    angle: BigEndian<F2Dot14>,
+    angle: F2Dot14,
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 1.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintSkew](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
 table PaintSkew {
     /// Set to 28.
     #[format = 28]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Angle of skew in the direction of the x-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
-    x_skew_angle: BigEndian<F2Dot14>,
+    x_skew_angle: F2Dot14,
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
-    y_skew_angle: BigEndian<F2Dot14>,
+    y_skew_angle: F2Dot14,
 }
 
 /// [PaintVarSkew](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
 table PaintVarSkew {
     /// Set to 29.
     #[format = 29]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Angle of skew in the direction of the x-axis, 180° ┬░ in
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 0.
-    x_skew_angle: BigEndian<F2Dot14>,
+    x_skew_angle: F2Dot14,
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 1.
-    y_skew_angle: BigEndian<F2Dot14>,
+    y_skew_angle: F2Dot14,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintSkewAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
 table PaintSkewAroundCenter {
     /// Set to 30.
     #[format = 30]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Angle of skew in the direction of the x-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
-    x_skew_angle: BigEndian<F2Dot14>,
+    x_skew_angle: F2Dot14,
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
-    y_skew_angle: BigEndian<F2Dot14>,
+    y_skew_angle: F2Dot14,
     /// x coordinate for the center of rotation.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of rotation.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
 }
 
 /// [PaintVarSkewAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
 table PaintVarSkewAroundCenter {
     /// Set to 31.
     #[format = 31]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a Paint subtable.
-    paint_offset: BigEndian<Offset24<Paint>>,
+    paint_offset: Offset24<Paint>,
     /// Angle of skew in the direction of the x-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 0.
-    x_skew_angle: BigEndian<F2Dot14>,
+    x_skew_angle: F2Dot14,
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 1.
-    y_skew_angle: BigEndian<F2Dot14>,
+    y_skew_angle: F2Dot14,
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
-    center_x: BigEndian<FWord>,
+    center_x: FWord,
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 3.
-    center_y: BigEndian<FWord>,
+    center_y: FWord,
     /// Base index into DeltaSetIndexMap.
-    var_index_base: BigEndian<u32>,
+    var_index_base: u32,
 }
 
 /// [PaintComposite](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite) table
 table PaintComposite {
     /// Set to 32.
     #[format = 32]
-    format: BigEndian<u8>,
+    format: u8,
     /// Offset to a source Paint table.
-    source_paint_offset: BigEndian<Offset24<Paint>>,
+    source_paint_offset: Offset24<Paint>,
     /// A CompositeMode enumeration value.
-    composite_mode: BigEndian<CompositeMode>,
+    composite_mode: CompositeMode,
     /// Offset to a backdrop Paint table.
-    backdrop_paint_offset: BigEndian<Offset24<Paint>>,
+    backdrop_paint_offset: Offset24<Paint>,
 }
 
 /// [CompositeMode](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite) enumeration

--- a/resources/codegen_inputs/cpal.rs
+++ b/resources/codegen_inputs/cpal.rs
@@ -4,22 +4,22 @@
 table Cpal {
     /// Table version number (=0).
     #[version]
-    version: BigEndian<u16>,
+    version: u16,
     /// Number of palette entries in each palette.
-    num_palette_entries: BigEndian<u16>,
+    num_palette_entries: u16,
     /// Number of palettes in the table.
-    num_palettes: BigEndian<u16>,
+    num_palettes: u16,
     /// Total number of color records, combined for all palettes.
-    num_color_records: BigEndian<u16>,
+    num_color_records: u16,
     /// Offset from the beginning of CPAL table to the first
     /// ColorRecord.
     #[nullable]
     #[read_offset_with($num_color_records)]
-    color_records_array_offset: BigEndian<Offset32<[ColorRecord]>>,
+    color_records_array_offset: Offset32<[ColorRecord]>,
     /// Index of each palette’s first color record in the combined
     /// color record array.
     #[count($num_palettes)]
-    color_record_indices: [BigEndian<u16>],
+    color_record_indices: [u16],
 
     /// Offset from the beginning of CPAL table to the [Palette Types Array][].
     ///
@@ -29,7 +29,7 @@ table Cpal {
     #[available(1)]
     #[nullable]
     #[read_offset_with($num_palettes)]
-    palette_types_array_offset: BigEndian<Offset32<[BigEndian<u32>]>>,
+    palette_types_array_offset: Offset32<[u32]>,
     /// Offset from the beginning of CPAL table to the [Palette Labels Array][].
     ///
     /// This is an array of 'name' table IDs (typically in the font-specific name
@@ -40,7 +40,7 @@ table Cpal {
     #[available(1)]
     #[nullable]
     #[read_offset_with($num_palettes)]
-    palette_labels_array_offset: BigEndian<Offset32<[BigEndian<u16>]>>,
+    palette_labels_array_offset: Offset32<[u16]>,
     /// Offset from the beginning of CPAL table to the [Palette Entry Labels Array][].
     ///
     /// This is an array of 'name' table IDs (typically in the font-specific name
@@ -53,17 +53,17 @@ table Cpal {
     #[available(1)]
     #[nullable]
     #[read_offset_with($num_palette_entries)]
-    palette_entry_labels_array_offset: BigEndian<Offset32<[BigEndian<u16>]>>,
+    palette_entry_labels_array_offset: Offset32<[u16]>,
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
 record ColorRecord {
     /// Blue value (B0).
-    blue: BigEndian<u8>,
+    blue: u8,
     /// Green value (B1).
-    green: BigEndian<u8>,
+    green: u8,
     ///     Red value (B2).
-    red: BigEndian<u8>,
+    red: u8,
     /// Alpha value (B3).
-    alpha: BigEndian<u8>,
+    alpha: u8,
 }

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -4,13 +4,13 @@
 #[skip_from_obj]
 table TableDirectory {
     /// 0x00010000 or 0x4F54544F
-    sfnt_version: BigEndian<u32>,
+    sfnt_version: u32,
     /// Number of tables.
     #[compile(array_len($table_records))]
-    num_tables: BigEndian<u16>,
-    search_range: BigEndian<u16>,
-    entry_selector: BigEndian<u16>,
-    range_shift: BigEndian<u16>,
+    num_tables: u16,
+    search_range: u16,
+    entry_selector: u16,
+    range_shift: u16,
     /// Table records array—one for each top-level table in the font
     #[count($num_tables)]
     table_records: [ TableRecord ],
@@ -20,36 +20,36 @@ table TableDirectory {
 #[skip_from_obj]
 record TableRecord {
     /// Table identifier.
-    tag: BigEndian<Tag>,
+    tag: Tag,
     /// Checksum for the table.
-    checksum: BigEndian<u32>,
+    checksum: u32,
     /// Offset from the beginning of the font data.
     #[compile_type(u32)] // we set these manually
-    offset: BigEndian<Offset32>,
+    offset: Offset32,
     /// Length of the table.
-    length: BigEndian<u32>,
+    length: u32,
 }
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 table TTCHeader {
     /// Font Collection ID string: "ttcf"
-    ttc_tag: BigEndian<Tag>,
+    ttc_tag: Tag,
     /// Major/minor version of the TTC Header
     #[version]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Number of fonts in TTC
-    num_fonts: BigEndian<u32>,
+    num_fonts: u32,
     /// Array of offsets to the TableDirectory for each font from the beginning of the file
     #[count($num_fonts)]
-    table_directory_offsets: [BigEndian<u32>],
+    table_directory_offsets: [u32],
 
     /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
     #[available(MajorMinor::VERSION_2_0)]
-    dsig_tag: BigEndian<u32>,
+    dsig_tag: u32,
     /// The length (in bytes) of the DSIG table (null if no signature)
     #[available(MajorMinor::VERSION_2_0)]
-    dsig_length: BigEndian<u32>,
+    dsig_length: u32,
     /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
     #[available(MajorMinor::VERSION_2_0)]
-    dsig_offset: BigEndian<u32>,
+    dsig_offset: u32,
 }

--- a/resources/codegen_inputs/gdef.rs
+++ b/resources/codegen_inputs/gdef.rs
@@ -5,33 +5,33 @@ table Gdef {
     /// The major/minor version of the GDEF table
     #[version]
     #[compile(self.compute_version())]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
     #[nullable]
-    glyph_class_def_offset: BigEndian<Offset16<ClassDef>>,
+    glyph_class_def_offset: Offset16<ClassDef>,
     /// Offset to attachment point list table, from beginning of GDEF
     /// header (may be NULL)
     #[nullable]
-    attach_list_offset: BigEndian<Offset16<AttachList>>,
+    attach_list_offset: Offset16<AttachList>,
     /// Offset to ligature caret list table, from beginning of GDEF
     /// header (may be NULL)
     #[nullable]
-    lig_caret_list_offset: BigEndian<Offset16<LigCaretList>>,
+    lig_caret_list_offset: Offset16<LigCaretList>,
     /// Offset to class definition table for mark attachment type, from
     /// beginning of GDEF header (may be NULL)
     #[nullable]
-    mark_attach_class_def_offset: BigEndian<Offset16<ClassDef>>,
+    mark_attach_class_def_offset: Offset16<ClassDef>,
     /// Offset to the table of mark glyph set definitions, from
     /// beginning of GDEF header (may be NULL)
     #[available(MajorMinor::VERSION_1_2)]
     #[nullable]
-    mark_glyph_sets_def_offset: BigEndian<Offset16<MarkGlyphSets>>,
+    mark_glyph_sets_def_offset: Offset16<MarkGlyphSets>,
     /// Offset to the Item Variation Store table, from beginning of
     /// GDEF header (may be NULL)
     #[available(MajorMinor::VERSION_1_3)]
     #[nullable]
-    item_var_store_offset: BigEndian<Offset32<ClassDef>>,
+    item_var_store_offset: Offset32<ClassDef>,
 }
 
 /// Used in the [Glyph Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table)
@@ -45,48 +45,48 @@ enum u16 GlyphClassDef {
 /// [Attachment Point List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#attachment-point-list-table)
 table AttachList {
     /// Offset to Coverage table - from beginning of AttachList table
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of glyphs with attachment points
     #[compile(array_len($attach_point_offsets))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Array of offsets to AttachPoint tables-from beginning of
     /// AttachList table-in Coverage Index order
     #[count($glyph_count)]
-    attach_point_offsets: [BigEndian<Offset16<AttachPoint>>],
+    attach_point_offsets: [Offset16<AttachPoint>],
 }
 
 /// Part of [AttachList]
 table AttachPoint {
     /// Number of attachment points on this glyph
     #[compile(array_len($point_indices))]
-    point_count: BigEndian<u16>,
+    point_count: u16,
     /// Array of contour point indices -in increasing numerical order
     #[count($point_count)]
-    point_indices: [BigEndian<u16>],
+    point_indices: [u16],
 }
 
 /// [Ligature Caret List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table)
 table LigCaretList {
     /// Offset to Coverage table - from beginning of LigCaretList table
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of ligature glyphs
     #[compile(array_len($lig_glyph_offsets))]
-    lig_glyph_count: BigEndian<u16>,
+    lig_glyph_count: u16,
     /// Array of offsets to LigGlyph tables, from beginning of
     /// LigCaretList table —in Coverage Index order
     #[count($lig_glyph_count)]
-    lig_glyph_offsets: [BigEndian<Offset16<LigGlyph>>],
+    lig_glyph_offsets: [Offset16<LigGlyph>],
 }
 
 /// [Ligature Glyph Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-glyph-table)
 table LigGlyph {
     /// Number of CaretValue tables for this ligature (components - 1)
     #[compile(array_len($caret_value_offsets))]
-    caret_count: BigEndian<u16>,
+    caret_count: u16,
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
     #[count($caret_count)]
-    caret_value_offsets: [BigEndian<Offset16<CaretValue>>],
+    caret_value_offsets: [Offset16<CaretValue>],
 }
 
 /// [Caret Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caret-value-tables)
@@ -100,18 +100,18 @@ format u16 CaretValue {
 table CaretValueFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    caret_value_format: BigEndian<u16>,
+    caret_value_format: u16,
     /// X or Y value, in design units
-    coordinate: BigEndian<i16>,
+    coordinate: i16,
 }
 
 /// [CaretValue Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-2)
 table CaretValueFormat2 {
     /// Format identifier: format = 2
     #[format = 2]
-    caret_value_format: BigEndian<u16>,
+    caret_value_format: u16,
     /// Contour point index on glyph
-    caret_value_point_index: BigEndian<u16>,
+    caret_value_point_index: u16,
 }
 
 /// [CaretValue Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-3)
@@ -119,25 +119,25 @@ table CaretValueFormat2 {
 table CaretValueFormat3 {
     /// Format identifier-format = 3
     #[format = 3]
-    caret_value_format: BigEndian<u16>,
+    caret_value_format: u16,
     /// X or Y value, in design units
-    coordinate: BigEndian<i16>,
+    coordinate: i16,
     /// Offset to Device table (non-variable font) / Variation Index
     /// table (variable font) for X or Y value-from beginning of
     /// CaretValue table
-    device_offset: BigEndian<Offset16<Device>>,
+    device_offset: Offset16<Device>,
 }
 
 /// [Mark Glyph Sets Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#mark-glyph-sets-table)
 table MarkGlyphSets {
     /// Format identifier == 1
     #[format = 1]
-    format: BigEndian<u16>,
+    format: u16,
     /// Number of mark glyph sets defined
     #[compile(array_len($coverage_offsets))]
-    mark_glyph_set_count: BigEndian<u16>,
+    mark_glyph_set_count: u16,
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.
     #[count($mark_glyph_set_count)]
-    coverage_offsets: [BigEndian<Offset32<CoverageTable>>],
+    coverage_offsets: [Offset32<CoverageTable>],
 }

--- a/resources/codegen_inputs/glyf.rs
+++ b/resources/codegen_inputs/glyf.rs
@@ -7,15 +7,15 @@ table Glyf {}
     ///// If the number of contours is greater than or equal to zero,
     ///// this is a simple glyph. If negative, this is a composite glyph
     ///// — the value -1 should be used for composite glyphs.
-    //number_of_contours: BigEndian<i16>,
+    //number_of_contours: i16,
     ///// Minimum x for coordinate data.
-    //x_min: BigEndian<i16>,
+    //x_min: i16,
     ///// Minimum y for coordinate data.
-    //y_min: BigEndian<i16>,
+    //y_min: i16,
     ///// Maximum x for coordinate data.
-    //x_max: BigEndian<i16>,
+    //x_max: i16,
     ///// Maximum y for coordinate data.
-    //y_max: BigEndian<i16>,
+    //y_max: i16,
 //}
 
 
@@ -24,26 +24,26 @@ table SimpleGlyph {
     /// If the number of contours is greater than or equal to zero,
     /// this is a simple glyph. If negative, this is a composite glyph
     /// — the value -1 should be used for composite glyphs.
-    number_of_contours: BigEndian<i16>,
+    number_of_contours: i16,
     /// Minimum x for coordinate data.
-    x_min: BigEndian<i16>,
+    x_min: i16,
     /// Minimum y for coordinate data.
-    y_min: BigEndian<i16>,
+    y_min: i16,
     /// Maximum x for coordinate data.
-    x_max: BigEndian<i16>,
+    x_max: i16,
     /// Maximum y for coordinate data.
-    y_max: BigEndian<i16>,
+    y_max: i16,
     /// Array of point indices for the last point of each contour,
     /// in increasing numeric order
     #[count($number_of_contours.max(0) as usize)]
-    end_pts_of_contours: [BigEndian<u16>],
+    end_pts_of_contours: [u16],
     /// Total number of bytes for instructions. If instructionLength is
     /// zero, no instructions are present for this glyph, and this
     /// field is followed directly by the flags field.
-    instruction_length: BigEndian<u16>,
+    instruction_length: u16,
     /// Array of instruction byte code for the glyph.
     #[count($instruction_length)]
-    instructions: [BigEndian<u8>],
+    instructions: [u8],
     #[count(..)]
     //#[hidden]
     /// the raw data for flags & x/y coordinates
@@ -52,7 +52,7 @@ table SimpleGlyph {
     ///// Array of flag elements. See below for details regarding the
     ///// number of flag array elements.
     //#[count(variable)]
-    //flags: [BigEndian<SimpleGlyphFlags>],
+    //flags: [SimpleGlyphFlags],
     ///// Contour point x-coordinates. See below for details regarding
     ///// the number of coordinate array elements. Coordinate for the
     ///// first point is relative to (0,0); others are relative to
@@ -143,20 +143,20 @@ table CompositeGlyph {
     /// If the number of contours is greater than or equal to zero,
     /// this is a simple glyph. If negative, this is a composite glyph
     /// — the value -1 should be used for composite glyphs.
-    number_of_contours: BigEndian<i16>,
+    number_of_contours: i16,
     /// Minimum x for coordinate data.
-    x_min: BigEndian<i16>,
+    x_min: i16,
     /// Minimum y for coordinate data.
-    y_min: BigEndian<i16>,
+    y_min: i16,
     /// Maximum x for coordinate data.
-    x_max: BigEndian<i16>,
+    x_max: i16,
     /// Maximum y for coordinate data.
-    y_max: BigEndian<i16>,
+    y_max: i16,
     //header: GlyphHeader,
     /// component flag
-    //flags: BigEndian<CompositeGlyphFlags>,
+    //flags: CompositeGlyphFlags,
     /// glyph index of component
-    //glyph_index: BigEndian<u16>,
+    //glyph_index: u16,
     #[count(..)]
     component_data: [u8],
 

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -7,16 +7,16 @@ table Gpos {
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
     #[version]
     #[compile(self.compute_version())]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Offset to ScriptList table, from beginning of GPOS table
-    script_list_offset: BigEndian<Offset16<ScriptList>>,
+    script_list_offset: Offset16<ScriptList>,
     /// Offset to FeatureList table, from beginning of GPOS table
-    feature_list_offset: BigEndian<Offset16<FeatureList>>,
+    feature_list_offset: Offset16<FeatureList>,
     /// Offset to LookupList table, from beginning of GPOS table
-    lookup_list_offset: BigEndian<Offset16<PositionLookupList>>,
+    lookup_list_offset: Offset16<PositionLookupList>,
     #[available(MajorMinor::VERSION_1_1)]
     #[nullable]
-    feature_variations_offset: BigEndian<Offset32<FeatureVariations>>,
+    feature_variations_offset: Offset32<FeatureVariations>,
 }
 
 /// A [GPOS Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#gsubLookupTypeEnum) subtable.
@@ -68,52 +68,52 @@ format u16 AnchorTable {
 table AnchorFormat1 {
     /// Format identifier, = 1
     #[format = 1]
-    anchor_format: BigEndian<u16>,
+    anchor_format: u16,
     /// Horizontal value, in design units
-    x_coordinate: BigEndian<i16>,
+    x_coordinate: i16,
     /// Vertical value, in design units
-    y_coordinate: BigEndian<i16>,
+    y_coordinate: i16,
 }
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
 table AnchorFormat2 {
     /// Format identifier, = 2
     #[format = 2]
-    anchor_format: BigEndian<u16>,
+    anchor_format: u16,
     /// Horizontal value, in design units
-    x_coordinate: BigEndian<i16>,
+    x_coordinate: i16,
     /// Vertical value, in design units
-    y_coordinate: BigEndian<i16>,
+    y_coordinate: i16,
     /// Index to glyph contour point
-    anchor_point: BigEndian<u16>,
+    anchor_point: u16,
 }
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
 table AnchorFormat3 {
     /// Format identifier, = 3
     #[format = 3]
-    anchor_format: BigEndian<u16>,
+    anchor_format: u16,
     /// Horizontal value, in design units
-    x_coordinate: BigEndian<i16>,
+    x_coordinate: i16,
     /// Vertical value, in design units
-    y_coordinate: BigEndian<i16>,
+    y_coordinate: i16,
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for X coordinate, from beginning of
     /// Anchor table (may be NULL)
     #[nullable]
-    x_device_offset: BigEndian<Offset16<Device>>,
+    x_device_offset: Offset16<Device>,
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for Y coordinate, from beginning of
     /// Anchor table (may be NULL)
     #[nullable]
-    y_device_offset: BigEndian<Offset16<Device>>,
+    y_device_offset: Offset16<Device>,
 }
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
 table MarkArray {
     /// Number of MarkRecords
     #[compile(array_len($mark_records))]
-    mark_count: BigEndian<u16>,
+    mark_count: u16,
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
     #[count($mark_count)]
@@ -123,9 +123,9 @@ table MarkArray {
 /// Part of [MarkArray]
 record MarkRecord {
     /// Class defined for the associated mark.
-    mark_class: BigEndian<u16>,
+    mark_class: u16,
     /// Offset to Anchor table, from beginning of MarkArray table.
-    mark_anchor_offset: BigEndian<Offset16<AnchorTable>>,
+    mark_anchor_offset: Offset16<AnchorTable>,
 }
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
@@ -138,12 +138,12 @@ format u16 SinglePos {
 table SinglePosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to Coverage table, from beginning of SinglePos subtable.
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Defines the types of data in the ValueRecord.
     #[compile(self.compute_value_format())]
-    value_format: BigEndian<ValueFormat>,
+    value_format: ValueFormat,
     /// Defines positioning value(s) — applied to all glyphs in the
     /// Coverage table.
     #[read_with($value_format)]
@@ -154,16 +154,16 @@ table SinglePosFormat1 {
 table SinglePosFormat2 {
     /// Format identifier: format = 2
     #[format = 2]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to Coverage table, from beginning of SinglePos subtable.
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Defines the types of data in the ValueRecords.
     #[compile(self.compute_value_format())]
-    value_format: BigEndian<ValueFormat>,
+    value_format: ValueFormat,
     /// Number of ValueRecords — must equal glyphCount in the
     /// Coverage table.
     #[compile(array_len($value_records))]
-    value_count: BigEndian<u16>,
+    value_count: u16,
     /// Array of ValueRecords — positioning values applied to glyphs.
     #[count($value_count)]
     #[read_with($value_format)]
@@ -180,25 +180,25 @@ format u16 PairPos {
 table PairPosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to Coverage table, from beginning of PairPos subtable.
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Defines the types of data in valueRecord1 — for the first
     /// glyph in the pair (may be zero).
     #[compile(self.compute_value_format1())]
-    value_format1: BigEndian<ValueFormat>,
+    value_format1: ValueFormat,
     /// Defines the types of data in valueRecord2 — for the second
     /// glyph in the pair (may be zero).
     #[compile(self.compute_value_format2())]
-    value_format2: BigEndian<ValueFormat>,
+    value_format2: ValueFormat,
     /// Number of PairSet tables
     #[compile(array_len($pair_set_offsets))]
-    pair_set_count: BigEndian<u16>,
+    pair_set_count: u16,
     /// Array of offsets to PairSet tables. Offsets are from beginning
     /// of PairPos subtable, ordered by Coverage Index.
     #[count($pair_set_count)]
     #[read_offset_with($value_format1, $value_format2)]
-    pair_set_offsets: [BigEndian<Offset16<PairSet>>],
+    pair_set_offsets: [Offset16<PairSet>],
 }
 
 /// Part of [PairPosFormat1]
@@ -206,7 +206,7 @@ table PairPosFormat1 {
 table PairSet {
     /// Number of PairValueRecords
     #[compile(array_len($pair_value_records))]
-    pair_value_count: BigEndian<u16>,
+    pair_value_count: u16,
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
     #[count($pair_value_count)]
@@ -219,7 +219,7 @@ table PairSet {
 record PairValueRecord {
     /// Glyph ID of second glyph in the pair (first glyph is listed in
     /// the Coverage table).
-    second_glyph: BigEndian<GlyphId>,
+    second_glyph: GlyphId,
     /// Positioning data for the first glyph in the pair.
     #[read_with($value_format1)]
     value_record1: ValueRecord,
@@ -232,29 +232,29 @@ record PairValueRecord {
 table PairPosFormat2 {
     /// Format identifier: format = 2
     #[format = 2]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to Coverage table, from beginning of PairPos subtable.
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// ValueRecord definition — for the first glyph of the pair (may
     /// be zero).
     #[compile(self.compute_value_format1())]
-    value_format1: BigEndian<ValueFormat>,
+    value_format1: ValueFormat,
     /// ValueRecord definition — for the second glyph of the pair
     /// (may be zero).
     #[compile(self.compute_value_format2())]
-    value_format2: BigEndian<ValueFormat>,
+    value_format2: ValueFormat,
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the first glyph of the pair.
-    class_def1_offset: BigEndian<Offset16<ClassDef>>,
+    class_def1_offset: Offset16<ClassDef>,
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the second glyph of the pair.
-    class_def2_offset: BigEndian<Offset16<ClassDef>>,
+    class_def2_offset: Offset16<ClassDef>,
     /// Number of classes in classDef1 table — includes Class 0.
     #[compile(self.compute_class1_count())]
-    class1_count: BigEndian<u16>,
+    class1_count: u16,
     /// Number of classes in classDef2 table — includes Class 0.
     #[compile(self.compute_class2_count())]
-    class2_count: BigEndian<u16>,
+    class2_count: u16,
     /// Array of Class1 records, ordered by classes in classDef1.
     #[read_with($class2_count, $value_format1, $value_format2)]
     #[count($class1_count)]
@@ -291,12 +291,12 @@ record Class2Record {
 table CursivePosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to Coverage table, from beginning of CursivePos subtable.
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of EntryExit records
     #[compile(array_len($entry_exit_record))]
-    entry_exit_count: BigEndian<u16>,
+    entry_exit_count: u16,
     /// Array of EntryExit records, in Coverage index order.
     #[count($entry_exit_count)]
     entry_exit_record: [EntryExitRecord],
@@ -307,11 +307,11 @@ record EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
     #[nullable]
-    entry_anchor_offset: BigEndian<Offset16<AnchorTable>>,
+    entry_anchor_offset: Offset16<AnchorTable>,
     /// Offset to exitAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
     #[nullable]
-    exit_anchor_offset: BigEndian<Offset16<AnchorTable>>,
+    exit_anchor_offset: Offset16<AnchorTable>,
 }
 
 /////// [Lookup Type 4](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable): Mark-to-Base Attachment Positioning Subtable
@@ -324,23 +324,23 @@ record EntryExitRecord {
 table MarkBasePosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
-    mark_coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    mark_coverage_offset: Offset16<CoverageTable>,
     /// Offset to baseCoverage table, from beginning of MarkBasePos
     /// subtable.
-    base_coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    base_coverage_offset: Offset16<CoverageTable>,
     /// Number of classes defined for marks
     #[compile(self.compute_mark_class_count())]
-    mark_class_count: BigEndian<u16>,
+    mark_class_count: u16,
     /// Offset to MarkArray table, from beginning of MarkBasePos
     /// subtable.
-    mark_array_offset: BigEndian<Offset16<MarkArray>>,
+    mark_array_offset: Offset16<MarkArray>,
     /// Offset to BaseArray table, from beginning of MarkBasePos
     /// subtable.
     #[read_offset_with($mark_class_count)]
-    base_array_offset: BigEndian<Offset16<BaseArray>>,
+    base_array_offset: Offset16<BaseArray>,
 }
 
 /// Part of [MarkBasePosFormat1]
@@ -348,7 +348,7 @@ table MarkBasePosFormat1 {
 table BaseArray {
     /// Number of BaseRecords
     #[compile(array_len($base_records))]
-    base_count: BigEndian<u16>,
+    base_count: u16,
     /// Array of BaseRecords, in order of baseCoverage Index.
     #[count($base_count)]
     #[read_with($mark_class_count)]
@@ -363,30 +363,30 @@ record BaseRecord<'a> {
     /// (offsets may be NULL).
     #[nullable]
     #[count($mark_class_count)]
-    base_anchor_offsets: [BigEndian<Offset16<AnchorTable>>],
+    base_anchor_offsets: [Offset16<AnchorTable>],
 }
 
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
 table MarkLigPosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
-    mark_coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    mark_coverage_offset: Offset16<CoverageTable>,
     /// Offset to ligatureCoverage table, from beginning of MarkLigPos
     /// subtable.
-    ligature_coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    ligature_coverage_offset: Offset16<CoverageTable>,
     /// Number of defined mark classes
     #[compile(self.compute_mark_class_count())]
-    mark_class_count: BigEndian<u16>,
+    mark_class_count: u16,
     /// Offset to MarkArray table, from beginning of MarkLigPos
     /// subtable.
-    mark_array_offset: BigEndian<Offset16<MarkArray>>,
+    mark_array_offset: Offset16<MarkArray>,
     /// Offset to LigatureArray table, from beginning of MarkLigPos
     /// subtable.
     #[read_offset_with($mark_class_count)]
-    ligature_array_offset: BigEndian<Offset16<LigatureArray>>,
+    ligature_array_offset: Offset16<LigatureArray>,
 }
 
 /// Part of [MarkLigPosFormat1]
@@ -394,13 +394,13 @@ table MarkLigPosFormat1 {
 table LigatureArray {
     /// Number of LigatureAttach table offsets
     #[compile(array_len($ligature_attach_offsets))]
-    ligature_count: BigEndian<u16>,
+    ligature_count: u16,
     /// Array of offsets to LigatureAttach tables. Offsets are from
     /// beginning of LigatureArray table, ordered by ligatureCoverage
     /// index.
     #[count($ligature_count)]
     #[read_offset_with($mark_class_count)]
-    ligature_attach_offsets: [BigEndian<Offset16<LigatureAttach>>],
+    ligature_attach_offsets: [Offset16<LigatureAttach>],
 }
 
 /// Part of [MarkLigPosFormat1]
@@ -408,7 +408,7 @@ table LigatureArray {
 table LigatureAttach {
     /// Number of ComponentRecords in this ligature
     #[compile(array_len($component_records))]
-    component_count: BigEndian<u16>,
+    component_count: u16,
     /// Array of Component records, ordered in writing direction.
     #[count($component_count)]
     #[read_with($mark_class_count)]
@@ -423,30 +423,30 @@ record ComponentRecord<'a> {
     /// (offsets may be NULL).
     #[nullable]
     #[count($mark_class_count)]
-    ligature_anchor_offsets: [BigEndian<Offset16<AnchorTable>>],
+    ligature_anchor_offsets: [Offset16<AnchorTable>],
 }
 
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
 table MarkMarkPosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
-    mark1_coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    mark1_coverage_offset: Offset16<CoverageTable>,
     /// Offset to Base Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
-    mark2_coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    mark2_coverage_offset: Offset16<CoverageTable>,
     /// Number of Combining Mark classes defined
     #[compile(self.compute_mark_class_count())]
-    mark_class_count: BigEndian<u16>,
+    mark_class_count: u16,
     /// Offset to MarkArray table for mark1, from beginning of
     /// MarkMarkPos subtable.
-    mark1_array_offset: BigEndian<Offset16<MarkArray>>,
+    mark1_array_offset: Offset16<MarkArray>,
     /// Offset to Mark2Array table for mark2, from beginning of
     /// MarkMarkPos subtable.
     #[read_offset_with($mark_class_count)]
-    mark2_array_offset: BigEndian<Offset16<Mark2Array>>,
+    mark2_array_offset: Offset16<Mark2Array>,
 }
 
 /// Part of [MarkMarkPosFormat1]Class2Record
@@ -454,7 +454,7 @@ table MarkMarkPosFormat1 {
 table Mark2Array {
     /// Number of Mark2 records
     #[compile(array_len($mark2_records))]
-    mark2_count: BigEndian<u16>,
+    mark2_count: u16,
     /// Array of Mark2Records, in Coverage order.
     #[count($mark2_count)]
     #[read_with($mark_class_count)]
@@ -469,7 +469,7 @@ record Mark2Record<'a> {
     /// be NULL).
     #[count($mark_class_count)]
     #[nullable]
-    mark2_anchor_offsets: [BigEndian<Offset16<AnchorTable>>],
+    mark2_anchor_offsets: [Offset16<AnchorTable>],
 }
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
@@ -478,14 +478,14 @@ record Mark2Record<'a> {
 table ExtensionPosFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    pos_format: BigEndian<u16>,
+    pos_format: u16,
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
-    extension_lookup_type: BigEndian<u16>,
+    extension_lookup_type: u16,
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
     /// ExtensionPosFormat1 subtable.
-    extension_offset: BigEndian<Offset32<T>>,
+    extension_offset: Offset32<T>,
 }
 
 /// A [GPOS Extension Positioning](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning) subtable

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -6,18 +6,18 @@ table Gsub {
     /// The major and minor version of the GSUB table, as a tuple (u16, u16)
     #[version]
     #[compile(self.compute_version())]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Offset to ScriptList table, from beginning of GSUB table
-    script_list_offset: BigEndian<Offset16<ScriptList>>,
+    script_list_offset: Offset16<ScriptList>,
     /// Offset to FeatureList table, from beginning of GSUB table
-    feature_list_offset: BigEndian<Offset16<FeatureList>>,
+    feature_list_offset: Offset16<FeatureList>,
     /// Offset to LookupList table, from beginning of GSUB table
-    lookup_list_offset: BigEndian<Offset16<SubstitutionLookupList>>,
+    lookup_list_offset: Offset16<SubstitutionLookupList>,
     /// Offset to FeatureVariations table, from beginning of the GSUB
     /// table (may be NULL)
     #[available(MajorMinor::VERSION_1_1)]
     #[nullable]
-    feature_variations_offset: BigEndian<Offset32<FeatureVariations>>,
+    feature_variations_offset: Offset32<FeatureVariations>,
 }
 
 /// A [GSUB Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsubLookupTypeEnum) subtable.
@@ -42,45 +42,45 @@ format u16 SingleSubst {
 table SingleSubstFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Add to original glyph ID to get substitute glyph ID
-    delta_glyph_id: BigEndian<i16>,
+    delta_glyph_id: i16,
 }
 
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
 table SingleSubstFormat2 {
     /// Format identifier: format = 2
     #[format = 2]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of glyph IDs in the substituteGlyphIDs array
     #[compile(array_len($substitute_glyph_ids))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Array of substitute glyph IDs — ordered by Coverage index
     #[count($glyph_count)]
-    substitute_glyph_ids: [BigEndian<GlyphId>],
+    substitute_glyph_ids: [GlyphId],
 }
 
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
 table MultipleSubstFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of Sequence table offsets in the sequenceOffsets array
     #[compile(array_len($sequence_offsets))]
-    sequence_count: BigEndian<u16>,
+    sequence_count: u16,
     /// Array of offsets to Sequence tables. Offsets are from beginning
     /// of substitution subtable, ordered by Coverage index
     #[count($sequence_count)]
-    sequence_offsets: [BigEndian<Offset16<Sequence>>],
+    sequence_offsets: [Offset16<Sequence>],
 }
 
 /// Part of [MultipleSubstFormat1]
@@ -88,78 +88,78 @@ table Sequence {
     /// Number of glyph IDs in the substituteGlyphIDs array. This must
     /// always be greater than 0.
     #[compile(array_len($substitute_glyph_ids))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// String of glyph IDs to substitute
     #[count($glyph_count)]
-    substitute_glyph_ids: [BigEndian<GlyphId>],
+    substitute_glyph_ids: [GlyphId],
 }
 
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
 table AlternateSubstFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of AlternateSet tables
     #[compile(array_len($alternate_set_offsets))]
-    alternate_set_count: BigEndian<u16>,
+    alternate_set_count: u16,
     /// Array of offsets to AlternateSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     #[count($alternate_set_count)]
-    alternate_set_offsets: [BigEndian<Offset16<AlternateSet>>],
+    alternate_set_offsets: [Offset16<AlternateSet>],
 }
 
 /// Part of [AlternateSubstFormat1]
 table AlternateSet {
     /// Number of glyph IDs in the alternateGlyphIDs array
     #[compile(array_len($alternate_glyph_ids))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Array of alternate glyph IDs, in arbitrary order
     #[count($glyph_count)]
-    alternate_glyph_ids: [BigEndian<GlyphId>],
+    alternate_glyph_ids: [GlyphId],
 }
 
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
 table LigatureSubstFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of LigatureSet tables
     #[compile(array_len($ligature_set_offsets))]
-    ligature_set_count: BigEndian<u16>,
+    ligature_set_count: u16,
     /// Array of offsets to LigatureSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     #[count($ligature_set_count)]
-    ligature_set_offsets: [BigEndian<Offset16<LigatureSet>>],
+    ligature_set_offsets: [Offset16<LigatureSet>],
 }
 
 /// Part of [LigatureSubstFormat1]
 table LigatureSet {
     /// Number of Ligature tables
     #[compile(array_len($ligature_offsets))]
-    ligature_count: BigEndian<u16>,
+    ligature_count: u16,
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
     #[count($ligature_count)]
-    ligature_offsets: [BigEndian<Offset16<Ligature>>],
+    ligature_offsets: [Offset16<Ligature>],
 }
 
 /// Part of [LigatureSubstFormat1]
 table Ligature {
     /// glyph ID of ligature to substitute
-    ligature_glyph: BigEndian<GlyphId>,
+    ligature_glyph: GlyphId,
     /// Number of components in the ligature
     #[compile(plus_one($component_glyph_ids.len()))]
-    component_count: BigEndian<u16>,
+    component_count: u16,
     /// Array of component glyph IDs — start with the second
     /// component, ordered in writing direction
     #[count(minus_one($component_count))]
-    component_glyph_ids: [BigEndian<GlyphId>],
+    component_glyph_ids: [GlyphId],
 }
 
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
@@ -168,14 +168,14 @@ table Ligature {
 table ExtensionSubstFormat1 {
     /// Format identifier. Set to 1.
     #[format = 1]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
-    extension_lookup_type: BigEndian<u16>,
+    extension_lookup_type: u16,
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
     /// ExtensionSubstFormat1 subtable.
-    extension_offset: BigEndian<Offset32<T>>,
+    extension_offset: Offset32<T>,
 }
 
 /// A [GSUB Extension Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#ES) subtable
@@ -193,29 +193,29 @@ table ExtensionSubstFormat1 {
 table ReverseChainSingleSubstFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    subst_format: BigEndian<u16>,
+    subst_format: u16,
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of glyphs in the backtrack sequence.
     #[compile(array_len($backtrack_coverage_offsets))]
-    backtrack_glyph_count: BigEndian<u16>,
+    backtrack_glyph_count: u16,
     /// Array of offsets to coverage tables in backtrack sequence, in
     /// glyph sequence order.
     #[count($backtrack_glyph_count)]
-    backtrack_coverage_offsets: [BigEndian<Offset16<CoverageTable>>],
+    backtrack_coverage_offsets: [Offset16<CoverageTable>],
     /// Number of glyphs in lookahead sequence.
     #[compile(array_len($lookahead_coverage_offsets))]
-    lookahead_glyph_count: BigEndian<u16>,
+    lookahead_glyph_count: u16,
     /// Array of offsets to coverage tables in lookahead sequence, in
     /// glyph sequence order.
     #[count($lookahead_glyph_count)]
-    lookahead_coverage_offsets: [BigEndian<Offset16<CoverageTable>>],
+    lookahead_coverage_offsets: [Offset16<CoverageTable>],
     /// Number of glyph IDs in the substituteGlyphIDs array.
     #[compile(array_len($substitute_glyph_ids))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Array of substitute glyph IDs — ordered by Coverage index.
     #[count($glyph_count)]
-    substitute_glyph_ids: [BigEndian<GlyphId>],
+    substitute_glyph_ids: [GlyphId],
 }
 

--- a/resources/codegen_inputs/head.rs
+++ b/resources/codegen_inputs/head.rs
@@ -4,49 +4,49 @@
 table Head {
     /// Version number of the font header table, set to (1, 0)
     #[compile(MajorMinor::VERSION_1_0)]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Set by font manufacturer.
-    font_revision: BigEndian<Fixed>,
+    font_revision: Fixed,
     /// To compute: set it to 0, sum the entire font as uint32, then
     /// store 0xB1B0AFBA - sum. If the font is used as a component in a
     /// font collection file, the value of this field will be
     /// invalidated by changes to the file structure and font table
     /// directory, and must be ignored.
-    checksum_adjustment: BigEndian<u32>,
+    checksum_adjustment: u32,
     /// Set to 0x5F0F3CF5.
     #[compile(0x5F0F3CF5)]
-    magic_number: BigEndian<u32>,
+    magic_number: u32,
     /// See the flags enum
-    flags: BigEndian<u16>,
+    flags: u16,
     /// Set to a value from 16 to 16384. Any value in this range is
     /// valid. In fonts that have TrueType outlines, a power of 2 is
     /// recommended as this allows performance optimizations in some
     /// rasterizers.
-    units_per_em: BigEndian<u16>,
+    units_per_em: u16,
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
-    created: BigEndian<LongDateTime>,
+    created: LongDateTime,
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
-    modified: BigEndian<LongDateTime>,
+    modified: LongDateTime,
     /// Minimum x coordinate across all glyph bounding boxes.
-    x_min: BigEndian<i16>,
+    x_min: i16,
     /// Minimum y coordinate across all glyph bounding boxes.
-    y_min: BigEndian<i16>,
+    y_min: i16,
     /// Maximum x coordinate across all glyph bounding boxes.
-    x_max: BigEndian<i16>,
+    x_max: i16,
     /// Maximum y coordinate across all glyph bounding boxes.
-    y_max: BigEndian<i16>,
+    y_max: i16,
     /// see somewhere else
-    mac_style: BigEndian<u16>,
+    mac_style: u16,
     /// Smallest readable size in pixels.
-    lowest_rec_ppem: BigEndian<u16>,
+    lowest_rec_ppem: u16,
     /// Deprecated (Set to 2).
     #[compile(2)]
-    font_direction_hint: BigEndian<i16>,
+    font_direction_hint: i16,
     /// 0 for short offsets (Offset16), 1 for long (Offset32).
-    index_to_loc_format: BigEndian<i16>,
+    index_to_loc_format: i16,
     /// 0 for current format.
     #[compile(0)]
-    glyph_data_format: BigEndian<i16>,
+    glyph_data_format: i16,
 }

--- a/resources/codegen_inputs/hhea.rs
+++ b/resources/codegen_inputs/hhea.rs
@@ -4,53 +4,53 @@
 table Hhea {
     /// The major/minor version (1, 0)
     #[compile(MajorMinor::VERSION_1_0)]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Typographic ascent—see note below.
-    ascender: BigEndian<FWord>,
+    ascender: FWord,
     /// Typographic descent—see note below.
-    descender: BigEndian<FWord>,
+    descender: FWord,
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
-    line_gap: BigEndian<FWord>,
+    line_gap: FWord,
     /// Maximum advance width value in 'hmtx' table.
-    advance_width_max: BigEndian<UfWord>,
+    advance_width_max: UfWord,
     /// Minimum left sidebearing value in 'hmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
-    min_left_side_bearing: BigEndian<FWord>,
+    min_left_side_bearing: FWord,
     /// Minimum right sidebearing value; calculated as min(aw - (lsb +
     /// xMax - xMin)) for glyphs with contours (empty glyphs should be
     /// ignored).
-    min_right_side_bearing: BigEndian<FWord>,
+    min_right_side_bearing: FWord,
     /// Max(lsb + (xMax - xMin)).
-    x_max_extent: BigEndian<FWord>,
+    x_max_extent: FWord,
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical.
-    caret_slope_rise: BigEndian<i16>,
+    caret_slope_rise: i16,
     /// 0 for vertical.
-    caret_slope_run: BigEndian<i16>,
+    caret_slope_run: i16,
     /// The amount by which a slanted highlight on a glyph needs to be
     /// shifted to produce the best appearance. Set to 0 for
     /// non-slanted fonts
-    caret_offset: BigEndian<i16>,
+    caret_offset: i16,
     /// set to 0
     #[skip_getter]
     #[compile(0)]
-    reserved1: BigEndian<i16>,
+    reserved1: i16,
     /// set to 0
     #[skip_getter]
     #[compile(0)]
-    reserved2: BigEndian<i16>,
+    reserved2: i16,
     /// set to 0
     #[skip_getter]
     #[compile(0)]
-    reserved3: BigEndian<i16>,
+    reserved3: i16,
     /// set to 0
     #[skip_getter]
     #[compile(0)]
-    reserved4: BigEndian<i16>,
+    reserved4: i16,
     /// 0 for current format.
     #[compile(0)]
-    metric_data_format: BigEndian<i16>,
+    metric_data_format: i16,
     /// Number of hMetric entries in 'hmtx' table
-    number_of_h_metrics: BigEndian<u16>,
+    number_of_h_metrics: u16,
 }

--- a/resources/codegen_inputs/hmtx.rs
+++ b/resources/codegen_inputs/hmtx.rs
@@ -10,13 +10,13 @@ table Hmtx {
     /// Left side bearings for glyph IDs greater than or equal to
     /// numberOfHMetrics.
     #[count($num_glyphs.saturating_sub($number_of_h_metrics) as usize)]
-    left_side_bearings: [BigEndian<i16>],
+    left_side_bearings: [i16],
 }
 
 record LongHorMetric {
     /// Advance width, in font design units.
-    advance_width: BigEndian<u16>,
+    advance_width: u16,
     /// Glyph left side bearing, in font design units.
-    lsb: BigEndian<i16>,
+    lsb: i16,
 }
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -5,7 +5,7 @@
 table ScriptList {
     /// Number of ScriptRecords
     #[compile(array_len($script_records))]
-    script_count: BigEndian<u16>,
+    script_count: u16,
     /// Array of ScriptRecords, listed alphabetically by script tag
     #[count($script_count)]
     script_records: [ScriptRecord],
@@ -14,9 +14,9 @@ table ScriptList {
 /// [Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 record ScriptRecord {
     /// 4-byte script tag identifier
-    script_tag: BigEndian<Tag>,
+    script_tag: Tag,
     /// Offset to Script table, from beginning of ScriptList
-    script_offset: BigEndian<Offset16<Script>>,
+    script_offset: Offset16<Script>,
 }
 
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
@@ -24,11 +24,11 @@ table Script {
     /// Offset to default LangSys table, from beginning of Script table
     /// — may be NULL
     #[nullable]
-    default_lang_sys_offset: BigEndian<Offset16<LangSys>>,
+    default_lang_sys_offset: Offset16<LangSys>,
     /// Number of LangSysRecords for this script — excluding the
     /// default LangSys
     #[compile(array_len($lang_sys_records))]
-    lang_sys_count: BigEndian<u16>,
+    lang_sys_count: u16,
     /// Array of LangSysRecords, listed alphabetically by LangSys tag
     #[count($lang_sys_count)]
     lang_sys_records: [LangSysRecord],
@@ -36,9 +36,9 @@ table Script {
 
 record LangSysRecord {
     /// 4-byte LangSysTag identifier
-    lang_sys_tag: BigEndian<Tag>,
+    lang_sys_tag: Tag,
     /// Offset to LangSys table, from beginning of Script table
-    lang_sys_offset: BigEndian<Offset16<LangSys>>,
+    lang_sys_offset: Offset16<LangSys>,
 }
 
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
@@ -46,24 +46,24 @@ table LangSys {
     /// = NULL (reserved for an offset to a reordering table)
     #[skip_getter]
     #[compile(0)]
-    lookup_order_offset: BigEndian<u16>,
+    lookup_order_offset: u16,
     /// Index of a feature required for this language system; if no
     /// required features = 0xFFFF
-    required_feature_index: BigEndian<u16>,
+    required_feature_index: u16,
     /// Number of feature index values for this language system —
     /// excludes the required feature
     #[compile(array_len($feature_indices))]
-    feature_index_count: BigEndian<u16>,
+    feature_index_count: u16,
     /// Array of indices into the FeatureList, in arbitrary order
     #[count($feature_index_count)]
-    feature_indices: [BigEndian<u16>],
+    feature_indices: [u16],
 }
 
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
 table FeatureList {
     /// Number of FeatureRecords in this table
     #[compile(array_len($feature_records))]
-    feature_count: BigEndian<u16>,
+    feature_count: u16,
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
     #[count($feature_count)]
@@ -73,10 +73,10 @@ table FeatureList {
 /// Part of [FeatureList]
 record FeatureRecord {
     /// 4-byte feature identification tag
-    feature_tag: BigEndian<Tag>,
+    feature_tag: Tag,
     /// Offset to Feature table, from beginning of FeatureList
     #[read_offset_with($feature_tag)]
-    feature_offset: BigEndian<Offset16<Feature>>,
+    feature_offset: Offset16<Feature>,
 }
 
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
@@ -85,14 +85,14 @@ table Feature {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     #[nullable]
     #[read_offset_with($feature_tag)]
-    feature_params_offset: BigEndian<Offset16<FeatureParams>>,
+    feature_params_offset: Offset16<FeatureParams>,
     /// Number of LookupList indices for this feature
     #[compile(array_len($lookup_list_indices))]
-    lookup_index_count: BigEndian<u16>,
+    lookup_index_count: u16,
     /// Array of indices into the LookupList — zero-based (first
     /// lookup is LookupListIndex = 0)
     #[count($lookup_index_count)]
-    lookup_list_indices: [BigEndian<u16>],
+    lookup_list_indices: [u16],
 }
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
@@ -100,11 +100,11 @@ table Feature {
 table LookupList {
     /// Number of lookups in this table
     #[compile(array_len($lookup_offsets))]
-    lookup_count: BigEndian<u16>,
+    lookup_count: u16,
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
     #[count($lookup_count)]
-    lookup_offsets: [BigEndian<Offset16<T>>],
+    lookup_offsets: [Offset16<T>],
 }
 
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
@@ -113,43 +113,43 @@ table LookupList {
 table Lookup {
     /// Different enumerations for GSUB and GPOS
     #[compile(skip)]
-    lookup_type: BigEndian<u16>,
+    lookup_type: u16,
     /// Lookup qualifiers
-    lookup_flag: BigEndian<u16>,
+    lookup_flag: u16,
     /// Number of subtables for this lookup
     #[compile(array_len($subtable_offsets))]
-    sub_table_count: BigEndian<u16>,
+    sub_table_count: u16,
     /// Array of offsets to lookup subtables, from beginning of Lookup
     /// table
     #[count($sub_table_count)]
-    subtable_offsets: [BigEndian<Offset16<T>>],
+    subtable_offsets: [Offset16<T>],
     /// Index (base 0) into GDEF mark glyph sets structure. This field
     /// is only present if the USE_MARK_FILTERING_SET lookup flag is
     /// set.
-    mark_filtering_set: BigEndian<u16>,
+    mark_filtering_set: u16,
 }
 
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
 table CoverageFormat1 {
     /// Format identifier — format = 1
     #[format = 1]
-    coverage_format: BigEndian<u16>,
+    coverage_format: u16,
     /// Number of glyphs in the glyph array
     #[compile(array_len($glyph_array))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Array of glyph IDs — in numerical order
     #[count($glyph_count)]
-    glyph_array: [BigEndian<GlyphId>],
+    glyph_array: [GlyphId],
 }
 
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
 table CoverageFormat2 {
     /// Format identifier — format = 2
     #[format = 2]
-    coverage_format: BigEndian<u16>,
+    coverage_format: u16,
     /// Number of RangeRecords
     #[compile(array_len($range_records))]
-    range_count: BigEndian<u16>,
+    range_count: u16,
     /// Array of glyph ranges — ordered by startGlyphID.
     #[count($range_count)]
     range_records: [RangeRecord],
@@ -158,11 +158,11 @@ table CoverageFormat2 {
 /// Used in [CoverageFormat2]
 record RangeRecord {
     /// First glyph ID in the range
-    start_glyph_id: BigEndian<GlyphId>,
+    start_glyph_id: GlyphId,
     /// Last glyph ID in the range
-    end_glyph_id: BigEndian<GlyphId>,
+    end_glyph_id: GlyphId,
     /// Coverage Index of first glyph ID in range
-    start_coverage_index: BigEndian<u16>,
+    start_coverage_index: u16,
 }
 
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
@@ -175,25 +175,25 @@ format u16 CoverageTable {
 table ClassDefFormat1 {
     /// Format identifier — format = 1
     #[format = 1]
-    class_format: BigEndian<u16>,
+    class_format: u16,
     /// First glyph ID of the classValueArray
-    start_glyph_id: BigEndian<GlyphId>,
+    start_glyph_id: GlyphId,
     /// Size of the classValueArray
     #[compile(array_len($class_value_array))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Array of Class Values — one per glyph ID
     #[count($glyph_count)]
-    class_value_array: [BigEndian<u16>],
+    class_value_array: [u16],
 }
 
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
 table ClassDefFormat2 {
     /// Format identifier — format = 2
     #[format = 2]
-    class_format: BigEndian<u16>,
+    class_format: u16,
     /// Number of ClassRangeRecords
     #[compile(array_len($class_range_records))]
-    class_range_count: BigEndian<u16>,
+    class_range_count: u16,
     /// Array of ClassRangeRecords — ordered by startGlyphID
     #[count($class_range_count)]
     class_range_records: [ClassRangeRecord],
@@ -203,11 +203,11 @@ table ClassDefFormat2 {
 record ClassRangeRecord {
     /// First glyph ID in the range
     #[validate(validate_glyph_range)]
-    start_glyph_id: BigEndian<GlyphId>,
+    start_glyph_id: GlyphId,
     /// Last glyph ID in the range
-    end_glyph_id: BigEndian<GlyphId>,
+    end_glyph_id: GlyphId,
     /// Applied to all glyphs in the range
-    class: BigEndian<u16>,
+    class: u16,
 }
 
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
@@ -219,51 +219,51 @@ format u16 ClassDef {
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
 record SequenceLookupRecord {
     /// Index (zero-based) into the input glyph sequence
-    sequence_index: BigEndian<u16>,
+    sequence_index: u16,
     /// Index (zero-based) into the LookupList
-    lookup_list_index: BigEndian<u16>,
+    lookup_list_index: u16,
 }
 
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
 table SequenceContextFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    format: BigEndian<u16>,
+    format: u16,
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of SequenceRuleSet tables
     #[compile(array_len($seq_rule_set_offsets))]
-    seq_rule_set_count: BigEndian<u16>,
+    seq_rule_set_count: u16,
     /// Array of offsets to SequenceRuleSet tables, from beginning of
     /// SequenceContextFormat1 table (offsets may be NULL)
     #[count($seq_rule_set_count)]
     #[nullable]
-    seq_rule_set_offsets: [BigEndian<Offset16<SequenceRuleSet>>],
+    seq_rule_set_offsets: [Offset16<SequenceRuleSet>],
 }
 
 /// Part of [SequenceContextFormat1]
 table SequenceRuleSet {
     /// Number of SequenceRule tables
     #[compile(array_len($seq_rule_offsets))]
-    seq_rule_count: BigEndian<u16>,
+    seq_rule_count: u16,
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
     #[count($seq_rule_count)]
-    seq_rule_offsets: [BigEndian<Offset16<SequenceRule>>],
+    seq_rule_offsets: [Offset16<SequenceRule>],
 }
 
 /// Part of [SequenceContextFormat1]
 table SequenceRule {
     /// Number of glyphs in the input glyph sequence
     #[compile(plus_one($input_sequence.len()))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
-    seq_lookup_count: BigEndian<u16>,
+    seq_lookup_count: u16,
     /// Array of input glyph IDs—starting with the second glyph
     #[count(minus_one($glyph_count))]
-    input_sequence: [BigEndian<u16>],
+    input_sequence: [u16],
     /// Array of Sequence lookup records
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -273,46 +273,46 @@ table SequenceRule {
 table SequenceContextFormat2 {
     /// Format identifier: format = 2
     #[format = 2]
-    format: BigEndian<u16>,
+    format: u16,
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Offset to ClassDef table, from beginning of
     /// SequenceContextFormat2 table
-    class_def_offset: BigEndian<Offset16<ClassDef>>,
+    class_def_offset: Offset16<ClassDef>,
     /// Number of ClassSequenceRuleSet tables
     #[compile(array_len($class_seq_rule_set_offsets))]
-    class_seq_rule_set_count: BigEndian<u16>,
+    class_seq_rule_set_count: u16,
     /// Array of offsets to ClassSequenceRuleSet tables, from beginning
     /// of SequenceContextFormat2 table (may be NULL)
     #[count($class_seq_rule_set_count)]
     #[nullable]
-    class_seq_rule_set_offsets: [BigEndian<Offset16<ClassSequenceRuleSet>>],
+    class_seq_rule_set_offsets: [Offset16<ClassSequenceRuleSet>],
 }
 
 /// Part of [SequenceContextFormat2]
 table ClassSequenceRuleSet {
     /// Number of ClassSequenceRule tables
     #[compile(array_len($class_seq_rule_offsets))]
-    class_seq_rule_count: BigEndian<u16>,
+    class_seq_rule_count: u16,
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
     #[count($class_seq_rule_count)]
-    class_seq_rule_offsets: [BigEndian<Offset16<ClassSequenceRule>>],
+    class_seq_rule_offsets: [Offset16<ClassSequenceRule>],
 }
 
 /// Part of [SequenceContextFormat2]
 table ClassSequenceRule {
     /// Number of glyphs to be matched
     #[compile(plus_one($input_sequence.len()))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
-    seq_lookup_count: BigEndian<u16>,
+    seq_lookup_count: u16,
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
     #[count(minus_one($glyph_count))]
-    input_sequence: [BigEndian<u16>],
+    input_sequence: [u16],
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -322,17 +322,17 @@ table ClassSequenceRule {
 table SequenceContextFormat3 {
     /// Format identifier: format = 3
     #[format = 3]
-    format: BigEndian<u16>,
+    format: u16,
     /// Number of glyphs in the input sequence
     #[compile(array_len($coverage_offsets))]
-    glyph_count: BigEndian<u16>,
+    glyph_count: u16,
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
-    seq_lookup_count: BigEndian<u16>,
+    seq_lookup_count: u16,
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
     #[count($glyph_count)]
-    coverage_offsets: [BigEndian<Offset16<CoverageTable>>],
+    coverage_offsets: [Offset16<CoverageTable>],
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -348,54 +348,54 @@ format u16 SequenceContext {
 table ChainedSequenceContextFormat1 {
     /// Format identifier: format = 1
     #[format = 1]
-    format: BigEndian<u16>,
+    format: u16,
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Number of ChainedSequenceRuleSet tables
     #[compile(array_len($chained_seq_rule_set_offsets))]
-    chained_seq_rule_set_count: BigEndian<u16>,
+    chained_seq_rule_set_count: u16,
     /// Array of offsets to ChainedSeqRuleSet tables, from beginning of
     /// ChainedSequenceContextFormat1 table (may be NULL)
     #[count($chained_seq_rule_set_count)]
     #[nullable]
-    chained_seq_rule_set_offsets: [BigEndian<Offset16<ChainedSequenceRuleSet>>],
+    chained_seq_rule_set_offsets: [Offset16<ChainedSequenceRuleSet>],
 }
 
 /// Part of [ChainedSequenceContextFormat1]
 table ChainedSequenceRuleSet {
     /// Number of ChainedSequenceRule tables
     #[compile(array_len($chained_seq_rule_offsets))]
-    chained_seq_rule_count: BigEndian<u16>,
+    chained_seq_rule_count: u16,
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
     #[count($chained_seq_rule_count)]
-    chained_seq_rule_offsets: [BigEndian<Offset16<ChainedSequenceRule>>],
+    chained_seq_rule_offsets: [Offset16<ChainedSequenceRule>],
 }
 
 /// Part of [ChainedSequenceContextFormat1]
 table ChainedSequenceRule {
     /// Number of glyphs in the backtrack sequence
     #[compile(array_len($backtrack_sequence))]
-    backtrack_glyph_count: BigEndian<u16>,
+    backtrack_glyph_count: u16,
     /// Array of backtrack glyph IDs
     #[count($backtrack_glyph_count)]
-    backtrack_sequence: [BigEndian<u16>],
+    backtrack_sequence: [u16],
     /// Number of glyphs in the input sequence
     #[compile(plus_one($input_sequence.len()))]
-    input_glyph_count: BigEndian<u16>,
+    input_glyph_count: u16,
     /// Array of input glyph IDs—start with second glyph
     #[count(minus_one($input_glyph_count))]
-    input_sequence: [BigEndian<u16>],
+    input_sequence: [u16],
     /// Number of glyphs in the lookahead sequence
     #[compile(array_len($lookahead_sequence))]
-    lookahead_glyph_count: BigEndian<u16>,
+    lookahead_glyph_count: u16,
     /// Array of lookahead glyph IDs
     #[count($lookahead_glyph_count)]
-    lookahead_sequence: [BigEndian<u16>],
+    lookahead_sequence: [u16],
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
-    seq_lookup_count: BigEndian<u16>,
+    seq_lookup_count: u16,
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -405,64 +405,64 @@ table ChainedSequenceRule {
 table ChainedSequenceContextFormat2 {
     /// Format identifier: format = 2
     #[format = 2]
-    format: BigEndian<u16>,
+    format: u16,
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
-    coverage_offset: BigEndian<Offset16<CoverageTable>>,
+    coverage_offset: Offset16<CoverageTable>,
     /// Offset to ClassDef table containing backtrack sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
-    backtrack_class_def_offset: BigEndian<Offset16<ClassDef>>,
+    backtrack_class_def_offset: Offset16<ClassDef>,
     /// Offset to ClassDef table containing input sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
-    input_class_def_offset: BigEndian<Offset16<ClassDef>>,
+    input_class_def_offset: Offset16<ClassDef>,
     /// Offset to ClassDef table containing lookahead sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
-    lookahead_class_def_offset: BigEndian<Offset16<ClassDef>>,
+    lookahead_class_def_offset: Offset16<ClassDef>,
     /// Number of ChainedClassSequenceRuleSet tables
     #[compile(array_len($chained_class_seq_rule_set_offsets))]
-    chained_class_seq_rule_set_count: BigEndian<u16>,
+    chained_class_seq_rule_set_count: u16,
     /// Array of offsets to ChainedClassSequenceRuleSet tables, from
     /// beginning of ChainedSequenceContextFormat2 table (may be NULL)
     #[count($chained_class_seq_rule_set_count)]
     #[nullable]
-    chained_class_seq_rule_set_offsets: [BigEndian<Offset16<ChainedClassSequenceRuleSet>>],
+    chained_class_seq_rule_set_offsets: [Offset16<ChainedClassSequenceRuleSet>],
 }
 
 /// Part of [ChainedSequenceContextFormat2]
 table ChainedClassSequenceRuleSet {
     /// Number of ChainedClassSequenceRule tables
     #[compile(array_len($chained_class_seq_rule_offsets))]
-    chained_class_seq_rule_count: BigEndian<u16>,
+    chained_class_seq_rule_count: u16,
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
     #[count($chained_class_seq_rule_count)]
-    chained_class_seq_rule_offsets: [BigEndian<Offset16<ChainedClassSequenceRule>>],
+    chained_class_seq_rule_offsets: [Offset16<ChainedClassSequenceRule>],
 }
 
 /// Part of [ChainedSequenceContextFormat2]
 table ChainedClassSequenceRule {
     /// Number of glyphs in the backtrack sequence
     #[compile(array_len($backtrack_sequence))]
-    backtrack_glyph_count: BigEndian<u16>,
+    backtrack_glyph_count: u16,
     /// Array of backtrack-sequence classes
     #[count($backtrack_glyph_count)]
-    backtrack_sequence: [BigEndian<u16>],
+    backtrack_sequence: [u16],
     /// Total number of glyphs in the input sequence
     #[compile(plus_one($input_sequence.len()))]
-    input_glyph_count: BigEndian<u16>,
+    input_glyph_count: u16,
     /// Array of input sequence classes, beginning with the second
     /// glyph position
     #[count(minus_one($input_glyph_count))]
-    input_sequence: [BigEndian<u16>],
+    input_sequence: [u16],
     /// Number of glyphs in the lookahead sequence
     #[compile(array_len($lookahead_sequence))]
-    lookahead_glyph_count: BigEndian<u16>,
+    lookahead_glyph_count: u16,
     /// Array of lookahead-sequence classes
     #[count($lookahead_glyph_count)]
-    lookahead_sequence: [BigEndian<u16>],
+    lookahead_sequence: [u16],
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
-    seq_lookup_count: BigEndian<u16>,
+    seq_lookup_count: u16,
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -472,28 +472,28 @@ table ChainedClassSequenceRule {
 table ChainedSequenceContextFormat3 {
     /// Format identifier: format = 3
     #[format = 3]
-    format: BigEndian<u16>,
+    format: u16,
     /// Number of glyphs in the backtrack sequence
     #[compile(array_len($backtrack_coverage_offsets))]
-    backtrack_glyph_count: BigEndian<u16>,
+    backtrack_glyph_count: u16,
     /// Array of offsets to coverage tables for the backtrack sequence
     #[count($backtrack_glyph_count)]
-    backtrack_coverage_offsets: [BigEndian<Offset16<CoverageTable>>],
+    backtrack_coverage_offsets: [Offset16<CoverageTable>],
     /// Number of glyphs in the input sequence
     #[compile(array_len($input_coverage_offsets))]
-    input_glyph_count: BigEndian<u16>,
+    input_glyph_count: u16,
     /// Array of offsets to coverage tables for the input sequence
     #[count($input_glyph_count)]
-    input_coverage_offsets: [BigEndian<Offset16<CoverageTable>>],
+    input_coverage_offsets: [Offset16<CoverageTable>],
     /// Number of glyphs in the lookahead sequence
     #[compile(array_len($lookahead_coverage_offsets))]
-    lookahead_glyph_count: BigEndian<u16>,
+    lookahead_glyph_count: u16,
     /// Array of offsets to coverage tables for the lookahead sequence
     #[count($lookahead_glyph_count)]
-    lookahead_coverage_offsets: [BigEndian<Offset16<CoverageTable>>],
+    lookahead_coverage_offsets: [Offset16<CoverageTable>],
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
-    seq_lookup_count: BigEndian<u16>,
+    seq_lookup_count: u16,
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -522,36 +522,36 @@ enum u16 DeltaFormat {
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 table Device {
     /// Smallest size to correct, in ppem
-    start_size: BigEndian<u16>,
+    start_size: u16,
     /// Largest size to correct, in ppem
-    end_size: BigEndian<u16>,
+    end_size: u16,
     /// Format of deltaValue array data: 0x0001, 0x0002, or 0x0003
     #[to_owned(convert_delta_format(obj.delta_format()))]
-    delta_format: BigEndian<DeltaFormat>,
+    delta_format: DeltaFormat,
     /// Array of compressed data
     #[count(delta_value_count($start_size, $end_size, $delta_format))]
-    delta_value: [BigEndian<u16>],
+    delta_value: [u16],
 }
 
 /// Variation index table
 table VariationIndex {
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
-    delta_set_outer_index: BigEndian<u16>,
+    delta_set_outer_index: u16,
     /// A delta-set inner index — used to select a delta-set row
     /// within an item variation data subtable.
-    delta_set_inner_index: BigEndian<u16>,
+    delta_set_inner_index: u16,
     /// Format, = 0x8000
-    delta_format: BigEndian<u16>,
+    delta_format: u16,
 }
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
 table FeatureVariations {
     #[compile(MajorMinor::VERSION_1_0)]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Number of feature variation records.
     #[compile(array_len($feature_variation_records))]
-    feature_variation_record_count: BigEndian<u32>,
+    feature_variation_record_count: u32,
     /// Array of feature variation records.
     #[count($feature_variation_record_count)]
     feature_variation_records: [FeatureVariationRecord],
@@ -561,21 +561,21 @@ table FeatureVariations {
 record FeatureVariationRecord {
     /// Offset to a condition set table, from beginning of
     /// FeatureVariations table.
-    condition_set_offset: BigEndian<Offset32<ConditionSet>>,
+    condition_set_offset: Offset32<ConditionSet>,
     /// Offset to a feature table substitution table, from beginning of
     /// the FeatureVariations table.
-    feature_table_substitution_offset: BigEndian<Offset32<FeatureTableSubstitution>>,
+    feature_table_substitution_offset: Offset32<FeatureTableSubstitution>,
 }
 
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
 table ConditionSet {
     /// Number of conditions for this condition set.
     #[compile(array_len($condition_offsets))]
-    condition_count: BigEndian<u16>,
+    condition_count: u16,
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
     #[count($condition_count)]
-    condition_offsets: [BigEndian<Offset32<ConditionFormat1>>],
+    condition_offsets: [Offset32<ConditionFormat1>],
 }
 
 ///// [Condition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table)
@@ -588,26 +588,26 @@ table ConditionSet {
 table ConditionFormat1 {
     /// Format, = 1
     #[format = 1]
-    format: BigEndian<u16>,
+    format: u16,
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
-    axis_index: BigEndian<u16>,
+    axis_index: u16,
     /// Minimum value of the font variation instances that satisfy this
     /// condition.
-    filter_range_min_value: BigEndian<F2Dot14>,
+    filter_range_min_value: F2Dot14,
     /// Maximum value of the font variation instances that satisfy this
     /// condition.
-    filter_range_max_value: BigEndian<F2Dot14>,
+    filter_range_max_value: F2Dot14,
 }
 
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
 table FeatureTableSubstitution {
     /// Major & minor version of the table: (1, 0)
     #[compile(MajorMinor::VERSION_1_0)]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// Number of feature table substitution records.
     #[compile(array_len($substitutions))]
-    substitution_count: BigEndian<u16>,
+    substitution_count: u16,
     /// Array of feature table substitution records.
     #[count($substitution_count)]
     substitutions: [FeatureTableSubstitutionRecord],
@@ -616,11 +616,11 @@ table FeatureTableSubstitution {
 /// Used in [FeatureTableSubstitution]
 record FeatureTableSubstitutionRecord {
     /// The feature table index to match.
-    feature_index: BigEndian<u16>,
+    feature_index: u16,
     /// Offset to an alternate feature table, from start of the
     /// FeatureTableSubstitution table.
     #[offset_getter(alternate_feature)] // custom impl, we need to pass a fake tag
-    alternate_feature_offset: BigEndian<Offset32<Feature>>,
+    alternate_feature_offset: Offset32<Feature>,
 }
 
 table SizeParams {
@@ -628,14 +628,14 @@ table SizeParams {
     ///
     /// The design size entry must be non-zero. When there is a design size but
     /// no recommended size range, the rest of the array will consist of zeros.
-    design_size: BigEndian<u16>,
+    design_size: u16,
     /// The second value has no independent meaning, but serves as an identifier that associates fonts in a subfamily.
     ///
     /// All fonts which share a Typographic or Font Family name and which differ
     /// only by size range shall have the same subfamily value, and no fonts
     /// which differ in weight or style shall have the same subfamily value.
     /// If this value is zero, the remaining fields in the array will be ignored.
-    identifier: BigEndian<u16>,
+    identifier: u16,
     /// The third value enables applications to use a single name for the subfamily identified by the second value.
     ///
     /// If the preceding value is non-zero, this value must be set in the range
@@ -646,20 +646,20 @@ table SizeParams {
     /// an application should use, in combination with the family name, to
     /// represent the subfamily in a menu. Applications will choose the
     /// appropriate version based on their selection criteria.
-    name_entry: BigEndian<u16>,
+    name_entry: u16,
     /// The fourth and fifth values represent the small end of the recommended
     /// usage range (exclusive) and the large end of the recommended usage range
     /// (inclusive), stored in 720/inch units (decipoints).
     ///
     /// Ranges must not overlap, and should generally be contiguous.
-    range_start: BigEndian<u16>,
-    range_end: BigEndian<u16>,
+    range_start: u16,
+    range_end: u16,
 }
 
 table StylisticSetParams {
     //#[version]
     #[compile(0)]
-    version: BigEndian<u16>,
+    version: u16,
     /// The 'name' table name ID that specifies a string (or strings, for
     /// multiple languages) for a user-interface label for this feature.
     ///
@@ -669,38 +669,38 @@ table StylisticSetParams {
     /// be provided in multiple languages. An English string should be included
     /// as a fallback. The string should be kept to a minimal length to fit
     /// comfortably with different application interfaces.
-    ui_name_id: BigEndian<u16>,
+    ui_name_id: u16,
 }
 
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
 table CharacterVariantParams {
     /// Format number is set to 0.
     #[format = 1]
-    format: BigEndian<u16>,
+    format: u16,
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) for a user-interface label for this
     /// feature. (May be NULL.)
-    feat_ui_label_name_id: BigEndian<u16>,
+    feat_ui_label_name_id: u16,
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) that an application can use for tooltip
     /// text for this feature. (May be NULL.)
-    feat_ui_tooltip_text_name_id: BigEndian<u16>,
+    feat_ui_tooltip_text_name_id: u16,
     /// The 'name' table name ID that specifies sample text that
     /// illustrates the effect of this feature. (May be NULL.)
-    sample_text_name_id: BigEndian<u16>,
+    sample_text_name_id: u16,
     /// Number of named parameters. (May be zero.)
-    num_named_parameters: BigEndian<u16>,
+    num_named_parameters: u16,
     /// The first 'name' table name ID used to specify strings for
     /// user-interface labels for the feature parameters. (Must be zero
     /// if numParameters is zero.)
-    first_param_ui_label_name_id: BigEndian<u16>,
+    first_param_ui_label_name_id: u16,
     /// The count of characters for which this feature provides glyph
     /// variants. (May be zero.)
     #[compile(array_len($character))]
-    char_count: BigEndian<u16>,
+    char_count: u16,
     /// The Unicode Scalar Value of the characters for which this
     /// feature provides glyph variants.
     #[count($char_count)]
-    character: [BigEndian<Uint24>],
+    character: [Uint24],
 }
 

--- a/resources/codegen_inputs/maxp.rs
+++ b/resources/codegen_inputs/maxp.rs
@@ -5,50 +5,50 @@ table Maxp {
     /// The version: 0x00005000 for version 0.5, 0x00010000 for version 1.0.
     #[version]
     #[compile(self.compute_version())]
-    version: BigEndian<Version16Dot16>,
+    version: Version16Dot16,
     /// The number of glyphs in the font.
-    num_glyphs: BigEndian<u16>,
+    num_glyphs: u16,
     /// Maximum points in a non-composite glyph.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_points: BigEndian<u16>,
+    max_points: u16,
     /// Maximum contours in a non-composite glyph.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_contours: BigEndian<u16>,
+    max_contours: u16,
     /// Maximum points in a composite glyph.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_composite_points: BigEndian<u16>,
+    max_composite_points: u16,
     /// Maximum contours in a composite glyph.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_composite_contours: BigEndian<u16>,
+    max_composite_contours: u16,
     /// 1 if instructions do not use the twilight zone (Z0), or 2 if
     /// instructions do use Z0; should be set to 2 in most cases.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_zones: BigEndian<u16>,
+    max_zones: u16,
     /// Maximum points used in Z0.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_twilight_points: BigEndian<u16>,
+    max_twilight_points: u16,
     /// Number of Storage Area locations.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_storage: BigEndian<u16>,
+    max_storage: u16,
     /// Number of FDEFs, equal to the highest function number + 1.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_function_defs: BigEndian<u16>,
+    max_function_defs: u16,
     /// Number of IDEFs.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_instruction_defs: BigEndian<u16>,
+    max_instruction_defs: u16,
     /// Maximum stack depth across Font Program ('fpgm' table), CVT
     /// Program ('prep' table) and all glyph instructions (in the
     /// 'glyf' table).
     #[available(Version16Dot16::VERSION_1_0)]
-    max_stack_elements: BigEndian<u16>,
+    max_stack_elements: u16,
     /// Maximum byte count for glyph instructions.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_size_of_instructions: BigEndian<u16>,
+    max_size_of_instructions: u16,
     /// Maximum number of components referenced at “top level” for
     /// any composite glyph.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_component_elements: BigEndian<u16>,
+    max_component_elements: u16,
     /// Maximum levels of recursion; 1 for simple components.
     #[available(Version16Dot16::VERSION_1_0)]
-    max_component_depth: BigEndian<u16>,
+    max_component_depth: u16,
 }

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -4,13 +4,13 @@
 table Name {
     /// Table version number (0 or 1)
     #[version]
-    version: BigEndian<u16>,
+    version: u16,
     /// Number of name records.
     #[compile(array_len($name_record))]
-    count: BigEndian<u16>,
+    count: u16,
     /// Offset to start of string storage (from start of table).
     #[compile(self.compute_storage_offset())]
-    storage_offset: BigEndian<u16>,
+    storage_offset: u16,
     /// The name records where count is the number of records.
     #[count($count)]
     #[offset_data_method(string_data)]
@@ -20,7 +20,7 @@ table Name {
     /// Number of language-tag records.
     #[available(1)]
     #[compile(array_len($lang_tag_record))]
-    lang_tag_count: BigEndian<u16>,
+    lang_tag_count: u16,
     /// The language-tag records where langTagCount is the number of records.
     #[count($lang_tag_count)]
     #[offset_data_method(string_data)]
@@ -34,34 +34,34 @@ table Name {
 record LangTagRecord {
     /// Language-tag string length (in bytes)
     #[compile(skip)]
-    length: BigEndian<u16>,
+    length: u16,
     /// Language-tag string offset from start of storage area (in
     /// bytes).
     #[offset_getter(lang_tag)]
     #[traverse_with(traverse_lang_tag)]
     #[compile_type(OffsetMarker<String>)]
     #[validate(skip)]
-    lang_tag_offset: BigEndian<Offset16<NameString>>,
+    lang_tag_offset: Offset16<NameString>,
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
 #[skip_font_write]
 record NameRecord {
     /// Platform ID.
-    platform_id: BigEndian<u16>,
+    platform_id: u16,
     /// Platform-specific encoding ID.
-    encoding_id: BigEndian<u16>,
+    encoding_id: u16,
     /// Language ID.
-    language_id: BigEndian<u16>,
+    language_id: u16,
     /// Name ID.
-    name_id: BigEndian<u16>,
+    name_id: u16,
     /// String length (in bytes).
     #[compile(skip)]
-    length: BigEndian<u16>,
+    length: u16,
     /// String offset from start of storage area (in bytes).
     #[traverse_with(traverse_string)]
     #[offset_getter(string)]
     #[compile_type(OffsetMarker<String>)]
     #[validate(validate_string_data)]
-    string_offset: BigEndian<Offset16<NameString>>,
+    string_offset: Offset16<NameString>,
 }

--- a/resources/codegen_inputs/post.rs
+++ b/resources/codegen_inputs/post.rs
@@ -6,11 +6,11 @@ table Post {
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version
     /// 3.0
     #[version]
-    version: BigEndian<Version16Dot16>,
+    version: Version16Dot16,
     /// Italic angle in counter-clockwise degrees from the vertical.
     /// Zero for upright text, negative for text that leans to the
     /// right (forward).
-    italic_angle: BigEndian<Fixed>,
+    italic_angle: Fixed,
     /// This is the suggested distance of the top of the underline from
     /// the baseline (negative values indicate below baseline). The
     /// PostScript definition of this FontInfo dictionary key (the y
@@ -18,33 +18,33 @@ table Post {
     /// historical reasons. The value of the PostScript key may be
     /// calculated by subtracting half the underlineThickness from the
     /// value of this field.
-    underline_position: BigEndian<FWord>,
+    underline_position: FWord,
     /// Suggested values for the underline thickness. In general, the
     /// underline thickness should match the thickness of the
     /// underscore character (U+005F LOW LINE), and should also match
     /// the strikeout thickness, which is specified in the OS/2 table.
-    underline_thickness: BigEndian<FWord>,
+    underline_thickness: FWord,
     /// Set to 0 if the font is proportionally spaced, non-zero if the
     /// font is not proportionally spaced (i.e. monospaced).
-    is_fixed_pitch: BigEndian<u32>,
+    is_fixed_pitch: u32,
     /// Minimum memory usage when an OpenType font is downloaded.
-    min_mem_type42: BigEndian<u32>,
+    min_mem_type42: u32,
     /// Maximum memory usage when an OpenType font is downloaded.
-    max_mem_type42: BigEndian<u32>,
+    max_mem_type42: u32,
     /// Minimum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
-    min_mem_type1: BigEndian<u32>,
+    min_mem_type1: u32,
     /// Maximum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
-    max_mem_type1: BigEndian<u32>,
+    max_mem_type1: u32,
     /// Number of glyphs (this should be the same as numGlyphs in
     /// 'maxp' table).
     #[available(Version16Dot16::VERSION_2_0)]
-    num_glyphs: BigEndian<u16>,
+    num_glyphs: u16,
     /// Array of indices into the string data. See below for details.
     #[count($num_glyphs)]
     #[available(Version16Dot16::VERSION_2_0)]
-    glyph_name_index: [BigEndian<u16>],
+    glyph_name_index: [u16],
     /// Storage for the string data.
     #[count(..)]
     #[validate(skip)]

--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -2,73 +2,73 @@
 #[offset_host]
 Stat1_0<'a> {
     /// Major version number of the style attributes table — set to 1.
-    major_version: BigEndian<u16>,
+    major_version: u16,
     /// Minor version number of the style attributes table — set to 2.
-    minor_version: BigEndian<u16>,
+    minor_version: u16,
     /// The size in bytes of each axis record.
-    design_axis_size: BigEndian<u16>,
+    design_axis_size: u16,
     /// The number of axis records. In a font with an 'fvar' table,
     /// this value must be greater than or equal to the axisCount value
     /// in the 'fvar' table. In all fonts, must be greater than zero if
     /// axisValueCount is greater than zero.
-    design_axis_count: BigEndian<u16>,
+    design_axis_count: u16,
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes array. If designAxisCount is zero, set
     /// to zero; if designAxisCount is greater than zero, must be
     /// greater than zero.
-    design_axes_offset: BigEndian<Offset32>,
+    design_axes_offset: Offset32,
     /// The number of axis value tables.
-    axis_value_count: BigEndian<u16>,
+    axis_value_count: u16,
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes value offsets array. If axisValueCount
     /// is zero, set to zero; if axisValueCount is greater than zero,
     /// must be greater than zero.
-    offset_to_axis_value_offsets: BigEndian<Offset32>,
+    offset_to_axis_value_offsets: Offset32,
 }
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
 #[offset_host]
 Stat1_2<'a> {
     /// Major version number of the style attributes table — set to 1.
-    major_version: BigEndian<u16>,
+    major_version: u16,
     /// Minor version number of the style attributes table — set to 2.
-    minor_version: BigEndian<u16>,
+    minor_version: u16,
     /// The size in bytes of each axis record.
-    design_axis_size: BigEndian<u16>,
+    design_axis_size: u16,
     /// The number of axis records. In a font with an 'fvar' table,
     /// this value must be greater than or equal to the axisCount value
     /// in the 'fvar' table. In all fonts, must be greater than zero if
     /// axisValueCount is greater than zero.
-    design_axis_count: BigEndian<u16>,
+    design_axis_count: u16,
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes array. If designAxisCount is zero, set
     /// to zero; if designAxisCount is greater than zero, must be
     /// greater than zero.
-    design_axes_offset: BigEndian<Offset32>,
+    design_axes_offset: Offset32,
     /// The number of axis value tables.
-    axis_value_count: BigEndian<u16>,
+    axis_value_count: u16,
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes value offsets array. If axisValueCount
     /// is zero, set to zero; if axisValueCount is greater than zero,
     /// must be greater than zero.
-    offset_to_axis_value_offsets: BigEndian<Offset32>,
+    offset_to_axis_value_offsets: Offset32,
     /// Name ID used as fallback when projection of names into a
     /// particular font model produces a subfamily name containing only
     /// elidable elements.
-    elided_fallback_name_id: BigEndian<u16>,
+    elided_fallback_name_id: u16,
 }
 
 /// [Axis Records](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records)
 AxisRecord {
     /// A tag identifying the axis of design variation.
-    axis_tag: BigEndian<Tag>,
+    axis_tag: Tag,
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this axis.
-    axis_name_id: BigEndian<u16>,
+    axis_name_id: u16,
     /// A value that applications can use to determine primary sorting
     /// of face names, or for ordering of labels when composing family
     /// or face names.
-    axis_ordering: BigEndian<u16>,
+    axis_ordering: u16,
 }
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
@@ -98,74 +98,74 @@ enum AxisValue<'a> {
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
 AxisValueFormat1 {
     /// Format identifier — set to 1.
-    format: BigEndian<u16>,
+    format: u16,
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
     /// be less than designAxisCount.
-    axis_index: BigEndian<u16>,
+    axis_index: u16,
     /// Flags — see below for details.
-    flags: BigEndian<AxisValueFlags>,
+    flags: AxisValueFlags,
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
-    value_name_id: BigEndian<u16>,
+    value_name_id: u16,
     /// A numeric value for this attribute value.
-    value: BigEndian<Fixed>,
+    value: Fixed,
 }
 
 /// [Axis value table format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2)
 AxisValueFormat2 {
     /// Format identifier — set to 2.
-    format: BigEndian<u16>,
+    format: u16,
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
     /// be less than designAxisCount.
-    axis_index: BigEndian<u16>,
+    axis_index: u16,
     /// Flags — see below for details.
-    flags: BigEndian<AxisValueFlags>,
+    flags: AxisValueFlags,
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
-    value_name_id: BigEndian<u16>,
+    value_name_id: u16,
     /// A nominal numeric value for this attribute value.
-    nominal_value: BigEndian<Fixed>,
+    nominal_value: Fixed,
     /// The minimum value for a range associated with the specified
     /// name ID.
-    range_min_value: BigEndian<Fixed>,
+    range_min_value: Fixed,
     /// The maximum value for a range associated with the specified
     /// name ID.
-    range_max_value: BigEndian<Fixed>,
+    range_max_value: Fixed,
 }
 
 /// [Axis value table format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3)
 AxisValueFormat3 {
     /// Format identifier — set to 3.
-    format: BigEndian<u16>,
+    format: u16,
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
     /// be less than designAxisCount.
-    axis_index: BigEndian<u16>,
+    axis_index: u16,
     /// Flags — see below for details.
-    flags: BigEndian<AxisValueFlags>,
+    flags: AxisValueFlags,
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
-    value_name_id: BigEndian<u16>,
+    value_name_id: u16,
     /// A numeric value for this attribute value.
-    value: BigEndian<Fixed>,
+    value: Fixed,
     /// The numeric value for a style-linked mapping from this value.
-    linked_value: BigEndian<Fixed>,
+    linked_value: Fixed,
 }
 
 /// [Axis value table format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4)
 AxisValueFormat4<'a> {
     /// Format identifier — set to 4.
-    format: BigEndian<u16>,
+    format: u16,
     /// The total number of axes contributing to this axis-values
     /// combination.
-    axis_count: BigEndian<u16>,
+    axis_count: u16,
     /// Flags — see below for details.
-    flags: BigEndian<AxisValueFlags>,
+    flags: AxisValueFlags,
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this combination of axis values.
-    value_name_id: BigEndian<u16>,
+    value_name_id: u16,
     /// Array of AxisValue records that provide the combination of axis
     /// values, one for each contributing axis.
     #[count(axis_count)]
@@ -176,9 +176,9 @@ AxisValueFormat4<'a> {
 AxisValueRecord {
     /// Zero-base index into the axis record array identifying the axis
     /// to which this value applies. Must be less than designAxisCount.
-    axis_index: BigEndian<u16>,
+    axis_index: u16,
     /// A numeric value for this attribute value.
-    value: BigEndian<Fixed>,
+    value: Fixed,
 }
 
 /// [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags).

--- a/resources/codegen_inputs/test.rs
+++ b/resources/codegen_inputs/test.rs
@@ -9,51 +9,51 @@
 table KindsOfOffsets {
     /// The major/minor version of the GDEF table
     #[version]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// A normal offset
-    nonnullable_offset: BigEndian<Offset16<Dummy>>,
+    nonnullable_offset: Offset16<Dummy>,
     /// An offset that is nullable, but always present
     #[nullable]
-    nullable_offset: BigEndian<Offset16<Dummy>>,
+    nullable_offset: Offset16<Dummy>,
     /// count of the array at array_offset
-    array_offset_count: BigEndian<u16>,
+    array_offset_count: u16,
     /// An offset to an array:
     #[read_offset_with($array_offset_count)]
-    array_offset: BigEndian<Offset16<[BigEndian<u16>]>>,
+    array_offset: Offset16<[u16]>,
     /// A normal offset that is versioned
     #[available(MajorMinor::VERSION_1_1)]
-    versioned_nonnullable_offset: BigEndian<Offset16<Dummy>>,
+    versioned_nonnullable_offset: Offset16<Dummy>,
     /// An offset that is nullable and versioned
     #[available(MajorMinor::VERSION_1_1)]
     #[nullable]
-    versioned_nullable_offset: BigEndian<Offset16<Dummy>>,
+    versioned_nullable_offset: Offset16<Dummy>,
 }
 
 table KindsOfArraysOfOffsets {
     /// The major/minor version of the GDEF table
     #[version]
-    version: BigEndian<MajorMinor>,
+    version: MajorMinor,
     /// The number of items in each array
-    count: BigEndian<u16>,
+    count: u16,
     /// A normal array offset
     #[count($count)]
-    nonnullable_offsets: [BigEndian<Offset16<Dummy>>],
+    nonnullable_offsets: [Offset16<Dummy>],
     /// An offset that is nullable, but always present
     #[nullable]
     #[count($count)]
-    nullable_offsets: [BigEndian<Offset16<Dummy>>],
+    nullable_offsets: [Offset16<Dummy>],
     /// A normal offset that is versioned
     #[available(MajorMinor::VERSION_1_1)]
     #[count($count)]
-    versioned_nonnullable_offsets: [BigEndian<Offset16<Dummy>>],
+    versioned_nonnullable_offsets: [Offset16<Dummy>],
     /// An offset that is nullable and versioned
     #[available(MajorMinor::VERSION_1_1)]
     #[nullable]
     #[count($count)]
-    versioned_nullable_offsets: [BigEndian<Offset16<Dummy>>],
+    versioned_nullable_offsets: [Offset16<Dummy>],
 }
 
 table Dummy {
-    value: BigEndian<u16>,
+    value: u16,
 }
 


### PR DESCRIPTION
Remove BigEndian from codegen inputs. Output is unchanged, except a few places where a (pointless?) `BigEndian<u8>` is changed to naked `u8`. Fixes #71.

* FieldType can now be PendingResolution at the end of the parse phase
* There is now an analysis phase that attempts to resolve anything pending
   * it is an error condition to have things pending at the end of analysis

I have a lot of noisy logging that I would ideally like to keep but have toggled off by default, akin to a debug level log in normal Google source. Not sure how best to get that in Rust. EDIT: per @dfrg I added log & env_logger which seem to work well.