### PR TITLE
Add convenience init methods to AnchorTable

### DIFF
--- a/write-fonts/src/layout/gpos.rs
+++ b/write-fonts/src/layout/gpos.rs
@@ -74,6 +74,25 @@ impl<'a> FontRead<'a> for PositionLookupList {
     }
 }
 
+impl AnchorTable {
+    /// Create a new [`AnchorFormat1`] table.
+    pub fn format_1(x_coordinate: i16, y_coordinate: i16) -> Self {
+        Self::Format1(AnchorFormat1 {
+            x_coordinate,
+            y_coordinate,
+        })
+    }
+
+    /// Create a new [`AnchorFormat2`] table.
+    pub fn format_2(x_coordinate: i16, y_coordinate: i16, anchor_point: u16) -> Self {
+        Self::Format2(AnchorFormat2 {
+            x_coordinate,
+            y_coordinate,
+            anchor_point,
+        })
+    }
+}
+
 impl SinglePosFormat1 {
     fn compute_value_format(&self) -> ValueFormat {
         self.value_record.format()


### PR DESCRIPTION
Constructing these otherwise is a bit annoying. We might consider generating this sort of code at some point, but we wouldn't want it for all multi-format types; this is perhaps another interesting example where we would want to augment a future schema?

Actually this maybe clarifies part of how I've been thinking about schema/codegen, and which I've struggled to express coherently, thus far. Basically, there are two related and heavily overlapping tasks performed by the current codegen inputs: the first is that they serve as a description of the tables in the spec, and the second is that *they serve as a description of the code we wish to generate*, and these things do not perfectly line up.