### PR TITLE
Setup shared git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ overview of what we generate and how it works, see the [codegen-tour][]. For an
 overview of how to use the `font-codegen` crate, see the readme at
 [`font-codegen/README.md`][codegen-readme].
 
+## contributing
+
+We have included a few git hooks that you may choose to use to ensure that
+patches will pass CI; these are in `resources/githooks`.
+
+If you would like to have these run automatically when you commit or push
+changes, you can set this as your git hooksPath:
+
+```sh
+git config core.hooksPath "./git_hooks"
+```
+
+
 [codegen-readme]: ./font-codegen/README.md
 [`read-fonts`]: ./read-fonts
 [`font-types`]: ./font-types

--- a/resources/githooks/pre-commit
+++ b/resources/githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+cargo fmt --all -- --check
+cargo check --all --no-default-features
+cargo check --all

--- a/resources/githooks/pre-push
+++ b/resources/githooks/pre-push
@@ -6,11 +6,16 @@
 set -o errexit
 set -o xtrace
 
+# ensure rustfmt has been run
 cargo fmt --all -- --check
+# ensure we don't have broken links in docs
+cargo doc --all-features --document-private-items
 
+# ensure we at least compile without default features
 cargo check --manifest-path=font-types/Cargo.toml --no-default-features
 cargo check --manifest-path=read-fonts/Cargo.toml --no-default-features
 
 cargo clippy --all-features --all-targets -- -D warnings
-cargo run --bin=codegen resources/codegen_plan.toml
-cargo test
+
+cargo test --all-features
+cargo test --no-default-features


### PR DESCRIPTION
This is opt-in, but it adds resources/githooks which includes pre-commit and pre-push (based on the presubmit.sh stand-alone script) that can be used with git hooks; it also documents how to configure git hooks in the readme.


(Just Merge Me™️)