### PR TITLE
Parallelize codegen execution

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -23,3 +23,4 @@ serde = {version = "1.0", features = ["derive"] }
 xflags = "0.2.4"
 log = "0.4"
 env_logger = "0.9.0"
+rayon = "1.5.3"

--- a/font-codegen/src/main.rs
+++ b/font-codegen/src/main.rs
@@ -5,8 +5,10 @@
 use std::path::{Path, PathBuf};
 
 use font_codegen::{ErrorReport, Mode};
+
 use log::{debug, error};
 use miette::miette;
+use rayon::prelude::*;
 use serde::Deserialize;
 
 fn main() -> miette::Result<()> {
@@ -51,7 +53,7 @@ fn run_plan(path: &Path) -> miette::Result<()> {
 
     let results = plan
         .generate
-        .iter()
+        .par_iter()
         .map(|op| run_for_path(&op.source, op.mode))
         .collect::<Result<Vec<_>, _>>()?;
 


### PR DESCRIPTION
This uses rayon to execute multiple codegen tasks in parallel, which is a significant speedup (I'm seeing wall-clock time cut in more than 1/3) for multi-file codegen runs.

running `time cargo run --bin=codegen resources/codegen_plan.toml`:

```
before: 4.43s user 0.61s system 95% cpu 5.262 total
after:  6.68s user 0.73s system 462% cpu 1.603 total
```
