### PR TITLE
No null offsetmarker

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -295,7 +295,7 @@ fn generate_to_owned_impl(item: &Table, parse_module: &syn::Path) -> syn::Result
         quote! {
             where
                 U: FontRead<'a>,
-                #t: FromTableRef<U> + 'static,
+                #t: FromTableRef<U> + Default + 'static,
         }
     });
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -1552,7 +1552,7 @@ impl<'a, T, U> FromObjRef<read_fonts::layout::gpos::ExtensionPosFormat1<'a, U>>
     for ExtensionPosFormat1<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(
         obj: &read_fonts::layout::gpos::ExtensionPosFormat1<'a, U>,
@@ -1569,7 +1569,7 @@ impl<'a, T, U> FromTableRef<read_fonts::layout::gpos::ExtensionPosFormat1<'a, U>
     for ExtensionPosFormat1<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
 }
 

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -677,7 +677,7 @@ impl<'a, T, U> FromObjRef<read_fonts::layout::gsub::ExtensionSubstFormat1<'a, U>
     for ExtensionSubstFormat1<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(
         obj: &read_fonts::layout::gsub::ExtensionSubstFormat1<'a, U>,
@@ -694,7 +694,7 @@ impl<'a, T, U> FromTableRef<read_fonts::layout::gsub::ExtensionSubstFormat1<'a, 
     for ExtensionSubstFormat1<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
 }
 

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -383,7 +383,7 @@ impl<T: Validate> Validate for LookupList<T> {
 impl<'a, T, U> FromObjRef<read_fonts::layout::LookupList<'a, U>> for LookupList<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(obj: &read_fonts::layout::LookupList<'a, U>, _: FontData) -> Self {
         LookupList {
@@ -395,7 +395,7 @@ where
 impl<'a, T, U> FromTableRef<read_fonts::layout::LookupList<'a, U>> for LookupList<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
 }
 
@@ -429,7 +429,7 @@ impl<T: Validate> Validate for Lookup<T> {
 impl<'a, T, U> FromObjRef<read_fonts::layout::Lookup<'a, U>> for Lookup<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(obj: &read_fonts::layout::Lookup<'a, U>, _: FontData) -> Self {
         Lookup {
@@ -443,7 +443,7 @@ where
 impl<'a, T, U> FromTableRef<read_fonts::layout::Lookup<'a, U>> for Lookup<T>
 where
     U: FontRead<'a>,
-    T: FromTableRef<U> + 'static,
+    T: FromTableRef<U> + Default + 'static,
 {
 }
 

--- a/write-fonts/src/from_obj.rs
+++ b/write-fonts/src/from_obj.rs
@@ -112,10 +112,12 @@ impl<T: FromTableRef<U>, U> FromTableRef<Option<U>> for Option<T> {
 
 /* blanket impls converting resolved offsets to offsetmarkers */
 
-impl<T: FromObjRef<U>, U, const N: usize> FromObjRef<Result<U, ReadError>> for OffsetMarker<T, N> {
+impl<T: FromObjRef<U> + Default, U, const N: usize> FromObjRef<Result<U, ReadError>>
+    for OffsetMarker<T, N>
+{
     fn from_obj_ref(from: &Result<U, ReadError>, data: FontData) -> Self {
         match from {
-            Err(_) => OffsetMarker::new_maybe_null(None),
+            Err(_) => OffsetMarker::default(),
             Ok(table) => OffsetMarker::new(table.to_owned_obj(data)),
         }
     }
@@ -133,12 +135,12 @@ impl<T: FromObjRef<U>, U, const N: usize> FromObjRef<Option<Result<U, ReadError>
 }
 
 // used for bare offsets
-impl<T: FromTableRef<U>, U, const N: usize> FromTableRef<Result<U, ReadError>>
+impl<T: FromTableRef<U> + Default, U, const N: usize> FromTableRef<Result<U, ReadError>>
     for OffsetMarker<T, N>
 {
     fn from_table_ref(from: &Result<U, ReadError>) -> Self {
         match from {
-            Err(_) => OffsetMarker::new_maybe_null(None),
+            Err(_) => OffsetMarker::default(),
             Ok(table) => OffsetMarker::new(table.to_owned_table()),
         }
     }

--- a/write-fonts/src/layout.rs
+++ b/write-fonts/src/layout.rs
@@ -20,7 +20,7 @@ macro_rules! lookup_type {
 /// lookups) can be given different lookup ids for each of GSUB/GPOS.
 macro_rules! table_newtype {
     ($name:ident, $inner:ident, $read_type:path) => {
-        #[derive(Debug, Clone)]
+        #[derive(Clone, Debug, Default)]
         pub struct $name($inner);
 
         impl std::ops::Deref for $name {

--- a/write-fonts/src/layout/gpos.rs
+++ b/write-fonts/src/layout/gpos.rs
@@ -33,7 +33,7 @@ table_newtype!(
 
 impl Gpos {
     fn compute_version(&self) -> MajorMinor {
-        if self.feature_variations_offset.get().is_none() {
+        if self.feature_variations_offset.is_none() {
             MajorMinor::VERSION_1_0
         } else {
             MajorMinor::VERSION_1_1
@@ -110,7 +110,6 @@ impl PairPosFormat1 {
     fn compute_value_format1(&self) -> ValueFormat {
         self.pair_set_offsets
             .first()
-            .and_then(|off| off.get())
             .and_then(|pairset| pairset.pair_value_records.first())
             .map(|rec| rec.value_record1.format())
             .unwrap_or(ValueFormat::empty())
@@ -119,7 +118,6 @@ impl PairPosFormat1 {
     fn compute_value_format2(&self) -> ValueFormat {
         self.pair_set_offsets
             .first()
-            .and_then(|off| off.get())
             .and_then(|pairset| pairset.pair_value_records.first())
             .map(|rec| rec.value_record2.format())
             .unwrap_or(ValueFormat::empty())
@@ -144,40 +142,30 @@ impl PairPosFormat2 {
     }
 
     fn compute_class1_count(&self) -> u16 {
-        self.class_def1_offset
-            .get()
-            .map(|cls| cls.class_count())
-            .unwrap_or_default()
+        self.class_def1_offset.class_count()
     }
 
     fn compute_class2_count(&self) -> u16 {
-        self.class_def2_offset
-            .get()
-            .map(|cls| cls.class_count())
-            .unwrap_or_default()
+        self.class_def2_offset.class_count()
     }
 }
 
 impl MarkBasePosFormat1 {
     fn compute_mark_class_count(&self) -> u16 {
-        mark_array_class_count(self.mark_array_offset.get())
+        self.mark_array_offset.class_count()
     }
 }
 
 impl MarkMarkPosFormat1 {
     fn compute_mark_class_count(&self) -> u16 {
-        mark_array_class_count(self.mark1_array_offset.get())
+        self.mark1_array_offset.class_count()
     }
 }
 
 impl MarkLigPosFormat1 {
     fn compute_mark_class_count(&self) -> u16 {
-        mark_array_class_count(self.mark_array_offset.get())
+        self.mark_array_offset.class_count()
     }
-}
-
-fn mark_array_class_count(mark_array: Option<&MarkArray>) -> u16 {
-    mark_array.map(MarkArray::class_count).unwrap_or_default()
 }
 
 impl MarkArray {

--- a/write-fonts/src/layout/gsub.rs
+++ b/write-fonts/src/layout/gsub.rs
@@ -30,7 +30,7 @@ table_newtype!(
 
 impl Gsub {
     fn compute_version(&self) -> MajorMinor {
-        if self.feature_variations_offset.get().is_none() {
+        if self.feature_variations_offset.is_none() {
             MajorMinor::VERSION_1_0
         } else {
             MajorMinor::VERSION_1_1

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -23,10 +23,7 @@ impl Name {
 
 impl NameRecord {
     fn string(&self) -> &str {
-        self.string_offset
-            .get()
-            .map(|s| s.as_str())
-            .unwrap_or_default()
+        self.string_offset.as_str()
     }
 
     fn string_writer(&self) -> NameStringWriter {
@@ -72,10 +69,7 @@ impl FontWrite for NameRecord {
 
 impl LangTagRecord {
     fn lang_tag(&self) -> &str {
-        self.lang_tag_offset
-            .get()
-            .map(|s| s.as_str())
-            .unwrap_or_default()
+        self.lang_tag_offset.as_str()
     }
 
     fn string_writer(&self) -> NameStringWriter {
@@ -146,7 +140,7 @@ impl PartialEq for NameRecord {
             && self.encoding_id == other.encoding_id
             && self.language_id == other.language_id
             && self.name_id == other.name_id
-            && self.string_offset.get() == other.string_offset.get()
+            && self.string_offset == other.string_offset
     }
 }
 

--- a/write-fonts/src/tests/gpos.rs
+++ b/write-fonts/src/tests/gpos.rs
@@ -58,8 +58,7 @@ fn markbaseposformat1() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#example-7-markbaseposformat1-subtable
 
     let table = MarkBasePosFormat1::read(test_data::MARKBASEPOSFORMAT1).unwrap();
-    let marks = table.mark_array_offset.get().unwrap();
-    assert_eq!(marks.mark_records.len(), 2);
+    assert_eq!(table.mark_array_offset.mark_records.len(), 2);
     let dumped = crate::write::dump_table(&table).unwrap();
 
     assert_hex_eq!(test_data::MARKBASEPOSFORMAT1.as_ref(), &dumped);
@@ -70,8 +69,7 @@ fn markligposformat1() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#example-8-markligposformat1-subtable
 
     let table = MarkLigPosFormat1::read(test_data::MARKLIGPOSFORMAT1).unwrap();
-    let marks = table.mark_array_offset.get().unwrap();
-    assert_eq!(marks.mark_records.len(), 2);
+    assert_eq!(table.mark_array_offset.mark_records.len(), 2);
     let dumped = crate::write::dump_table(&table).unwrap();
 
     assert_hex_eq!(test_data::MARKLIGPOSFORMAT1.as_ref(), &dumped);
@@ -82,11 +80,10 @@ fn markmarkposformat1() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#example-9-markmarkposformat1-subtable
 
     let table = MarkMarkPosFormat1::read(test_data::MARKMARKPOSFORMAT1).unwrap();
-    let mark2array = table.mark2_array_offset.get().unwrap();
-    assert_eq!(mark2array.mark2_records.len(), 1);
-    let record = mark2array.mark2_records.get(0).unwrap();
+    assert_eq!(table.mark2_array_offset.mark2_records.len(), 1);
+    let record = &table.mark2_array_offset.mark2_records[0];
     assert_eq!(record.mark2_anchor_offsets.len(), 1);
-    let anchor = record.mark2_anchor_offsets[0].get().unwrap();
+    let anchor = &record.mark2_anchor_offsets[0].as_ref().unwrap();
     let anchor = match anchor {
         AnchorTable::Format1(table) => table,
         _ => panic!("wrong table format"),

--- a/write-fonts/src/validate.rs
+++ b/write-fonts/src/validate.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::BTreeSet,
     fmt::{Debug, Display},
+    ops::Deref,
 };
 
 use crate::offsets::{NullableOffsetMarker, OffsetMarker};
@@ -204,18 +205,13 @@ impl<T: Validate> Validate for Vec<T> {
 
 impl<const N: usize, T: Validate> Validate for OffsetMarker<T, N> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
-        match self.get() {
-            Some(item) => item.validate_impl(ctx),
-            None => ctx.report("null offset"),
-        }
+        self.deref().validate_impl(ctx)
     }
 }
 
 impl<const N: usize, T: Validate> Validate for NullableOffsetMarker<T, N> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
-        if let Some(item) = self.get() {
-            item.validate_impl(ctx)
-        }
+        self.deref().validate_impl(ctx)
     }
 }
 


### PR DESCRIPTION
This PR makes `OffsetMarker` not be an `Option` internally. It makes `OffsetMarker` implement `Deref<Target=T>`, (and `NullableOffsetMarker` impls `Deref<Target=Option<T>>`) so they now act basically as transparent wrappers.

Basically, I think this was a design mistake. From the commit message:

>For the record, the original idea was that if we were parsing an
existing font into compile types, and we encountered an offset that was
malformed, we would represent that with the `None` case, and then during
validation we would warn if an offset was unexpectedly null.

>As we now expect all tables and records to implement Default, we can
drop the Option, and just insert a new empty table in this particular
case.


This is a big API simplification, and should remove the need for the user to interact directly with these marker types in most cases (and we can hopefully improve API to fix any remaining cases.)