### PR TITLE
[codegen] Manually reformat generated bitflags! decls

### DIFF
--- a/font-codegen/src/formatting.rs
+++ b/font-codegen/src/formatting.rs
@@ -1,0 +1,225 @@
+//! improve readability of generated code
+
+use std::borrow::Cow;
+use std::fmt::Write;
+
+use regex::Captures;
+
+/// reformats the generated code to improve readability.
+pub(crate) fn format(tables: proc_macro2::TokenStream) -> Result<String, syn::Error> {
+    // if this is not valid code just pass it through directly, and then we
+    // can see the compiler errors
+    let source_str = match rustfmt_wrapper::rustfmt(&tables) {
+        Ok(s) => s,
+        Err(_) => return Ok(tables.to_string()),
+    };
+    // convert doc comment attributes into normal doc comments
+    let doc_comments = regex::Regex::new(r#"#\[doc = "(.*)"\]"#).unwrap();
+    let source_str = doc_comments.replace_all(&source_str, "///$1");
+    let newlines_before_docs = regex::Regex::new(r#"([;\}])\r?\n( *)(///|pub|impl|#)"#).unwrap();
+    let source_str = newlines_before_docs.replace_all(&source_str, "$1\n\n$2$3");
+
+    // add newlines after top-level items
+    let re2 = regex::Regex::new(r"\r?\n\}").unwrap();
+    let source_str = re2.replace_all(&source_str, "\n}\n\n");
+    let source_str = manual_format_bitflags(&source_str);
+    Ok(rustfmt_wrapper::rustfmt(source_str).unwrap())
+}
+
+/// rustfmt can't format `bitflags!` declarations so we do it manually -_-
+///
+/// This is... inelegant. Basically we manually reparse the output and
+/// then manually reformat it. Is this a good idea? Time will tell.
+fn manual_format_bitflags(code: &str) -> Cow<str> {
+    fn bitflag_formatter(captures: &Captures) -> String {
+        formatter_impl(captures.get(1).unwrap().as_str())
+    }
+
+    let re = regex::Regex::new(r"(?m)(^bitflags.*$)").unwrap();
+    re.replace_all(code, bitflag_formatter)
+}
+
+fn formatter_impl(input: &str) -> String {
+    let bitflags = BitFlagContents::parse(input);
+    bitflags.generate()
+}
+
+/// the contents of a bitflags! declaration.
+///
+/// This can only be parsed from the output of `quote`.
+struct BitFlagContents<'a> {
+    docs: Vec<&'a str>,
+    default: Option<&'a str>,
+    name: &'a str,
+    typ: &'a str,
+    consts: Vec<BitFlagConst<'a>>,
+}
+
+/// A single const declared in a flagset
+struct BitFlagConst<'a> {
+    docs: Vec<&'a str>,
+    name: &'a str,
+    value: &'a str,
+}
+
+struct BitFlagCursor<'a>(&'a str);
+
+impl<'a> BitFlagContents<'a> {
+    fn parse(contents: &'a str) -> Self {
+        let mut cursor = BitFlagCursor(contents);
+        cursor.eat_decl().unwrap();
+        let docs = cursor.eat_docs();
+        let default = cursor.eat_derive_default();
+        cursor.eat("pub struct").unwrap();
+        let name = cursor.eat_word().unwrap();
+        cursor.eat(":").unwrap();
+        let typ = cursor.eat_word().unwrap();
+        cursor.eat("{").unwrap();
+
+        let consts = BitFlagConst::parse_all(&mut cursor);
+
+        Self {
+            docs,
+            default,
+            name,
+            typ,
+            consts,
+        }
+    }
+
+    fn generate(&self) -> String {
+        let mut result = String::new();
+        writeln!(result, "{DECL}").unwrap();
+        for doc in &self.docs {
+            writeln!(result, "    ///{doc}").unwrap();
+        }
+        if let Some(default) = self.default {
+            writeln!(result, "    {default}").unwrap();
+        }
+        writeln!(result, "    pub struct {}: {} {{", self.name, self.typ).unwrap();
+        for c in &self.consts {
+            for doc in &c.docs {
+                writeln!(result, "        ///{doc}").unwrap();
+            }
+            writeln!(result, "        const {} = {};", c.name, c.value).unwrap();
+        }
+        writeln!(result, "    }}").unwrap();
+        writeln!(result, "}}").unwrap();
+
+        result
+    }
+}
+
+impl<'a> BitFlagConst<'a> {
+    fn parse_all(cursor: &mut BitFlagCursor<'a>) -> Vec<Self> {
+        let mut result = Vec::new();
+        while cursor.0.len() > 8 {
+            result.push(Self::parse(cursor));
+        }
+        result
+    }
+
+    fn parse(cursor: &mut BitFlagCursor<'a>) -> Self {
+        let docs = cursor.eat_docs();
+        cursor.eat("const").unwrap();
+        let name = cursor.eat_word().unwrap();
+        cursor.eat("=").unwrap();
+        let value = cursor.eat_word().unwrap();
+        cursor.eat(";").unwrap();
+        Self { docs, name, value }
+    }
+}
+
+static DECL: &str = "bitflags::bitflags! {";
+
+impl<'a> BitFlagCursor<'a> {
+    fn eat_decl(&mut self) -> Option<&'a str> {
+        self.eat(DECL)
+    }
+
+    fn eat(&mut self, pat: &str) -> Option<&'a str> {
+        self.eat_spaces();
+        if self.0.starts_with(pat) {
+            let result = &self.0[..pat.len()];
+            self.advance(pat.len());
+            return Some(result);
+        }
+        None
+    }
+
+    fn advance(&mut self, len: usize) {
+        self.0 = &self.0[len..];
+    }
+
+    fn eat_spaces(&mut self) {
+        let len = self.0.bytes().take_while(|b| *b == b' ').count();
+        self.advance(len);
+    }
+
+    fn eat_word(&mut self) -> Option<&'a str> {
+        self.eat_spaces();
+        let next_space = self.0.find(' ')?;
+        let word = &self.0[..next_space];
+        self.advance(next_space);
+        Some(word)
+    }
+
+    fn eat_docs(&mut self) -> Vec<&'a str> {
+        let mut docs = Vec::new();
+        while let Some(doc) = self.eat_doc_string() {
+            docs.push(doc);
+        }
+        docs
+    }
+
+    fn eat_derive_default(&mut self) -> Option<&'a str> {
+        static DEFAULT: &str = "# [derive (Default)]";
+        self.eat_spaces();
+        if self.eat(DEFAULT).is_some() {
+            return Some("#[derive(Default)]");
+        }
+        None
+    }
+
+    /// if a docstring is present, return the string itself with quotes removed
+    fn eat_doc_string(&mut self) -> Option<&'a str> {
+        static DOC_HEADER: &str = "# [doc = \"";
+        self.eat_spaces();
+        if self.0.starts_with(DOC_HEADER) {
+            self.advance(DOC_HEADER.len());
+            let idx = self.0.find("\"]").unwrap();
+            let result = &self.0[..idx];
+            self.advance(idx + 2);
+            return Some(result);
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bitflags_formatting() {
+        static INPUT: &str = r#"bitflags::bitflags! { # [doc = " See [ValueRecord]"] pub struct ValueFormat : u16 { # [doc = " Includes horizontal adjustment for placement"] const X_PLACEMENT = 0x0001 ; # [doc = " Includes vertical adjustment for placement"] const Y_PLACEMENT = 0x0002 ; } }"#;
+        static OUTPUT: &str = "\
+bitflags::bitflags! {
+    /// See [ValueRecord]
+    pub struct ValueFormat: u16 {
+        /// Includes horizontal adjustment for placement
+        const X_PLACEMENT = 0x0001;
+        /// Includes vertical adjustment for placement
+        const Y_PLACEMENT = 0x0002;
+    }
+}
+";
+
+        let output = formatter_impl(INPUT);
+        assert_eq!(output, OUTPUT);
+        static INPUT_WITH_DEFAULT: &str = r#"bitflags::bitflags! { # [doc = " See [ValueRecord]"] # [derive (Default)] pub struct ValueFormat : u16 { # [doc = " Includes horizontal adjustment for placement"] const X_PLACEMENT = 0x0001 ; # [doc = " Includes vertical adjustment for placement"] const Y_PLACEMENT = 0x0002 ; } }"#;
+
+        // ensure we can also handle the presence of this attribute
+        assert!(formatter_impl(INPUT_WITH_DEFAULT).contains("#[derive(Default)]"));
+    }
+}

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -212,7 +212,75 @@ impl<'a> std::fmt::Debug for SimpleGlyph<'a> {
     }
 }
 
-bitflags::bitflags! { # [doc = " Flags used in [SimpleGlyph]"] pub struct SimpleGlyphFlags : u8 { # [doc = " Bit 0: If set, the point is on the curve; otherwise, it is off"] # [doc = " the curve."] const ON_CURVE_POINT = 0x01 ; # [doc = " Bit 1: If set, the corresponding x-coordinate is 1 byte long,"] # [doc = " and the sign is determined by the"] # [doc = " X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR flag. If not set, its"] # [doc = " interpretation depends on the"] # [doc = " X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR flag: If that other flag"] # [doc = " is set, the x-coordinate is the same as the previous"] # [doc = " x-coordinate, and no element is added to the xCoordinates"] # [doc = " array. If both flags are not set, the corresponding element in"] # [doc = " the xCoordinates array is two bytes and interpreted as a signed"] # [doc = " integer. See the description of the"] # [doc = " X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR flag for additional"] # [doc = " information."] const X_SHORT_VECTOR = 0x02 ; # [doc = " Bit 2: If set, the corresponding y-coordinate is 1 byte long,"] # [doc = " and the sign is determined by the"] # [doc = " Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR flag. If not set, its"] # [doc = " interpretation depends on the"] # [doc = " Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR flag: If that other flag"] # [doc = " is set, the y-coordinate is the same as the previous"] # [doc = " y-coordinate, and no element is added to the yCoordinates"] # [doc = " array. If both flags are not set, the corresponding element in"] # [doc = " the yCoordinates array is two bytes and interpreted as a signed"] # [doc = " integer. See the description of the"] # [doc = " Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR flag for additional"] # [doc = " information."] const Y_SHORT_VECTOR = 0x04 ; # [doc = " Bit 3: If set, the next byte (read as unsigned) specifies the"] # [doc = " number of additional times this flag byte is to be repeated in"] # [doc = " the logical flags array — that is, the number of additional"] # [doc = " logical flag entries inserted after this entry. (In the"] # [doc = " expanded logical array, this bit is ignored.) In this way, the"] # [doc = " number of flags listed can be smaller than the number of points"] # [doc = " in the glyph description."] const REPEAT_FLAG = 0x08 ; # [doc = " Bit 4: This flag has two meanings, depending on how the"] # [doc = " X_SHORT_VECTOR flag is set. If X_SHORT_VECTOR is set, this bit"] # [doc = " describes the sign of the value, with 1 equalling positive and"] # [doc = " 0 negative. If X_SHORT_VECTOR is not set and this bit is set,"] # [doc = " then the current x-coordinate is the same as the previous"] # [doc = " x-coordinate. If X_SHORT_VECTOR is not set and this bit is also"] # [doc = " not set, the current x-coordinate is a signed 16-bit delta"] # [doc = " vector."] const X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR = 0x10 ; # [doc = " Bit 5: This flag has two meanings, depending on how the"] # [doc = " Y_SHORT_VECTOR flag is set. If Y_SHORT_VECTOR is set, this bit"] # [doc = " describes the sign of the value, with 1 equalling positive and"] # [doc = " 0 negative. If Y_SHORT_VECTOR is not set and this bit is set,"] # [doc = " then the current y-coordinate is the same as the previous"] # [doc = " y-coordinate. If Y_SHORT_VECTOR is not set and this bit is also"] # [doc = " not set, the current y-coordinate is a signed 16-bit delta"] # [doc = " vector."] const Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR = 0x20 ; # [doc = " Bit 6: If set, contours in the glyph description may overlap."] # [doc = " Use of this flag is not required in OpenType — that is, it is"] # [doc = " valid to have contours overlap without having this flag set. It"] # [doc = " may affect behaviors in some platforms, however. (See the"] # [doc = " discussion of “Overlapping contours” in Apple’s"] # [doc = " specification for details regarding behavior in Apple"] # [doc = " platforms.) When used, it must be set on the first flag byte"] # [doc = " for the glyph. See additional details below."] const OVERLAP_SIMPLE = 0x40 ; } }
+bitflags::bitflags! {
+    /// Flags used in [SimpleGlyph]
+    pub struct SimpleGlyphFlags: u8 {
+        /// Bit 0: If set, the point is on the curve; otherwise, it is off
+        /// the curve.
+        const ON_CURVE_POINT = 0x01;
+        /// Bit 1: If set, the corresponding x-coordinate is 1 byte long,
+        /// and the sign is determined by the
+        /// X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR flag. If not set, its
+        /// interpretation depends on the
+        /// X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR flag: If that other flag
+        /// is set, the x-coordinate is the same as the previous
+        /// x-coordinate, and no element is added to the xCoordinates
+        /// array. If both flags are not set, the corresponding element in
+        /// the xCoordinates array is two bytes and interpreted as a signed
+        /// integer. See the description of the
+        /// X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR flag for additional
+        /// information.
+        const X_SHORT_VECTOR = 0x02;
+        /// Bit 2: If set, the corresponding y-coordinate is 1 byte long,
+        /// and the sign is determined by the
+        /// Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR flag. If not set, its
+        /// interpretation depends on the
+        /// Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR flag: If that other flag
+        /// is set, the y-coordinate is the same as the previous
+        /// y-coordinate, and no element is added to the yCoordinates
+        /// array. If both flags are not set, the corresponding element in
+        /// the yCoordinates array is two bytes and interpreted as a signed
+        /// integer. See the description of the
+        /// Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR flag for additional
+        /// information.
+        const Y_SHORT_VECTOR = 0x04;
+        /// Bit 3: If set, the next byte (read as unsigned) specifies the
+        /// number of additional times this flag byte is to be repeated in
+        /// the logical flags array — that is, the number of additional
+        /// logical flag entries inserted after this entry. (In the
+        /// expanded logical array, this bit is ignored.) In this way, the
+        /// number of flags listed can be smaller than the number of points
+        /// in the glyph description.
+        const REPEAT_FLAG = 0x08;
+        /// Bit 4: This flag has two meanings, depending on how the
+        /// X_SHORT_VECTOR flag is set. If X_SHORT_VECTOR is set, this bit
+        /// describes the sign of the value, with 1 equalling positive and
+        /// 0 negative. If X_SHORT_VECTOR is not set and this bit is set,
+        /// then the current x-coordinate is the same as the previous
+        /// x-coordinate. If X_SHORT_VECTOR is not set and this bit is also
+        /// not set, the current x-coordinate is a signed 16-bit delta
+        /// vector.
+        const X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR = 0x10;
+        /// Bit 5: This flag has two meanings, depending on how the
+        /// Y_SHORT_VECTOR flag is set. If Y_SHORT_VECTOR is set, this bit
+        /// describes the sign of the value, with 1 equalling positive and
+        /// 0 negative. If Y_SHORT_VECTOR is not set and this bit is set,
+        /// then the current y-coordinate is the same as the previous
+        /// y-coordinate. If Y_SHORT_VECTOR is not set and this bit is also
+        /// not set, the current y-coordinate is a signed 16-bit delta
+        /// vector.
+        const Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR = 0x20;
+        /// Bit 6: If set, contours in the glyph description may overlap.
+        /// Use of this flag is not required in OpenType — that is, it is
+        /// valid to have contours overlap without having this flag set. It
+        /// may affect behaviors in some platforms, however. (See the
+        /// discussion of “Overlapping contours” in Apple’s
+        /// specification for details regarding behavior in Apple
+        /// platforms.) When used, it must be set on the first flag byte
+        /// for the glyph. See additional details below.
+        const OVERLAP_SIMPLE = 0x40;
+    }
+}
 
 impl font_types::Scalar for SimpleGlyphFlags {
     type Raw = <u8 as font_types::Scalar>::Raw;
@@ -351,7 +419,54 @@ impl<'a> std::fmt::Debug for CompositeGlyph<'a> {
     }
 }
 
-bitflags::bitflags! { # [doc = " Flags used in [CompositeGlyph]"] pub struct CompositeGlyphFlags : u16 { # [doc = " Bit 0: If this is set, the arguments are 16-bit (uint16 or"] # [doc = " int16); otherwise, they are bytes (uint8 or int8)."] const ARG_1_AND_2_ARE_WORDS = 0x0001 ; # [doc = " Bit 1: If this is set, the arguments are signed xy values;"] # [doc = " otherwise, they are unsigned point numbers."] const ARGS_ARE_XY_VALUES = 0x0002 ; # [doc = " Bit 2: If set and ARGS_ARE_XY_VALUES is also set, the xy values"] # [doc = " are rounded to the nearest grid line. Ignored if"] # [doc = " ARGS_ARE_XY_VALUES is not set."] const ROUND_XY_TO_GRID = 0x0004 ; # [doc = " Bit 3: This indicates that there is a simple scale for the"] # [doc = " component. Otherwise, scale = 1.0."] const WE_HAVE_A_SCALE = 0x0008 ; # [doc = " Bit 5: Indicates at least one more glyph after this one."] const MORE_COMPONENTS = 0x0020 ; # [doc = " Bit 6: The x direction will use a different scale from the y"] # [doc = " direction."] const WE_HAVE_AN_X_AND_Y_SCALE = 0x0040 ; # [doc = " Bit 7: There is a 2 by 2 transformation that will be used to"] # [doc = " scale the component."] const WE_HAVE_A_TWO_BY_TWO = 0x0080 ; # [doc = " Bit 8: Following the last component are instructions for the"] # [doc = " composite character."] const WE_HAVE_INSTRUCTIONS = 0x0100 ; # [doc = " Bit 9: If set, this forces the aw and lsb (and rsb) for the"] # [doc = " composite to be equal to those from this component glyph. This"] # [doc = " works for hinted and unhinted glyphs."] const USE_MY_METRICS = 0x0200 ; # [doc = " Bit 10: If set, the components of the compound glyph overlap."] # [doc = " Use of this flag is not required in OpenType — that is, it is"] # [doc = " valid to have components overlap without having this flag set."] # [doc = " It may affect behaviors in some platforms, however. (See"] # [doc = " Apple’s specification for details regarding behavior in Apple"] # [doc = " platforms.) When used, it must be set on the flag word for the"] # [doc = " first component. See additional remarks, above, for the similar"] # [doc = " OVERLAP_SIMPLE flag used in simple-glyph descriptions."] const OVERLAP_COMPOUND = 0x0400 ; # [doc = " Bit 11: The composite is designed to have the component offset"] # [doc = " scaled. Ignored if ARGS_ARE_XY_VALUES is not set."] const SCALED_COMPONENT_OFFSET = 0x0800 ; # [doc = " Bit 12: The composite is designed not to have the component"] # [doc = " offset scaled. Ignored if ARGS_ARE_XY_VALUES is not set."] const UNSCALED_COMPONENT_OFFSET = 0x1000 ; } }
+bitflags::bitflags! {
+    /// Flags used in [CompositeGlyph]
+    pub struct CompositeGlyphFlags: u16 {
+        /// Bit 0: If this is set, the arguments are 16-bit (uint16 or
+        /// int16); otherwise, they are bytes (uint8 or int8).
+        const ARG_1_AND_2_ARE_WORDS = 0x0001;
+        /// Bit 1: If this is set, the arguments are signed xy values;
+        /// otherwise, they are unsigned point numbers.
+        const ARGS_ARE_XY_VALUES = 0x0002;
+        /// Bit 2: If set and ARGS_ARE_XY_VALUES is also set, the xy values
+        /// are rounded to the nearest grid line. Ignored if
+        /// ARGS_ARE_XY_VALUES is not set.
+        const ROUND_XY_TO_GRID = 0x0004;
+        /// Bit 3: This indicates that there is a simple scale for the
+        /// component. Otherwise, scale = 1.0.
+        const WE_HAVE_A_SCALE = 0x0008;
+        /// Bit 5: Indicates at least one more glyph after this one.
+        const MORE_COMPONENTS = 0x0020;
+        /// Bit 6: The x direction will use a different scale from the y
+        /// direction.
+        const WE_HAVE_AN_X_AND_Y_SCALE = 0x0040;
+        /// Bit 7: There is a 2 by 2 transformation that will be used to
+        /// scale the component.
+        const WE_HAVE_A_TWO_BY_TWO = 0x0080;
+        /// Bit 8: Following the last component are instructions for the
+        /// composite character.
+        const WE_HAVE_INSTRUCTIONS = 0x0100;
+        /// Bit 9: If set, this forces the aw and lsb (and rsb) for the
+        /// composite to be equal to those from this component glyph. This
+        /// works for hinted and unhinted glyphs.
+        const USE_MY_METRICS = 0x0200;
+        /// Bit 10: If set, the components of the compound glyph overlap.
+        /// Use of this flag is not required in OpenType — that is, it is
+        /// valid to have components overlap without having this flag set.
+        /// It may affect behaviors in some platforms, however. (See
+        /// Apple’s specification for details regarding behavior in Apple
+        /// platforms.) When used, it must be set on the flag word for the
+        /// first component. See additional remarks, above, for the similar
+        /// OVERLAP_SIMPLE flag used in simple-glyph descriptions.
+        const OVERLAP_COMPOUND = 0x0400;
+        /// Bit 11: The composite is designed to have the component offset
+        /// scaled. Ignored if ARGS_ARE_XY_VALUES is not set.
+        const SCALED_COMPONENT_OFFSET = 0x0800;
+        /// Bit 12: The composite is designed not to have the component
+        /// offset scaled. Ignored if ARGS_ARE_XY_VALUES is not set.
+        const UNSCALED_COMPONENT_OFFSET = 0x1000;
+    }
+}
 
 impl font_types::Scalar for CompositeGlyphFlags {
     type Raw = <u16 as font_types::Scalar>::Raw;

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -213,7 +213,31 @@ impl<'a> SomeTable<'a> for PositionLookup<'a> {
     }
 }
 
-bitflags::bitflags! { # [doc = " See [ValueRecord]"] pub struct ValueFormat : u16 { # [doc = " Includes horizontal adjustment for placement"] const X_PLACEMENT = 0x0001 ; # [doc = " Includes vertical adjustment for placement"] const Y_PLACEMENT = 0x0002 ; # [doc = " Includes horizontal adjustment for advance"] const X_ADVANCE = 0x0004 ; # [doc = " Includes vertical adjustment for advance"] const Y_ADVANCE = 0x0008 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for horizontal placement"] const X_PLACEMENT_DEVICE = 0x0010 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for vertical placement"] const Y_PLACEMENT_DEVICE = 0x0020 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for horizontal advance"] const X_ADVANCE_DEVICE = 0x0040 ; # [doc = " Includes Device table (non-variable font) / VariationIndex"] # [doc = " table (variable font) for vertical advance"] const Y_ADVANCE_DEVICE = 0x0080 ; } }
+bitflags::bitflags! {
+    /// See [ValueRecord]
+    pub struct ValueFormat: u16 {
+        /// Includes horizontal adjustment for placement
+        const X_PLACEMENT = 0x0001;
+        /// Includes vertical adjustment for placement
+        const Y_PLACEMENT = 0x0002;
+        /// Includes horizontal adjustment for advance
+        const X_ADVANCE = 0x0004;
+        /// Includes vertical adjustment for advance
+        const Y_ADVANCE = 0x0008;
+        /// Includes Device table (non-variable font) / VariationIndex
+        /// table (variable font) for horizontal placement
+        const X_PLACEMENT_DEVICE = 0x0010;
+        /// Includes Device table (non-variable font) / VariationIndex
+        /// table (variable font) for vertical placement
+        const Y_PLACEMENT_DEVICE = 0x0020;
+        /// Includes Device table (non-variable font) / VariationIndex
+        /// table (variable font) for horizontal advance
+        const X_ADVANCE_DEVICE = 0x0040;
+        /// Includes Device table (non-variable font) / VariationIndex
+        /// table (variable font) for vertical advance
+        const Y_ADVANCE_DEVICE = 0x0080;
+    }
+}
 
 impl font_types::Scalar for ValueFormat {
     type Raw = <u16 as font_types::Scalar>::Raw;

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -889,7 +889,22 @@ impl<'a> SomeRecord<'a> for AxisValueRecord {
     }
 }
 
-bitflags::bitflags! { # [doc = " [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags)."] pub struct AxisValueTableFlags : u16 { # [doc = " If set, this axis value table provides axis value information"] # [doc = " that is applicable to other fonts within the same font family."] # [doc = " This is used if the other fonts were released earlier and did"] # [doc = " not include information about values for some axis. If newer"] # [doc = " versions of the other fonts include the information themselves"] # [doc = " and are present, then this table is ignored."] const OLDER_SIBLING_FONT_ATTRIBUTE = 0x0001 ; # [doc = " If set, it indicates that the axis value represents the"] # [doc = " “normal” value for the axis and may be omitted when"] # [doc = " composing name strings."] const ELIDABLE_AXIS_VALUE_NAME = 0x0002 ; } }
+bitflags::bitflags! {
+    /// [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags).
+    pub struct AxisValueTableFlags: u16 {
+        /// If set, this axis value table provides axis value information
+        /// that is applicable to other fonts within the same font family.
+        /// This is used if the other fonts were released earlier and did
+        /// not include information about values for some axis. If newer
+        /// versions of the other fonts include the information themselves
+        /// and are present, then this table is ignored.
+        const OLDER_SIBLING_FONT_ATTRIBUTE = 0x0001;
+        /// If set, it indicates that the axis value represents the
+        /// “normal” value for the axis and may be omitted when
+        /// composing name strings.
+        const ELIDABLE_AXIS_VALUE_NAME = 0x0002;
+    }
+}
 
 impl font_types::Scalar for AxisValueTableFlags {
     type Raw = <u16 as font_types::Scalar>::Raw;


### PR DESCRIPTION
Because the contents of this macro is not value Rust code, rustfmt doesn't know what to do with it, which means we currently end up with monolithic single line blobs in our generated files for any declared bitflags.

This patch adds an additional post-processing step that finds any such declarations and manually reparses and rewrites them.

Maybe this is not a good idea? This was definitely me scratching an itch at the end of the day.