### PR TITLE
Update parser for glyf table

### DIFF
--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -36,11 +36,11 @@ fn touchup_code(tables: proc_macro2::TokenStream) -> Result<String, syn::Error> 
     // convert doc comment attributes into normal doc comments
     let doc_comments = regex::Regex::new(r#"#\[doc = "(.*)"\]"#).unwrap();
     let source_str = doc_comments.replace_all(&source_str, "///$1");
-    let newlines_before_docs = regex::Regex::new(r#"([;\}])\n( *)(///|pub|impl|#)"#).unwrap();
+    let newlines_before_docs = regex::Regex::new(r#"([;\}])\r?\n( *)(///|pub|impl|#)"#).unwrap();
     let source_str = newlines_before_docs.replace_all(&source_str, "$1\n\n$2$3");
 
     // add newlines after top-level items
-    let re2 = regex::Regex::new(r"\n\}").unwrap();
+    let re2 = regex::Regex::new(r"\r?\n\}").unwrap();
     let source_str = re2.replace_all(&source_str, "\n}\n\n");
     Ok(rustfmt_wrapper::rustfmt(source_str).unwrap())
 }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -371,6 +371,7 @@ impl<'a> From<CompositeGlyphFlags> for FieldType<'a> {
     }
 }
 
+/// Simple or composite glyph.
 pub enum Glyph<'a> {
     Simple(SimpleGlyph<'a>),
     Composite(CompositeGlyph<'a>),

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -24,6 +24,7 @@ pub struct FontData<'a> {
 /// # Note
 ///
 /// call `finish` when you're done to ensure you're in bounds
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Cursor<'a> {
     pos: usize,
     data: FontData<'a>,

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -1,7 +1,5 @@
 //! The [glyf (Glyph Data)](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf) table
 
-use font_types::ReadScalar;
-
 use crate::{FontData, ReadError};
 
 /// 'glyf'
@@ -33,16 +31,17 @@ impl<'a> Glyph<'a> {
 // the interim?
 
 impl<'a> SimpleGlyph<'a> {
-    pub fn iter_points(&self) -> PointIter<'_> {
-        self.iter_points_impl()
+    /// Returns an iterator over the points in the glyph.
+    pub fn points(&self) -> impl Iterator<Item = Point> + 'a + Clone {
+        self.points_impl()
             .unwrap_or_else(|| PointIter::new(&[], &[], &[], &[]))
     }
 
-    fn iter_points_impl(&self) -> Option<PointIter<'_>> {
+    fn points_impl(&self) -> Option<PointIter<'a>> {
         let end_points = self.end_pts_of_contours();
         let n_points = end_points.last()?.get().checked_add(1)?;
         let data = self.glyph_data();
-        let lens = resolve_coords_len(data, n_points)?;
+        let lens = resolve_coords_len(data, n_points).ok()?;
         let total_len = lens.flags + lens.x_coords + lens.y_coords;
         if data.len() < total_len as usize {
             return None;
@@ -55,25 +54,24 @@ impl<'a> SimpleGlyph<'a> {
     }
 }
 
+/// Point for a simple glyph.
 #[derive(Clone, Copy, Debug)]
 pub struct Point {
+    /// X component.
     pub x: i16,
+    /// Y component.
     pub y: i16,
+    /// True if this is an on-curve point.
+    pub on_curve: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum GlyphPoint {
-    OffCurve(Point),
-    OnCurve(Point),
-    End(Point),
-}
-
-pub struct PointIter<'a> {
+#[derive(Clone)]
+struct PointIter<'a> {
     end_points: &'a [BigEndian<u16>],
     cur_point: u16,
-    flags: OldCursor<'a>,
-    x_coords: OldCursor<'a>,
-    y_coords: OldCursor<'a>,
+    flags: Cursor<'a>,
+    x_coords: Cursor<'a>,
+    y_coords: Cursor<'a>,
     flag_repeats: u8,
     cur_flags: SimpleGlyphFlags,
     cur_x: i16,
@@ -81,8 +79,8 @@ pub struct PointIter<'a> {
 }
 
 impl<'a> Iterator for PointIter<'a> {
-    type Item = GlyphPoint;
-    fn next(&mut self) -> Option<GlyphPoint> {
+    type Item = Point;
+    fn next(&mut self) -> Option<Self::Item> {
         let next_end = self.end_points.first()?.get();
         let is_end = next_end <= self.cur_point; // LE because points could be out of order?
         if is_end {
@@ -91,19 +89,11 @@ impl<'a> Iterator for PointIter<'a> {
         self.advance_flags();
         self.advance_points();
         self.cur_point = self.cur_point.saturating_add(1);
-
-        let point = Point {
+        Some(Point {
             x: self.cur_x,
             y: self.cur_y,
-        };
-
-        if is_end {
-            Some(GlyphPoint::End(point))
-        } else if self.cur_flags.contains(SimpleGlyphFlags::ON_CURVE_POINT) {
-            Some(GlyphPoint::OnCurve(point))
-        } else {
-            Some(GlyphPoint::OffCurve(point))
-        }
+            on_curve: self.cur_flags.contains(SimpleGlyphFlags::ON_CURVE_POINT),
+        })
     }
 }
 
@@ -116,9 +106,9 @@ impl<'a> PointIter<'a> {
     ) -> Self {
         Self {
             end_points,
-            flags: OldCursor::new(flags),
-            x_coords: OldCursor::new(x_coords),
-            y_coords: OldCursor::new(y_coords),
+            flags: FontData::new(flags).cursor(),
+            x_coords: FontData::new(x_coords).cursor(),
+            y_coords: FontData::new(y_coords).cursor(),
             cur_point: 0,
             flag_repeats: 0,
             cur_flags: SimpleGlyphFlags::empty(),
@@ -130,11 +120,11 @@ impl<'a> PointIter<'a> {
     fn advance_flags(&mut self) {
         if self.flag_repeats == 0 {
             self.cur_flags =
-                SimpleGlyphFlags::from_bits_truncate(self.flags.bump().unwrap_or_default());
+                SimpleGlyphFlags::from_bits_truncate(self.flags.read().unwrap_or_default());
             self.flag_repeats = self
                 .cur_flags
                 .contains(SimpleGlyphFlags::REPEAT_FLAG)
-                .then(|| self.flags.bump())
+                .then(|| self.flags.read().ok())
                 .flatten()
                 .unwrap_or(1);
         }
@@ -152,16 +142,16 @@ impl<'a> PointIter<'a> {
             .contains(SimpleGlyphFlags::Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR);
 
         let delta_x = match (x_short, x_same_or_pos) {
-            (true, false) => -(self.x_coords.bump::<u8>().unwrap_or(0) as i16),
-            (true, true) => self.x_coords.bump::<u8>().unwrap_or(0) as i16,
-            (false, false) => self.x_coords.bump::<i16>().unwrap_or(0),
+            (true, false) => -(self.x_coords.read::<u8>().unwrap_or(0) as i16),
+            (true, true) => self.x_coords.read::<u8>().unwrap_or(0) as i16,
+            (false, false) => self.x_coords.read::<i16>().unwrap_or(0),
             _ => 0,
         };
 
         let delta_y = match (y_short, y_same_or_pos) {
-            (true, false) => -(self.y_coords.bump::<u8>().unwrap_or(0) as i16),
-            (true, true) => self.y_coords.bump::<u8>().unwrap_or(0) as i16,
-            (false, false) => self.y_coords.bump::<i16>().unwrap_or(0),
+            (true, false) => -(self.y_coords.read::<u8>().unwrap_or(0) as i16),
+            (true, true) => self.y_coords.read::<u8>().unwrap_or(0) as i16,
+            (false, false) => self.y_coords.read::<i16>().unwrap_or(0),
             _ => 0,
         };
 
@@ -174,27 +164,26 @@ impl<'a> PointIter<'a> {
 /// Resolves coordinate arrays length.
 ///
 /// The length depends on *Simple Glyph Flags*, so we have to process them all to find it.
-fn resolve_coords_len(data: &[u8], points_total: u16) -> Option<FieldLengths> {
-    let mut cursor = OldCursor::new(data);
-
+fn resolve_coords_len(data: &[u8], points_total: u16) -> Result<FieldLengths, ReadError> {
+    let mut cursor = FontData::new(data).cursor();
     let mut flags_left = u32::from(points_total);
     //let mut repeats;
     let mut x_coords_len = 0;
     let mut y_coords_len = 0;
     //let mut flags_seen = 0;
     while flags_left > 0 {
-        let flags: SimpleGlyphFlags = cursor.bump()?;
+        let flags: SimpleGlyphFlags = cursor.read()?;
 
         // The number of times a glyph point repeats.
         let repeats = if flags.contains(SimpleGlyphFlags::REPEAT_FLAG) {
-            let repeats: u8 = cursor.bump()?;
+            let repeats: u8 = cursor.read()?;
             u32::from(repeats) + 1
         } else {
             1
         };
 
         if repeats > flags_left {
-            return None;
+            return Err(ReadError::MalformedData("repeat count too large in glyf"));
         }
 
         // Non-obfuscated code below.
@@ -229,8 +218,8 @@ fn resolve_coords_len(data: &[u8], points_total: u16) -> Option<FieldLengths> {
         flags_left -= repeats;
     }
 
-    Some(FieldLengths {
-        flags: cursor.pos as u32,
+    Ok(FieldLengths {
+        flags: cursor.position()? as u32,
         x_coords: x_coords_len,
         y_coords: y_coords_len,
     })
@@ -243,51 +232,90 @@ struct FieldLengths {
     y_coords: u32,
 }
 
-/// A slice of bytes and an index into them.
-struct OldCursor<'a> {
-    data: &'a [u8],
-    pos: usize,
+/// Transform for a composite component.
+#[derive(Clone, Debug)]
+pub struct Transform {
+    /// X scale factor.
+    pub xx: F2Dot14,
+    /// YX skew factor.
+    pub yx: F2Dot14,
+    /// XY skew factor.
+    pub xy: F2Dot14,
+    /// Y scale factor.
+    pub yy: F2Dot14,
 }
 
-impl<'a> OldCursor<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self { data, pos: 0 }
-    }
-
-    /// Attempt to read `T` at the current location, advancing if successful.
-    fn bump<T: ReadScalar>(&mut self) -> Option<T> {
-        let r = T::read(self.data.get(self.pos..)?);
-        self.pos += T::RAW_BYTE_LEN;
-        r
+impl Default for Transform {
+    fn default() -> Self {
+        Self {
+            xx: F2Dot14::from_f32(1.0),
+            yx: F2Dot14::from_f32(0.0),
+            xy: F2Dot14::from_f32(0.0),
+            yy: F2Dot14::from_f32(1.0),
+        }
     }
 }
 
 /// A reference to another glyph. Part of [CompositeGlyph].
 pub struct Component {
+    /// Component flags.
     pub flags: CompositeGlyphFlags,
+    /// Glyph identifier.
     pub glyph: GlyphId,
-    pub pos: ComponentPos,
-    //TODO: transforms
+    /// Anchor for component placement.
+    pub anchor: Anchor,
+    /// Component transformation matrix.
+    pub transform: Transform,
 }
 
+/// Anchor position for a composite component.
 #[derive(Debug, Clone, Copy)]
-pub enum ComponentPos {
+pub enum Anchor {
     Offset { x: i16, y: i16 },
     Point { base: u16, component: u16 },
 }
 
 impl<'a> CompositeGlyph<'a> {
-    pub fn iter_components(&self) -> ComponentIter<'a> {
+    /// Returns an iterator over the components of the composite glyph.
+    pub fn components(&self) -> impl Iterator<Item = Component> + 'a + Clone {
         ComponentIter {
+            cur_flags: CompositeGlyphFlags::empty(),
             done: false,
             cursor: FontData::new(self.component_data()).cursor(),
         }
     }
+
+    /// Returns the TrueType interpreter instructions.
+    pub fn instructions(&self) -> Option<&'a [u8]> {
+        ComponentIter {
+            cur_flags: CompositeGlyphFlags::empty(),
+            done: false,
+            cursor: FontData::new(self.component_data()).cursor(),
+        }
+        .instructions()
+    }
 }
 
-pub struct ComponentIter<'a> {
+#[derive(Clone)]
+struct ComponentIter<'a> {
+    cur_flags: CompositeGlyphFlags,
     done: bool,
     cursor: Cursor<'a>,
+}
+
+impl<'a> ComponentIter<'a> {
+    fn instructions(&mut self) -> Option<&'a [u8]> {
+        while self.by_ref().next().is_some() {}
+        if self
+            .cur_flags
+            .contains(CompositeGlyphFlags::WE_HAVE_INSTRUCTIONS)
+        {
+            let len = self.cursor.read::<u16>().ok()? as usize;
+            self.cursor.read_array(len).ok()
+        } else {
+            None
+        }
+    }
 }
 
 impl Iterator for ComponentIter<'_> {
@@ -298,41 +326,49 @@ impl Iterator for ComponentIter<'_> {
             return None;
         }
         let flags: CompositeGlyphFlags = self.cursor.read().ok()?;
+        self.cur_flags = flags;
         let glyph = self.cursor.read::<GlyphId>().ok()?;
         let args_are_word = flags.contains(CompositeGlyphFlags::ARG_1_AND_2_ARE_WORDS);
         let are_signed = flags.contains(CompositeGlyphFlags::ARG_1_AND_2_ARE_WORDS);
-        let pos = match (are_signed, args_are_word) {
-            (true, true) => ComponentPos::Offset {
+        let anchor = match (are_signed, args_are_word) {
+            (true, true) => Anchor::Offset {
                 x: self.cursor.read().ok()?,
                 y: self.cursor.read().ok()?,
             },
-            (true, false) => ComponentPos::Offset {
+            (true, false) => Anchor::Offset {
                 x: self.cursor.read::<u8>().ok()? as _,
                 y: self.cursor.read::<u8>().ok()? as _,
             },
-            (false, true) => ComponentPos::Point {
+            (false, true) => Anchor::Point {
                 base: self.cursor.read().ok()?,
                 component: self.cursor.read().ok()?,
             },
-            (false, false) => ComponentPos::Point {
+            (false, false) => Anchor::Point {
                 base: self.cursor.read::<u8>().ok()? as _,
                 component: self.cursor.read::<u8>().ok()? as _,
             },
         };
-
-        let bytes_to_skip = if flags.contains(CompositeGlyphFlags::WE_HAVE_A_SCALE) {
-            2
+        let mut transform = Transform::default();
+        if flags.contains(CompositeGlyphFlags::WE_HAVE_A_SCALE) {
+            transform.xx = self.cursor.read().ok()?;
+            transform.yy = transform.xx;
         } else if flags.contains(CompositeGlyphFlags::WE_HAVE_AN_X_AND_Y_SCALE) {
-            4
+            transform.xx = self.cursor.read().ok()?;
+            transform.yy = self.cursor.read().ok()?;
         } else if flags.contains(CompositeGlyphFlags::WE_HAVE_A_TWO_BY_TWO) {
-            8
-        } else {
-            0
-        };
-        self.cursor.advance_by(bytes_to_skip);
+            transform.xx = self.cursor.read().ok()?;
+            transform.yx = self.cursor.read().ok()?;
+            transform.xy = self.cursor.read().ok()?;
+            transform.yy = self.cursor.read().ok()?;
+        }
         self.done = !flags.contains(CompositeGlyphFlags::MORE_COMPONENTS);
 
-        Some(Component { flags, glyph, pos })
+        Some(Component {
+            flags,
+            glyph,
+            anchor,
+            transform,
+        })
     }
 }
 
@@ -346,13 +382,13 @@ impl<'a> SomeTable<'a> for Component {
         match idx {
             0 => Some(Field::new("flags", self.flags.bits())),
             1 => Some(Field::new("glyph", self.glyph)),
-            2 => match self.pos {
-                ComponentPos::Point { base, .. } => Some(Field::new("base", base)),
-                ComponentPos::Offset { x, .. } => Some(Field::new("x", x)),
+            2 => match self.anchor {
+                Anchor::Point { base, .. } => Some(Field::new("base", base)),
+                Anchor::Offset { x, .. } => Some(Field::new("x", x)),
             },
-            3 => match self.pos {
-                ComponentPos::Point { component, .. } => Some(Field::new("component", component)),
-                ComponentPos::Offset { y, .. } => Some(Field::new("y", y)),
+            3 => match self.anchor {
+                Anchor::Point { component, .. } => Some(Field::new("component", component)),
+                Anchor::Offset { y, .. } => Some(Field::new("y", y)),
             },
             _ => None,
         }

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -408,3 +408,48 @@ impl<'a> SomeTable<'a> for Component {
 //}),
 //))
 //}
+
+#[cfg(test)]
+mod tests {
+    use super::Glyph;
+    use crate::test_data;
+    use crate::{FontRef, GlyphId, TableProvider};
+
+    #[test]
+    fn simple_glyph() {
+        let font = FontRef::new(test_data::test_fonts::COLR_GRADIENT_RECT).unwrap();
+        let loca = font.loca(None).unwrap();
+        let glyf = font.glyf().unwrap();
+        let glyph = loca.get_glyf(GlyphId::new(0), &glyf).unwrap();
+        assert_eq!(glyph.number_of_contours(), 2);
+        let simple_glyph = if let Glyph::Simple(simple) = glyph {
+            simple
+        } else {
+            panic!("expected simple glyph");
+        };
+        assert_eq!(
+            simple_glyph
+                .end_pts_of_contours()
+                .iter()
+                .map(|x| x.get())
+                .collect::<Vec<_>>(),
+            &[3, 7]
+        );
+        assert_eq!(
+            simple_glyph
+                .points()
+                .map(|pt| (pt.x, pt.y, pt.on_curve))
+                .collect::<Vec<_>>(),
+            &[
+                (5, 0, true),
+                (5, 100, true),
+                (45, 100, true),
+                (45, 0, true),
+                (10, 5, true),
+                (40, 5, true),
+                (40, 95, true),
+                (10, 95, true),
+            ]
+        );
+    }
+}

--- a/resources/codegen_inputs/glyf.rs
+++ b/resources/codegen_inputs/glyf.rs
@@ -218,6 +218,7 @@ flags u16 CompositeGlyphFlags {
     //Reserved = 0xE010,
 }
 
+/// Simple or composite glyph.
 format i16 Glyph {
     #[match_if($format >= 0)]
     Simple(SimpleGlyph),


### PR DESCRIPTION
This is basically just some cleanup of the hand-written glyf outline parsing code with a few additions (transforms and instructions for composite components).

I've added some docs, a basic test, and made some small stylistic changes as well.

Also (hopefully) fixes the newline issue on Windows.