### PR TITLE
Rationalize from obj conversions

### DIFF
--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -1060,20 +1060,13 @@ fn build_type_map(items: &Items) -> HashMap<String, FieldType> {
 fn resolve_ident<'a>(
     known: &'a HashMap<String, FieldType>,
     field_name: &syn::Ident,
-    ident: &syn::Ident,
+    field_type: &syn::Ident,
 ) -> Result<&'a FieldType, syn::Error> {
-    if let Some(item) = known.get(&ident.to_string()) {
-        debug!("Resolve {}: {} to {:?}", field_name, ident, item);
+    if let Some(item) = known.get(&field_type.to_string()) {
+        debug!("Resolve {}: {} to {:?}", field_name, field_type, item);
         Ok(item)
     } else {
-        Err(syn::Error::new(
-            field_name.span(),
-            format!(
-                "I don't know what this is, do you? {}: {}",
-                field_name.to_string().as_str(),
-                ident
-            ),
-        ))
+        Err(syn::Error::new(field_type.span(), "Error: undeclared type"))
     }
 }
 

--- a/resources/codegen_inputs/test.rs
+++ b/resources/codegen_inputs/test.rs
@@ -31,7 +31,7 @@ table KindsOfOffsets {
 }
 
 table KindsOfArraysOfOffsets {
-    /// The major/minor version of the GDEF table
+    /// The version
     #[version]
     #[compile(MajorMinor::VERSION_1_1)]
     version: MajorMinor,
@@ -55,7 +55,33 @@ table KindsOfArraysOfOffsets {
     versioned_nullable_offsets: [Offset16<Dummy>],
 }
 
+table KindsOfArrays {
+    #[version]
+    #[default(1)]
+    version: u16,
+    /// the number of items in each array
+    count: u16,
+    /// an array of scalars
+    #[count($count)]
+    scalars: [u16],
+    /// an array of records
+    #[count($count)]
+    records: [Shmecord],
+    /// a versioned array of scalars
+    #[available(1)]
+    #[count($count)]
+    versioned_scalars: [u16],
+    /// a versioned array of scalars
+    #[available(1)]
+    #[count($count)]
+    versioned_records: [Shmecord],
+}
+
 table Dummy {
     value: u16,
 }
 
+record Shmecord {
+    length: u16,
+    breadth: u32,
+}

--- a/resources/codegen_inputs/test.rs
+++ b/resources/codegen_inputs/test.rs
@@ -21,13 +21,21 @@ table KindsOfOffsets {
     /// An offset to an array:
     #[read_offset_with($array_offset_count)]
     array_offset: Offset16<[u16]>,
+    /// An offset to an array of records
+    #[read_offset_with($array_offset_count)]
+    record_array_offset: Offset16<[Shmecord]>,
+    /// A nullable, versioned offset to an array of records
+    #[read_offset_with($array_offset_count)]
+    #[nullable]
+    #[available(MajorMinor::VERSION_1_1)]
+    versioned_nullable_record_array_offset: Offset16<[Shmecord]>,
     /// A normal offset that is versioned
     #[available(MajorMinor::VERSION_1_1)]
     versioned_nonnullable_offset: Offset16<Dummy>,
     /// An offset that is nullable and versioned
     #[available(MajorMinor::VERSION_1_1)]
     #[nullable]
-    versioned_nullable_offset: Offset16<Dummy>,
+    versioned_nullable_offset: Offset32<Dummy>,
 }
 
 table KindsOfArraysOfOffsets {

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -85,12 +85,13 @@ impl Validate for Cpal {
 
 impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
     fn from_obj_ref(obj: &read_fonts::tables::cpal::Cpal<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         Cpal {
             num_palette_entries: obj.num_palette_entries(),
             num_palettes: obj.num_palettes(),
             num_color_records: obj.num_color_records(),
             color_records_array_offset: obj.color_records_array().into(),
-            color_record_indices: obj.color_record_indices().iter().map(|x| x.get()).collect(),
+            color_record_indices: obj.color_record_indices().to_owned_obj(offset_data),
             palette_types_array_offset: obj.palette_types_array().into(),
             palette_labels_array_offset: obj.palette_labels_array().into(),
             palette_entry_labels_array_offset: obj.palette_entry_labels_array().into(),

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -90,11 +90,13 @@ impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
             num_palette_entries: obj.num_palette_entries(),
             num_palettes: obj.num_palettes(),
             num_color_records: obj.num_color_records(),
-            color_records_array_offset: obj.color_records_array().into(),
+            color_records_array_offset: obj.color_records_array().to_owned_obj(offset_data),
             color_record_indices: obj.color_record_indices().to_owned_obj(offset_data),
-            palette_types_array_offset: obj.palette_types_array().into(),
-            palette_labels_array_offset: obj.palette_labels_array().into(),
-            palette_entry_labels_array_offset: obj.palette_entry_labels_array().into(),
+            palette_types_array_offset: obj.palette_types_array().to_owned_obj(offset_data),
+            palette_labels_array_offset: obj.palette_labels_array().to_owned_obj(offset_data),
+            palette_entry_labels_array_offset: obj
+                .palette_entry_labels_array()
+                .to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -182,8 +182,9 @@ impl Validate for AttachPoint {
 
 impl<'a> FromObjRef<read_fonts::layout::gdef::AttachPoint<'a>> for AttachPoint {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachPoint<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         AttachPoint {
-            point_indices: obj.point_indices().iter().map(|x| x.get()).collect(),
+            point_indices: obj.point_indices().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -76,12 +76,12 @@ impl Validate for Gdef {
 impl<'a> FromObjRef<read_fonts::layout::gdef::Gdef<'a>> for Gdef {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::Gdef<'a>, _: FontData) -> Self {
         Gdef {
-            glyph_class_def_offset: obj.glyph_class_def().into(),
-            attach_list_offset: obj.attach_list().into(),
-            lig_caret_list_offset: obj.lig_caret_list().into(),
-            mark_attach_class_def_offset: obj.mark_attach_class_def().into(),
-            mark_glyph_sets_def_offset: obj.mark_glyph_sets_def().into(),
-            item_var_store_offset: obj.item_var_store().into(),
+            glyph_class_def_offset: obj.glyph_class_def().to_owned_table(),
+            attach_list_offset: obj.attach_list().to_owned_table(),
+            lig_caret_list_offset: obj.lig_caret_list().to_owned_table(),
+            mark_attach_class_def_offset: obj.mark_attach_class_def().to_owned_table(),
+            mark_glyph_sets_def_offset: obj.mark_glyph_sets_def().to_owned_table(),
+            item_var_store_offset: obj.item_var_store().to_owned_table(),
         }
     }
 }
@@ -139,8 +139,8 @@ impl Validate for AttachList {
 impl<'a> FromObjRef<read_fonts::layout::gdef::AttachList<'a>> for AttachList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachList<'a>, _: FontData) -> Self {
         AttachList {
-            coverage_offset: obj.coverage().into(),
-            attach_point_offsets: obj.attach_points().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            attach_point_offsets: obj.attach_points().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -235,8 +235,8 @@ impl Validate for LigCaretList {
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigCaretList<'a>> for LigCaretList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigCaretList<'a>, _: FontData) -> Self {
         LigCaretList {
-            coverage_offset: obj.coverage().into(),
-            lig_glyph_offsets: obj.lig_glyphs().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            lig_glyph_offsets: obj.lig_glyphs().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -281,7 +281,7 @@ impl Validate for LigGlyph {
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigGlyph<'a>> for LigGlyph {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigGlyph<'a>, _: FontData) -> Self {
         LigGlyph {
-            caret_value_offsets: obj.caret_values().map(|x| x.into()).collect(),
+            caret_value_offsets: obj.caret_values().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -453,7 +453,7 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat3<'a>> for CaretVa
     fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat3<'a>, _: FontData) -> Self {
         CaretValueFormat3 {
             coordinate: obj.coordinate(),
-            device_offset: obj.device().into(),
+            device_offset: obj.device().to_owned_table(),
         }
     }
 }
@@ -500,7 +500,7 @@ impl Validate for MarkGlyphSets {
 impl<'a> FromObjRef<read_fonts::layout::gdef::MarkGlyphSets<'a>> for MarkGlyphSets {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::MarkGlyphSets<'a>, _: FontData) -> Self {
         MarkGlyphSets {
-            coverage_offsets: obj.coverages().map(|x| x.into()).collect(),
+            coverage_offsets: obj.coverages().map(|x| x.to_owned_table()).collect(),
         }
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -398,11 +398,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::MarkArray<'a>> for MarkArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkArray<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         MarkArray {
-            mark_records: obj
-                .mark_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            mark_records: obj.mark_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -977,11 +973,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::CursivePosFormat1<'a>> for Cursive
         let offset_data = obj.offset_data();
         CursivePosFormat1 {
             coverage_offset: obj.coverage().into(),
-            entry_exit_record: obj
-                .entry_exit_record()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            entry_exit_record: obj.entry_exit_record().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -56,10 +56,10 @@ impl Validate for Gpos {
 impl<'a> FromObjRef<read_fonts::layout::gpos::Gpos<'a>> for Gpos {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Gpos<'a>, _: FontData) -> Self {
         Gpos {
-            script_list_offset: obj.script_list().into(),
-            feature_list_offset: obj.feature_list().into(),
-            lookup_list_offset: obj.lookup_list().into(),
-            feature_variations_offset: obj.feature_variations().into(),
+            script_list_offset: obj.script_list().to_owned_table(),
+            feature_list_offset: obj.feature_list().to_owned_table(),
+            lookup_list_offset: obj.lookup_list().to_owned_table(),
+            feature_variations_offset: obj.feature_variations().to_owned_table(),
         }
     }
 }
@@ -350,8 +350,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat3<'a>> for AnchorForma
         AnchorFormat3 {
             x_coordinate: obj.x_coordinate(),
             y_coordinate: obj.y_coordinate(),
-            x_device_offset: obj.x_device().into(),
-            y_device_offset: obj.y_device().into(),
+            x_device_offset: obj.x_device().to_owned_table(),
+            y_device_offset: obj.y_device().to_owned_table(),
         }
     }
 }
@@ -441,7 +441,7 @@ impl FromObjRef<read_fonts::layout::gpos::MarkRecord> for MarkRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkRecord, offset_data: FontData) -> Self {
         MarkRecord {
             mark_class: obj.mark_class(),
-            mark_anchor_offset: obj.mark_anchor(offset_data).into(),
+            mark_anchor_offset: obj.mark_anchor(offset_data).to_owned_table(),
         }
     }
 }
@@ -529,7 +529,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat1<'a>> for SinglePo
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat1<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SinglePosFormat1 {
-            coverage_offset: obj.coverage().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
             value_record: obj.value_record().to_owned_obj(offset_data),
         }
     }
@@ -584,7 +584,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat2<'a>> for SinglePo
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SinglePosFormat2 {
-            coverage_offset: obj.coverage().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
             value_records: obj
                 .value_records()
                 .iter()
@@ -693,8 +693,8 @@ impl Validate for PairPosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat1<'a>> for PairPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat1<'a>, _: FontData) -> Self {
         PairPosFormat1 {
-            coverage_offset: obj.coverage().into(),
-            pair_set_offsets: obj.pair_sets().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            pair_set_offsets: obj.pair_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -845,9 +845,9 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat2<'a>> for PairPosFor
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         PairPosFormat2 {
-            coverage_offset: obj.coverage().into(),
-            class_def1_offset: obj.class_def1().into(),
-            class_def2_offset: obj.class_def2().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            class_def1_offset: obj.class_def1().to_owned_table(),
+            class_def2_offset: obj.class_def2().to_owned_table(),
             class1_records: obj
                 .class1_records()
                 .iter()
@@ -972,7 +972,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::CursivePosFormat1<'a>> for Cursive
     fn from_obj_ref(obj: &read_fonts::layout::gpos::CursivePosFormat1<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         CursivePosFormat1 {
-            coverage_offset: obj.coverage().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
             entry_exit_record: obj.entry_exit_record().to_owned_obj(offset_data),
         }
     }
@@ -1024,8 +1024,8 @@ impl FromObjRef<read_fonts::layout::gpos::EntryExitRecord> for EntryExitRecord {
         offset_data: FontData,
     ) -> Self {
         EntryExitRecord {
-            entry_anchor_offset: obj.entry_anchor(offset_data).into(),
-            exit_anchor_offset: obj.exit_anchor(offset_data).into(),
+            entry_anchor_offset: obj.entry_anchor(offset_data).to_owned_table(),
+            exit_anchor_offset: obj.exit_anchor(offset_data).to_owned_table(),
         }
     }
 }
@@ -1081,10 +1081,10 @@ impl Validate for MarkBasePosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkBasePosFormat1<'a>> for MarkBasePosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkBasePosFormat1<'a>, _: FontData) -> Self {
         MarkBasePosFormat1 {
-            mark_coverage_offset: obj.mark_coverage().into(),
-            base_coverage_offset: obj.base_coverage().into(),
-            mark_array_offset: obj.mark_array().into(),
-            base_array_offset: obj.base_array().into(),
+            mark_coverage_offset: obj.mark_coverage().to_owned_table(),
+            base_coverage_offset: obj.base_coverage().to_owned_table(),
+            mark_array_offset: obj.mark_array().to_owned_table(),
+            base_array_offset: obj.base_array().to_owned_table(),
         }
     }
 }
@@ -1172,7 +1172,10 @@ impl Validate for BaseRecord {
 impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseRecord, offset_data: FontData) -> Self {
         BaseRecord {
-            base_anchor_offsets: obj.base_anchors(offset_data).map(|x| x.into()).collect(),
+            base_anchor_offsets: obj
+                .base_anchors(offset_data)
+                .map(|x| x.to_owned_table())
+                .collect(),
         }
     }
 }
@@ -1228,10 +1231,10 @@ impl Validate for MarkLigPosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkLigPosFormat1<'a>> for MarkLigPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkLigPosFormat1<'a>, _: FontData) -> Self {
         MarkLigPosFormat1 {
-            mark_coverage_offset: obj.mark_coverage().into(),
-            ligature_coverage_offset: obj.ligature_coverage().into(),
-            mark_array_offset: obj.mark_array().into(),
-            ligature_array_offset: obj.ligature_array().into(),
+            mark_coverage_offset: obj.mark_coverage().to_owned_table(),
+            ligature_coverage_offset: obj.ligature_coverage().to_owned_table(),
+            mark_array_offset: obj.mark_array().to_owned_table(),
+            ligature_array_offset: obj.ligature_array().to_owned_table(),
         }
     }
 }
@@ -1278,7 +1281,10 @@ impl Validate for LigatureArray {
 impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureArray<'a>, _: FontData) -> Self {
         LigatureArray {
-            ligature_attach_offsets: obj.ligature_attaches().map(|x| x.into()).collect(),
+            ligature_attach_offsets: obj
+                .ligature_attaches()
+                .map(|x| x.to_owned_table())
+                .collect(),
         }
     }
 }
@@ -1364,7 +1370,7 @@ impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentReco
         ComponentRecord {
             ligature_anchor_offsets: obj
                 .ligature_anchors(offset_data)
-                .map(|x| x.into())
+                .map(|x| x.to_owned_table())
                 .collect(),
         }
     }
@@ -1421,10 +1427,10 @@ impl Validate for MarkMarkPosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkMarkPosFormat1<'a>> for MarkMarkPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkMarkPosFormat1<'a>, _: FontData) -> Self {
         MarkMarkPosFormat1 {
-            mark1_coverage_offset: obj.mark1_coverage().into(),
-            mark2_coverage_offset: obj.mark2_coverage().into(),
-            mark1_array_offset: obj.mark1_array().into(),
-            mark2_array_offset: obj.mark2_array().into(),
+            mark1_coverage_offset: obj.mark1_coverage().to_owned_table(),
+            mark2_coverage_offset: obj.mark2_coverage().to_owned_table(),
+            mark1_array_offset: obj.mark1_array().to_owned_table(),
+            mark2_array_offset: obj.mark2_array().to_owned_table(),
         }
     }
 }
@@ -1512,7 +1518,10 @@ impl Validate for Mark2Record {
 impl FromObjRef<read_fonts::layout::gpos::Mark2Record<'_>> for Mark2Record {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Record, offset_data: FontData) -> Self {
         Mark2Record {
-            mark2_anchor_offsets: obj.mark2_anchors(offset_data).map(|x| x.into()).collect(),
+            mark2_anchor_offsets: obj
+                .mark2_anchors(offset_data)
+                .map(|x| x.to_owned_table())
+                .collect(),
         }
     }
 }
@@ -1551,7 +1560,7 @@ where
     ) -> Self {
         ExtensionPosFormat1 {
             extension_lookup_type: obj.extension_lookup_type(),
-            extension_offset: obj.extension().into(),
+            extension_offset: obj.extension().to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -289,9 +289,10 @@ impl Validate for SingleSubstFormat2 {
 
 impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat2<'a>> for SingleSubstFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat2<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         SingleSubstFormat2 {
             coverage_offset: obj.coverage().into(),
-            substitute_glyph_ids: obj.substitute_glyph_ids().iter().map(|x| x.get()).collect(),
+            substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }
 }
@@ -389,8 +390,9 @@ impl Validate for Sequence {
 
 impl<'a> FromObjRef<read_fonts::layout::gsub::Sequence<'a>> for Sequence {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Sequence<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         Sequence {
-            substitute_glyph_ids: obj.substitute_glyph_ids().iter().map(|x| x.get()).collect(),
+            substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }
 }
@@ -493,8 +495,9 @@ impl Validate for AlternateSet {
 
 impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSet<'a>> for AlternateSet {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::AlternateSet<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         AlternateSet {
-            alternate_glyph_ids: obj.alternate_glyph_ids().iter().map(|x| x.get()).collect(),
+            alternate_glyph_ids: obj.alternate_glyph_ids().to_owned_obj(offset_data),
         }
     }
 }
@@ -632,9 +635,10 @@ impl Validate for Ligature {
 
 impl<'a> FromObjRef<read_fonts::layout::gsub::Ligature<'a>> for Ligature {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Ligature<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         Ligature {
             ligature_glyph: obj.ligature_glyph(),
-            component_glyph_ids: obj.component_glyph_ids().iter().map(|x| x.get()).collect(),
+            component_glyph_ids: obj.component_glyph_ids().to_owned_obj(offset_data),
         }
     }
 }
@@ -837,11 +841,12 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>
         obj: &read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>,
         _: FontData,
     ) -> Self {
+        let offset_data = obj.offset_data();
         ReverseChainSingleSubstFormat1 {
             coverage_offset: obj.coverage().into(),
             backtrack_coverage_offsets: obj.backtrack_coverages().map(|x| x.into()).collect(),
             lookahead_coverage_offsets: obj.lookahead_coverages().map(|x| x.into()).collect(),
-            substitute_glyph_ids: obj.substitute_glyph_ids().iter().map(|x| x.get()).collect(),
+            substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -55,10 +55,10 @@ impl Validate for Gsub {
 impl<'a> FromObjRef<read_fonts::layout::gsub::Gsub<'a>> for Gsub {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Gsub<'a>, _: FontData) -> Self {
         Gsub {
-            script_list_offset: obj.script_list().into(),
-            feature_list_offset: obj.feature_list().into(),
-            lookup_list_offset: obj.lookup_list().into(),
-            feature_variations_offset: obj.feature_variations().into(),
+            script_list_offset: obj.script_list().to_owned_table(),
+            feature_list_offset: obj.feature_list().to_owned_table(),
+            lookup_list_offset: obj.lookup_list().to_owned_table(),
+            feature_variations_offset: obj.feature_variations().to_owned_table(),
         }
     }
 }
@@ -237,7 +237,7 @@ impl Validate for SingleSubstFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat1<'a>> for SingleSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat1<'a>, _: FontData) -> Self {
         SingleSubstFormat1 {
-            coverage_offset: obj.coverage().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
             delta_glyph_id: obj.delta_glyph_id(),
         }
     }
@@ -291,7 +291,7 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat2<'a>> for Single
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SingleSubstFormat2 {
-            coverage_offset: obj.coverage().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
             substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }
@@ -346,8 +346,8 @@ impl Validate for MultipleSubstFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gsub::MultipleSubstFormat1<'a>> for MultipleSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::MultipleSubstFormat1<'a>, _: FontData) -> Self {
         MultipleSubstFormat1 {
-            coverage_offset: obj.coverage().into(),
-            sequence_offsets: obj.sequences().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            sequence_offsets: obj.sequences().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -448,8 +448,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSubstFormat1<'a>> for Alt
         _: FontData,
     ) -> Self {
         AlternateSubstFormat1 {
-            coverage_offset: obj.coverage().into(),
-            alternate_set_offsets: obj.alternate_sets().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            alternate_set_offsets: obj.alternate_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -550,8 +550,8 @@ impl Validate for LigatureSubstFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSubstFormat1<'a>> for LigatureSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSubstFormat1<'a>, _: FontData) -> Self {
         LigatureSubstFormat1 {
-            coverage_offset: obj.coverage().into(),
-            ligature_set_offsets: obj.ligature_sets().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            ligature_set_offsets: obj.ligature_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -597,7 +597,7 @@ impl Validate for LigatureSet {
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSet<'a>> for LigatureSet {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSet<'a>, _: FontData) -> Self {
         LigatureSet {
-            ligature_offsets: obj.ligatures().map(|x| x.into()).collect(),
+            ligature_offsets: obj.ligatures().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -685,7 +685,7 @@ where
     ) -> Self {
         ExtensionSubstFormat1 {
             extension_lookup_type: obj.extension_lookup_type(),
-            extension_offset: obj.extension().into(),
+            extension_offset: obj.extension().to_owned_table(),
         }
     }
 }
@@ -843,9 +843,15 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>
     ) -> Self {
         let offset_data = obj.offset_data();
         ReverseChainSingleSubstFormat1 {
-            coverage_offset: obj.coverage().into(),
-            backtrack_coverage_offsets: obj.backtrack_coverages().map(|x| x.into()).collect(),
-            lookahead_coverage_offsets: obj.lookahead_coverages().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            backtrack_coverage_offsets: obj
+                .backtrack_coverages()
+                .map(|x| x.to_owned_table())
+                .collect(),
+            lookahead_coverage_offsets: obj
+                .lookahead_coverages()
+                .map(|x| x.to_owned_table())
+                .collect(),
             substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -40,12 +40,8 @@ impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
     fn from_obj_ref(obj: &read_fonts::tables::hmtx::Hmtx<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Hmtx {
-            h_metrics: obj
-                .h_metrics()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
-            left_side_bearings: obj.left_side_bearings().iter().map(|x| x.get()).collect(),
+            h_metrics: obj.h_metrics().to_owned_obj(offset_data),
+            left_side_bearings: obj.left_side_bearings().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -82,7 +82,7 @@ impl FromObjRef<read_fonts::layout::ScriptRecord> for ScriptRecord {
     fn from_obj_ref(obj: &read_fonts::layout::ScriptRecord, offset_data: FontData) -> Self {
         ScriptRecord {
             script_tag: obj.script_tag(),
-            script_offset: obj.script(offset_data).into(),
+            script_offset: obj.script(offset_data).to_owned_table(),
         }
     }
 }
@@ -126,7 +126,7 @@ impl<'a> FromObjRef<read_fonts::layout::Script<'a>> for Script {
     fn from_obj_ref(obj: &read_fonts::layout::Script<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Script {
-            default_lang_sys_offset: obj.default_lang_sys().into(),
+            default_lang_sys_offset: obj.default_lang_sys().to_owned_table(),
             lang_sys_records: obj.lang_sys_records().to_owned_obj(offset_data),
         }
     }
@@ -169,7 +169,7 @@ impl FromObjRef<read_fonts::layout::LangSysRecord> for LangSysRecord {
     fn from_obj_ref(obj: &read_fonts::layout::LangSysRecord, offset_data: FontData) -> Self {
         LangSysRecord {
             lang_sys_tag: obj.lang_sys_tag(),
-            lang_sys_offset: obj.lang_sys(offset_data).into(),
+            lang_sys_offset: obj.lang_sys(offset_data).to_owned_table(),
         }
     }
 }
@@ -300,7 +300,7 @@ impl FromObjRef<read_fonts::layout::FeatureRecord> for FeatureRecord {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureRecord, offset_data: FontData) -> Self {
         FeatureRecord {
             feature_tag: obj.feature_tag(),
-            feature_offset: obj.feature(offset_data).into(),
+            feature_offset: obj.feature(offset_data).to_owned_table(),
         }
     }
 }
@@ -343,7 +343,7 @@ impl<'a> FromObjRef<read_fonts::layout::Feature<'a>> for Feature {
     fn from_obj_ref(obj: &read_fonts::layout::Feature<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Feature {
-            feature_params_offset: obj.feature_params().into(),
+            feature_params_offset: obj.feature_params().to_owned_table(),
             lookup_list_indices: obj.lookup_list_indices().to_owned_obj(offset_data),
         }
     }
@@ -387,7 +387,7 @@ where
 {
     fn from_obj_ref(obj: &read_fonts::layout::LookupList<'a, U>, _: FontData) -> Self {
         LookupList {
-            lookup_offsets: obj.lookups().map(|x| x.into()).collect(),
+            lookup_offsets: obj.lookups().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -434,7 +434,7 @@ where
     fn from_obj_ref(obj: &read_fonts::layout::Lookup<'a, U>, _: FontData) -> Self {
         Lookup {
             lookup_flag: obj.lookup_flag(),
-            subtable_offsets: obj.subtables().map(|x| x.into()).collect(),
+            subtable_offsets: obj.subtables().map(|x| x.to_owned_table()).collect(),
             mark_filtering_set: obj.mark_filtering_set(),
         }
     }
@@ -872,8 +872,8 @@ impl Validate for SequenceContextFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat1<'a>> for SequenceContextFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat1<'a>, _: FontData) -> Self {
         SequenceContextFormat1 {
-            coverage_offset: obj.coverage().into(),
-            seq_rule_set_offsets: obj.seq_rule_sets().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            seq_rule_set_offsets: obj.seq_rule_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -919,7 +919,7 @@ impl Validate for SequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::SequenceRuleSet<'a>> for SequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceRuleSet<'a>, _: FontData) -> Self {
         SequenceRuleSet {
-            seq_rule_offsets: obj.seq_rules().map(|x| x.into()).collect(),
+            seq_rule_offsets: obj.seq_rules().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -1029,9 +1029,12 @@ impl Validate for SequenceContextFormat2 {
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat2<'a>> for SequenceContextFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat2<'a>, _: FontData) -> Self {
         SequenceContextFormat2 {
-            coverage_offset: obj.coverage().into(),
-            class_def_offset: obj.class_def().into(),
-            class_seq_rule_set_offsets: obj.class_seq_rule_sets().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            class_def_offset: obj.class_def().to_owned_table(),
+            class_seq_rule_set_offsets: obj
+                .class_seq_rule_sets()
+                .map(|x| x.to_owned_table())
+                .collect(),
         }
     }
 }
@@ -1077,7 +1080,7 @@ impl Validate for ClassSequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRuleSet<'a>> for ClassSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRuleSet<'a>, _: FontData) -> Self {
         ClassSequenceRuleSet {
-            class_seq_rule_offsets: obj.class_seq_rules().map(|x| x.into()).collect(),
+            class_seq_rule_offsets: obj.class_seq_rules().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -1186,7 +1189,7 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat3<'a>> for Sequence
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat3<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SequenceContextFormat3 {
-            coverage_offsets: obj.coverages().map(|x| x.into()).collect(),
+            coverage_offsets: obj.coverages().map(|x| x.to_owned_table()).collect(),
             seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
@@ -1298,8 +1301,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat1<'a>>
         _: FontData,
     ) -> Self {
         ChainedSequenceContextFormat1 {
-            coverage_offset: obj.coverage().into(),
-            chained_seq_rule_set_offsets: obj.chained_seq_rule_sets().map(|x| x.into()).collect(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            chained_seq_rule_set_offsets: obj
+                .chained_seq_rule_sets()
+                .map(|x| x.to_owned_table())
+                .collect(),
         }
     }
 }
@@ -1348,7 +1354,10 @@ impl Validate for ChainedSequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRuleSet<'a>> for ChainedSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRuleSet<'a>, _: FontData) -> Self {
         ChainedSequenceRuleSet {
-            chained_seq_rule_offsets: obj.chained_seq_rules().map(|x| x.into()).collect(),
+            chained_seq_rule_offsets: obj
+                .chained_seq_rules()
+                .map(|x| x.to_owned_table())
+                .collect(),
         }
     }
 }
@@ -1499,13 +1508,13 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat2<'a>>
         _: FontData,
     ) -> Self {
         ChainedSequenceContextFormat2 {
-            coverage_offset: obj.coverage().into(),
-            backtrack_class_def_offset: obj.backtrack_class_def().into(),
-            input_class_def_offset: obj.input_class_def().into(),
-            lookahead_class_def_offset: obj.lookahead_class_def().into(),
+            coverage_offset: obj.coverage().to_owned_table(),
+            backtrack_class_def_offset: obj.backtrack_class_def().to_owned_table(),
+            input_class_def_offset: obj.input_class_def().to_owned_table(),
+            lookahead_class_def_offset: obj.lookahead_class_def().to_owned_table(),
             chained_class_seq_rule_set_offsets: obj
                 .chained_class_seq_rule_sets()
-                .map(|x| x.into())
+                .map(|x| x.to_owned_table())
                 .collect(),
         }
     }
@@ -1562,7 +1571,7 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRuleSet<'a>>
         ChainedClassSequenceRuleSet {
             chained_class_seq_rule_offsets: obj
                 .chained_class_seq_rules()
-                .map(|x| x.into())
+                .map(|x| x.to_owned_table())
                 .collect(),
         }
     }
@@ -1723,9 +1732,15 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
     ) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceContextFormat3 {
-            backtrack_coverage_offsets: obj.backtrack_coverages().map(|x| x.into()).collect(),
-            input_coverage_offsets: obj.input_coverages().map(|x| x.into()).collect(),
-            lookahead_coverage_offsets: obj.lookahead_coverages().map(|x| x.into()).collect(),
+            backtrack_coverage_offsets: obj
+                .backtrack_coverages()
+                .map(|x| x.to_owned_table())
+                .collect(),
+            input_coverage_offsets: obj.input_coverages().map(|x| x.to_owned_table()).collect(),
+            lookahead_coverage_offsets: obj
+                .lookahead_coverages()
+                .map(|x| x.to_owned_table())
+                .collect(),
             seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
@@ -1975,8 +1990,10 @@ impl FromObjRef<read_fonts::layout::FeatureVariationRecord> for FeatureVariation
         offset_data: FontData,
     ) -> Self {
         FeatureVariationRecord {
-            condition_set_offset: obj.condition_set(offset_data).into(),
-            feature_table_substitution_offset: obj.feature_table_substitution(offset_data).into(),
+            condition_set_offset: obj.condition_set(offset_data).to_owned_table(),
+            feature_table_substitution_offset: obj
+                .feature_table_substitution(offset_data)
+                .to_owned_table(),
         }
     }
 }
@@ -2013,7 +2030,7 @@ impl Validate for ConditionSet {
 impl<'a> FromObjRef<read_fonts::layout::ConditionSet<'a>> for ConditionSet {
     fn from_obj_ref(obj: &read_fonts::layout::ConditionSet<'a>, _: FontData) -> Self {
         ConditionSet {
-            condition_offsets: obj.conditions().map(|x| x.into()).collect(),
+            condition_offsets: obj.conditions().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -2158,7 +2175,7 @@ impl FromObjRef<read_fonts::layout::FeatureTableSubstitutionRecord>
     ) -> Self {
         FeatureTableSubstitutionRecord {
             feature_index: obj.feature_index(),
-            alternate_feature_offset: obj.alternate_feature(offset_data).into(),
+            alternate_feature_offset: obj.alternate_feature(offset_data).to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -39,11 +39,7 @@ impl<'a> FromObjRef<read_fonts::layout::ScriptList<'a>> for ScriptList {
     fn from_obj_ref(obj: &read_fonts::layout::ScriptList<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ScriptList {
-            script_records: obj
-                .script_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            script_records: obj.script_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -131,11 +127,7 @@ impl<'a> FromObjRef<read_fonts::layout::Script<'a>> for Script {
         let offset_data = obj.offset_data();
         Script {
             default_lang_sys_offset: obj.default_lang_sys().into(),
-            lang_sys_records: obj
-                .lang_sys_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            lang_sys_records: obj.lang_sys_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -216,9 +208,10 @@ impl Validate for LangSys {
 
 impl<'a> FromObjRef<read_fonts::layout::LangSys<'a>> for LangSys {
     fn from_obj_ref(obj: &read_fonts::layout::LangSys<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         LangSys {
             required_feature_index: obj.required_feature_index(),
-            feature_indices: obj.feature_indices().iter().map(|x| x.get()).collect(),
+            feature_indices: obj.feature_indices().to_owned_obj(offset_data),
         }
     }
 }
@@ -264,11 +257,7 @@ impl<'a> FromObjRef<read_fonts::layout::FeatureList<'a>> for FeatureList {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureList<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         FeatureList {
-            feature_records: obj
-                .feature_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            feature_records: obj.feature_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -352,9 +341,10 @@ impl Validate for Feature {
 
 impl<'a> FromObjRef<read_fonts::layout::Feature<'a>> for Feature {
     fn from_obj_ref(obj: &read_fonts::layout::Feature<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         Feature {
             feature_params_offset: obj.feature_params().into(),
-            lookup_list_indices: obj.lookup_list_indices().iter().map(|x| x.get()).collect(),
+            lookup_list_indices: obj.lookup_list_indices().to_owned_obj(offset_data),
         }
     }
 }
@@ -487,8 +477,9 @@ impl Validate for CoverageFormat1 {
 
 impl<'a> FromObjRef<read_fonts::layout::CoverageFormat1<'a>> for CoverageFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat1<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         CoverageFormat1 {
-            glyph_array: obj.glyph_array().iter().map(|x| x.get()).collect(),
+            glyph_array: obj.glyph_array().to_owned_obj(offset_data),
         }
     }
 }
@@ -534,11 +525,7 @@ impl<'a> FromObjRef<read_fonts::layout::CoverageFormat2<'a>> for CoverageFormat2
     fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         CoverageFormat2 {
-            range_records: obj
-                .range_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            range_records: obj.range_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -666,9 +653,10 @@ impl Validate for ClassDefFormat1 {
 
 impl<'a> FromObjRef<read_fonts::layout::ClassDefFormat1<'a>> for ClassDefFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat1<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         ClassDefFormat1 {
             start_glyph_id: obj.start_glyph_id(),
-            class_value_array: obj.class_value_array().iter().map(|x| x.get()).collect(),
+            class_value_array: obj.class_value_array().to_owned_obj(offset_data),
         }
     }
 }
@@ -714,11 +702,7 @@ impl<'a> FromObjRef<read_fonts::layout::ClassDefFormat2<'a>> for ClassDefFormat2
     fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ClassDefFormat2 {
-            class_range_records: obj
-                .class_range_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            class_range_records: obj.class_range_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -984,12 +968,8 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceRule<'a>> for SequenceRule {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SequenceRule {
-            input_sequence: obj.input_sequence().iter().map(|x| x.get()).collect(),
-            seq_lookup_records: obj
-                .seq_lookup_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            input_sequence: obj.input_sequence().to_owned_obj(offset_data),
+            seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -1148,12 +1128,8 @@ impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRule<'a>> for ClassSequence
     fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ClassSequenceRule {
-            input_sequence: obj.input_sequence().iter().map(|x| x.get()).collect(),
-            seq_lookup_records: obj
-                .seq_lookup_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            input_sequence: obj.input_sequence().to_owned_obj(offset_data),
+            seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -1211,11 +1187,7 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat3<'a>> for Sequence
         let offset_data = obj.offset_data();
         SequenceContextFormat3 {
             coverage_offsets: obj.coverages().map(|x| x.into()).collect(),
-            seq_lookup_records: obj
-                .seq_lookup_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -1444,14 +1416,10 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRule<'a>> for ChainedSequ
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceRule {
-            backtrack_sequence: obj.backtrack_sequence().iter().map(|x| x.get()).collect(),
-            input_sequence: obj.input_sequence().iter().map(|x| x.get()).collect(),
-            lookahead_sequence: obj.lookahead_sequence().iter().map(|x| x.get()).collect(),
-            seq_lookup_records: obj
-                .seq_lookup_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            backtrack_sequence: obj.backtrack_sequence().to_owned_obj(offset_data),
+            input_sequence: obj.input_sequence().to_owned_obj(offset_data),
+            lookahead_sequence: obj.lookahead_sequence().to_owned_obj(offset_data),
+            seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -1667,14 +1635,10 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRule<'a>> for Chaine
     fn from_obj_ref(obj: &read_fonts::layout::ChainedClassSequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         ChainedClassSequenceRule {
-            backtrack_sequence: obj.backtrack_sequence().iter().map(|x| x.get()).collect(),
-            input_sequence: obj.input_sequence().iter().map(|x| x.get()).collect(),
-            lookahead_sequence: obj.lookahead_sequence().iter().map(|x| x.get()).collect(),
-            seq_lookup_records: obj
-                .seq_lookup_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            backtrack_sequence: obj.backtrack_sequence().to_owned_obj(offset_data),
+            input_sequence: obj.input_sequence().to_owned_obj(offset_data),
+            lookahead_sequence: obj.lookahead_sequence().to_owned_obj(offset_data),
+            seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -1762,11 +1726,7 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
             backtrack_coverage_offsets: obj.backtrack_coverages().map(|x| x.into()).collect(),
             input_coverage_offsets: obj.input_coverages().map(|x| x.into()).collect(),
             lookahead_coverage_offsets: obj.lookahead_coverages().map(|x| x.into()).collect(),
-            seq_lookup_records: obj
-                .seq_lookup_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -1871,11 +1831,12 @@ impl Validate for Device {
 
 impl<'a> FromObjRef<read_fonts::layout::Device<'a>> for Device {
     fn from_obj_ref(obj: &read_fonts::layout::Device<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         Device {
             start_size: obj.start_size(),
             end_size: obj.end_size(),
             delta_format: obj.delta_format(),
-            delta_value: obj.delta_value().iter().map(|x| x.get()).collect(),
+            delta_value: obj.delta_value().to_owned_obj(offset_data),
         }
     }
 }
@@ -1964,11 +1925,7 @@ impl<'a> FromObjRef<read_fonts::layout::FeatureVariations<'a>> for FeatureVariat
     fn from_obj_ref(obj: &read_fonts::layout::FeatureVariations<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         FeatureVariations {
-            feature_variation_records: obj
-                .feature_variation_records()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            feature_variation_records: obj.feature_variation_records().to_owned_obj(offset_data),
         }
     }
 }
@@ -2148,11 +2105,7 @@ impl<'a> FromObjRef<read_fonts::layout::FeatureTableSubstitution<'a>> for Featur
     fn from_obj_ref(obj: &read_fonts::layout::FeatureTableSubstitution<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         FeatureTableSubstitution {
-            substitutions: obj
-                .substitutions()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
+            substitutions: obj.substitutions().to_owned_obj(offset_data),
         }
     }
 }
@@ -2373,13 +2326,14 @@ impl Validate for CharacterVariantParams {
 
 impl<'a> FromObjRef<read_fonts::layout::CharacterVariantParams<'a>> for CharacterVariantParams {
     fn from_obj_ref(obj: &read_fonts::layout::CharacterVariantParams<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
         CharacterVariantParams {
             feat_ui_label_name_id: obj.feat_ui_label_name_id(),
             feat_ui_tooltip_text_name_id: obj.feat_ui_tooltip_text_name_id(),
             sample_text_name_id: obj.sample_text_name_id(),
             num_named_parameters: obj.num_named_parameters(),
             first_param_ui_label_name_id: obj.first_param_ui_label_name_id(),
-            character: obj.character().iter().map(|x| x.get()).collect(),
+            character: obj.character().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -96,7 +96,7 @@ impl Validate for LangTagRecord {
 impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
     fn from_obj_ref(obj: &read_fonts::tables::name::LangTagRecord, offset_data: FontData) -> Self {
         LangTagRecord {
-            lang_tag_offset: obj.lang_tag(offset_data).into(),
+            lang_tag_offset: obj.lang_tag(offset_data).to_owned_table(),
         }
     }
 }
@@ -133,7 +133,7 @@ impl FromObjRef<read_fonts::tables::name::NameRecord> for NameRecord {
             encoding_id: obj.encoding_id(),
             language_id: obj.language_id(),
             name_id: obj.name_id(),
-            string_offset: obj.string(offset_data).into(),
+            string_offset: obj.string(offset_data).to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -67,16 +67,8 @@ impl<'a> FromObjRef<read_fonts::tables::name::Name<'a>> for Name {
     fn from_obj_ref(obj: &read_fonts::tables::name::Name<'a>, _: FontData) -> Self {
         let offset_data = obj.string_data();
         Name {
-            name_record: obj
-                .name_record()
-                .iter()
-                .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                .collect(),
-            lang_tag_record: obj.lang_tag_record().map(|obj| {
-                obj.iter()
-                    .map(|x| FromObjRef::from_obj_ref(x, offset_data))
-                    .collect()
-            }),
+            name_record: obj.name_record().to_owned_obj(offset_data),
+            lang_tag_record: obj.lang_tag_record().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -142,9 +142,7 @@ impl<'a> FromObjRef<read_fonts::tables::post::Post<'a>> for Post {
             min_mem_type1: obj.min_mem_type1(),
             max_mem_type1: obj.max_mem_type1(),
             num_glyphs: obj.num_glyphs(),
-            glyph_name_index: obj
-                .glyph_name_index()
-                .map(|obj| obj.iter().map(|x| x.get()).collect()),
+            glyph_name_index: obj.glyph_name_index().to_owned_obj(offset_data),
             string_data: obj.string_data().map(|obj| {
                 obj.iter()
                     .filter_map(|x| x.map(|x| FromObjRef::from_obj_ref(&x, offset_data)).ok())

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -1,9 +1,5 @@
 //! compile-time representations of offsets
 
-use crate::from_obj::FromTableRef;
-use font_types::{BigEndian, Scalar};
-use read_fonts::ReadError;
-
 use super::write::{FontWrite, TableWriter};
 
 /// The width in bytes of an Offset16
@@ -146,57 +142,6 @@ impl<T, const N: usize> Default for NullableOffsetMarker<T, N> {
         Self { obj: None }
     }
 }
-
-impl<const N: usize, T, U> From<Result<U, ReadError>> for OffsetMarker<T, N>
-where
-    T: FromTableRef<U>,
-{
-    fn from(from: Result<U, ReadError>) -> Self {
-        OffsetMarker::new_maybe_null(from.ok().map(|x| T::from_table_ref(&x)))
-    }
-}
-
-impl<const N: usize, T, U> From<Option<Result<U, ReadError>>> for NullableOffsetMarker<T, N>
-where
-    T: FromTableRef<U>,
-{
-    fn from(from: Option<Result<U, ReadError>>) -> Self {
-        NullableOffsetMarker::new(
-            from.transpose()
-                .ok()
-                .flatten()
-                .map(|x| T::from_table_ref(&x)),
-        )
-    }
-}
-
-impl<'a, const N: usize, T: Scalar> From<Result<&'a [BigEndian<T>], ReadError>>
-    for OffsetMarker<Vec<T>, N>
-where
-    BigEndian<T>: Copy,
-{
-    fn from(from: Result<&'a [BigEndian<T>], ReadError>) -> Self {
-        // convert slice to vec, converting to native types:
-        let as_vec = from.map(|slice| slice.iter().copied().map(BigEndian::get).collect());
-        OffsetMarker::new_maybe_null(as_vec.ok())
-    }
-}
-
-impl<'a, const N: usize, T: Scalar> From<Option<Result<&'a [BigEndian<T>], ReadError>>>
-    for NullableOffsetMarker<Vec<T>, N>
-where
-    BigEndian<T>: Copy,
-{
-    fn from(from: Option<Result<&'a [BigEndian<T>], read_fonts::ReadError>>) -> Self {
-        NullableOffsetMarker::new(
-            from.transpose()
-                .ok()
-                .flatten()
-                .map(|vec| vec.iter().map(|x| x.get()).collect()),
-        )
-    }
-}
-
 // In case I still want to use these?
 
 //impl<T: std::fmt::Debug, const N: usize> std::fmt::Debug for OffsetMarker<T, N> {


### PR DESCRIPTION
This cleans up our code for converting the parse types to the compile types.

Previously we were writing a lot of different bespoke impls for these conversions, using a variety of different patterns; this patch replaces a lot of those custom implementations with recursive calls to the `FromObjRef`/`FromTableRef` methods.

This simplifies our codegen code somewhat, but the main advantage is that it is more sustainable as we add new types; one particular wart of the previous implementation was that relied on a blanket impl of `From` to convert offset types, and this was going to break once we had offsets to arrays of records and not just offsets to arrays of scalars, which I ran into in STAT.

The one place where we still need bespoke impls is in handling arrays of offsets; this is because the getters for these types currently return an iterator, but there is no way to write a blanket impl that refers to the iterator's `Item` type, since it is an associated type and not a generic parameter. 

I have an idea for how we could replace the iterator business, which would look something like,

```rust
pub trait ArrayOfOffsets<'a, T> {
    fn len(&self) -> usize;
    fn get(&self, index: usize) -> Result<T, ReadError>;
    fn iter(&self) -> impl Iterator<Item=Result<T, ReadError>>;
}

impl MyTable<'a> {
    fn some_array_of_offsets(&self) -> impl ArrayOfOffsets<'a, OffsetTarget<'a>> { .. }
}
```

but the problem here is the `iter` method, which has a method with a generic param, which means we can't use it with impl Trait until we get GATs? I think? In any case, this is an improvement for now, and unblocks STAT.

edit: and we're getting GATS on November 3rd, so this API change should be possible then.