### PR TITLE
Add blanket From<T> and From<Option<T>> for offset markers

### DIFF
--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -142,6 +142,25 @@ impl<T, const N: usize> Default for NullableOffsetMarker<T, N> {
         Self { obj: None }
     }
 }
+
+impl<T, const N: usize> From<T> for OffsetMarker<T, N> {
+    fn from(src: T) -> Self {
+        OffsetMarker::new(src)
+    }
+}
+
+impl<T, const N: usize> From<T> for NullableOffsetMarker<T, N> {
+    fn from(src: T) -> Self {
+        NullableOffsetMarker::new(Some(src))
+    }
+}
+
+impl<T, const N: usize> From<Option<T>> for NullableOffsetMarker<T, N> {
+    fn from(src: Option<T>) -> Self {
+        NullableOffsetMarker::new(src)
+    }
+}
+
 // In case I still want to use these?
 
 //impl<T: std::fmt::Debug, const N: usize> std::fmt::Debug for OffsetMarker<T, N> {


### PR DESCRIPTION
(based off of #96)

This seems generally useful, and is now possible since we've gotten rid of all the other weird From impls in #96