### PR TITLE
Implement Default for write-fonts types

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -187,6 +187,9 @@ The following annotations are supported on top-level objects:
   compile type.
 - `#[compile_type(type)]`: specify an alternate type to be used in the struct
   generated for this type.
+- `#[default(expr)]`: specify a value that will be used in the implementation of
+  `Default` for the containing type. Unlike with `#[compile]`, this value is set
+  when the type is created, and can be manually modified by the user.
 - `#[read_with(args,+)]`: specify that this field's type needs to be read with
   `FontReadWithArgs`, and passed the provided args. Args is a comma separated
   list of fields or input args to the type.

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -82,8 +82,11 @@ impl Fields {
 
     /// `Ok(true)` if no fields have custom default values, `Ok(false)` otherwise.
     ///
-    /// Returns an error if a field that requires a custom default or compile value
-    /// does not have one.
+    /// This serves double duty as a validation method: if we know that default
+    /// should not be derived on a field (such as with version fields) but there
+    /// is no apprporiate annotation, we will return an error explaining the problem.
+    /// This is more helpful than generating code that does not compile, or compile_write_stmt
+    /// but is likely not desired.
     pub(crate) fn can_derive_default(&self) -> syn::Result<bool> {
         for field in self.iter() {
             if !field.supports_derive_default()? {

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::spanned::Spanned;
 
 use crate::parsing::{Attr, FieldValidation, OffsetTarget, Phase};
 
@@ -73,6 +74,23 @@ impl Fields {
 
     pub(crate) fn iter_compile_write_stmts(&self) -> impl Iterator<Item = TokenStream> + '_ {
         self.fields.iter().map(Field::compile_write_stmt)
+    }
+
+    pub(crate) fn iter_compile_default_inits(&self) -> impl Iterator<Item = TokenStream> + '_ {
+        self.fields.iter().filter_map(Field::compile_default_init)
+    }
+
+    /// `Ok(true)` if no fields have custom default values, `Ok(false)` otherwise.
+    ///
+    /// Returns an error if a field that requires a custom default or compile value
+    /// does not have one.
+    pub(crate) fn can_derive_default(&self) -> syn::Result<bool> {
+        for field in self.iter() {
+            if !field.supports_derive_default()? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     // we use this to add disable a clippy lint if needed
@@ -972,6 +990,38 @@ impl Field {
         let docs = &self.attrs.docs;
         let typ = self.owned_type();
         Some(quote!( #( #docs)* pub #name: #typ ))
+    }
+
+    fn supports_derive_default(&self) -> syn::Result<bool> {
+        if self.attrs.default.is_some() {
+            return Ok(false);
+        }
+        // this should maybe be in sanity check, but it's easier here, because
+        // this is only called if codegen is running in 'compile' mode; if we
+        // aren't in compile mode then this isn't an error.
+        if let Some(version) = &self.attrs.version {
+            if self.attrs.compile.is_none() {
+                return Err(syn::Error::new(
+                    version.span(),
+                    "version field needs explicit #[default(x)] or #[compile(x)] attribute.",
+                ));
+            }
+        }
+        Ok(true)
+    }
+
+    /// 'None' if this field's value is computed at compile time
+    fn compile_default_init(&self) -> Option<TokenStream> {
+        if self.is_computed() {
+            return None;
+        }
+
+        let name = &self.name;
+        if let Some(expr) = self.attrs.default.as_deref() {
+            Some(quote!( #name: #expr ))
+        } else {
+            Some(quote!( #name: Default::default() ))
+        }
     }
 
     fn compile_write_stmt(&self) -> TokenStream {

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -182,6 +182,7 @@ pub(crate) struct FieldAttrs {
     pub(crate) format: Option<Attr<syn::LitInt>>,
     pub(crate) count: Option<Attr<Count>>,
     pub(crate) compile: Option<Attr<CustomCompile>>,
+    pub(crate) default: Option<Attr<syn::Expr>>,
     pub(crate) compile_type: Option<Attr<syn::Path>>,
     pub(crate) read_with_args: Option<Attr<FieldReadArgs>>,
     pub(crate) read_offset_args: Option<Attr<FieldReadArgs>>,
@@ -887,6 +888,7 @@ static OFFSET_DATA: &str = "offset_data_method";
 static OFFSET_ADJUSTMENT: &str = "offset_adjustment";
 static COMPILE: &str = "compile";
 static COMPILE_TYPE: &str = "compile_type";
+static DEFAULT: &str = "default";
 static READ_WITH: &str = "read_with";
 static READ_OFFSET_WITH: &str = "read_offset_with";
 static TRAVERSE_WITH: &str = "traverse_with";
@@ -923,6 +925,8 @@ impl Parse for FieldAttrs {
                 this.compile = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == COMPILE_TYPE {
                 this.compile_type = Some(Attr::new(ident.clone(), attr.parse_args()?));
+            } else if ident == DEFAULT {
+                this.default = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == VALIDATE {
                 this.validation = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == TO_OWNED {

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -210,7 +210,7 @@ pub(crate) fn generate_compile_impl(
     });
 
     let can_derive_default = fields.can_derive_default()?;
-    let maybe_derive_default = can_derive_default.then(|| quote!(Default));
+    let maybe_derive_default = can_derive_default.then(|| quote!(, Default));
     let maybe_custom_default = (!can_derive_default).then(|| {
         let default_field_inits = fields.iter_compile_default_inits();
         let default_impl_params = generic_param.map(|t| quote! { <#t: Default> });
@@ -227,7 +227,7 @@ pub(crate) fn generate_compile_impl(
 
     Ok(quote! {
         #( #docs )*
-        #[derive(Clone, Debug, #maybe_derive_default)]
+        #[derive(Clone, Debug #maybe_derive_default)]
         pub struct #name <#generic_param> {
             #( #field_decls, )*
         }

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -209,12 +209,30 @@ pub(crate) fn generate_compile_impl(
         }
     });
 
+    let can_derive_default = fields.can_derive_default()?;
+    let maybe_derive_default = can_derive_default.then(|| quote!(Default));
+    let maybe_custom_default = (!can_derive_default).then(|| {
+        let default_field_inits = fields.iter_compile_default_inits();
+        let default_impl_params = generic_param.map(|t| quote! { <#t: Default> });
+        quote! {
+        impl #default_impl_params Default for #name <#generic_param> {
+            fn default() -> Self {
+                Self {
+                    #( #default_field_inits, )*
+                }
+            }
+        }
+        }
+    });
+
     Ok(quote! {
         #( #docs )*
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, #maybe_derive_default)]
         pub struct #name <#generic_param> {
             #( #field_decls, )*
         }
+
+        #maybe_custom_default
 
         #font_write_impl
 

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -352,11 +352,7 @@ pub(crate) fn generate_group_compile(
     let mut validate_match_arms = Vec::new();
     let mut from_obj_match_arms = Vec::new();
     let from_type = quote!(#parse_module :: #name);
-    let mut first_var_name = None;
     for var in &item.variants {
-        if first_var_name.is_none() {
-            first_var_name = Some(&var.name);
-        }
         let var_name = &var.name;
         let typ = &var.typ;
 
@@ -367,6 +363,7 @@ pub(crate) fn generate_group_compile(
             quote! { #from_type :: #var_name(table) => Self :: #var_name(table.to_owned_obj(data)) },
         );
     }
+    let first_var_name = &item.variants.first().unwrap().name;
 
     Ok(quote! {
         #( #docs)*
@@ -422,11 +419,7 @@ pub(crate) fn generate_format_compile(
         quote! ( #( #docs )* #name(#typ) )
     });
 
-    let default_variant = &item
-        .variants
-        .first()
-        .expect("empty format groups not supported")
-        .name;
+    let default_variant = &item.variants.first().unwrap().name;
 
     let write_arms = item.variants.iter().map(|variant| {
         let var_name = &variant.name;

--- a/font-types/src/fword.rs
+++ b/font-types/src/fword.rs
@@ -1,11 +1,11 @@
 //! 16-bit signed and unsigned font-units
 
 /// 16-bit signed quantity in font design units.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FWord(i16);
 
 /// 16-bit unsigned quantity in font design units.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UfWord(u16);
 
 impl FWord {

--- a/font-types/src/glyph_id.rs
+++ b/font-types/src/glyph_id.rs
@@ -26,6 +26,12 @@ impl GlyphId {
     }
 }
 
+impl Default for GlyphId {
+    fn default() -> Self {
+        GlyphId::NOTDEF
+    }
+}
+
 impl std::fmt::Display for GlyphId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "GID_{}", self.0)

--- a/font-types/src/longdatetime.rs
+++ b/font-types/src/longdatetime.rs
@@ -3,7 +3,7 @@
 /// A simple datetime type.
 ///
 /// This represented as a number of seconds since 12:00 midnight, January 1, 1904, UTC.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LongDateTime(i64);
 
 impl LongDateTime {

--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -12,14 +12,14 @@ use std::{
 pub struct Tag([u8; 4]);
 
 impl Tag {
-    /// Generate a `Tag` from a string literal, verifying it conforms to the
+    /// Generate a `Tag` from a byte slice, verifying it conforms to the
     /// OpenType spec.
     ///
-    /// The argument must be a non-empty string literal. Containing at most four
-    /// characters in the printable ascii range, `0x20..=0x7E`.
+    /// The argument must be a non-empty slice, containing at most four
+    /// bytes in the printable ascii range, `0x20..=0x7E`.
     ///
-    /// If the input has fewer than four characters, it will be padded with the space
-    /// (' ', `0x20`) character.
+    /// If the input has fewer than four bytes, it will be padded with spaces
+    /// (`0x20`).
     ///
     /// # Panics
     ///
@@ -180,6 +180,13 @@ impl Debug for Tag {
         }
         dbg.field(&std::str::from_utf8(&bytes).unwrap());
         dbg.finish()
+    }
+}
+
+// a meaningless placeholder value.
+impl Default for Tag {
+    fn default() -> Self {
+        Tag([b' '; 4])
     }
 }
 

--- a/resources/codegen_inputs/cpal.rs
+++ b/resources/codegen_inputs/cpal.rs
@@ -4,6 +4,7 @@
 table Cpal {
     /// Table version number (=0).
     #[version]
+    #[compile(0)]
     version: u16,
     /// Number of palette entries in each palette.
     num_palette_entries: u16,

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -31,11 +31,14 @@ record TableRecord {
 }
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
+#[skip_from_obj]
+#[skip_font_write]
 table TTCHeader {
     /// Font Collection ID string: "ttcf"
     ttc_tag: Tag,
     /// Major/minor version of the TTC Header
     #[version]
+    #[compile(self.compute_version())]
     version: MajorMinor,
     /// Number of fonts in TTC
     num_fonts: u32,

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -4,6 +4,7 @@
 table Name {
     /// Table version number (0 or 1)
     #[version]
+    #[compile(self.compute_version())]
     version: u16,
     /// Number of name records.
     #[compile(array_len($name_record))]

--- a/resources/codegen_inputs/post.rs
+++ b/resources/codegen_inputs/post.rs
@@ -6,6 +6,9 @@ table Post {
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version
     /// 3.0
     #[version]
+    // NOTE: we will need some sort of builder to compile post tables, and that
+    // builder should set the version. This attribute is a placeholder.
+    #[default(Version16Dot16::VERSION_1_0)]
     version: Version16Dot16,
     /// Italic angle in counter-clockwise degrees from the vertical.
     /// Zero for upright text, negative for text that leans to the

--- a/resources/codegen_inputs/test.rs
+++ b/resources/codegen_inputs/test.rs
@@ -9,6 +9,7 @@
 table KindsOfOffsets {
     /// The major/minor version of the GDEF table
     #[version]
+    #[default(MajorMinor::VERSION_1_1)]
     version: MajorMinor,
     /// A normal offset
     nonnullable_offset: Offset16<Dummy>,
@@ -32,6 +33,7 @@ table KindsOfOffsets {
 table KindsOfArraysOfOffsets {
     /// The major/minor version of the GDEF table
     #[version]
+    #[compile(MajorMinor::VERSION_1_1)]
     version: MajorMinor,
     /// The number of items in each array
     count: u16,

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -6,10 +6,8 @@
 use crate::codegen_prelude::*;
 
 /// [CPAL (Color Palette Table)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-table-header) table
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Cpal {
-    /// Table version number (=0).
-    pub version: u16,
     /// Number of palette entries in each palette.
     pub num_palette_entries: u16,
     /// Number of palettes in the table.
@@ -49,8 +47,9 @@ pub struct Cpal {
 }
 
 impl FontWrite for Cpal {
+    #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        let version = self.version;
+        let version = 0 as u16;
         version.write_into(writer);
         self.num_palette_entries.write_into(writer);
         self.num_palettes.write_into(writer);
@@ -87,7 +86,6 @@ impl Validate for Cpal {
 impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
     fn from_obj_ref(obj: &read_fonts::tables::cpal::Cpal<'a>, _: FontData) -> Self {
         Cpal {
-            version: obj.version(),
             num_palette_entries: obj.num_palette_entries(),
             num_palettes: obj.num_palettes(),
             num_color_records: obj.num_color_records(),
@@ -109,7 +107,7 @@ impl<'a> FontRead<'a> for Cpal {
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ColorRecord {
     /// Blue value (B0).
     pub blue: u8,

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::layout::gdef::GlyphClassDef;
 
 /// [GDEF](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#gdef-header) 1.0
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Gdef {
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
@@ -102,7 +102,7 @@ impl FontWrite for GlyphClassDef {
 }
 
 /// [Attachment Point List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#attachment-point-list-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AttachList {
     /// Offset to Coverage table - from beginning of AttachList table
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -154,7 +154,7 @@ impl<'a> FontRead<'a> for AttachList {
 }
 
 /// Part of [AttachList]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AttachPoint {
     /// Array of contour point indices -in increasing numerical order
     pub point_indices: Vec<u16>,
@@ -197,7 +197,7 @@ impl<'a> FontRead<'a> for AttachPoint {
 }
 
 /// [Ligature Caret List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LigCaretList {
     /// Offset to Coverage table - from beginning of LigCaretList table
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -249,7 +249,7 @@ impl<'a> FontRead<'a> for LigCaretList {
 }
 
 /// [Ligature Glyph Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-glyph-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LigGlyph {
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
@@ -301,6 +301,12 @@ pub enum CaretValue {
     Format3(CaretValueFormat3),
 }
 
+impl Default for CaretValue {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for CaretValue {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -341,7 +347,7 @@ impl<'a> FontRead<'a> for CaretValue {
 }
 
 /// [CaretValue Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CaretValueFormat1 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -377,7 +383,7 @@ impl<'a> FontRead<'a> for CaretValueFormat1 {
 }
 
 /// [CaretValue Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-2)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CaretValueFormat2 {
     /// Contour point index on glyph
     pub caret_value_point_index: u16,
@@ -413,7 +419,7 @@ impl<'a> FontRead<'a> for CaretValueFormat2 {
 }
 
 /// [CaretValue Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-3)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CaretValueFormat3 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -461,7 +467,7 @@ impl<'a> FontRead<'a> for CaretValueFormat3 {
 }
 
 /// [Mark Glyph Sets Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#mark-glyph-sets-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MarkGlyphSets {
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -9,7 +9,7 @@ pub use read_fonts::layout::gpos::ValueFormat;
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Gpos {
     /// Offset to ScriptList table, from beginning of GPOS table
     pub script_list_offset: OffsetMarker<ScriptList>,
@@ -84,6 +84,12 @@ pub enum PositionLookup {
     Contextual(Lookup<PositionSequenceContext>),
     ChainContextual(Lookup<PositionChainContext>),
     Extension(Lookup<ExtensionSubtable>),
+}
+
+impl Default for PositionLookup {
+    fn default() -> Self {
+        Self::Single(Default::default())
+    }
 }
 
 impl FontWrite for PositionLookup {
@@ -169,6 +175,12 @@ pub enum AnchorTable {
     Format3(AnchorFormat3),
 }
 
+impl Default for AnchorTable {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for AnchorTable {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -209,7 +221,7 @@ impl<'a> FontRead<'a> for AnchorTable {
 }
 
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AnchorFormat1 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -249,7 +261,7 @@ impl<'a> FontRead<'a> for AnchorFormat1 {
 }
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AnchorFormat2 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -293,7 +305,7 @@ impl<'a> FontRead<'a> for AnchorFormat2 {
 }
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AnchorFormat3 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -354,7 +366,7 @@ impl<'a> FontRead<'a> for AnchorFormat3 {
 }
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MarkArray {
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
@@ -404,7 +416,7 @@ impl<'a> FontRead<'a> for MarkArray {
 }
 
 /// Part of [MarkArray]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MarkRecord {
     /// Class defined for the associated mark.
     pub mark_class: u16,
@@ -445,6 +457,12 @@ pub enum SinglePos {
     Format2(SinglePosFormat2),
 }
 
+impl Default for SinglePos {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for SinglePos {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -482,7 +500,7 @@ impl<'a> FontRead<'a> for SinglePos {
 }
 
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SinglePosFormat1 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -531,7 +549,7 @@ impl<'a> FontRead<'a> for SinglePosFormat1 {
 }
 
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SinglePosFormat2 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -596,6 +614,12 @@ pub enum PairPos {
     Format2(PairPosFormat2),
 }
 
+impl Default for PairPos {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for PairPos {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -633,7 +657,7 @@ impl<'a> FontRead<'a> for PairPos {
 }
 
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PairPosFormat1 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -689,7 +713,7 @@ impl<'a> FontRead<'a> for PairPosFormat1 {
 }
 
 /// Part of [PairPosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PairSet {
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
@@ -733,7 +757,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairSet<'a>> for PairSet {
 impl<'a> FromTableRef<read_fonts::layout::gpos::PairSet<'a>> for PairSet {}
 
 /// Part of [PairSet]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PairValueRecord {
     /// Glyph ID of second glyph in the pair (first glyph is listed in
     /// the Coverage table).
@@ -770,7 +794,7 @@ impl FromObjRef<read_fonts::layout::gpos::PairValueRecord> for PairValueRecord {
 }
 
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PairPosFormat2 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -847,7 +871,7 @@ impl<'a> FontRead<'a> for PairPosFormat2 {
 }
 
 /// Part of [PairPosFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Class1Record {
     /// Array of Class2 records, ordered by classes in classDef2.
     pub class2_records: Vec<Class2Record>,
@@ -885,7 +909,7 @@ impl FromObjRef<read_fonts::layout::gpos::Class1Record<'_>> for Class1Record {
 }
 
 /// Part of [PairPosFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Class2Record {
     /// Positioning for first glyph — empty if valueFormat1 = 0.
     pub value_record1: ValueRecord,
@@ -914,7 +938,7 @@ impl FromObjRef<read_fonts::layout::gpos::Class2Record> for Class2Record {
 }
 
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CursivePosFormat1 {
     /// Offset to Coverage table, from beginning of CursivePos subtable.
     pub coverage_offset: OffsetMarker<CoverageTable>,
@@ -972,7 +996,7 @@ impl<'a> FontRead<'a> for CursivePosFormat1 {
 }
 
 /// Part of [CursivePosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
@@ -1015,7 +1039,7 @@ impl FromObjRef<read_fonts::layout::gpos::EntryExitRecord> for EntryExitRecord {
 }
 
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MarkBasePosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
@@ -1083,7 +1107,7 @@ impl<'a> FontRead<'a> for MarkBasePosFormat1 {
 }
 
 /// Part of [MarkBasePosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BaseArray {
     /// Array of BaseRecords, in order of baseCoverage Index.
     pub base_records: Vec<BaseRecord>,
@@ -1126,7 +1150,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::BaseArray<'a>> for BaseArray {
 impl<'a> FromTableRef<read_fonts::layout::gpos::BaseArray<'a>> for BaseArray {}
 
 /// Part of [BaseArray]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BaseRecord {
     /// Array of offsets (one per mark class) to Anchor tables. Offsets
     /// are from beginning of BaseArray table, ordered by class
@@ -1162,7 +1186,7 @@ impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
 }
 
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MarkLigPosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
@@ -1230,7 +1254,7 @@ impl<'a> FontRead<'a> for MarkLigPosFormat1 {
 }
 
 /// Part of [MarkLigPosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LigatureArray {
     /// Array of offsets to LigatureAttach tables. Offsets are from
     /// beginning of LigatureArray table, ordered by ligatureCoverage
@@ -1270,7 +1294,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArr
 impl<'a> FromTableRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArray {}
 
 /// Part of [MarkLigPosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LigatureAttach {
     /// Array of Component records, ordered in writing direction.
     pub component_records: Vec<ComponentRecord>,
@@ -1313,7 +1337,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureAttach<'a>> for LigatureAt
 impl<'a> FromTableRef<read_fonts::layout::gpos::LigatureAttach<'a>> for LigatureAttach {}
 
 /// Part of [MarkLigPosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ComponentRecord {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of LigatureAttach table, ordered by class
@@ -1355,7 +1379,7 @@ impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentReco
 }
 
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MarkMarkPosFormat1 {
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
@@ -1423,7 +1447,7 @@ impl<'a> FontRead<'a> for MarkMarkPosFormat1 {
 }
 
 /// Part of [MarkMarkPosFormat1]Class2Record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Mark2Array {
     /// Array of Mark2Records, in Coverage order.
     pub mark2_records: Vec<Mark2Record>,
@@ -1466,7 +1490,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::Mark2Array<'a>> for Mark2Array {
 impl<'a> FromTableRef<read_fonts::layout::gpos::Mark2Array<'a>> for Mark2Array {}
 
 /// Part of [MarkMarkPosFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Mark2Record {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of Mark2Array table, in class order (offsets may
@@ -1502,7 +1526,7 @@ impl FromObjRef<read_fonts::layout::gpos::Mark2Record<'_>> for Mark2Record {
 }
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ExtensionPosFormat1<T> {
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
@@ -1559,6 +1583,12 @@ pub enum ExtensionSubtable {
     MarkToMark(ExtensionPosFormat1<MarkMarkPosFormat1>),
     Contextual(ExtensionPosFormat1<PositionSequenceContext>),
     ChainContextual(ExtensionPosFormat1<PositionChainContext>),
+}
+
+impl Default for ExtensionSubtable {
+    fn default() -> Self {
+        Self::Single(Default::default())
+    }
 }
 
 impl FontWrite for ExtensionSubtable {

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Gsub {
     /// Offset to ScriptList table, from beginning of GSUB table
     pub script_list_offset: OffsetMarker<ScriptList>,
@@ -84,6 +84,12 @@ pub enum SubstitutionLookup {
     Reverse(Lookup<ReverseChainSingleSubstFormat1>),
 }
 
+impl Default for SubstitutionLookup {
+    fn default() -> Self {
+        Self::Single(Default::default())
+    }
+}
+
 impl FontWrite for SubstitutionLookup {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -157,6 +163,12 @@ pub enum SingleSubst {
     Format2(SingleSubstFormat2),
 }
 
+impl Default for SingleSubst {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for SingleSubst {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -194,7 +206,7 @@ impl<'a> FontRead<'a> for SingleSubst {
 }
 
 /// [Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -241,7 +253,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat1 {
 }
 
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SingleSubstFormat2 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -294,7 +306,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat2 {
 }
 
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MultipleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -349,7 +361,7 @@ impl<'a> FontRead<'a> for MultipleSubstFormat1 {
 }
 
 /// Part of [MultipleSubstFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Sequence {
     /// String of glyph IDs to substitute
     pub substitute_glyph_ids: Vec<GlyphId>,
@@ -392,7 +404,7 @@ impl<'a> FontRead<'a> for Sequence {
 }
 
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AlternateSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -453,7 +465,7 @@ impl<'a> FontRead<'a> for AlternateSubstFormat1 {
 }
 
 /// Part of [AlternateSubstFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AlternateSet {
     /// Array of alternate glyph IDs, in arbitrary order
     pub alternate_glyph_ids: Vec<GlyphId>,
@@ -496,7 +508,7 @@ impl<'a> FontRead<'a> for AlternateSet {
 }
 
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LigatureSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -551,7 +563,7 @@ impl<'a> FontRead<'a> for LigatureSubstFormat1 {
 }
 
 /// Part of [LigatureSubstFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LigatureSet {
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
@@ -596,7 +608,7 @@ impl<'a> FontRead<'a> for LigatureSet {
 }
 
 /// Part of [LigatureSubstFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Ligature {
     /// glyph ID of ligature to substitute
     pub ligature_glyph: GlyphId,
@@ -636,7 +648,7 @@ impl<'a> FontRead<'a> for Ligature {
 }
 
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ExtensionSubstFormat1<T> {
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
@@ -692,6 +704,12 @@ pub enum ExtensionSubtable {
     Contextual(ExtensionSubstFormat1<SubstitutionSequenceContext>),
     ChainContextual(ExtensionSubstFormat1<SubstitutionChainContext>),
     Reverse(ExtensionSubstFormat1<ReverseChainSingleSubstFormat1>),
+}
+
+impl Default for ExtensionSubtable {
+    fn default() -> Self {
+        Self::Single(Default::default())
+    }
 }
 
 impl FontWrite for ExtensionSubtable {
@@ -756,7 +774,7 @@ impl FromObjRef<read_fonts::layout::gsub::ExtensionSubtable<'_>> for ExtensionSu
 impl FromTableRef<read_fonts::layout::gsub::ExtensionSubtable<'_>> for ExtensionSubtable {}
 
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ReverseChainSingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/head>
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Head {
     /// Set by font manufacturer.
     pub font_revision: Fixed,

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Hhea {
     /// Typographic ascent—see note below.
     pub ascender: FWord,

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Hmtx {
     /// Paired advance width and left side bearing values for each
     /// glyph. Records are indexed by glyph ID.
@@ -52,7 +52,7 @@ impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
 
 impl<'a> FromTableRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {}
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LongHorMetric {
     /// Advance width, in font design units.
     pub advance_width: u16,

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::layout::DeltaFormat;
 
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ScriptList {
     /// Array of ScriptRecords, listed alphabetically by script tag
     pub script_records: Vec<ScriptRecord>,
@@ -57,7 +57,7 @@ impl<'a> FontRead<'a> for ScriptList {
 }
 
 /// [Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ScriptRecord {
     /// 4-byte script tag identifier
     pub script_tag: Tag,
@@ -92,7 +92,7 @@ impl FromObjRef<read_fonts::layout::ScriptRecord> for ScriptRecord {
 }
 
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Script {
     /// Offset to default LangSys table, from beginning of Script table
     /// — may be NULL
@@ -148,7 +148,7 @@ impl<'a> FontRead<'a> for Script {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LangSysRecord {
     /// 4-byte LangSysTag identifier
     pub lang_sys_tag: Tag,
@@ -183,7 +183,7 @@ impl FromObjRef<read_fonts::layout::LangSysRecord> for LangSysRecord {
 }
 
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LangSys {
     /// Index of a feature required for this language system; if no
     /// required features = 0xFFFF
@@ -232,7 +232,7 @@ impl<'a> FontRead<'a> for LangSys {
 }
 
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FeatureList {
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
@@ -282,7 +282,7 @@ impl<'a> FontRead<'a> for FeatureList {
 }
 
 /// Part of [FeatureList]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FeatureRecord {
     /// 4-byte feature identification tag
     pub feature_tag: Tag,
@@ -317,7 +317,7 @@ impl FromObjRef<read_fonts::layout::FeatureRecord> for FeatureRecord {
 }
 
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Feature {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     pub feature_params_offset: NullableOffsetMarker<FeatureParams>,
@@ -362,7 +362,7 @@ impl<'a> FromObjRef<read_fonts::layout::Feature<'a>> for Feature {
 impl<'a> FromTableRef<read_fonts::layout::Feature<'a>> for Feature {}
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LookupList<T> {
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
@@ -410,7 +410,7 @@ where
 }
 
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Lookup<T> {
     /// Lookup qualifiers
     pub lookup_flag: u16,
@@ -458,7 +458,7 @@ where
 }
 
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CoverageFormat1 {
     /// Array of glyph IDs — in numerical order
     pub glyph_array: Vec<GlyphId>,
@@ -502,7 +502,7 @@ impl<'a> FontRead<'a> for CoverageFormat1 {
 }
 
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CoverageFormat2 {
     /// Array of glyph ranges — ordered by startGlyphID.
     pub range_records: Vec<RangeRecord>,
@@ -552,7 +552,7 @@ impl<'a> FontRead<'a> for CoverageFormat2 {
 }
 
 /// Used in [CoverageFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RangeRecord {
     /// First glyph ID in the range
     pub start_glyph_id: GlyphId,
@@ -589,6 +589,12 @@ impl FromObjRef<read_fonts::layout::RangeRecord> for RangeRecord {
 pub enum CoverageTable {
     Format1(CoverageFormat1),
     Format2(CoverageFormat2),
+}
+
+impl Default for CoverageTable {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl FontWrite for CoverageTable {
@@ -628,7 +634,7 @@ impl<'a> FontRead<'a> for CoverageTable {
 }
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ClassDefFormat1 {
     /// First glyph ID of the classValueArray
     pub start_glyph_id: GlyphId,
@@ -676,7 +682,7 @@ impl<'a> FontRead<'a> for ClassDefFormat1 {
 }
 
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ClassDefFormat2 {
     /// Array of ClassRangeRecords — ordered by startGlyphID
     pub class_range_records: Vec<ClassRangeRecord>,
@@ -726,7 +732,7 @@ impl<'a> FontRead<'a> for ClassDefFormat2 {
 }
 
 /// Used in [ClassDefFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ClassRangeRecord {
     /// First glyph ID in the range
     pub start_glyph_id: GlyphId,
@@ -771,6 +777,12 @@ pub enum ClassDef {
     Format2(ClassDefFormat2),
 }
 
+impl Default for ClassDef {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for ClassDef {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -808,7 +820,7 @@ impl<'a> FontRead<'a> for ClassDef {
 }
 
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceLookupRecord {
     /// Index (zero-based) into the input glyph sequence
     pub sequence_index: u16,
@@ -837,7 +849,7 @@ impl FromObjRef<read_fonts::layout::SequenceLookupRecord> for SequenceLookupReco
 }
 
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
@@ -892,7 +904,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat1 {
 }
 
 /// Part of [SequenceContextFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceRuleSet {
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
@@ -937,7 +949,7 @@ impl<'a> FontRead<'a> for SequenceRuleSet {
 }
 
 /// Part of [SequenceContextFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceRule {
     /// Array of input glyph IDs—starting with the second glyph
     pub input_sequence: Vec<u16>,
@@ -991,7 +1003,7 @@ impl<'a> FontRead<'a> for SequenceRule {
 }
 
 /// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
@@ -1054,7 +1066,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat2 {
 }
 
 /// Part of [SequenceContextFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ClassSequenceRuleSet {
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
@@ -1100,7 +1112,7 @@ impl<'a> FontRead<'a> for ClassSequenceRuleSet {
 }
 
 /// Part of [SequenceContextFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ClassSequenceRule {
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
@@ -1155,7 +1167,7 @@ impl<'a> FontRead<'a> for ClassSequenceRule {
 }
 
 /// [Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceContextFormat3 {
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
@@ -1224,6 +1236,12 @@ pub enum SequenceContext {
     Format3(SequenceContextFormat3),
 }
 
+impl Default for SequenceContext {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for SequenceContext {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -1264,7 +1282,7 @@ impl<'a> FontRead<'a> for SequenceContext {
 }
 
 /// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedSequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
@@ -1327,7 +1345,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat1 {
 }
 
 /// Part of [ChainedSequenceContextFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedSequenceRuleSet {
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
@@ -1373,7 +1391,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRuleSet {
 }
 
 /// Part of [ChainedSequenceContextFormat1]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedSequenceRule {
     /// Array of backtrack glyph IDs
     pub backtrack_sequence: Vec<u16>,
@@ -1448,7 +1466,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRule {
 }
 
 /// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedSequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
@@ -1538,7 +1556,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat2 {
 }
 
 /// Part of [ChainedSequenceContextFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedClassSequenceRuleSet {
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
@@ -1595,7 +1613,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet {
 }
 
 /// Part of [ChainedSequenceContextFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedClassSequenceRule {
     /// Array of backtrack-sequence classes
     pub backtrack_sequence: Vec<u16>,
@@ -1674,7 +1692,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule {
 }
 
 /// [Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChainedSequenceContextFormat3 {
     /// Array of offsets to coverage tables for the backtrack sequence
     pub backtrack_coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
@@ -1772,6 +1790,12 @@ pub enum ChainedSequenceContext {
     Format3(ChainedSequenceContextFormat3),
 }
 
+impl Default for ChainedSequenceContext {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl FontWrite for ChainedSequenceContext {
     fn write_into(&self, writer: &mut TableWriter) {
         match self {
@@ -1820,7 +1844,7 @@ impl FontWrite for DeltaFormat {
 }
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Device {
     /// Smallest size to correct, in ppem
     pub start_size: u16,
@@ -1865,7 +1889,7 @@ impl<'a> FontRead<'a> for Device {
 }
 
 /// Variation index table
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct VariationIndex {
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
@@ -1908,7 +1932,7 @@ impl<'a> FontRead<'a> for VariationIndex {
 }
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FeatureVariations {
     /// Array of feature variation records.
     pub feature_variation_records: Vec<FeatureVariationRecord>,
@@ -1958,7 +1982,7 @@ impl<'a> FontRead<'a> for FeatureVariations {
 }
 
 /// Part of [FeatureVariations]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FeatureVariationRecord {
     /// Offset to a condition set table, from beginning of
     /// FeatureVariations table.
@@ -2001,7 +2025,7 @@ impl FromObjRef<read_fonts::layout::FeatureVariationRecord> for FeatureVariation
 }
 
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ConditionSet {
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
@@ -2046,7 +2070,7 @@ impl<'a> FontRead<'a> for ConditionSet {
 }
 
 /// [Condition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range): Font Variation Axis Range
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ConditionFormat1 {
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
@@ -2092,7 +2116,7 @@ impl<'a> FontRead<'a> for ConditionFormat1 {
 }
 
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FeatureTableSubstitution {
     /// Array of feature table substitution records.
     pub substitutions: Vec<FeatureTableSubstitutionRecord>,
@@ -2146,7 +2170,7 @@ impl<'a> FontRead<'a> for FeatureTableSubstitution {
 }
 
 /// Used in [FeatureTableSubstitution]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct FeatureTableSubstitutionRecord {
     /// The feature table index to match.
     pub feature_index: u16,
@@ -2186,7 +2210,7 @@ impl FromObjRef<read_fonts::layout::FeatureTableSubstitutionRecord>
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SizeParams {
     /// The first value represents the design size in 720/inch units (decipoints).
     ///
@@ -2254,7 +2278,7 @@ impl<'a> FontRead<'a> for SizeParams {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct StylisticSetParams {
     /// The 'name' table name ID that specifies a string (or strings, for
     /// multiple languages) for a user-interface label for this feature.
@@ -2297,7 +2321,7 @@ impl<'a> FontRead<'a> for StylisticSetParams {
 }
 
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CharacterVariantParams {
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) for a user-interface label for this

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [`maxp`](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Maxp {
     /// The number of glyphs in the font.
     pub num_glyphs: u16,

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -51,6 +51,25 @@ pub struct Post {
     pub string_data: Option<Vec<PString>>,
 }
 
+impl Default for Post {
+    fn default() -> Self {
+        Self {
+            version: Version16Dot16::VERSION_1_0,
+            italic_angle: Default::default(),
+            underline_position: Default::default(),
+            underline_thickness: Default::default(),
+            is_fixed_pitch: Default::default(),
+            min_mem_type42: Default::default(),
+            max_mem_type42: Default::default(),
+            min_mem_type1: Default::default(),
+            max_mem_type1: Default::default(),
+            num_glyphs: Default::default(),
+            glyph_name_index: Default::default(),
+            string_data: Default::default(),
+        }
+    }
+}
+
 impl FontWrite for Post {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.version;

--- a/write-fonts/generated/generated_test.rs
+++ b/write-fonts/generated/generated_test.rs
@@ -23,6 +23,20 @@ pub struct KindsOfOffsets {
     pub versioned_nullable_offset: NullableOffsetMarker<Dummy>,
 }
 
+impl Default for KindsOfOffsets {
+    fn default() -> Self {
+        Self {
+            version: MajorMinor::VERSION_1_1,
+            nonnullable_offset: Default::default(),
+            nullable_offset: Default::default(),
+            array_offset_count: Default::default(),
+            array_offset: Default::default(),
+            versioned_nonnullable_offset: Default::default(),
+            versioned_nullable_offset: Default::default(),
+        }
+    }
+}
+
 impl FontWrite for KindsOfOffsets {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.version;
@@ -91,10 +105,8 @@ impl<'a> FontRead<'a> for KindsOfOffsets {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct KindsOfArraysOfOffsets {
-    /// The major/minor version of the GDEF table
-    pub version: MajorMinor,
     /// The number of items in each array
     pub count: u16,
     /// A normal array offset
@@ -108,8 +120,9 @@ pub struct KindsOfArraysOfOffsets {
 }
 
 impl FontWrite for KindsOfArraysOfOffsets {
+    #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        let version = self.version;
+        let version = MajorMinor::VERSION_1_1 as MajorMinor;
         version.write_into(writer);
         self.count.write_into(writer);
         self.nonnullable_offsets.write_into(writer);
@@ -132,7 +145,7 @@ impl FontWrite for KindsOfArraysOfOffsets {
 impl Validate for KindsOfArraysOfOffsets {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("KindsOfArraysOfOffsets", |ctx| {
-            let version = self.version;
+            let version: MajorMinor = MajorMinor::VERSION_1_1;
             ctx.in_field("nonnullable_offsets", |ctx| {
                 if self.nonnullable_offsets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
@@ -184,7 +197,6 @@ impl<'a> FromObjRef<read_fonts::codegen_test::KindsOfArraysOfOffsets<'a>>
         _: FontData,
     ) -> Self {
         KindsOfArraysOfOffsets {
-            version: obj.version(),
             count: obj.count(),
             nonnullable_offsets: obj.nonnullables().map(|x| x.into()).collect(),
             nullable_offsets: obj.nullables().map(|x| x.into()).collect(),
@@ -210,7 +222,7 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Dummy {
     pub value: u16,
 }

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -85,3 +85,9 @@ fn checksum_and_padding(table: &[u8]) -> (u32, u32) {
 
     (sum.wrapping_add(rem), padding as u32)
 }
+
+impl TTCHeader {
+    fn compute_version(&self) -> MajorMinor {
+        panic!("TTCHeader writing not supported")
+    }
+}

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -88,6 +88,6 @@ fn checksum_and_padding(table: &[u8]) -> (u32, u32) {
 
 impl TTCHeader {
     fn compute_version(&self) -> MajorMinor {
-        panic!("TTCHeader writing not supported")
+        panic!("TTCHeader writing not supported (yet)")
     }
 }

--- a/write-fonts/src/layout/gdef.rs
+++ b/write-fonts/src/layout/gdef.rs
@@ -28,17 +28,13 @@ mod tests {
     fn var_store_without_glyph_sets() {
         // this should compile, and version should be 1.3
         let gdef = Gdef {
-            glyph_class_def_offset: NullableOffsetMarker::new(None),
-            attach_list_offset: NullableOffsetMarker::new(None),
-            lig_caret_list_offset: NullableOffsetMarker::new(None),
-            mark_attach_class_def_offset: NullableOffsetMarker::new(None),
-            mark_glyph_sets_def_offset: NullableOffsetMarker::new(None),
             item_var_store_offset: NullableOffsetMarker::new(Some(ClassDef::Format1(
                 crate::layout::ClassDefFormat1 {
                     start_glyph_id: GlyphId::new(2),
                     class_value_array: vec![1, 2, 0],
                 },
             ))),
+            ..Default::default()
         };
 
         assert_eq!(gdef.compute_version(), MajorMinor::VERSION_1_3);

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -17,7 +17,7 @@ pub const WIDTH_32: usize = 4;
 /// An offset subtable.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
     obj: Option<T>,
 }
@@ -25,7 +25,7 @@ pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
 /// An offset subtable which may be null.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NullableOffsetMarker<T, const N: usize = WIDTH_16> {
     obj: Option<T>,
 }
@@ -130,6 +130,20 @@ impl<const N: usize, T: FontWrite> FontWrite for NullableOffsetMarker<T, N> {
             Some(obj) => writer.write_offset(obj, N),
             None => writer.write_slice([0u8; N].as_slice()),
         }
+    }
+}
+
+impl<T: Default, const N: usize> Default for OffsetMarker<T, N> {
+    fn default() -> Self {
+        Self {
+            obj: Some(T::default()),
+        }
+    }
+}
+
+impl<T, const N: usize> Default for NullableOffsetMarker<T, N> {
+    fn default() -> Self {
+        Self { obj: None }
     }
 }
 

--- a/write-fonts/src/tables/maxp.rs
+++ b/write-fonts/src/tables/maxp.rs
@@ -33,19 +33,7 @@ mod tests {
     fn maxp_05() {
         let maxp_05 = Maxp {
             num_glyphs: 5,
-            max_points: None,
-            max_contours: None,
-            max_composite_points: None,
-            max_composite_contours: None,
-            max_zones: None,
-            max_twilight_points: None,
-            max_storage: None,
-            max_function_defs: None,
-            max_instruction_defs: None,
-            max_stack_elements: None,
-            max_size_of_instructions: None,
-            max_component_elements: None,
-            max_component_depth: None,
+            ..Default::default()
         };
 
         let dumped = crate::write::dump_table(&maxp_05).unwrap();

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -15,6 +15,14 @@ impl Name {
         .try_into()
         .unwrap()
     }
+
+    fn compute_version(&self) -> u16 {
+        if self.lang_tag_record.is_some() {
+            1
+        } else {
+            0
+        }
+    }
 }
 
 impl NameRecord {
@@ -186,11 +194,7 @@ mod tests {
 
     #[test]
     fn sorting() {
-        let mut table = Name {
-            version: 0,
-            name_record: Default::default(),
-            lang_tag_record: None,
-        };
+        let mut table = Name::default();
         table.name_record.insert(NameRecord {
             platform_id: 3,
             encoding_id: 1,

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -17,11 +17,7 @@ impl Name {
     }
 
     fn compute_version(&self) -> u16 {
-        if self.lang_tag_record.is_some() {
-            1
-        } else {
-            0
-        }
+        self.lang_tag_record.is_some().into()
     }
 }
 
@@ -190,6 +186,14 @@ mod tests {
             string: "hello",
         };
         assert_eq!(stringthing.compute_length(), 10);
+    }
+
+    #[test]
+    fn compute_version() {
+        let mut table = Name::default();
+        assert_eq!(table.compute_version(), 0);
+        table.lang_tag_record = Some(Vec::new());
+        assert_eq!(table.compute_version(), 1);
     }
 
     #[test]

--- a/write-fonts/src/tests/gpos.rs
+++ b/write-fonts/src/tests/gpos.rs
@@ -195,18 +195,7 @@ fn anchorformat2() {
 // fields inappropriately.
 #[test]
 fn no_write_versioned_fields() {
-    let mut gpos = Gpos {
-        script_list_offset: OffsetMarker::new(ScriptList {
-            script_records: Vec::new(),
-        }),
-        feature_list_offset: OffsetMarker::new(FeatureList {
-            feature_records: Vec::new(),
-        }),
-        lookup_list_offset: OffsetMarker::new(PositionLookupList {
-            lookup_offsets: Vec::new(),
-        }),
-        feature_variations_offset: NullableOffsetMarker::new(None),
-    };
+    let mut gpos = Gpos::default();
 
     let dumped = crate::write::dump_table(&gpos).unwrap();
     assert_eq!(dumped.len(), 12);


### PR DESCRIPTION
In general this is as simple as adding `Default` to the `#[derive(_)]` attribute, but we also allow the user to specify specific values via a #[default(..)] attribute, in which case we have to generate a manual implementation.

This patch also includes a number of supporting fixups:
- implement `Default` for the font-types scalars (except for MajorMinor and Version16Dot16, for which the appropriate default value is generally context specific)
- Updating a few codegen input files to specify default or compile values for versions where they were missing
- Add explanation for #[default(..)] attr in codegen README
- Use new Default impls where appropriate when constructing types in tests

closes #107 