### PR TITLE
Capture backtraces when codegen goes awry

### DIFF
--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -1,5 +1,7 @@
 //! Generating types from the opentype spec
 
+use std::backtrace::Backtrace;
+
 use log::debug;
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -30,7 +32,11 @@ pub fn generate_code(code_str: &str, mode: Mode) -> Result<String, syn::Error> {
     // Generation is done in phases (https://github.com/googlefonts/fontations/issues/71):
     // 1. Parse
     debug!("Parse (mode {:?})", mode);
-    let mut items: Items = syn::parse_str(code_str)?;
+    // This is the one step where we can't readily intercept the error with logged_syn_error
+    let mut items: Items = syn::parse_str(code_str).map_err(|e| {
+        debug!("{}", Backtrace::capture());
+        e
+    })?;
     items.sanity_check(Phase::Parse)?;
 
     // 2. Contemplate (semantic analysis)

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::parsing::Phase;
+use crate::parsing::{logged_syn_error, Phase};
 
 use super::parsing::{CustomCompile, Field, Fields, Record, TableAttrs};
 
@@ -270,11 +270,11 @@ impl Record {
             .iter()
             .find(|fld| fld.is_computed_array() || fld.is_array());
         match (field_needs_lifetime, &self.lifetime) {
-            (Some(_), None) => Err(syn::Error::new(
+            (Some(_), None) => Err(logged_syn_error(
                 self.name.span(),
                 "This record contains an array, and so must have a lifetime",
             )),
-            (None, Some(_)) => Err(syn::Error::new(
+            (None, Some(_)) => Err(logged_syn_error(
                 self.name.span(),
                 "unexpected lifetime; record contains no array",
             )),


### PR DESCRIPTION
Feel free to merge if acceptable. Helps with #82, though spots where we propagate an error with ? still get missed. Baby steps.