### PR TITLE
Impl default for generated bitflags

### DIFF
--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -22,6 +22,7 @@ pub(crate) fn generate_flags(raw: &BitFlags) -> proc_macro2::TokenStream {
     quote! {
         bitflags::bitflags! {
             #( #docs )*
+            #[derive(Default)]
             pub struct #name: #typ {
                 #( #variants )*
             }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -214,6 +214,7 @@ impl<'a> std::fmt::Debug for SimpleGlyph<'a> {
 
 bitflags::bitflags! {
     /// Flags used in [SimpleGlyph]
+    #[derive(Default)]
     pub struct SimpleGlyphFlags: u8 {
         /// Bit 0: If set, the point is on the curve; otherwise, it is off
         /// the curve.
@@ -421,6 +422,7 @@ impl<'a> std::fmt::Debug for CompositeGlyph<'a> {
 
 bitflags::bitflags! {
     /// Flags used in [CompositeGlyph]
+    #[derive(Default)]
     pub struct CompositeGlyphFlags: u16 {
         /// Bit 0: If this is set, the arguments are 16-bit (uint16 or
         /// int16); otherwise, they are bytes (uint8 or int8).

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -215,6 +215,7 @@ impl<'a> SomeTable<'a> for PositionLookup<'a> {
 
 bitflags::bitflags! {
     /// See [ValueRecord]
+    #[derive(Default)]
     pub struct ValueFormat: u16 {
         /// Includes horizontal adjustment for placement
         const X_PLACEMENT = 0x0001;

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -891,6 +891,7 @@ impl<'a> SomeRecord<'a> for AxisValueRecord {
 
 bitflags::bitflags! {
     /// [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags).
+    #[derive(Default)]
     pub struct AxisValueTableFlags: u16 {
         /// If set, this axis value table provides axis value information
         /// that is applicable to other fonts within the same font family.


### PR DESCRIPTION
The default will always be empty flags. If this is not acceptable, we can add an attribute for specifying the desired default value, or an attribute indicating we won't generate a Default impl.

Default for enums is more annoying: not all enums have a meaningful default value, and we don't want to guess, so maybe for now the best bet is to just require the user to implement the trait, or otherwise just specify an explicit default value for each field in a table that contains a raw enum.

Another approach altogether (which had mentioned in relation to NameIds) would be to not use an actual rust enum to represent these enums, and make them instead by newtype structs with associated constants. This feels un-rusty, but also an awful lot simpler and closer to representing the underlying truth.