### PR TITLE
Make `read-fonts` a hard dep of `write-fonts`

### DIFF
--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -50,31 +50,10 @@ pub(crate) fn generate_flags(raw: &BitFlags) -> proc_macro2::TokenStream {
 }
 
 pub(crate) fn generate_flags_compile(raw: &BitFlags) -> TokenStream {
-    //NOTE: we can reuse the declarations of these from parsing, but you need
-    //to import them manually; we only implement the traits.
+    // we reuse the type from the read-fonts crate, and so only implement our trait.
 
     let name = &raw.name;
-    let docs = &raw.docs;
-    let typ = &raw.typ;
-    let variants = raw.variants.iter().map(|variant| {
-        let name = &variant.name;
-        let value = &variant.value;
-        let docs = &variant.docs;
-        quote! {
-            #( #docs )*
-            const #name = #value;
-        }
-    });
-
     quote! {
-        bitflags::bitflags! {
-            #( #docs )*
-            pub struct #name: #typ {
-                #( #variants )*
-            }
-        }
-
-
         impl FontWrite for #name {
             fn write_into(&self, writer: &mut TableWriter) {
                 writer.write_slice(&self.bits().to_be_bytes())

--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -87,6 +87,7 @@ pub(crate) fn generate_raw_enum(raw: &RawEnum) -> TokenStream {
         #[repr(#typ)]
         pub enum #name {
             #( #variants )*
+            #[doc(hidden)]
             Unknown,
         }
 
@@ -125,41 +126,15 @@ pub(crate) fn generate_raw_enum(raw: &RawEnum) -> TokenStream {
 }
 
 pub(crate) fn generate_raw_enum_compile(raw: &RawEnum) -> TokenStream {
-    //NOTE: we can reuse the declarations of these from parsing, but you need
-    //to import them manually; we only implement the traits.
+    //NOTE: we reuse the decls of these from read-fonts, and only implement the traits.
 
     let name = &raw.name;
-    let docs = &raw.docs;
     let typ = &raw.typ;
-    let variants = raw.variants.iter().map(|variant| {
-        let name = &variant.name;
-        let value = &variant.value;
-        let docs = &variant.docs;
-        quote! {
-            #( #docs )*
-            #name = #value,
-        }
-    });
-
-    let match_arms = raw.variants.iter().map(|variant| {
-        let name = &variant.name;
-        let value = &variant.value;
-        quote!( Self::#name => #value, )
-    });
 
     quote! {
-        #( #docs )*
-        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-        #[repr(#typ)]
-        pub enum #name {
-            #( #variants )*
-        }
-
         impl FontWrite for #name {
             fn write_into(&self, writer: &mut TableWriter) {
-                let val: #typ = match self {
-                    #( #match_arms )*
-                };
+                let val = *self as #typ;
                 writer.write_slice(&val.to_be_bytes())
             }
         }

--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -121,6 +121,7 @@ pub(crate) fn generate_compile_module(
 
     let import_from_parse_mod = items.items.iter().filter_map(|item| match item {
         Item::Flags(item) => Some(&item.name),
+        Item::RawEnum(item) => Some(&item.name),
         _ => None,
     });
     let parse_mod_path = &items.parse_module_path;

--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -119,9 +119,16 @@ pub(crate) fn generate_compile_module(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    let import_from_parse_mod = items.items.iter().filter_map(|item| match item {
+        Item::Flags(item) => Some(&item.name),
+        _ => None,
+    });
+    let parse_mod_path = &items.parse_module_path;
+
     Ok(quote! {
         #[allow(unused_imports)]
         use crate::codegen_prelude::*;
+        pub use #parse_mod_path::{ #( #import_from_parse_mod, )* };
 
         #( #code )*
     })

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -234,7 +234,6 @@ fn generate_from_obj_impl(item: &Record, parse_module: &syn::Path) -> syn::Resul
     };
 
     Ok(quote! {
-        #[cfg(feature = "parsing")]
         impl FromObjRef<#parse_module:: #name #lifetime> for #name {
             fn from_obj_ref(obj: &#parse_module:: #name, #offset_data_ident: FontData) -> Self {
                 #name {

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -302,7 +302,6 @@ fn generate_to_owned_impl(item: &Table, parse_module: &syn::Path) -> syn::Result
     let impl_font_read = item.attrs.read_args.is_none() && item.attrs.generic_offset.is_none();
     let maybe_font_read = impl_font_read.then(|| {
         quote! {
-            #[cfg(feature = "parsing")]
             impl<'a> FontRead<'a> for #name {
                 fn read(data: FontData<'a>) -> Result<Self, ReadError> {
                     <#parse_module :: #name as FontRead>::read(data)
@@ -325,7 +324,6 @@ fn generate_to_owned_impl(item: &Table, parse_module: &syn::Path) -> syn::Result
     });
 
     Ok(quote! {
-        #[cfg(feature = "parsing")]
         impl<'a, #( #impl_generics, )* > FromObjRef<#parse_module :: #name<'a, #parse_generic>> for #name<#comp_generic> #where_clause {
             fn from_obj_ref(obj: &#parse_module :: #name<'a, #parse_generic>, _: FontData) -> Self {
                 #maybe_bind_offset_data
@@ -335,7 +333,6 @@ fn generate_to_owned_impl(item: &Table, parse_module: &syn::Path) -> syn::Result
             }
         }
 
-        #[cfg(feature = "parsing")]
         impl<'a, #(#impl_generics2,)* > FromTableRef<#parse_module :: #name<'a, #parse_generic >> for #name<#comp_generic> #where_clause {}
 
         #maybe_font_read
@@ -391,7 +388,6 @@ pub(crate) fn generate_group_compile(
             }
         }
 
-        #[cfg(feature = "parsing")]
         impl FromObjRef< #from_type :: <'_>> for #name {
             fn from_obj_ref(from: & #from_type :: <'_>, data: FontData) -> Self {
                 match from {
@@ -400,7 +396,6 @@ pub(crate) fn generate_group_compile(
             }
         }
 
-        #[cfg(feature = "parsing")]
         impl FromTableRef< #from_type <'_>> for #name {}
     })
 }
@@ -473,7 +468,6 @@ fn generate_format_from_obj(
     });
 
     Ok(quote! {
-        #[cfg(feature = "parsing")]
         impl FromObjRef<#parse_module:: #name<'_>> for #name {
             fn from_obj_ref(obj: &#parse_module:: #name, _: FontData) -> Self {
                 use #parse_module::#name as ObjRefType;
@@ -483,10 +477,8 @@ fn generate_format_from_obj(
             }
         }
 
-        #[cfg(feature = "parsing")]
         impl FromTableRef<#parse_module::#name<'_>> for #name {}
 
-        #[cfg(feature = "parsing")]
         impl<'a> FontRead<'a> for #name {
             fn read(data: FontData<'a>) -> Result<Self, ReadError> {
                 <#parse_module :: #name as FontRead>::read(data)

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -161,6 +161,7 @@ pub enum PlatformId {
     ISO = 2,
     Windows = 3,
     Custom = 4,
+    #[doc(hidden)]
     Unknown,
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -1364,6 +1364,7 @@ pub enum Extend {
     Pad = 0,
     Repeat = 1,
     Reflect = 2,
+    #[doc(hidden)]
     Unknown,
 }
 
@@ -5459,6 +5460,7 @@ pub enum CompositeMode {
     HslSaturation = 25,
     HslColor = 26,
     HslLuminosity = 27,
+    #[doc(hidden)]
     Unknown,
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -224,6 +224,7 @@ pub enum GlyphClassDef {
     Ligature = 2,
     Mark = 3,
     Component = 4,
+    #[doc(hidden)]
     Unknown,
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -3510,6 +3510,7 @@ pub enum DeltaFormat {
     Local8BitDeltas = 0x0003,
     /// VariationIndex table, contains a delta-set index pair.
     VariationIndex = 0x8000,
+    #[doc(hidden)]
     Unknown,
 }
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -526,7 +526,6 @@ table Device {
     /// Largest size to correct, in ppem
     end_size: u16,
     /// Format of deltaValue array data: 0x0001, 0x0002, or 0x0003
-    #[to_owned(convert_delta_format(obj.delta_format()))]
     delta_format: DeltaFormat,
     /// Array of compressed data
     #[count(delta_value_count($start_size, $end_size, $delta_format))]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -9,12 +9,10 @@ readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 
 [features]
-parsing = ["read-fonts"]
-default = ["parsing"]
 
 [dependencies]
 font-types = { version = "0.0.2", path = "../font-types" }
-read-fonts = { version = "0.0.2", path = "../read-fonts", optional = true }
+read-fonts = { version = "0.0.2", path = "../read-fonts" }
 bitflags = "1.3"
 
 [dev-dependencies]

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -84,7 +84,6 @@ impl Validate for Cpal {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
     fn from_obj_ref(obj: &read_fonts::tables::cpal::Cpal<'a>, _: FontData) -> Self {
         Cpal {
@@ -101,10 +100,8 @@ impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Cpal {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::cpal::Cpal as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -137,7 +134,6 @@ impl Validate for ColorRecord {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::tables::cpal::ColorRecord> for ColorRecord {
     fn from_obj_ref(obj: &read_fonts::tables::cpal::ColorRecord, _: FontData) -> Self {
         ColorRecord {

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -143,7 +143,6 @@ impl Validate for TTCHeader {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::TTCHeader<'a>> for TTCHeader {
     fn from_obj_ref(obj: &read_fonts::TTCHeader<'a>, _: FontData) -> Self {
         TTCHeader {
@@ -162,10 +161,8 @@ impl<'a> FromObjRef<read_fonts::TTCHeader<'a>> for TTCHeader {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::TTCHeader<'a>> for TTCHeader {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for TTCHeader {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::TTCHeader as FontRead>::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -71,7 +71,6 @@ impl Validate for Gdef {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::Gdef<'a>> for Gdef {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::Gdef<'a>, _: FontData) -> Self {
         Gdef {
@@ -85,10 +84,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::Gdef<'a>> for Gdef {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::Gdef<'a>> for Gdef {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Gdef {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::Gdef as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -152,7 +149,6 @@ impl Validate for AttachList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::AttachList<'a>> for AttachList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachList<'a>, _: FontData) -> Self {
         AttachList {
@@ -162,10 +158,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::AttachList<'a>> for AttachList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::AttachList<'a>> for AttachList {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AttachList {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::AttachList as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -199,7 +193,6 @@ impl Validate for AttachPoint {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::AttachPoint<'a>> for AttachPoint {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachPoint<'a>, _: FontData) -> Self {
         AttachPoint {
@@ -208,10 +201,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::AttachPoint<'a>> for AttachPoint {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::AttachPoint<'a>> for AttachPoint {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AttachPoint {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::AttachPoint as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -253,7 +244,6 @@ impl Validate for LigCaretList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigCaretList<'a>> for LigCaretList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigCaretList<'a>, _: FontData) -> Self {
         LigCaretList {
@@ -263,10 +253,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::LigCaretList<'a>> for LigCaretList
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::LigCaretList<'a>> for LigCaretList {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for LigCaretList {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::LigCaretList as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -302,7 +290,6 @@ impl Validate for LigGlyph {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigGlyph<'a>> for LigGlyph {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigGlyph<'a>, _: FontData) -> Self {
         LigGlyph {
@@ -311,10 +298,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::LigGlyph<'a>> for LigGlyph {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::LigGlyph<'a>> for LigGlyph {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for LigGlyph {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::LigGlyph as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -349,7 +334,6 @@ impl Validate for CaretValue {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gdef::CaretValue<'_>> for CaretValue {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValue, _: FontData) -> Self {
         use read_fonts::layout::gdef::CaretValue as ObjRefType;
@@ -361,10 +345,8 @@ impl FromObjRef<read_fonts::layout::gdef::CaretValue<'_>> for CaretValue {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gdef::CaretValue<'_>> for CaretValue {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CaretValue {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::CaretValue as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -390,7 +372,6 @@ impl Validate for CaretValueFormat1 {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat1<'a>> for CaretValueFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat1<'a>, _: FontData) -> Self {
         CaretValueFormat1 {
@@ -399,10 +380,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat1<'a>> for CaretVa
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::CaretValueFormat1<'a>> for CaretValueFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CaretValueFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::CaretValueFormat1 as FontRead>::read(data)
@@ -429,7 +408,6 @@ impl Validate for CaretValueFormat2 {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat2<'a>> for CaretValueFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat2<'a>, _: FontData) -> Self {
         CaretValueFormat2 {
@@ -438,10 +416,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat2<'a>> for CaretVa
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::CaretValueFormat2<'a>> for CaretValueFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CaretValueFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::CaretValueFormat2 as FontRead>::read(data)
@@ -479,7 +455,6 @@ impl Validate for CaretValueFormat3 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat3<'a>> for CaretValueFormat3 {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat3<'a>, _: FontData) -> Self {
         CaretValueFormat3 {
@@ -489,10 +464,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat3<'a>> for CaretVa
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::CaretValueFormat3<'a>> for CaretValueFormat3 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CaretValueFormat3 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::CaretValueFormat3 as FontRead>::read(data)
@@ -530,7 +503,6 @@ impl Validate for MarkGlyphSets {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gdef::MarkGlyphSets<'a>> for MarkGlyphSets {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::MarkGlyphSets<'a>, _: FontData) -> Self {
         MarkGlyphSets {
@@ -539,10 +511,8 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::MarkGlyphSets<'a>> for MarkGlyphSe
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gdef::MarkGlyphSets<'a>> for MarkGlyphSets {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for MarkGlyphSets {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gdef::MarkGlyphSets as FontRead>::read(data)

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -5,6 +5,8 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+pub use read_fonts::layout::gdef::GlyphClassDef;
+
 /// [GDEF](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#gdef-header) 1.0
 #[derive(Clone, Debug)]
 pub struct Gdef {
@@ -92,24 +94,9 @@ impl<'a> FontRead<'a> for Gdef {
     }
 }
 
-/// Used in the [Glyph Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table)
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u16)]
-pub enum GlyphClassDef {
-    Base = 1,
-    Ligature = 2,
-    Mark = 3,
-    Component = 4,
-}
-
 impl FontWrite for GlyphClassDef {
     fn write_into(&self, writer: &mut TableWriter) {
-        let val: u16 = match self {
-            Self::Base => 1,
-            Self::Ligature => 2,
-            Self::Mark => 3,
-            Self::Component => 4,
-        };
+        let val = *self as u16;
         writer.write_slice(&val.to_be_bytes())
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -51,7 +51,6 @@ impl Validate for Gpos {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::Gpos<'a>> for Gpos {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Gpos<'a>, _: FontData) -> Self {
         Gpos {
@@ -63,10 +62,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::Gpos<'a>> for Gpos {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::Gpos<'a>> for Gpos {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Gpos {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::Gpos as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -119,7 +116,6 @@ impl Validate for PositionLookup {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLookup {
     fn from_obj_ref(from: &read_fonts::layout::gpos::PositionLookup<'_>, data: FontData) -> Self {
         match from {
@@ -154,7 +150,6 @@ impl FromObjRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLookup
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLookup {}
 bitflags::bitflags! { # [doc = " See [ValueRecord]"] pub struct ValueFormat : u16 { # [doc = " Includes horizontal adjustment for placement"] const X_PLACEMENT = 0x0001 ; # [doc = " Includes vertical adjustment for placement"] const Y_PLACEMENT = 0x0002 ; # [doc = " Includes horizontal adjustment for advance"] const X_ADVANCE = 0x0004 ; # [doc = " Includes vertical adjustment for advance"] const Y_ADVANCE = 0x0008 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for horizontal placement"] const X_PLACEMENT_DEVICE = 0x0010 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for vertical placement"] const Y_PLACEMENT_DEVICE = 0x0020 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for horizontal advance"] const X_ADVANCE_DEVICE = 0x0040 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for vertical advance"] const Y_ADVANCE_DEVICE = 0x0080 ; } }
 
@@ -193,7 +188,6 @@ impl Validate for AnchorTable {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::AnchorTable<'_>> for AnchorTable {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorTable, _: FontData) -> Self {
         use read_fonts::layout::gpos::AnchorTable as ObjRefType;
@@ -205,10 +199,8 @@ impl FromObjRef<read_fonts::layout::gpos::AnchorTable<'_>> for AnchorTable {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gpos::AnchorTable<'_>> for AnchorTable {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AnchorTable {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::AnchorTable as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -237,7 +229,6 @@ impl Validate for AnchorFormat1 {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat1<'a>> for AnchorFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat1<'a>, _: FontData) -> Self {
         AnchorFormat1 {
@@ -247,10 +238,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat1<'a>> for AnchorForma
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::AnchorFormat1<'a>> for AnchorFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AnchorFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::AnchorFormat1 as FontRead>::read(data)
@@ -283,7 +272,6 @@ impl Validate for AnchorFormat2 {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat2<'a>> for AnchorFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat2<'a>, _: FontData) -> Self {
         AnchorFormat2 {
@@ -294,10 +282,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat2<'a>> for AnchorForma
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::AnchorFormat2<'a>> for AnchorFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AnchorFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::AnchorFormat2 as FontRead>::read(data)
@@ -346,7 +332,6 @@ impl Validate for AnchorFormat3 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat3<'a>> for AnchorFormat3 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::AnchorFormat3<'a>, _: FontData) -> Self {
         AnchorFormat3 {
@@ -358,10 +343,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat3<'a>> for AnchorForma
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::AnchorFormat3<'a>> for AnchorFormat3 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AnchorFormat3 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::AnchorFormat3 as FontRead>::read(data)
@@ -398,7 +381,6 @@ impl Validate for MarkArray {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkArray<'a>> for MarkArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkArray<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -412,10 +394,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::MarkArray<'a>> for MarkArray {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::MarkArray<'a>> for MarkArray {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for MarkArray {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::MarkArray as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -448,7 +428,6 @@ impl Validate for MarkRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::MarkRecord> for MarkRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkRecord, offset_data: FontData) -> Self {
         MarkRecord {
@@ -483,7 +462,6 @@ impl Validate for SinglePos {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::SinglePos<'_>> for SinglePos {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePos, _: FontData) -> Self {
         use read_fonts::layout::gpos::SinglePos as ObjRefType;
@@ -494,10 +472,8 @@ impl FromObjRef<read_fonts::layout::gpos::SinglePos<'_>> for SinglePos {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gpos::SinglePos<'_>> for SinglePos {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SinglePos {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::SinglePos as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -534,7 +510,6 @@ impl Validate for SinglePosFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat1<'a>> for SinglePosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat1<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -545,10 +520,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat1<'a>> for SinglePo
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::SinglePosFormat1<'a>> for SinglePosFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SinglePosFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::SinglePosFormat1 as FontRead>::read(data)
@@ -592,7 +565,6 @@ impl Validate for SinglePosFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat2<'a>> for SinglePosFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -607,10 +579,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat2<'a>> for SinglePo
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::SinglePosFormat2<'a>> for SinglePosFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SinglePosFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::SinglePosFormat2 as FontRead>::read(data)
@@ -643,7 +613,6 @@ impl Validate for PairPos {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PairPos<'_>> for PairPos {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPos, _: FontData) -> Self {
         use read_fonts::layout::gpos::PairPos as ObjRefType;
@@ -654,10 +623,8 @@ impl FromObjRef<read_fonts::layout::gpos::PairPos<'_>> for PairPos {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gpos::PairPos<'_>> for PairPos {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for PairPos {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::PairPos as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -702,7 +669,6 @@ impl Validate for PairPosFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat1<'a>> for PairPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat1<'a>, _: FontData) -> Self {
         PairPosFormat1 {
@@ -712,10 +678,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat1<'a>> for PairPosFor
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::PairPosFormat1<'a>> for PairPosFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for PairPosFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::PairPosFormat1 as FontRead>::read(data)
@@ -752,7 +716,6 @@ impl Validate for PairSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::PairSet<'a>> for PairSet {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairSet<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -766,7 +729,6 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairSet<'a>> for PairSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::PairSet<'a>> for PairSet {}
 
 /// Part of [PairSet]
@@ -793,7 +755,6 @@ impl Validate for PairValueRecord {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::PairValueRecord> for PairValueRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::PairValueRecord,
@@ -859,7 +820,6 @@ impl Validate for PairPosFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat2<'a>> for PairPosFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -876,10 +836,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat2<'a>> for PairPosFor
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::PairPosFormat2<'a>> for PairPosFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for PairPosFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::PairPosFormat2 as FontRead>::read(data)
@@ -913,7 +871,6 @@ impl Validate for Class1Record {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Class1Record<'_>> for Class1Record {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Class1Record, offset_data: FontData) -> Self {
         Class1Record {
@@ -946,7 +903,6 @@ impl Validate for Class2Record {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Class2Record> for Class2Record {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Class2Record, offset_data: FontData) -> Self {
         Class2Record {
@@ -991,7 +947,6 @@ impl Validate for CursivePosFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::CursivePosFormat1<'a>> for CursivePosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::CursivePosFormat1<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1006,10 +961,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::CursivePosFormat1<'a>> for Cursive
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::CursivePosFormat1<'a>> for CursivePosFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CursivePosFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::CursivePosFormat1 as FontRead>::read(data)
@@ -1048,7 +1001,6 @@ impl Validate for EntryExitRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::EntryExitRecord> for EntryExitRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::EntryExitRecord,
@@ -1109,7 +1061,6 @@ impl Validate for MarkBasePosFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkBasePosFormat1<'a>> for MarkBasePosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkBasePosFormat1<'a>, _: FontData) -> Self {
         MarkBasePosFormat1 {
@@ -1121,10 +1072,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::MarkBasePosFormat1<'a>> for MarkBa
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::MarkBasePosFormat1<'a>> for MarkBasePosFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for MarkBasePosFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::MarkBasePosFormat1 as FontRead>::read(data)
@@ -1160,7 +1109,6 @@ impl Validate for BaseArray {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::BaseArray<'a>> for BaseArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseArray<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1174,7 +1122,6 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::BaseArray<'a>> for BaseArray {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::BaseArray<'a>> for BaseArray {}
 
 /// Part of [BaseArray]
@@ -1205,7 +1152,6 @@ impl Validate for BaseRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseRecord, offset_data: FontData) -> Self {
         BaseRecord {
@@ -1262,7 +1208,6 @@ impl Validate for MarkLigPosFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkLigPosFormat1<'a>> for MarkLigPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkLigPosFormat1<'a>, _: FontData) -> Self {
         MarkLigPosFormat1 {
@@ -1274,10 +1219,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::MarkLigPosFormat1<'a>> for MarkLig
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::MarkLigPosFormat1<'a>> for MarkLigPosFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for MarkLigPosFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::MarkLigPosFormat1 as FontRead>::read(data)
@@ -1315,7 +1258,6 @@ impl Validate for LigatureArray {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureArray<'a>, _: FontData) -> Self {
         LigatureArray {
@@ -1324,7 +1266,6 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArr
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArray {}
 
 /// Part of [MarkLigPosFormat1]
@@ -1355,7 +1296,6 @@ impl Validate for LigatureAttach {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureAttach<'a>> for LigatureAttach {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureAttach<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1369,7 +1309,6 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureAttach<'a>> for LigatureAt
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::LigatureAttach<'a>> for LigatureAttach {}
 
 /// Part of [MarkLigPosFormat1]
@@ -1400,7 +1339,6 @@ impl Validate for ComponentRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::ComponentRecord,
@@ -1463,7 +1401,6 @@ impl Validate for MarkMarkPosFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkMarkPosFormat1<'a>> for MarkMarkPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkMarkPosFormat1<'a>, _: FontData) -> Self {
         MarkMarkPosFormat1 {
@@ -1475,10 +1412,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::MarkMarkPosFormat1<'a>> for MarkMa
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::MarkMarkPosFormat1<'a>> for MarkMarkPosFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for MarkMarkPosFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gpos::MarkMarkPosFormat1 as FontRead>::read(data)
@@ -1514,7 +1449,6 @@ impl Validate for Mark2Array {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gpos::Mark2Array<'a>> for Mark2Array {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Array<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1528,7 +1462,6 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::Mark2Array<'a>> for Mark2Array {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gpos::Mark2Array<'a>> for Mark2Array {}
 
 /// Part of [MarkMarkPosFormat1]
@@ -1559,7 +1492,6 @@ impl Validate for Mark2Record {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::Mark2Record<'_>> for Mark2Record {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Record, offset_data: FontData) -> Self {
         Mark2Record {
@@ -1590,7 +1522,6 @@ impl<T: Validate> Validate for ExtensionPosFormat1<T> {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromObjRef<read_fonts::layout::gpos::ExtensionPosFormat1<'a, U>>
     for ExtensionPosFormat1<T>
 where
@@ -1608,7 +1539,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromTableRef<read_fonts::layout::gpos::ExtensionPosFormat1<'a, U>>
     for ExtensionPosFormat1<T>
 where
@@ -1660,7 +1590,6 @@ impl Validate for ExtensionSubtable {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::ExtensionSubtable<'_>> for ExtensionSubtable {
     fn from_obj_ref(
         from: &read_fonts::layout::gpos::ExtensionSubtable<'_>,
@@ -1695,5 +1624,4 @@ impl FromObjRef<read_fonts::layout::gpos::ExtensionSubtable<'_>> for ExtensionSu
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gpos::ExtensionSubtable<'_>> for ExtensionSubtable {}

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -5,6 +5,8 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+pub use read_fonts::layout::gpos::ValueFormat;
+
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
 #[derive(Clone, Debug)]
@@ -151,7 +153,6 @@ impl FromObjRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLookup
 }
 
 impl FromTableRef<read_fonts::layout::gpos::PositionLookup<'_>> for PositionLookup {}
-bitflags::bitflags! { # [doc = " See [ValueRecord]"] pub struct ValueFormat : u16 { # [doc = " Includes horizontal adjustment for placement"] const X_PLACEMENT = 0x0001 ; # [doc = " Includes vertical adjustment for placement"] const Y_PLACEMENT = 0x0002 ; # [doc = " Includes horizontal adjustment for advance"] const X_ADVANCE = 0x0004 ; # [doc = " Includes vertical adjustment for advance"] const Y_ADVANCE = 0x0008 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for horizontal placement"] const X_PLACEMENT_DEVICE = 0x0010 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for vertical placement"] const Y_PLACEMENT_DEVICE = 0x0020 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for horizontal advance"] const X_ADVANCE_DEVICE = 0x0040 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for vertical advance"] const Y_ADVANCE_DEVICE = 0x0080 ; } }
 
 impl FontWrite for ValueFormat {
     fn write_into(&self, writer: &mut TableWriter) {

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -52,7 +52,6 @@ impl Validate for Gsub {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::Gsub<'a>> for Gsub {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Gsub<'a>, _: FontData) -> Self {
         Gsub {
@@ -64,10 +63,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::Gsub<'a>> for Gsub {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::Gsub<'a>> for Gsub {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Gsub {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::Gsub as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -117,7 +114,6 @@ impl Validate for SubstitutionLookup {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gsub::SubstitutionLookup<'_>> for SubstitutionLookup {
     fn from_obj_ref(
         from: &read_fonts::layout::gsub::SubstitutionLookup<'_>,
@@ -152,7 +148,6 @@ impl FromObjRef<read_fonts::layout::gsub::SubstitutionLookup<'_>> for Substituti
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gsub::SubstitutionLookup<'_>> for SubstitutionLookup {}
 
 /// LookupType 1: [Single Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-1-single-substitution-subtable) Subtable
@@ -180,7 +175,6 @@ impl Validate for SingleSubst {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gsub::SingleSubst<'_>> for SingleSubst {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubst, _: FontData) -> Self {
         use read_fonts::layout::gsub::SingleSubst as ObjRefType;
@@ -191,10 +185,8 @@ impl FromObjRef<read_fonts::layout::gsub::SingleSubst<'_>> for SingleSubst {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gsub::SingleSubst<'_>> for SingleSubst {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SingleSubst {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::SingleSubst as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -230,7 +222,6 @@ impl Validate for SingleSubstFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat1<'a>> for SingleSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat1<'a>, _: FontData) -> Self {
         SingleSubstFormat1 {
@@ -240,10 +231,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat1<'a>> for Single
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::SingleSubstFormat1<'a>> for SingleSubstFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SingleSubstFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::SingleSubstFormat1 as FontRead>::read(data)
@@ -286,7 +275,6 @@ impl Validate for SingleSubstFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat2<'a>> for SingleSubstFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat2<'a>, _: FontData) -> Self {
         SingleSubstFormat2 {
@@ -296,10 +284,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat2<'a>> for Single
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::SingleSubstFormat2<'a>> for SingleSubstFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SingleSubstFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::SingleSubstFormat2 as FontRead>::read(data)
@@ -344,7 +330,6 @@ impl Validate for MultipleSubstFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::MultipleSubstFormat1<'a>> for MultipleSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::MultipleSubstFormat1<'a>, _: FontData) -> Self {
         MultipleSubstFormat1 {
@@ -354,10 +339,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::MultipleSubstFormat1<'a>> for Mult
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::MultipleSubstFormat1<'a>> for MultipleSubstFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for MultipleSubstFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::MultipleSubstFormat1 as FontRead>::read(data)
@@ -392,7 +375,6 @@ impl Validate for Sequence {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::Sequence<'a>> for Sequence {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Sequence<'a>, _: FontData) -> Self {
         Sequence {
@@ -401,10 +383,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::Sequence<'a>> for Sequence {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::Sequence<'a>> for Sequence {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Sequence {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::Sequence as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -448,7 +428,6 @@ impl Validate for AlternateSubstFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSubstFormat1<'a>> for AlternateSubstFormat1 {
     fn from_obj_ref(
         obj: &read_fonts::layout::gsub::AlternateSubstFormat1<'a>,
@@ -461,13 +440,11 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSubstFormat1<'a>> for Alt
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::AlternateSubstFormat1<'a>>
     for AlternateSubstFormat1
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AlternateSubstFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::AlternateSubstFormat1 as FontRead>::read(data)
@@ -502,7 +479,6 @@ impl Validate for AlternateSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSet<'a>> for AlternateSet {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::AlternateSet<'a>, _: FontData) -> Self {
         AlternateSet {
@@ -511,10 +487,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSet<'a>> for AlternateSet
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::AlternateSet<'a>> for AlternateSet {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for AlternateSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::AlternateSet as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -558,7 +532,6 @@ impl Validate for LigatureSubstFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSubstFormat1<'a>> for LigatureSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSubstFormat1<'a>, _: FontData) -> Self {
         LigatureSubstFormat1 {
@@ -568,10 +541,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSubstFormat1<'a>> for Liga
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::LigatureSubstFormat1<'a>> for LigatureSubstFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for LigatureSubstFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::LigatureSubstFormat1 as FontRead>::read(data)
@@ -608,7 +579,6 @@ impl Validate for LigatureSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSet<'a>> for LigatureSet {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSet<'a>, _: FontData) -> Self {
         LigatureSet {
@@ -617,10 +587,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSet<'a>> for LigatureSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::LigatureSet<'a>> for LigatureSet {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for LigatureSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::LigatureSet as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -650,7 +618,6 @@ impl Validate for Ligature {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::Ligature<'a>> for Ligature {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Ligature<'a>, _: FontData) -> Self {
         Ligature {
@@ -660,10 +627,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::Ligature<'a>> for Ligature {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::Ligature<'a>> for Ligature {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Ligature {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::Ligature as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -692,7 +657,6 @@ impl<T: Validate> Validate for ExtensionSubstFormat1<T> {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromObjRef<read_fonts::layout::gsub::ExtensionSubstFormat1<'a, U>>
     for ExtensionSubstFormat1<T>
 where
@@ -710,7 +674,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromTableRef<read_fonts::layout::gsub::ExtensionSubstFormat1<'a, U>>
     for ExtensionSubstFormat1<T>
 where
@@ -759,7 +722,6 @@ impl Validate for ExtensionSubtable {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gsub::ExtensionSubtable<'_>> for ExtensionSubtable {
     fn from_obj_ref(
         from: &read_fonts::layout::gsub::ExtensionSubtable<'_>,
@@ -791,7 +753,6 @@ impl FromObjRef<read_fonts::layout::gsub::ExtensionSubtable<'_>> for ExtensionSu
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::gsub::ExtensionSubtable<'_>> for ExtensionSubtable {}
 
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
@@ -851,7 +812,6 @@ impl Validate for ReverseChainSingleSubstFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>>
     for ReverseChainSingleSubstFormat1
 {
@@ -868,13 +828,11 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>>
     for ReverseChainSingleSubstFormat1
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::gsub::ReverseChainSingleSubstFormat1 as FontRead>::read(data)

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -72,7 +72,6 @@ impl Validate for Head {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::head::Head<'a>> for Head {
     fn from_obj_ref(obj: &read_fonts::tables::head::Head<'a>, _: FontData) -> Self {
         Head {
@@ -93,10 +92,8 @@ impl<'a> FromObjRef<read_fonts::tables::head::Head<'a>> for Head {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::head::Head<'a>> for Head {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Head {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::head::Head as FontRead>::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -66,7 +66,6 @@ impl Validate for Hhea {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::hhea::Hhea<'a>> for Hhea {
     fn from_obj_ref(obj: &read_fonts::tables::hhea::Hhea<'a>, _: FontData) -> Self {
         Hhea {
@@ -85,10 +84,8 @@ impl<'a> FromObjRef<read_fonts::tables::hhea::Hhea<'a>> for Hhea {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::hhea::Hhea<'a>> for Hhea {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Hhea {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::hhea::Hhea as FontRead>::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -36,7 +36,6 @@ impl Validate for Hmtx {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
     fn from_obj_ref(obj: &read_fonts::tables::hmtx::Hmtx<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -51,7 +50,6 @@ impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {}
 
 #[derive(Clone, Debug)]
@@ -73,7 +71,6 @@ impl Validate for LongHorMetric {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::tables::hmtx::LongHorMetric> for LongHorMetric {
     fn from_obj_ref(obj: &read_fonts::tables::hmtx::LongHorMetric, _: FontData) -> Self {
         LongHorMetric {

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -5,6 +5,8 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+pub use read_fonts::layout::DeltaFormat;
+
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 #[derive(Clone, Debug)]
 pub struct ScriptList {
@@ -1810,29 +1812,9 @@ impl<'a> FontRead<'a> for ChainedSequenceContext {
     }
 }
 
-/// [Device](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
-/// delta formats
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u16)]
-pub enum DeltaFormat {
-    /// Signed 2-bit value, 8 values per uint16
-    Local2BitDeltas = 0x0001,
-    /// Signed 4-bit value, 4 values per uint16
-    Local4BitDeltas = 0x0002,
-    /// Signed 8-bit value, 2 values per uint16
-    Local8BitDeltas = 0x0003,
-    /// VariationIndex table, contains a delta-set index pair.
-    VariationIndex = 0x8000,
-}
-
 impl FontWrite for DeltaFormat {
     fn write_into(&self, writer: &mut TableWriter) {
-        let val: u16 = match self {
-            Self::Local2BitDeltas => 0x0001,
-            Self::Local4BitDeltas => 0x0002,
-            Self::Local8BitDeltas => 0x0003,
-            Self::VariationIndex => 0x8000,
-        };
+        let val = *self as u16;
         writer.write_slice(&val.to_be_bytes())
     }
 }
@@ -1868,7 +1850,7 @@ impl<'a> FromObjRef<read_fonts::layout::Device<'a>> for Device {
         Device {
             start_size: obj.start_size(),
             end_size: obj.end_size(),
-            delta_format: convert_delta_format(obj.delta_format()),
+            delta_format: obj.delta_format(),
             delta_value: obj.delta_value().iter().map(|x| x.get()).collect(),
         }
     }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -33,7 +33,6 @@ impl Validate for ScriptList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ScriptList<'a>> for ScriptList {
     fn from_obj_ref(obj: &read_fonts::layout::ScriptList<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -47,10 +46,8 @@ impl<'a> FromObjRef<read_fonts::layout::ScriptList<'a>> for ScriptList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ScriptList<'a>> for ScriptList {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ScriptList {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ScriptList as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -83,7 +80,6 @@ impl Validate for ScriptRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ScriptRecord> for ScriptRecord {
     fn from_obj_ref(obj: &read_fonts::layout::ScriptRecord, offset_data: FontData) -> Self {
         ScriptRecord {
@@ -128,7 +124,6 @@ impl Validate for Script {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::Script<'a>> for Script {
     fn from_obj_ref(obj: &read_fonts::layout::Script<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -143,10 +138,8 @@ impl<'a> FromObjRef<read_fonts::layout::Script<'a>> for Script {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::Script<'a>> for Script {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Script {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::Script as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -178,7 +171,6 @@ impl Validate for LangSysRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::LangSysRecord> for LangSysRecord {
     fn from_obj_ref(obj: &read_fonts::layout::LangSysRecord, offset_data: FontData) -> Self {
         LangSysRecord {
@@ -220,7 +212,6 @@ impl Validate for LangSys {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::LangSys<'a>> for LangSys {
     fn from_obj_ref(obj: &read_fonts::layout::LangSys<'a>, _: FontData) -> Self {
         LangSys {
@@ -230,10 +221,8 @@ impl<'a> FromObjRef<read_fonts::layout::LangSys<'a>> for LangSys {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::LangSys<'a>> for LangSys {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for LangSys {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::LangSys as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -269,7 +258,6 @@ impl Validate for FeatureList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::FeatureList<'a>> for FeatureList {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureList<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -283,10 +271,8 @@ impl<'a> FromObjRef<read_fonts::layout::FeatureList<'a>> for FeatureList {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::FeatureList<'a>> for FeatureList {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for FeatureList {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::FeatureList as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -319,7 +305,6 @@ impl Validate for FeatureRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureRecord> for FeatureRecord {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureRecord, offset_data: FontData) -> Self {
         FeatureRecord {
@@ -363,7 +348,6 @@ impl Validate for Feature {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::Feature<'a>> for Feature {
     fn from_obj_ref(obj: &read_fonts::layout::Feature<'a>, _: FontData) -> Self {
         Feature {
@@ -373,7 +357,6 @@ impl<'a> FromObjRef<read_fonts::layout::Feature<'a>> for Feature {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::Feature<'a>> for Feature {}
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
@@ -405,7 +388,6 @@ impl<T: Validate> Validate for LookupList<T> {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromObjRef<read_fonts::layout::LookupList<'a, U>> for LookupList<T>
 where
     U: FontRead<'a>,
@@ -418,7 +400,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromTableRef<read_fonts::layout::LookupList<'a, U>> for LookupList<T>
 where
     U: FontRead<'a>,
@@ -453,7 +434,6 @@ impl<T: Validate> Validate for Lookup<T> {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromObjRef<read_fonts::layout::Lookup<'a, U>> for Lookup<T>
 where
     U: FontRead<'a>,
@@ -468,7 +448,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, T, U> FromTableRef<read_fonts::layout::Lookup<'a, U>> for Lookup<T>
 where
     U: FontRead<'a>,
@@ -504,7 +483,6 @@ impl Validate for CoverageFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::CoverageFormat1<'a>> for CoverageFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat1<'a>, _: FontData) -> Self {
         CoverageFormat1 {
@@ -513,10 +491,8 @@ impl<'a> FromObjRef<read_fonts::layout::CoverageFormat1<'a>> for CoverageFormat1
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::CoverageFormat1<'a>> for CoverageFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CoverageFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::CoverageFormat1 as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -552,7 +528,6 @@ impl Validate for CoverageFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::CoverageFormat2<'a>> for CoverageFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::CoverageFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -566,10 +541,8 @@ impl<'a> FromObjRef<read_fonts::layout::CoverageFormat2<'a>> for CoverageFormat2
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::CoverageFormat2<'a>> for CoverageFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CoverageFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::CoverageFormat2 as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -599,7 +572,6 @@ impl Validate for RangeRecord {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::RangeRecord> for RangeRecord {
     fn from_obj_ref(obj: &read_fonts::layout::RangeRecord, _: FontData) -> Self {
         RangeRecord {
@@ -635,7 +607,6 @@ impl Validate for CoverageTable {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::CoverageTable<'_>> for CoverageTable {
     fn from_obj_ref(obj: &read_fonts::layout::CoverageTable, _: FontData) -> Self {
         use read_fonts::layout::CoverageTable as ObjRefType;
@@ -646,10 +617,8 @@ impl FromObjRef<read_fonts::layout::CoverageTable<'_>> for CoverageTable {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::CoverageTable<'_>> for CoverageTable {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CoverageTable {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::CoverageTable as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -687,7 +656,6 @@ impl Validate for ClassDefFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ClassDefFormat1<'a>> for ClassDefFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat1<'a>, _: FontData) -> Self {
         ClassDefFormat1 {
@@ -697,10 +665,8 @@ impl<'a> FromObjRef<read_fonts::layout::ClassDefFormat1<'a>> for ClassDefFormat1
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ClassDefFormat1<'a>> for ClassDefFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ClassDefFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ClassDefFormat1 as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -736,7 +702,6 @@ impl Validate for ClassDefFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ClassDefFormat2<'a>> for ClassDefFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::ClassDefFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -750,10 +715,8 @@ impl<'a> FromObjRef<read_fonts::layout::ClassDefFormat2<'a>> for ClassDefFormat2
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ClassDefFormat2<'a>> for ClassDefFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ClassDefFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ClassDefFormat2 as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -789,7 +752,6 @@ impl Validate for ClassRangeRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassRangeRecord> for ClassRangeRecord {
     fn from_obj_ref(obj: &read_fonts::layout::ClassRangeRecord, _: FontData) -> Self {
         ClassRangeRecord {
@@ -825,7 +787,6 @@ impl Validate for ClassDef {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ClassDef<'_>> for ClassDef {
     fn from_obj_ref(obj: &read_fonts::layout::ClassDef, _: FontData) -> Self {
         use read_fonts::layout::ClassDef as ObjRefType;
@@ -836,10 +797,8 @@ impl FromObjRef<read_fonts::layout::ClassDef<'_>> for ClassDef {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::ClassDef<'_>> for ClassDef {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ClassDef {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ClassDef as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -866,7 +825,6 @@ impl Validate for SequenceLookupRecord {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceLookupRecord> for SequenceLookupRecord {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceLookupRecord, _: FontData) -> Self {
         SequenceLookupRecord {
@@ -913,7 +871,6 @@ impl Validate for SequenceContextFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat1<'a>> for SequenceContextFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat1<'a>, _: FontData) -> Self {
         SequenceContextFormat1 {
@@ -923,10 +880,8 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat1<'a>> for Sequence
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::SequenceContextFormat1<'a>> for SequenceContextFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SequenceContextFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SequenceContextFormat1 as FontRead>::read(data)
@@ -963,7 +918,6 @@ impl Validate for SequenceRuleSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::SequenceRuleSet<'a>> for SequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceRuleSet<'a>, _: FontData) -> Self {
         SequenceRuleSet {
@@ -972,10 +926,8 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceRuleSet<'a>> for SequenceRuleSet
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::SequenceRuleSet<'a>> for SequenceRuleSet {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SequenceRuleSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SequenceRuleSet as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -1014,7 +966,6 @@ impl Validate for SequenceRule {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::SequenceRule<'a>> for SequenceRule {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1029,10 +980,8 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceRule<'a>> for SequenceRule {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::SequenceRule<'a>> for SequenceRule {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SequenceRule {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SequenceRule as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -1083,7 +1032,6 @@ impl Validate for SequenceContextFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat2<'a>> for SequenceContextFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat2<'a>, _: FontData) -> Self {
         SequenceContextFormat2 {
@@ -1094,10 +1042,8 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat2<'a>> for Sequence
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::SequenceContextFormat2<'a>> for SequenceContextFormat2 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SequenceContextFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SequenceContextFormat2 as FontRead>::read(data)
@@ -1134,7 +1080,6 @@ impl Validate for ClassSequenceRuleSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRuleSet<'a>> for ClassSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRuleSet<'a>, _: FontData) -> Self {
         ClassSequenceRuleSet {
@@ -1143,10 +1088,8 @@ impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRuleSet<'a>> for ClassSeque
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ClassSequenceRuleSet<'a>> for ClassSequenceRuleSet {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ClassSequenceRuleSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ClassSequenceRuleSet as FontRead>::read(data)
@@ -1187,7 +1130,6 @@ impl Validate for ClassSequenceRule {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRule<'a>> for ClassSequenceRule {
     fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1202,10 +1144,8 @@ impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRule<'a>> for ClassSequence
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ClassSequenceRule<'a>> for ClassSequenceRule {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ClassSequenceRule {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ClassSequenceRule as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -1252,7 +1192,6 @@ impl Validate for SequenceContextFormat3 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat3<'a>> for SequenceContextFormat3 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat3<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1267,10 +1206,8 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat3<'a>> for Sequence
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::SequenceContextFormat3<'a>> for SequenceContextFormat3 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SequenceContextFormat3 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SequenceContextFormat3 as FontRead>::read(data)
@@ -1305,7 +1242,6 @@ impl Validate for SequenceContext {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::SequenceContext<'_>> for SequenceContext {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContext, _: FontData) -> Self {
         use read_fonts::layout::SequenceContext as ObjRefType;
@@ -1317,10 +1253,8 @@ impl FromObjRef<read_fonts::layout::SequenceContext<'_>> for SequenceContext {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::SequenceContext<'_>> for SequenceContext {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SequenceContext {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SequenceContext as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -1364,7 +1298,6 @@ impl Validate for ChainedSequenceContextFormat1 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat1<'a>>
     for ChainedSequenceContextFormat1
 {
@@ -1379,13 +1312,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat1<'a>>
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedSequenceContextFormat1<'a>>
     for ChainedSequenceContextFormat1
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedSequenceContextFormat1 as FontRead>::read(data)
@@ -1422,7 +1353,6 @@ impl Validate for ChainedSequenceRuleSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRuleSet<'a>> for ChainedSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRuleSet<'a>, _: FontData) -> Self {
         ChainedSequenceRuleSet {
@@ -1431,10 +1361,8 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRuleSet<'a>> for ChainedS
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedSequenceRuleSet<'a>> for ChainedSequenceRuleSet {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedSequenceRuleSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedSequenceRuleSet as FontRead>::read(data)
@@ -1492,7 +1420,6 @@ impl Validate for ChainedSequenceRule {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRule<'a>> for ChainedSequenceRule {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1509,10 +1436,8 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRule<'a>> for ChainedSequ
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedSequenceRule<'a>> for ChainedSequenceRule {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedSequenceRule {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedSequenceRule as FontRead>::read(data)
@@ -1578,7 +1503,6 @@ impl Validate for ChainedSequenceContextFormat2 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat2<'a>>
     for ChainedSequenceContextFormat2
 {
@@ -1599,13 +1523,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat2<'a>>
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedSequenceContextFormat2<'a>>
     for ChainedSequenceContextFormat2
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat2 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedSequenceContextFormat2 as FontRead>::read(data)
@@ -1642,7 +1564,6 @@ impl Validate for ChainedClassSequenceRuleSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRuleSet<'a>>
     for ChainedClassSequenceRuleSet
 {
@@ -1659,13 +1580,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRuleSet<'a>>
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedClassSequenceRuleSet<'a>>
     for ChainedClassSequenceRuleSet
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedClassSequenceRuleSet as FontRead>::read(data)
@@ -1724,7 +1643,6 @@ impl Validate for ChainedClassSequenceRule {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRule<'a>> for ChainedClassSequenceRule {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedClassSequenceRule<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -1741,13 +1659,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRule<'a>> for Chaine
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedClassSequenceRule<'a>>
     for ChainedClassSequenceRule
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedClassSequenceRule {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedClassSequenceRule as FontRead>::read(data)
@@ -1814,7 +1730,6 @@ impl Validate for ChainedSequenceContextFormat3 {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
     for ChainedSequenceContextFormat3
 {
@@ -1836,13 +1751,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
     for ChainedSequenceContextFormat3
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat3 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedSequenceContextFormat3 as FontRead>::read(data)
@@ -1877,7 +1790,6 @@ impl Validate for ChainedSequenceContext {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::ChainedSequenceContext<'_>> for ChainedSequenceContext {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceContext, _: FontData) -> Self {
         use read_fonts::layout::ChainedSequenceContext as ObjRefType;
@@ -1889,10 +1801,8 @@ impl FromObjRef<read_fonts::layout::ChainedSequenceContext<'_>> for ChainedSeque
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::ChainedSequenceContext<'_>> for ChainedSequenceContext {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ChainedSequenceContext {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ChainedSequenceContext as FontRead>::read(data)
@@ -1953,7 +1863,6 @@ impl Validate for Device {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::Device<'a>> for Device {
     fn from_obj_ref(obj: &read_fonts::layout::Device<'a>, _: FontData) -> Self {
         Device {
@@ -1965,10 +1874,8 @@ impl<'a> FromObjRef<read_fonts::layout::Device<'a>> for Device {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::Device<'a>> for Device {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Device {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::Device as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2000,7 +1907,6 @@ impl Validate for VariationIndex {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::VariationIndex<'a>> for VariationIndex {
     fn from_obj_ref(obj: &read_fonts::layout::VariationIndex<'a>, _: FontData) -> Self {
         VariationIndex {
@@ -2011,10 +1917,8 @@ impl<'a> FromObjRef<read_fonts::layout::VariationIndex<'a>> for VariationIndex {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::VariationIndex<'a>> for VariationIndex {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for VariationIndex {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::VariationIndex as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2050,7 +1954,6 @@ impl Validate for FeatureVariations {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::FeatureVariations<'a>> for FeatureVariations {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureVariations<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -2064,10 +1967,8 @@ impl<'a> FromObjRef<read_fonts::layout::FeatureVariations<'a>> for FeatureVariat
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::FeatureVariations<'a>> for FeatureVariations {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for FeatureVariations {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::FeatureVariations as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2105,7 +2006,6 @@ impl Validate for FeatureVariationRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureVariationRecord> for FeatureVariationRecord {
     fn from_obj_ref(
         obj: &read_fonts::layout::FeatureVariationRecord,
@@ -2147,7 +2047,6 @@ impl Validate for ConditionSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ConditionSet<'a>> for ConditionSet {
     fn from_obj_ref(obj: &read_fonts::layout::ConditionSet<'a>, _: FontData) -> Self {
         ConditionSet {
@@ -2156,10 +2055,8 @@ impl<'a> FromObjRef<read_fonts::layout::ConditionSet<'a>> for ConditionSet {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ConditionSet<'a>> for ConditionSet {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ConditionSet {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ConditionSet as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2194,7 +2091,6 @@ impl Validate for ConditionFormat1 {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::ConditionFormat1<'a>> for ConditionFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::ConditionFormat1<'a>, _: FontData) -> Self {
         ConditionFormat1 {
@@ -2205,10 +2101,8 @@ impl<'a> FromObjRef<read_fonts::layout::ConditionFormat1<'a>> for ConditionForma
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::ConditionFormat1<'a>> for ConditionFormat1 {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for ConditionFormat1 {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::ConditionFormat1 as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2244,7 +2138,6 @@ impl Validate for FeatureTableSubstitution {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::FeatureTableSubstitution<'a>> for FeatureTableSubstitution {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureTableSubstitution<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -2258,13 +2151,11 @@ impl<'a> FromObjRef<read_fonts::layout::FeatureTableSubstitution<'a>> for Featur
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::FeatureTableSubstitution<'a>>
     for FeatureTableSubstitution
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for FeatureTableSubstitution {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::FeatureTableSubstitution as FontRead>::read(data)
@@ -2299,7 +2190,6 @@ impl Validate for FeatureTableSubstitutionRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureTableSubstitutionRecord>
     for FeatureTableSubstitutionRecord
 {
@@ -2362,7 +2252,6 @@ impl Validate for SizeParams {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::SizeParams<'a>> for SizeParams {
     fn from_obj_ref(obj: &read_fonts::layout::SizeParams<'a>, _: FontData) -> Self {
         SizeParams {
@@ -2375,10 +2264,8 @@ impl<'a> FromObjRef<read_fonts::layout::SizeParams<'a>> for SizeParams {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::SizeParams<'a>> for SizeParams {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SizeParams {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::SizeParams as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2411,7 +2298,6 @@ impl Validate for StylisticSetParams {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::StylisticSetParams<'a>> for StylisticSetParams {
     fn from_obj_ref(obj: &read_fonts::layout::StylisticSetParams<'a>, _: FontData) -> Self {
         StylisticSetParams {
@@ -2420,10 +2306,8 @@ impl<'a> FromObjRef<read_fonts::layout::StylisticSetParams<'a>> for StylisticSet
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::StylisticSetParams<'a>> for StylisticSetParams {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for StylisticSetParams {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::StylisticSetParams as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -2481,7 +2365,6 @@ impl Validate for CharacterVariantParams {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::layout::CharacterVariantParams<'a>> for CharacterVariantParams {
     fn from_obj_ref(obj: &read_fonts::layout::CharacterVariantParams<'a>, _: FontData) -> Self {
         CharacterVariantParams {
@@ -2495,10 +2378,8 @@ impl<'a> FromObjRef<read_fonts::layout::CharacterVariantParams<'a>> for Characte
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::layout::CharacterVariantParams<'a>> for CharacterVariantParams {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for CharacterVariantParams {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::layout::CharacterVariantParams as FontRead>::read(data)

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -220,7 +220,6 @@ impl Validate for Maxp {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::maxp::Maxp<'a>> for Maxp {
     fn from_obj_ref(obj: &read_fonts::tables::maxp::Maxp<'a>, _: FontData) -> Self {
         Maxp {
@@ -242,10 +241,8 @@ impl<'a> FromObjRef<read_fonts::tables::maxp::Maxp<'a>> for Maxp {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::maxp::Maxp<'a>> for Maxp {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Maxp {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::maxp::Maxp as FontRead>::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -65,7 +65,6 @@ impl Validate for Name {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::name::Name<'a>> for Name {
     fn from_obj_ref(obj: &read_fonts::tables::name::Name<'a>, _: FontData) -> Self {
         let offset_data = obj.string_data();
@@ -85,10 +84,8 @@ impl<'a> FromObjRef<read_fonts::tables::name::Name<'a>> for Name {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::name::Name<'a>> for Name {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Name {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::name::Name as FontRead>::read(data).map(|x| x.to_owned_table())
@@ -107,7 +104,6 @@ impl Validate for LangTagRecord {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
     fn from_obj_ref(obj: &read_fonts::tables::name::LangTagRecord, offset_data: FontData) -> Self {
         LangTagRecord {
@@ -141,7 +137,6 @@ impl Validate for NameRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::tables::name::NameRecord> for NameRecord {
     fn from_obj_ref(obj: &read_fonts::tables::name::NameRecord, offset_data: FontData) -> Self {
         NameRecord {

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -109,7 +109,6 @@ impl Validate for Post {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::post::Post<'a>> for Post {
     fn from_obj_ref(obj: &read_fonts::tables::post::Post<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
@@ -136,10 +135,8 @@ impl<'a> FromObjRef<read_fonts::tables::post::Post<'a>> for Post {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::tables::post::Post<'a>> for Post {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Post {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::post::Post as FontRead>::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/generated/generated_test.rs
+++ b/write-fonts/generated/generated_test.rs
@@ -68,7 +68,6 @@ impl Validate for KindsOfOffsets {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfOffsets<'a>> for KindsOfOffsets {
     fn from_obj_ref(obj: &read_fonts::codegen_test::KindsOfOffsets<'a>, _: FontData) -> Self {
         KindsOfOffsets {
@@ -83,10 +82,8 @@ impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfOffsets<'a>> for KindsOfOff
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::codegen_test::KindsOfOffsets<'a>> for KindsOfOffsets {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for KindsOfOffsets {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::codegen_test::KindsOfOffsets as FontRead>::read(data)
@@ -179,7 +176,6 @@ impl Validate for KindsOfArraysOfOffsets {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfArraysOfOffsets<'a>>
     for KindsOfArraysOfOffsets
 {
@@ -202,13 +198,11 @@ impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfArraysOfOffsets<'a>>
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::codegen_test::KindsOfArraysOfOffsets<'a>>
     for KindsOfArraysOfOffsets
 {
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for KindsOfArraysOfOffsets {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::codegen_test::KindsOfArraysOfOffsets as FontRead>::read(data)
@@ -231,17 +225,14 @@ impl Validate for Dummy {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::codegen_test::Dummy<'a>> for Dummy {
     fn from_obj_ref(obj: &read_fonts::codegen_test::Dummy<'a>, _: FontData) -> Self {
         Dummy { value: obj.value() }
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromTableRef<read_fonts::codegen_test::Dummy<'a>> for Dummy {}
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for Dummy {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::codegen_test::Dummy as FontRead>::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/src/layout.rs
+++ b/write-fonts/src/layout.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{BTreeMap, HashSet};
 
-#[cfg(feature = "parsing")]
 use read_fonts::FontRead;
 
 /// A macro to implement the [LookupType] trait.
@@ -49,14 +48,12 @@ macro_rules! table_newtype {
             }
         }
 
-        #[cfg(feature = "parsing")]
         impl<'a> FromObjRef<$read_type> for $name {
             fn from_obj_ref(obj: &$read_type, _data: FontData) -> Self {
                 Self(FromObjRef::from_obj_ref(obj, _data))
             }
         }
 
-        #[cfg(feature = "parsing")]
         impl<'a> FromTableRef<$read_type> for $name {}
     };
 }
@@ -71,7 +68,6 @@ pub use value_record::ValueRecord;
 
 #[cfg(test)]
 #[path = "./tests/layout.rs"]
-#[cfg(feature = "parsing")]
 mod spec_tests;
 
 include!("../generated/generated_layout.rs");
@@ -124,7 +120,6 @@ impl Validate for FeatureParams {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::FeatureParams<'_>> for FeatureParams {
     fn from_obj_ref(from: &read_fonts::layout::FeatureParams, data: FontData) -> Self {
         use read_fonts::layout::FeatureParams as FromType;
@@ -140,7 +135,6 @@ impl FromObjRef<read_fonts::layout::FeatureParams<'_>> for FeatureParams {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::layout::FeatureParams<'_>> for FeatureParams {}
 
 impl ClassDefFormat1 {
@@ -428,7 +422,6 @@ impl RangeRecord {
     }
 }
 
-#[cfg(feature = "parsing")]
 fn convert_delta_format(from: read_fonts::layout::DeltaFormat) -> DeltaFormat {
     match from as u16 {
         0x0002 => DeltaFormat::Local4BitDeltas,

--- a/write-fonts/src/layout.rs
+++ b/write-fonts/src/layout.rs
@@ -422,21 +422,6 @@ impl RangeRecord {
     }
 }
 
-fn convert_delta_format(from: read_fonts::layout::DeltaFormat) -> DeltaFormat {
-    match from as u16 {
-        0x0002 => DeltaFormat::Local4BitDeltas,
-        0x0003 => DeltaFormat::Local8BitDeltas,
-        0x8000 => DeltaFormat::VariationIndex,
-        _ => DeltaFormat::Local2BitDeltas,
-    }
-}
-
-impl Default for DeltaFormat {
-    fn default() -> Self {
-        Self::Local2BitDeltas
-    }
-}
-
 fn iter_gids(gid1: GlyphId, gid2: GlyphId) -> impl Iterator<Item = GlyphId> {
     (gid1.to_u16()..=gid2.to_u16()).map(GlyphId::new)
 }
@@ -500,5 +485,11 @@ mod tests {
             .collect();
 
         assert!(builder.prefer_format_1());
+    }
+
+    #[test]
+    fn delta_format_dflt() {
+        let some: DeltaFormat = Default::default();
+        assert_eq!(some, DeltaFormat::Local2BitDeltas);
     }
 }

--- a/write-fonts/src/layout/gdef.rs
+++ b/write-fonts/src/layout/gdef.rs
@@ -43,13 +43,10 @@ mod tests {
 
         assert_eq!(gdef.compute_version(), MajorMinor::VERSION_1_3);
         let _dumped = crate::write::dump_table(&gdef).unwrap();
-        #[cfg(feature = "parsing")]
-        {
-            let data = FontData::new(&_dumped);
-            let loaded = read_fonts::tables::gdef::Gdef::read(data).unwrap();
+        let data = FontData::new(&_dumped);
+        let loaded = read_fonts::tables::gdef::Gdef::read(data).unwrap();
 
-            assert_eq!(loaded.version(), MajorMinor::VERSION_1_3);
-            assert!(!loaded.item_var_store_offset().unwrap().is_null());
-        }
+        assert_eq!(loaded.version(), MajorMinor::VERSION_1_3);
+        assert!(!loaded.item_var_store_offset().unwrap().is_null());
     }
 }

--- a/write-fonts/src/layout/gpos.rs
+++ b/write-fonts/src/layout/gpos.rs
@@ -12,7 +12,7 @@ use super::{
     Lookup, LookupList, LookupType, ScriptList, SequenceContext,
 };
 
-#[cfg(all(test, feature = "parsing"))]
+#[cfg(test)]
 #[path = "../tests/gpos.rs"]
 mod tests;
 
@@ -60,14 +60,12 @@ impl<T: LookupType + FontWrite> FontWrite for ExtensionPosFormat1<T> {
 }
 
 // these can't have auto impls because the traits don't support generics
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for PositionLookup {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         read_fonts::layout::gpos::PositionLookup::read(data).map(|x| x.to_owned_table())
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for PositionLookupList {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         read_fonts::layout::gpos::PositionLookupList::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/src/layout/gsub.rs
+++ b/write-fonts/src/layout/gsub.rs
@@ -9,7 +9,7 @@ use super::{
     LookupType, ScriptList, SequenceContext,
 };
 
-#[cfg(all(test, feature = "parsing"))]
+#[cfg(test)]
 #[path = "../tests/test_gsub.rs"]
 mod tests;
 
@@ -56,14 +56,12 @@ impl<T: LookupType + FontWrite> FontWrite for ExtensionSubstFormat1<T> {
 }
 
 // these can't have auto impls because the traits don't support generics
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SubstitutionLookup {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         read_fonts::layout::gsub::SubstitutionLookup::read(data).map(|x| x.to_owned_table())
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FontRead<'a> for SubstitutionLookupList {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         read_fonts::layout::gsub::SubstitutionLookupList::read(data).map(|x| x.to_owned_table())

--- a/write-fonts/src/layout/value_record.rs
+++ b/write-fonts/src/layout/value_record.rs
@@ -1,8 +1,6 @@
 //! The ValueRecord type used in the GPOS table
 
-#[cfg(feature = "parsing")]
 use crate::from_obj::FromObjRef;
-#[cfg(feature = "parsing")]
 use read_fonts::FontData;
 
 use super::gpos::ValueFormat;
@@ -90,7 +88,6 @@ impl Validate for ValueRecord {
     fn validate_impl(&self, _ctx: &mut crate::validate::ValidationCtx) {}
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::layout::gpos::ValueRecord> for ValueRecord {
     fn from_obj_ref(from: &read_fonts::layout::gpos::ValueRecord, _data: FontData) -> Self {
         ValueRecord {

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod collections;
 mod font_builder;
-#[cfg(feature = "parsing")]
 pub mod from_obj;
 mod graph;
 pub mod layout;
@@ -24,15 +23,13 @@ pub use write::{dump_table, FontWrite, TableWriter};
 pub(crate) mod codegen_prelude {
     use std::num::TryFromIntError;
 
+    pub use super::from_obj::{FromObjRef, FromTableRef, ToOwnedObj, ToOwnedTable};
     pub use super::offsets::{NullableOffsetMarker, OffsetMarker, WIDTH_16, WIDTH_24, WIDTH_32};
     pub use super::validate::{Validate, ValidationCtx};
     pub use super::write::{FontWrite, TableWriter};
     pub use font_types::*;
     pub use std::collections::BTreeSet;
 
-    #[cfg(feature = "parsing")]
-    pub use super::from_obj::{FromObjRef, FromTableRef, ToOwnedObj, ToOwnedTable};
-    #[cfg(feature = "parsing")]
     pub use read_fonts::{
         FontData, FontRead, FontReadWithArgs, ReadArgs, ReadError, ResolveOffset,
     };

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -1,10 +1,7 @@
 //! compile-time representations of offsets
 
-#[cfg(feature = "parsing")]
 use crate::from_obj::FromTableRef;
-#[cfg(feature = "parsing")]
 use font_types::{BigEndian, Scalar};
-#[cfg(feature = "parsing")]
 use read_fonts::ReadError;
 
 use super::write::{FontWrite, TableWriter};
@@ -136,7 +133,6 @@ impl<const N: usize, T: FontWrite> FontWrite for NullableOffsetMarker<T, N> {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<const N: usize, T, U> From<Result<U, ReadError>> for OffsetMarker<T, N>
 where
     T: FromTableRef<U>,
@@ -146,7 +142,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<const N: usize, T, U> From<Option<Result<U, ReadError>>> for NullableOffsetMarker<T, N>
 where
     T: FromTableRef<U>,
@@ -161,7 +156,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, const N: usize, T: Scalar> From<Result<&'a [BigEndian<T>], ReadError>>
     for OffsetMarker<Vec<T>, N>
 where
@@ -174,7 +168,6 @@ where
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a, const N: usize, T: Scalar> From<Option<Result<&'a [BigEndian<T>], ReadError>>>
     for NullableOffsetMarker<Vec<T>, N>
 where

--- a/write-fonts/src/tables/hhea.rs
+++ b/write-fonts/src/tables/hhea.rs
@@ -23,18 +23,15 @@ mod tests {
         };
 
         let _dumped = crate::write::dump_table(&hhea).unwrap();
-        #[cfg(feature = "parsing")]
-        {
-            let data = FontData::new(&_dumped);
-            let loaded = read_fonts::tables::hhea::Hhea::read(data).unwrap();
-            assert_eq!(loaded.advance_width_max(), hhea.advance_width_max);
-            assert_eq!(loaded.ascender(), hhea.ascender);
-            assert_eq!(loaded.descender(), hhea.descender);
-            assert_eq!(loaded.version(), MajorMinor::VERSION_1_0);
-            assert_eq!(loaded.min_left_side_bearing(), hhea.min_left_side_bearing);
-            assert_eq!(loaded.min_right_side_bearing(), hhea.min_right_side_bearing);
-            assert_eq!(loaded.min_right_side_bearing(), hhea.min_right_side_bearing);
-            assert_eq!(loaded.number_of_h_metrics(), hhea.number_of_h_metrics);
-        }
+        let data = FontData::new(&_dumped);
+        let loaded = read_fonts::tables::hhea::Hhea::read(data).unwrap();
+        assert_eq!(loaded.advance_width_max(), hhea.advance_width_max);
+        assert_eq!(loaded.ascender(), hhea.ascender);
+        assert_eq!(loaded.descender(), hhea.descender);
+        assert_eq!(loaded.version(), MajorMinor::VERSION_1_0);
+        assert_eq!(loaded.min_left_side_bearing(), hhea.min_left_side_bearing);
+        assert_eq!(loaded.min_right_side_bearing(), hhea.min_right_side_bearing);
+        assert_eq!(loaded.min_right_side_bearing(), hhea.min_right_side_bearing);
+        assert_eq!(loaded.number_of_h_metrics(), hhea.number_of_h_metrics);
     }
 }

--- a/write-fonts/src/tables/hmtx.rs
+++ b/write-fonts/src/tables/hmtx.rs
@@ -18,13 +18,10 @@ mod tests {
 
         let _dumped = crate::write::dump_table(&hmtx).unwrap();
 
-        #[cfg(feature = "parsing")]
-        {
-            let data = FontData::new(&_dumped);
-            let loaded = read_fonts::tables::hmtx::Hmtx::read_with_args(data, &(1, 5)).unwrap();
-            assert_eq!(loaded.h_metrics()[0].advance_width(), 602);
-            assert_eq!(loaded.h_metrics()[0].lsb(), -214);
-            assert_eq!(loaded.left_side_bearings(), &hmtx.left_side_bearings);
-        }
+        let data = FontData::new(&_dumped);
+        let loaded = read_fonts::tables::hmtx::Hmtx::read_with_args(data, &(1, 5)).unwrap();
+        assert_eq!(loaded.h_metrics()[0].advance_width(), 602);
+        assert_eq!(loaded.h_metrics()[0].lsb(), -214);
+        assert_eq!(loaded.left_side_bearings(), &hmtx.left_side_bearings);
     }
 }

--- a/write-fonts/src/tables/maxp.rs
+++ b/write-fonts/src/tables/maxp.rs
@@ -50,13 +50,10 @@ mod tests {
 
         let dumped = crate::write::dump_table(&maxp_05).unwrap();
         assert_eq!(dumped.len(), 6);
-        #[cfg(feature = "parsing")]
-        {
-            let data = FontData::new(&dumped);
-            let loaded = read_fonts::tables::maxp::Maxp::read(data).unwrap();
-            assert_eq!(loaded.version(), Version16Dot16::VERSION_0_5);
-            assert_eq!(loaded.num_glyphs(), 5);
-        }
+        let data = FontData::new(&dumped);
+        let loaded = read_fonts::tables::maxp::Maxp::read(data).unwrap();
+        assert_eq!(loaded.version(), Version16Dot16::VERSION_0_5);
+        assert_eq!(loaded.num_glyphs(), 5);
     }
 
     #[test]
@@ -80,14 +77,11 @@ mod tests {
 
         let _dumped = crate::write::dump_table(&maxp_05).unwrap();
 
-        #[cfg(feature = "parsing")]
-        {
-            let data = FontData::new(&_dumped);
-            let loaded = read_fonts::tables::maxp::Maxp::read(data).unwrap();
-            assert_eq!(loaded.version(), Version16Dot16::VERSION_1_0);
-            assert_eq!(loaded.max_composite_contours(), Some(9));
-            assert_eq!(loaded.max_zones(), Some(10));
-            assert_eq!(loaded.max_component_depth(), Some(18));
-        }
+        let data = FontData::new(&_dumped);
+        let loaded = read_fonts::tables::maxp::Maxp::read(data).unwrap();
+        assert_eq!(loaded.version(), Version16Dot16::VERSION_1_0);
+        assert_eq!(loaded.max_composite_contours(), Some(9));
+        assert_eq!(loaded.max_zones(), Some(10));
+        assert_eq!(loaded.max_component_depth(), Some(18));
     }
 }

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -139,14 +139,12 @@ impl FontWrite for NameStringWriter<'_> {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromObjRef<read_fonts::tables::name::NameString<'_>> for String {
     fn from_obj_ref(obj: &read_fonts::tables::name::NameString<'_>, _: FontData) -> Self {
         obj.chars().collect()
     }
 }
 
-#[cfg(feature = "parsing")]
 impl FromTableRef<read_fonts::tables::name::NameString<'_>> for String {}
 
 impl PartialEq for NameRecord {
@@ -261,17 +259,13 @@ mod tests {
         });
 
         let _dumped = crate::dump_table(&table).unwrap();
-        #[cfg(feature = "parsing")]
-        {
-            let loaded = read_fonts::tables::name::Name::read(FontData::new(&_dumped)).unwrap();
-            assert_eq!(loaded.name_record()[0].encoding_id, 4);
-            assert_eq!(loaded.name_record()[1].name_id, 1029);
-            assert_eq!(loaded.name_record()[2].name_id, 1030);
-        }
+        let loaded = read_fonts::tables::name::Name::read(FontData::new(&_dumped)).unwrap();
+        assert_eq!(loaded.name_record()[0].encoding_id, 4);
+        assert_eq!(loaded.name_record()[1].name_id, 1029);
+        assert_eq!(loaded.name_record()[2].name_id, 1030);
     }
 
     #[test]
-    #[cfg(feature = "parsing")]
     fn roundtrip() {
         #[rustfmt::skip]
         static COLINS_BESPOKE_DATA: &[u8] = &[

--- a/write-fonts/src/tables/post.rs
+++ b/write-fonts/src/tables/post.rs
@@ -21,7 +21,6 @@ impl AsRef<str> for PString {
     }
 }
 
-#[cfg(feature = "parsing")]
 impl<'a> FromObjRef<read_fonts::tables::post::PString<'a>> for PString {
     fn from_obj_ref(from: &read_fonts::tables::post::PString<'a>, _: FontData) -> Self {
         PString(from.as_str().to_owned())
@@ -46,7 +45,6 @@ impl PartialEq<&str> for PString {
 mod tests {
 
     #[test]
-    #[cfg(feature = "parsing")]
     fn roundtrip() {
         use super::*;
         use read_fonts::test_data::post as test_data;


### PR DESCRIPTION
- make `read-fonts` dependency non-optional 
- removes the "parsing" feature, and any code that referenced it (we now always generate parsing code)
- `write-fonts` reexports flags and enums declared in `read-fonts`, instead of re-declaring them
- types related to the Mac OS Roman encoding are now reused between crates (and have a cleaned up API)

closes #110 