### PR TITLE
Re-export font-types in read-fonts

### DIFF
--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -37,6 +37,9 @@ pub use read::{ComputeSize, FontRead, FontReadWithArgs, ReadArgs, ReadError, Var
 pub use table_provider::TableProvider;
 pub use table_ref::TableRef;
 
+/// Public re-export of the font-types crate.
+pub use font_types as types;
+
 /// All the types that may be referenced in auto-generated code.
 #[doc(hidden)]
 pub(crate) mod codegen_prelude {


### PR DESCRIPTION
Simple change that re-exports font-types from read-fonts so that those types can be accessed from `read_fonts::types` without having to sync dependency versions in your own Cargo.toml.