### PR TITLE
Impl PartialEq<u16> for GlyphId

### DIFF
--- a/font-types/src/glyph_id.rs
+++ b/font-types/src/glyph_id.rs
@@ -32,4 +32,10 @@ impl std::fmt::Display for GlyphId {
     }
 }
 
+impl PartialEq<u16> for GlyphId {
+    fn eq(&self, other: &u16) -> bool {
+        self.0 == *other
+    }
+}
+
 crate::newtype_scalar!(GlyphId, [u8; 2]);


### PR DESCRIPTION
This makes life a bit easier, especially during testing.

We may also want to consider supporting addition of GlyphId and u16? this is something we end up wanting to do reasonably often in places like cmap, and it seems *unlikely* to be a source of bugs.