### PR TITLE
Tweak signature of NullableOffsetMarker::new

### DIFF
--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -110,8 +110,15 @@ impl<const N: usize, T> NullableOffsetMarker<T, N> {
 }
 
 impl<const N: usize, T> NullableOffsetMarker<T, N> {
-    pub fn new(obj: Option<T>) -> Self {
+    /// Create a new offset marker.
+    pub fn new(obj: impl Into<Option<T>>) -> Self {
+        let obj = obj.into();
         NullableOffsetMarker { obj }
+    }
+
+    /// Create a new null offset marker.
+    pub fn null() -> Self {
+        NullableOffsetMarker { obj: None }
     }
 }
 


### PR DESCRIPTION
Longer term I don't expect this to be called directly very often, but if it is this signature is a bit nicer, since you don't need to explicity specify Some(_) during normal use.

This also adds NullableOffsetMarker::null as a convenience method. Does this mean we can make new() just take T? Maybe? But I think allowing None in new makes some sense, since this would now be very annoying to construct in the not-unreasonable case that you have an Option<T> in your compiler and you want to convert it to a NullableOffsetMarker<T>.

In any case I expect that once we land #97, the most common way to make an offset marker will just be via From/Into, and this will be moot.