### PR TITLE
[codegen] Trim '_offset' from field names in write-fonts

### DIFF
--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -16,7 +16,7 @@ pub struct Cpal {
     pub num_color_records: u16,
     /// Offset from the beginning of CPAL table to the first
     /// ColorRecord.
-    pub color_records_array_offset: NullableOffsetMarker<Vec<ColorRecord>, WIDTH_32>,
+    pub color_records_array: NullableOffsetMarker<Vec<ColorRecord>, WIDTH_32>,
     /// Index of each palette’s first color record in the combined
     /// color record array.
     pub color_record_indices: Vec<u16>,
@@ -25,7 +25,7 @@ pub struct Cpal {
     /// This is an array of 32-bit flag fields that describe properties of each palette.
     ///
     /// [Palette Types Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-type-array
-    pub palette_types_array_offset: NullableOffsetMarker<Vec<u32>, WIDTH_32>,
+    pub palette_types_array: NullableOffsetMarker<Vec<u32>, WIDTH_32>,
     /// Offset from the beginning of CPAL table to the [Palette Labels Array][].
     ///
     /// This is an array of 'name' table IDs (typically in the font-specific name
@@ -33,7 +33,7 @@ pub struct Cpal {
     /// Use 0xFFFF if no name ID is provided for a palette.
     ///
     /// [Palette Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-labels-array
-    pub palette_labels_array_offset: NullableOffsetMarker<Vec<u16>, WIDTH_32>,
+    pub palette_labels_array: NullableOffsetMarker<Vec<u16>, WIDTH_32>,
     /// Offset from the beginning of CPAL table to the [Palette Entry Labels Array][].
     ///
     /// This is an array of 'name' table IDs (typically in the font-specific name
@@ -43,7 +43,7 @@ pub struct Cpal {
     /// palette entry.
     ///
     /// [Palette Entry Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entry-label-array
-    pub palette_entry_labels_array_offset: NullableOffsetMarker<Vec<u16>, WIDTH_32>,
+    pub palette_entry_labels_array: NullableOffsetMarker<Vec<u16>, WIDTH_32>,
 }
 
 impl FontWrite for Cpal {
@@ -54,25 +54,25 @@ impl FontWrite for Cpal {
         self.num_palette_entries.write_into(writer);
         self.num_palettes.write_into(writer);
         self.num_color_records.write_into(writer);
-        self.color_records_array_offset.write_into(writer);
+        self.color_records_array.write_into(writer);
         self.color_record_indices.write_into(writer);
         version
             .compatible(1)
-            .then(|| self.palette_types_array_offset.write_into(writer));
+            .then(|| self.palette_types_array.write_into(writer));
         version
             .compatible(1)
-            .then(|| self.palette_labels_array_offset.write_into(writer));
+            .then(|| self.palette_labels_array.write_into(writer));
         version
             .compatible(1)
-            .then(|| self.palette_entry_labels_array_offset.write_into(writer));
+            .then(|| self.palette_entry_labels_array.write_into(writer));
     }
 }
 
 impl Validate for Cpal {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cpal", |ctx| {
-            ctx.in_field("color_records_array_offset", |ctx| {
-                self.color_records_array_offset.validate_impl(ctx);
+            ctx.in_field("color_records_array", |ctx| {
+                self.color_records_array.validate_impl(ctx);
             });
             ctx.in_field("color_record_indices", |ctx| {
                 if self.color_record_indices.len() > (u16::MAX as usize) {
@@ -90,13 +90,11 @@ impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
             num_palette_entries: obj.num_palette_entries(),
             num_palettes: obj.num_palettes(),
             num_color_records: obj.num_color_records(),
-            color_records_array_offset: obj.color_records_array().to_owned_obj(offset_data),
+            color_records_array: obj.color_records_array().to_owned_obj(offset_data),
             color_record_indices: obj.color_record_indices().to_owned_obj(offset_data),
-            palette_types_array_offset: obj.palette_types_array().to_owned_obj(offset_data),
-            palette_labels_array_offset: obj.palette_labels_array().to_owned_obj(offset_data),
-            palette_entry_labels_array_offset: obj
-                .palette_entry_labels_array()
-                .to_owned_obj(offset_data),
+            palette_types_array: obj.palette_types_array().to_owned_obj(offset_data),
+            palette_labels_array: obj.palette_labels_array().to_owned_obj(offset_data),
+            palette_entry_labels_array: obj.palette_entry_labels_array().to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -12,22 +12,22 @@ pub use read_fonts::layout::gdef::GlyphClassDef;
 pub struct Gdef {
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
-    pub glyph_class_def_offset: NullableOffsetMarker<ClassDef>,
+    pub glyph_class_def: NullableOffsetMarker<ClassDef>,
     /// Offset to attachment point list table, from beginning of GDEF
     /// header (may be NULL)
-    pub attach_list_offset: NullableOffsetMarker<AttachList>,
+    pub attach_list: NullableOffsetMarker<AttachList>,
     /// Offset to ligature caret list table, from beginning of GDEF
     /// header (may be NULL)
-    pub lig_caret_list_offset: NullableOffsetMarker<LigCaretList>,
+    pub lig_caret_list: NullableOffsetMarker<LigCaretList>,
     /// Offset to class definition table for mark attachment type, from
     /// beginning of GDEF header (may be NULL)
-    pub mark_attach_class_def_offset: NullableOffsetMarker<ClassDef>,
+    pub mark_attach_class_def: NullableOffsetMarker<ClassDef>,
     /// Offset to the table of mark glyph set definitions, from
     /// beginning of GDEF header (may be NULL)
-    pub mark_glyph_sets_def_offset: NullableOffsetMarker<MarkGlyphSets>,
+    pub mark_glyph_sets_def: NullableOffsetMarker<MarkGlyphSets>,
     /// Offset to the Item Variation Store table, from beginning of
     /// GDEF header (may be NULL)
-    pub item_var_store_offset: NullableOffsetMarker<ClassDef, WIDTH_32>,
+    pub item_var_store: NullableOffsetMarker<ClassDef, WIDTH_32>,
 }
 
 impl FontWrite for Gdef {
@@ -35,39 +35,39 @@ impl FontWrite for Gdef {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.compute_version() as MajorMinor;
         version.write_into(writer);
-        self.glyph_class_def_offset.write_into(writer);
-        self.attach_list_offset.write_into(writer);
-        self.lig_caret_list_offset.write_into(writer);
-        self.mark_attach_class_def_offset.write_into(writer);
+        self.glyph_class_def.write_into(writer);
+        self.attach_list.write_into(writer);
+        self.lig_caret_list.write_into(writer);
+        self.mark_attach_class_def.write_into(writer);
         version
             .compatible(MajorMinor::VERSION_1_2)
-            .then(|| self.mark_glyph_sets_def_offset.write_into(writer));
+            .then(|| self.mark_glyph_sets_def.write_into(writer));
         version
             .compatible(MajorMinor::VERSION_1_3)
-            .then(|| self.item_var_store_offset.write_into(writer));
+            .then(|| self.item_var_store.write_into(writer));
     }
 }
 
 impl Validate for Gdef {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Gdef", |ctx| {
-            ctx.in_field("glyph_class_def_offset", |ctx| {
-                self.glyph_class_def_offset.validate_impl(ctx);
+            ctx.in_field("glyph_class_def", |ctx| {
+                self.glyph_class_def.validate_impl(ctx);
             });
-            ctx.in_field("attach_list_offset", |ctx| {
-                self.attach_list_offset.validate_impl(ctx);
+            ctx.in_field("attach_list", |ctx| {
+                self.attach_list.validate_impl(ctx);
             });
-            ctx.in_field("lig_caret_list_offset", |ctx| {
-                self.lig_caret_list_offset.validate_impl(ctx);
+            ctx.in_field("lig_caret_list", |ctx| {
+                self.lig_caret_list.validate_impl(ctx);
             });
-            ctx.in_field("mark_attach_class_def_offset", |ctx| {
-                self.mark_attach_class_def_offset.validate_impl(ctx);
+            ctx.in_field("mark_attach_class_def", |ctx| {
+                self.mark_attach_class_def.validate_impl(ctx);
             });
-            ctx.in_field("mark_glyph_sets_def_offset", |ctx| {
-                self.mark_glyph_sets_def_offset.validate_impl(ctx);
+            ctx.in_field("mark_glyph_sets_def", |ctx| {
+                self.mark_glyph_sets_def.validate_impl(ctx);
             });
-            ctx.in_field("item_var_store_offset", |ctx| {
-                self.item_var_store_offset.validate_impl(ctx);
+            ctx.in_field("item_var_store", |ctx| {
+                self.item_var_store.validate_impl(ctx);
             });
         })
     }
@@ -76,12 +76,12 @@ impl Validate for Gdef {
 impl<'a> FromObjRef<read_fonts::layout::gdef::Gdef<'a>> for Gdef {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::Gdef<'a>, _: FontData) -> Self {
         Gdef {
-            glyph_class_def_offset: obj.glyph_class_def().to_owned_table(),
-            attach_list_offset: obj.attach_list().to_owned_table(),
-            lig_caret_list_offset: obj.lig_caret_list().to_owned_table(),
-            mark_attach_class_def_offset: obj.mark_attach_class_def().to_owned_table(),
-            mark_glyph_sets_def_offset: obj.mark_glyph_sets_def().to_owned_table(),
-            item_var_store_offset: obj.item_var_store().to_owned_table(),
+            glyph_class_def: obj.glyph_class_def().to_owned_table(),
+            attach_list: obj.attach_list().to_owned_table(),
+            lig_caret_list: obj.lig_caret_list().to_owned_table(),
+            mark_attach_class_def: obj.mark_attach_class_def().to_owned_table(),
+            mark_glyph_sets_def: obj.mark_glyph_sets_def().to_owned_table(),
+            item_var_store: obj.item_var_store().to_owned_table(),
         }
     }
 }
@@ -105,32 +105,32 @@ impl FontWrite for GlyphClassDef {
 #[derive(Clone, Debug, Default)]
 pub struct AttachList {
     /// Offset to Coverage table - from beginning of AttachList table
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to AttachPoint tables-from beginning of
     /// AttachList table-in Coverage Index order
-    pub attach_point_offsets: Vec<OffsetMarker<AttachPoint>>,
+    pub attach_points: Vec<OffsetMarker<AttachPoint>>,
 }
 
 impl FontWrite for AttachList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.attach_point_offsets).unwrap() as u16).write_into(writer);
-        self.attach_point_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.attach_points).unwrap() as u16).write_into(writer);
+        self.attach_points.write_into(writer);
     }
 }
 
 impl Validate for AttachList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AttachList", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("attach_point_offsets", |ctx| {
-                if self.attach_point_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("attach_points", |ctx| {
+                if self.attach_points.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.attach_point_offsets.validate_impl(ctx);
+                self.attach_points.validate_impl(ctx);
             });
         })
     }
@@ -139,8 +139,8 @@ impl Validate for AttachList {
 impl<'a> FromObjRef<read_fonts::layout::gdef::AttachList<'a>> for AttachList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::AttachList<'a>, _: FontData) -> Self {
         AttachList {
-            coverage_offset: obj.coverage().to_owned_table(),
-            attach_point_offsets: obj.attach_points().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            attach_points: obj.attach_points().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -201,32 +201,32 @@ impl<'a> FontRead<'a> for AttachPoint {
 #[derive(Clone, Debug, Default)]
 pub struct LigCaretList {
     /// Offset to Coverage table - from beginning of LigCaretList table
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to LigGlyph tables, from beginning of
     /// LigCaretList table —in Coverage Index order
-    pub lig_glyph_offsets: Vec<OffsetMarker<LigGlyph>>,
+    pub lig_glyphs: Vec<OffsetMarker<LigGlyph>>,
 }
 
 impl FontWrite for LigCaretList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.lig_glyph_offsets).unwrap() as u16).write_into(writer);
-        self.lig_glyph_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.lig_glyphs).unwrap() as u16).write_into(writer);
+        self.lig_glyphs.write_into(writer);
     }
 }
 
 impl Validate for LigCaretList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigCaretList", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("lig_glyph_offsets", |ctx| {
-                if self.lig_glyph_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("lig_glyphs", |ctx| {
+                if self.lig_glyphs.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.lig_glyph_offsets.validate_impl(ctx);
+                self.lig_glyphs.validate_impl(ctx);
             });
         })
     }
@@ -235,8 +235,8 @@ impl Validate for LigCaretList {
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigCaretList<'a>> for LigCaretList {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigCaretList<'a>, _: FontData) -> Self {
         LigCaretList {
-            coverage_offset: obj.coverage().to_owned_table(),
-            lig_glyph_offsets: obj.lig_glyphs().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            lig_glyphs: obj.lig_glyphs().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -254,25 +254,25 @@ impl<'a> FontRead<'a> for LigCaretList {
 pub struct LigGlyph {
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
-    pub caret_value_offsets: Vec<OffsetMarker<CaretValue>>,
+    pub caret_values: Vec<OffsetMarker<CaretValue>>,
 }
 
 impl FontWrite for LigGlyph {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.caret_value_offsets).unwrap() as u16).write_into(writer);
-        self.caret_value_offsets.write_into(writer);
+        (array_len(&self.caret_values).unwrap() as u16).write_into(writer);
+        self.caret_values.write_into(writer);
     }
 }
 
 impl Validate for LigGlyph {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigGlyph", |ctx| {
-            ctx.in_field("caret_value_offsets", |ctx| {
-                if self.caret_value_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("caret_values", |ctx| {
+                if self.caret_values.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.caret_value_offsets.validate_impl(ctx);
+                self.caret_values.validate_impl(ctx);
             });
         })
     }
@@ -281,7 +281,7 @@ impl Validate for LigGlyph {
 impl<'a> FromObjRef<read_fonts::layout::gdef::LigGlyph<'a>> for LigGlyph {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::LigGlyph<'a>, _: FontData) -> Self {
         LigGlyph {
-            caret_value_offsets: obj.caret_values().map(|x| x.to_owned_table()).collect(),
+            caret_values: obj.caret_values().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -427,7 +427,7 @@ pub struct CaretValueFormat3 {
     /// Offset to Device table (non-variable font) / Variation Index
     /// table (variable font) for X or Y value-from beginning of
     /// CaretValue table
-    pub device_offset: OffsetMarker<Device>,
+    pub device: OffsetMarker<Device>,
 }
 
 impl FontWrite for CaretValueFormat3 {
@@ -435,15 +435,15 @@ impl FontWrite for CaretValueFormat3 {
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
         self.coordinate.write_into(writer);
-        self.device_offset.write_into(writer);
+        self.device.write_into(writer);
     }
 }
 
 impl Validate for CaretValueFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("CaretValueFormat3", |ctx| {
-            ctx.in_field("device_offset", |ctx| {
-                self.device_offset.validate_impl(ctx);
+            ctx.in_field("device", |ctx| {
+                self.device.validate_impl(ctx);
             });
         })
     }
@@ -453,7 +453,7 @@ impl<'a> FromObjRef<read_fonts::layout::gdef::CaretValueFormat3<'a>> for CaretVa
     fn from_obj_ref(obj: &read_fonts::layout::gdef::CaretValueFormat3<'a>, _: FontData) -> Self {
         CaretValueFormat3 {
             coordinate: obj.coordinate(),
-            device_offset: obj.device().to_owned_table(),
+            device: obj.device().to_owned_table(),
         }
     }
 }
@@ -472,26 +472,26 @@ impl<'a> FontRead<'a> for CaretValueFormat3 {
 pub struct MarkGlyphSets {
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.
-    pub coverage_offsets: Vec<OffsetMarker<CoverageTable, WIDTH_32>>,
+    pub coverages: Vec<OffsetMarker<CoverageTable, WIDTH_32>>,
 }
 
 impl FontWrite for MarkGlyphSets {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        (array_len(&self.coverage_offsets).unwrap() as u16).write_into(writer);
-        self.coverage_offsets.write_into(writer);
+        (array_len(&self.coverages).unwrap() as u16).write_into(writer);
+        self.coverages.write_into(writer);
     }
 }
 
 impl Validate for MarkGlyphSets {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkGlyphSets", |ctx| {
-            ctx.in_field("coverage_offsets", |ctx| {
-                if self.coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("coverages", |ctx| {
+                if self.coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.coverage_offsets.validate_impl(ctx);
+                self.coverages.validate_impl(ctx);
             });
         })
     }
@@ -500,7 +500,7 @@ impl Validate for MarkGlyphSets {
 impl<'a> FromObjRef<read_fonts::layout::gdef::MarkGlyphSets<'a>> for MarkGlyphSets {
     fn from_obj_ref(obj: &read_fonts::layout::gdef::MarkGlyphSets<'a>, _: FontData) -> Self {
         MarkGlyphSets {
-            coverage_offsets: obj.coverages().map(|x| x.to_owned_table()).collect(),
+            coverages: obj.coverages().map(|x| x.to_owned_table()).collect(),
         }
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -12,12 +12,12 @@ pub use read_fonts::layout::gpos::ValueFormat;
 #[derive(Clone, Debug, Default)]
 pub struct Gpos {
     /// Offset to ScriptList table, from beginning of GPOS table
-    pub script_list_offset: OffsetMarker<ScriptList>,
+    pub script_list: OffsetMarker<ScriptList>,
     /// Offset to FeatureList table, from beginning of GPOS table
-    pub feature_list_offset: OffsetMarker<FeatureList>,
+    pub feature_list: OffsetMarker<FeatureList>,
     /// Offset to LookupList table, from beginning of GPOS table
-    pub lookup_list_offset: OffsetMarker<PositionLookupList>,
-    pub feature_variations_offset: NullableOffsetMarker<FeatureVariations, WIDTH_32>,
+    pub lookup_list: OffsetMarker<PositionLookupList>,
+    pub feature_variations: NullableOffsetMarker<FeatureVariations, WIDTH_32>,
 }
 
 impl FontWrite for Gpos {
@@ -25,29 +25,29 @@ impl FontWrite for Gpos {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.compute_version() as MajorMinor;
         version.write_into(writer);
-        self.script_list_offset.write_into(writer);
-        self.feature_list_offset.write_into(writer);
-        self.lookup_list_offset.write_into(writer);
+        self.script_list.write_into(writer);
+        self.feature_list.write_into(writer);
+        self.lookup_list.write_into(writer);
         version
             .compatible(MajorMinor::VERSION_1_1)
-            .then(|| self.feature_variations_offset.write_into(writer));
+            .then(|| self.feature_variations.write_into(writer));
     }
 }
 
 impl Validate for Gpos {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Gpos", |ctx| {
-            ctx.in_field("script_list_offset", |ctx| {
-                self.script_list_offset.validate_impl(ctx);
+            ctx.in_field("script_list", |ctx| {
+                self.script_list.validate_impl(ctx);
             });
-            ctx.in_field("feature_list_offset", |ctx| {
-                self.feature_list_offset.validate_impl(ctx);
+            ctx.in_field("feature_list", |ctx| {
+                self.feature_list.validate_impl(ctx);
             });
-            ctx.in_field("lookup_list_offset", |ctx| {
-                self.lookup_list_offset.validate_impl(ctx);
+            ctx.in_field("lookup_list", |ctx| {
+                self.lookup_list.validate_impl(ctx);
             });
-            ctx.in_field("feature_variations_offset", |ctx| {
-                self.feature_variations_offset.validate_impl(ctx);
+            ctx.in_field("feature_variations", |ctx| {
+                self.feature_variations.validate_impl(ctx);
             });
         })
     }
@@ -56,10 +56,10 @@ impl Validate for Gpos {
 impl<'a> FromObjRef<read_fonts::layout::gpos::Gpos<'a>> for Gpos {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Gpos<'a>, _: FontData) -> Self {
         Gpos {
-            script_list_offset: obj.script_list().to_owned_table(),
-            feature_list_offset: obj.feature_list().to_owned_table(),
-            lookup_list_offset: obj.lookup_list().to_owned_table(),
-            feature_variations_offset: obj.feature_variations().to_owned_table(),
+            script_list: obj.script_list().to_owned_table(),
+            feature_list: obj.feature_list().to_owned_table(),
+            lookup_list: obj.lookup_list().to_owned_table(),
+            feature_variations: obj.feature_variations().to_owned_table(),
         }
     }
 }
@@ -314,11 +314,11 @@ pub struct AnchorFormat3 {
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for X coordinate, from beginning of
     /// Anchor table (may be NULL)
-    pub x_device_offset: NullableOffsetMarker<Device>,
+    pub x_device: NullableOffsetMarker<Device>,
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for Y coordinate, from beginning of
     /// Anchor table (may be NULL)
-    pub y_device_offset: NullableOffsetMarker<Device>,
+    pub y_device: NullableOffsetMarker<Device>,
 }
 
 impl FontWrite for AnchorFormat3 {
@@ -327,19 +327,19 @@ impl FontWrite for AnchorFormat3 {
         (3 as u16).write_into(writer);
         self.x_coordinate.write_into(writer);
         self.y_coordinate.write_into(writer);
-        self.x_device_offset.write_into(writer);
-        self.y_device_offset.write_into(writer);
+        self.x_device.write_into(writer);
+        self.y_device.write_into(writer);
     }
 }
 
 impl Validate for AnchorFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AnchorFormat3", |ctx| {
-            ctx.in_field("x_device_offset", |ctx| {
-                self.x_device_offset.validate_impl(ctx);
+            ctx.in_field("x_device", |ctx| {
+                self.x_device.validate_impl(ctx);
             });
-            ctx.in_field("y_device_offset", |ctx| {
-                self.y_device_offset.validate_impl(ctx);
+            ctx.in_field("y_device", |ctx| {
+                self.y_device.validate_impl(ctx);
             });
         })
     }
@@ -350,8 +350,8 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::AnchorFormat3<'a>> for AnchorForma
         AnchorFormat3 {
             x_coordinate: obj.x_coordinate(),
             y_coordinate: obj.y_coordinate(),
-            x_device_offset: obj.x_device().to_owned_table(),
-            y_device_offset: obj.y_device().to_owned_table(),
+            x_device: obj.x_device().to_owned_table(),
+            y_device: obj.y_device().to_owned_table(),
         }
     }
 }
@@ -417,21 +417,21 @@ pub struct MarkRecord {
     /// Class defined for the associated mark.
     pub mark_class: u16,
     /// Offset to Anchor table, from beginning of MarkArray table.
-    pub mark_anchor_offset: OffsetMarker<AnchorTable>,
+    pub mark_anchor: OffsetMarker<AnchorTable>,
 }
 
 impl FontWrite for MarkRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.mark_class.write_into(writer);
-        self.mark_anchor_offset.write_into(writer);
+        self.mark_anchor.write_into(writer);
     }
 }
 
 impl Validate for MarkRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkRecord", |ctx| {
-            ctx.in_field("mark_anchor_offset", |ctx| {
-                self.mark_anchor_offset.validate_impl(ctx);
+            ctx.in_field("mark_anchor", |ctx| {
+                self.mark_anchor.validate_impl(ctx);
             });
         })
     }
@@ -441,7 +441,7 @@ impl FromObjRef<read_fonts::layout::gpos::MarkRecord> for MarkRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkRecord, offset_data: FontData) -> Self {
         MarkRecord {
             mark_class: obj.mark_class(),
-            mark_anchor_offset: obj.mark_anchor(offset_data).to_owned_table(),
+            mark_anchor: obj.mark_anchor(offset_data).to_owned_table(),
         }
     }
 }
@@ -499,7 +499,7 @@ impl<'a> FontRead<'a> for SinglePos {
 #[derive(Clone, Debug, Default)]
 pub struct SinglePosFormat1 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Defines positioning value(s) — applied to all glyphs in the
     /// Coverage table.
     pub value_record: ValueRecord,
@@ -509,7 +509,7 @@ impl FontWrite for SinglePosFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         (self.compute_value_format() as ValueFormat).write_into(writer);
         self.value_record.write_into(writer);
     }
@@ -518,8 +518,8 @@ impl FontWrite for SinglePosFormat1 {
 impl Validate for SinglePosFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SinglePosFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
         })
     }
@@ -529,7 +529,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat1<'a>> for SinglePo
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat1<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SinglePosFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
+            coverage: obj.coverage().to_owned_table(),
             value_record: obj.value_record().to_owned_obj(offset_data),
         }
     }
@@ -548,7 +548,7 @@ impl<'a> FontRead<'a> for SinglePosFormat1 {
 #[derive(Clone, Debug, Default)]
 pub struct SinglePosFormat2 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of ValueRecords — positioning values applied to glyphs.
     pub value_records: Vec<ValueRecord>,
 }
@@ -557,7 +557,7 @@ impl FontWrite for SinglePosFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         (self.compute_value_format() as ValueFormat).write_into(writer);
         (array_len(&self.value_records).unwrap() as u16).write_into(writer);
         self.value_records.write_into(writer);
@@ -567,8 +567,8 @@ impl FontWrite for SinglePosFormat2 {
 impl Validate for SinglePosFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SinglePosFormat2", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
             ctx.in_field("value_records", |ctx| {
                 if self.value_records.len() > (u16::MAX as usize) {
@@ -584,7 +584,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::SinglePosFormat2<'a>> for SinglePo
     fn from_obj_ref(obj: &read_fonts::layout::gpos::SinglePosFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SinglePosFormat2 {
-            coverage_offset: obj.coverage().to_owned_table(),
+            coverage: obj.coverage().to_owned_table(),
             value_records: obj
                 .value_records()
                 .iter()
@@ -656,35 +656,35 @@ impl<'a> FontRead<'a> for PairPos {
 #[derive(Clone, Debug, Default)]
 pub struct PairPosFormat1 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to PairSet tables. Offsets are from beginning
     /// of PairPos subtable, ordered by Coverage Index.
-    pub pair_set_offsets: Vec<OffsetMarker<PairSet>>,
+    pub pair_sets: Vec<OffsetMarker<PairSet>>,
 }
 
 impl FontWrite for PairPosFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         (self.compute_value_format1() as ValueFormat).write_into(writer);
         (self.compute_value_format2() as ValueFormat).write_into(writer);
-        (array_len(&self.pair_set_offsets).unwrap() as u16).write_into(writer);
-        self.pair_set_offsets.write_into(writer);
+        (array_len(&self.pair_sets).unwrap() as u16).write_into(writer);
+        self.pair_sets.write_into(writer);
     }
 }
 
 impl Validate for PairPosFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("PairPosFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("pair_set_offsets", |ctx| {
-                if self.pair_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("pair_sets", |ctx| {
+                if self.pair_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.pair_set_offsets.validate_impl(ctx);
+                self.pair_sets.validate_impl(ctx);
             });
         })
     }
@@ -693,8 +693,8 @@ impl Validate for PairPosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat1<'a>> for PairPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat1<'a>, _: FontData) -> Self {
         PairPosFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            pair_set_offsets: obj.pair_sets().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            pair_sets: obj.pair_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -793,13 +793,13 @@ impl FromObjRef<read_fonts::layout::gpos::PairValueRecord> for PairValueRecord {
 #[derive(Clone, Debug, Default)]
 pub struct PairPosFormat2 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the first glyph of the pair.
-    pub class_def1_offset: OffsetMarker<ClassDef>,
+    pub class_def1: OffsetMarker<ClassDef>,
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the second glyph of the pair.
-    pub class_def2_offset: OffsetMarker<ClassDef>,
+    pub class_def2: OffsetMarker<ClassDef>,
     /// Array of Class1 records, ordered by classes in classDef1.
     pub class1_records: Vec<Class1Record>,
 }
@@ -808,11 +808,11 @@ impl FontWrite for PairPosFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         (self.compute_value_format1() as ValueFormat).write_into(writer);
         (self.compute_value_format2() as ValueFormat).write_into(writer);
-        self.class_def1_offset.write_into(writer);
-        self.class_def2_offset.write_into(writer);
+        self.class_def1.write_into(writer);
+        self.class_def2.write_into(writer);
         (self.compute_class1_count() as u16).write_into(writer);
         (self.compute_class2_count() as u16).write_into(writer);
         self.class1_records.write_into(writer);
@@ -822,14 +822,14 @@ impl FontWrite for PairPosFormat2 {
 impl Validate for PairPosFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("PairPosFormat2", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("class_def1_offset", |ctx| {
-                self.class_def1_offset.validate_impl(ctx);
+            ctx.in_field("class_def1", |ctx| {
+                self.class_def1.validate_impl(ctx);
             });
-            ctx.in_field("class_def2_offset", |ctx| {
-                self.class_def2_offset.validate_impl(ctx);
+            ctx.in_field("class_def2", |ctx| {
+                self.class_def2.validate_impl(ctx);
             });
             ctx.in_field("class1_records", |ctx| {
                 if self.class1_records.len() > (u16::MAX as usize) {
@@ -845,9 +845,9 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::PairPosFormat2<'a>> for PairPosFor
     fn from_obj_ref(obj: &read_fonts::layout::gpos::PairPosFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         PairPosFormat2 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            class_def1_offset: obj.class_def1().to_owned_table(),
-            class_def2_offset: obj.class_def2().to_owned_table(),
+            coverage: obj.coverage().to_owned_table(),
+            class_def1: obj.class_def1().to_owned_table(),
+            class_def2: obj.class_def2().to_owned_table(),
             class1_records: obj
                 .class1_records()
                 .iter()
@@ -937,7 +937,7 @@ impl FromObjRef<read_fonts::layout::gpos::Class2Record> for Class2Record {
 #[derive(Clone, Debug, Default)]
 pub struct CursivePosFormat1 {
     /// Offset to Coverage table, from beginning of CursivePos subtable.
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of EntryExit records, in Coverage index order.
     pub entry_exit_record: Vec<EntryExitRecord>,
 }
@@ -946,7 +946,7 @@ impl FontWrite for CursivePosFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         (array_len(&self.entry_exit_record).unwrap() as u16).write_into(writer);
         self.entry_exit_record.write_into(writer);
     }
@@ -955,8 +955,8 @@ impl FontWrite for CursivePosFormat1 {
 impl Validate for CursivePosFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("CursivePosFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
             ctx.in_field("entry_exit_record", |ctx| {
                 if self.entry_exit_record.len() > (u16::MAX as usize) {
@@ -972,7 +972,7 @@ impl<'a> FromObjRef<read_fonts::layout::gpos::CursivePosFormat1<'a>> for Cursive
     fn from_obj_ref(obj: &read_fonts::layout::gpos::CursivePosFormat1<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         CursivePosFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
+            coverage: obj.coverage().to_owned_table(),
             entry_exit_record: obj.entry_exit_record().to_owned_obj(offset_data),
         }
     }
@@ -992,27 +992,27 @@ impl<'a> FontRead<'a> for CursivePosFormat1 {
 pub struct EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
-    pub entry_anchor_offset: NullableOffsetMarker<AnchorTable>,
+    pub entry_anchor: NullableOffsetMarker<AnchorTable>,
     /// Offset to exitAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
-    pub exit_anchor_offset: NullableOffsetMarker<AnchorTable>,
+    pub exit_anchor: NullableOffsetMarker<AnchorTable>,
 }
 
 impl FontWrite for EntryExitRecord {
     fn write_into(&self, writer: &mut TableWriter) {
-        self.entry_anchor_offset.write_into(writer);
-        self.exit_anchor_offset.write_into(writer);
+        self.entry_anchor.write_into(writer);
+        self.exit_anchor.write_into(writer);
     }
 }
 
 impl Validate for EntryExitRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("EntryExitRecord", |ctx| {
-            ctx.in_field("entry_anchor_offset", |ctx| {
-                self.entry_anchor_offset.validate_impl(ctx);
+            ctx.in_field("entry_anchor", |ctx| {
+                self.entry_anchor.validate_impl(ctx);
             });
-            ctx.in_field("exit_anchor_offset", |ctx| {
-                self.exit_anchor_offset.validate_impl(ctx);
+            ctx.in_field("exit_anchor", |ctx| {
+                self.exit_anchor.validate_impl(ctx);
             });
         })
     }
@@ -1024,8 +1024,8 @@ impl FromObjRef<read_fonts::layout::gpos::EntryExitRecord> for EntryExitRecord {
         offset_data: FontData,
     ) -> Self {
         EntryExitRecord {
-            entry_anchor_offset: obj.entry_anchor(offset_data).to_owned_table(),
-            exit_anchor_offset: obj.exit_anchor(offset_data).to_owned_table(),
+            entry_anchor: obj.entry_anchor(offset_data).to_owned_table(),
+            exit_anchor: obj.exit_anchor(offset_data).to_owned_table(),
         }
     }
 }
@@ -1035,44 +1035,44 @@ impl FromObjRef<read_fonts::layout::gpos::EntryExitRecord> for EntryExitRecord {
 pub struct MarkBasePosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
-    pub mark_coverage_offset: OffsetMarker<CoverageTable>,
+    pub mark_coverage: OffsetMarker<CoverageTable>,
     /// Offset to baseCoverage table, from beginning of MarkBasePos
     /// subtable.
-    pub base_coverage_offset: OffsetMarker<CoverageTable>,
+    pub base_coverage: OffsetMarker<CoverageTable>,
     /// Offset to MarkArray table, from beginning of MarkBasePos
     /// subtable.
-    pub mark_array_offset: OffsetMarker<MarkArray>,
+    pub mark_array: OffsetMarker<MarkArray>,
     /// Offset to BaseArray table, from beginning of MarkBasePos
     /// subtable.
-    pub base_array_offset: OffsetMarker<BaseArray>,
+    pub base_array: OffsetMarker<BaseArray>,
 }
 
 impl FontWrite for MarkBasePosFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.mark_coverage_offset.write_into(writer);
-        self.base_coverage_offset.write_into(writer);
+        self.mark_coverage.write_into(writer);
+        self.base_coverage.write_into(writer);
         (self.compute_mark_class_count() as u16).write_into(writer);
-        self.mark_array_offset.write_into(writer);
-        self.base_array_offset.write_into(writer);
+        self.mark_array.write_into(writer);
+        self.base_array.write_into(writer);
     }
 }
 
 impl Validate for MarkBasePosFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkBasePosFormat1", |ctx| {
-            ctx.in_field("mark_coverage_offset", |ctx| {
-                self.mark_coverage_offset.validate_impl(ctx);
+            ctx.in_field("mark_coverage", |ctx| {
+                self.mark_coverage.validate_impl(ctx);
             });
-            ctx.in_field("base_coverage_offset", |ctx| {
-                self.base_coverage_offset.validate_impl(ctx);
+            ctx.in_field("base_coverage", |ctx| {
+                self.base_coverage.validate_impl(ctx);
             });
-            ctx.in_field("mark_array_offset", |ctx| {
-                self.mark_array_offset.validate_impl(ctx);
+            ctx.in_field("mark_array", |ctx| {
+                self.mark_array.validate_impl(ctx);
             });
-            ctx.in_field("base_array_offset", |ctx| {
-                self.base_array_offset.validate_impl(ctx);
+            ctx.in_field("base_array", |ctx| {
+                self.base_array.validate_impl(ctx);
             });
         })
     }
@@ -1081,10 +1081,10 @@ impl Validate for MarkBasePosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkBasePosFormat1<'a>> for MarkBasePosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkBasePosFormat1<'a>, _: FontData) -> Self {
         MarkBasePosFormat1 {
-            mark_coverage_offset: obj.mark_coverage().to_owned_table(),
-            base_coverage_offset: obj.base_coverage().to_owned_table(),
-            mark_array_offset: obj.mark_array().to_owned_table(),
-            base_array_offset: obj.base_array().to_owned_table(),
+            mark_coverage: obj.mark_coverage().to_owned_table(),
+            base_coverage: obj.base_coverage().to_owned_table(),
+            mark_array: obj.mark_array().to_owned_table(),
+            base_array: obj.base_array().to_owned_table(),
         }
     }
 }
@@ -1147,23 +1147,23 @@ pub struct BaseRecord {
     /// Array of offsets (one per mark class) to Anchor tables. Offsets
     /// are from beginning of BaseArray table, ordered by class
     /// (offsets may be NULL).
-    pub base_anchor_offsets: Vec<NullableOffsetMarker<AnchorTable>>,
+    pub base_anchors: Vec<NullableOffsetMarker<AnchorTable>>,
 }
 
 impl FontWrite for BaseRecord {
     fn write_into(&self, writer: &mut TableWriter) {
-        self.base_anchor_offsets.write_into(writer);
+        self.base_anchors.write_into(writer);
     }
 }
 
 impl Validate for BaseRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseRecord", |ctx| {
-            ctx.in_field("base_anchor_offsets", |ctx| {
-                if self.base_anchor_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("base_anchors", |ctx| {
+                if self.base_anchors.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.base_anchor_offsets.validate_impl(ctx);
+                self.base_anchors.validate_impl(ctx);
             });
         })
     }
@@ -1172,7 +1172,7 @@ impl Validate for BaseRecord {
 impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::BaseRecord, offset_data: FontData) -> Self {
         BaseRecord {
-            base_anchor_offsets: obj
+            base_anchors: obj
                 .base_anchors(offset_data)
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1185,44 +1185,44 @@ impl FromObjRef<read_fonts::layout::gpos::BaseRecord<'_>> for BaseRecord {
 pub struct MarkLigPosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
-    pub mark_coverage_offset: OffsetMarker<CoverageTable>,
+    pub mark_coverage: OffsetMarker<CoverageTable>,
     /// Offset to ligatureCoverage table, from beginning of MarkLigPos
     /// subtable.
-    pub ligature_coverage_offset: OffsetMarker<CoverageTable>,
+    pub ligature_coverage: OffsetMarker<CoverageTable>,
     /// Offset to MarkArray table, from beginning of MarkLigPos
     /// subtable.
-    pub mark_array_offset: OffsetMarker<MarkArray>,
+    pub mark_array: OffsetMarker<MarkArray>,
     /// Offset to LigatureArray table, from beginning of MarkLigPos
     /// subtable.
-    pub ligature_array_offset: OffsetMarker<LigatureArray>,
+    pub ligature_array: OffsetMarker<LigatureArray>,
 }
 
 impl FontWrite for MarkLigPosFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.mark_coverage_offset.write_into(writer);
-        self.ligature_coverage_offset.write_into(writer);
+        self.mark_coverage.write_into(writer);
+        self.ligature_coverage.write_into(writer);
         (self.compute_mark_class_count() as u16).write_into(writer);
-        self.mark_array_offset.write_into(writer);
-        self.ligature_array_offset.write_into(writer);
+        self.mark_array.write_into(writer);
+        self.ligature_array.write_into(writer);
     }
 }
 
 impl Validate for MarkLigPosFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkLigPosFormat1", |ctx| {
-            ctx.in_field("mark_coverage_offset", |ctx| {
-                self.mark_coverage_offset.validate_impl(ctx);
+            ctx.in_field("mark_coverage", |ctx| {
+                self.mark_coverage.validate_impl(ctx);
             });
-            ctx.in_field("ligature_coverage_offset", |ctx| {
-                self.ligature_coverage_offset.validate_impl(ctx);
+            ctx.in_field("ligature_coverage", |ctx| {
+                self.ligature_coverage.validate_impl(ctx);
             });
-            ctx.in_field("mark_array_offset", |ctx| {
-                self.mark_array_offset.validate_impl(ctx);
+            ctx.in_field("mark_array", |ctx| {
+                self.mark_array.validate_impl(ctx);
             });
-            ctx.in_field("ligature_array_offset", |ctx| {
-                self.ligature_array_offset.validate_impl(ctx);
+            ctx.in_field("ligature_array", |ctx| {
+                self.ligature_array.validate_impl(ctx);
             });
         })
     }
@@ -1231,10 +1231,10 @@ impl Validate for MarkLigPosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkLigPosFormat1<'a>> for MarkLigPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkLigPosFormat1<'a>, _: FontData) -> Self {
         MarkLigPosFormat1 {
-            mark_coverage_offset: obj.mark_coverage().to_owned_table(),
-            ligature_coverage_offset: obj.ligature_coverage().to_owned_table(),
-            mark_array_offset: obj.mark_array().to_owned_table(),
-            ligature_array_offset: obj.ligature_array().to_owned_table(),
+            mark_coverage: obj.mark_coverage().to_owned_table(),
+            ligature_coverage: obj.ligature_coverage().to_owned_table(),
+            mark_array: obj.mark_array().to_owned_table(),
+            ligature_array: obj.ligature_array().to_owned_table(),
         }
     }
 }
@@ -1254,25 +1254,25 @@ pub struct LigatureArray {
     /// Array of offsets to LigatureAttach tables. Offsets are from
     /// beginning of LigatureArray table, ordered by ligatureCoverage
     /// index.
-    pub ligature_attach_offsets: Vec<OffsetMarker<LigatureAttach>>,
+    pub ligature_attaches: Vec<OffsetMarker<LigatureAttach>>,
 }
 
 impl FontWrite for LigatureArray {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.ligature_attach_offsets).unwrap() as u16).write_into(writer);
-        self.ligature_attach_offsets.write_into(writer);
+        (array_len(&self.ligature_attaches).unwrap() as u16).write_into(writer);
+        self.ligature_attaches.write_into(writer);
     }
 }
 
 impl Validate for LigatureArray {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigatureArray", |ctx| {
-            ctx.in_field("ligature_attach_offsets", |ctx| {
-                if self.ligature_attach_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("ligature_attaches", |ctx| {
+                if self.ligature_attaches.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.ligature_attach_offsets.validate_impl(ctx);
+                self.ligature_attaches.validate_impl(ctx);
             });
         })
     }
@@ -1281,7 +1281,7 @@ impl Validate for LigatureArray {
 impl<'a> FromObjRef<read_fonts::layout::gpos::LigatureArray<'a>> for LigatureArray {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::LigatureArray<'a>, _: FontData) -> Self {
         LigatureArray {
-            ligature_attach_offsets: obj
+            ligature_attaches: obj
                 .ligature_attaches()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1340,23 +1340,23 @@ pub struct ComponentRecord {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of LigatureAttach table, ordered by class
     /// (offsets may be NULL).
-    pub ligature_anchor_offsets: Vec<NullableOffsetMarker<AnchorTable>>,
+    pub ligature_anchors: Vec<NullableOffsetMarker<AnchorTable>>,
 }
 
 impl FontWrite for ComponentRecord {
     fn write_into(&self, writer: &mut TableWriter) {
-        self.ligature_anchor_offsets.write_into(writer);
+        self.ligature_anchors.write_into(writer);
     }
 }
 
 impl Validate for ComponentRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ComponentRecord", |ctx| {
-            ctx.in_field("ligature_anchor_offsets", |ctx| {
-                if self.ligature_anchor_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("ligature_anchors", |ctx| {
+                if self.ligature_anchors.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.ligature_anchor_offsets.validate_impl(ctx);
+                self.ligature_anchors.validate_impl(ctx);
             });
         })
     }
@@ -1368,7 +1368,7 @@ impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentReco
         offset_data: FontData,
     ) -> Self {
         ComponentRecord {
-            ligature_anchor_offsets: obj
+            ligature_anchors: obj
                 .ligature_anchors(offset_data)
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1381,44 +1381,44 @@ impl FromObjRef<read_fonts::layout::gpos::ComponentRecord<'_>> for ComponentReco
 pub struct MarkMarkPosFormat1 {
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
-    pub mark1_coverage_offset: OffsetMarker<CoverageTable>,
+    pub mark1_coverage: OffsetMarker<CoverageTable>,
     /// Offset to Base Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
-    pub mark2_coverage_offset: OffsetMarker<CoverageTable>,
+    pub mark2_coverage: OffsetMarker<CoverageTable>,
     /// Offset to MarkArray table for mark1, from beginning of
     /// MarkMarkPos subtable.
-    pub mark1_array_offset: OffsetMarker<MarkArray>,
+    pub mark1_array: OffsetMarker<MarkArray>,
     /// Offset to Mark2Array table for mark2, from beginning of
     /// MarkMarkPos subtable.
-    pub mark2_array_offset: OffsetMarker<Mark2Array>,
+    pub mark2_array: OffsetMarker<Mark2Array>,
 }
 
 impl FontWrite for MarkMarkPosFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.mark1_coverage_offset.write_into(writer);
-        self.mark2_coverage_offset.write_into(writer);
+        self.mark1_coverage.write_into(writer);
+        self.mark2_coverage.write_into(writer);
         (self.compute_mark_class_count() as u16).write_into(writer);
-        self.mark1_array_offset.write_into(writer);
-        self.mark2_array_offset.write_into(writer);
+        self.mark1_array.write_into(writer);
+        self.mark2_array.write_into(writer);
     }
 }
 
 impl Validate for MarkMarkPosFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkMarkPosFormat1", |ctx| {
-            ctx.in_field("mark1_coverage_offset", |ctx| {
-                self.mark1_coverage_offset.validate_impl(ctx);
+            ctx.in_field("mark1_coverage", |ctx| {
+                self.mark1_coverage.validate_impl(ctx);
             });
-            ctx.in_field("mark2_coverage_offset", |ctx| {
-                self.mark2_coverage_offset.validate_impl(ctx);
+            ctx.in_field("mark2_coverage", |ctx| {
+                self.mark2_coverage.validate_impl(ctx);
             });
-            ctx.in_field("mark1_array_offset", |ctx| {
-                self.mark1_array_offset.validate_impl(ctx);
+            ctx.in_field("mark1_array", |ctx| {
+                self.mark1_array.validate_impl(ctx);
             });
-            ctx.in_field("mark2_array_offset", |ctx| {
-                self.mark2_array_offset.validate_impl(ctx);
+            ctx.in_field("mark2_array", |ctx| {
+                self.mark2_array.validate_impl(ctx);
             });
         })
     }
@@ -1427,10 +1427,10 @@ impl Validate for MarkMarkPosFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gpos::MarkMarkPosFormat1<'a>> for MarkMarkPosFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::MarkMarkPosFormat1<'a>, _: FontData) -> Self {
         MarkMarkPosFormat1 {
-            mark1_coverage_offset: obj.mark1_coverage().to_owned_table(),
-            mark2_coverage_offset: obj.mark2_coverage().to_owned_table(),
-            mark1_array_offset: obj.mark1_array().to_owned_table(),
-            mark2_array_offset: obj.mark2_array().to_owned_table(),
+            mark1_coverage: obj.mark1_coverage().to_owned_table(),
+            mark2_coverage: obj.mark2_coverage().to_owned_table(),
+            mark1_array: obj.mark1_array().to_owned_table(),
+            mark2_array: obj.mark2_array().to_owned_table(),
         }
     }
 }
@@ -1493,23 +1493,23 @@ pub struct Mark2Record {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of Mark2Array table, in class order (offsets may
     /// be NULL).
-    pub mark2_anchor_offsets: Vec<NullableOffsetMarker<AnchorTable>>,
+    pub mark2_anchors: Vec<NullableOffsetMarker<AnchorTable>>,
 }
 
 impl FontWrite for Mark2Record {
     fn write_into(&self, writer: &mut TableWriter) {
-        self.mark2_anchor_offsets.write_into(writer);
+        self.mark2_anchors.write_into(writer);
     }
 }
 
 impl Validate for Mark2Record {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Mark2Record", |ctx| {
-            ctx.in_field("mark2_anchor_offsets", |ctx| {
-                if self.mark2_anchor_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("mark2_anchors", |ctx| {
+                if self.mark2_anchors.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.mark2_anchor_offsets.validate_impl(ctx);
+                self.mark2_anchors.validate_impl(ctx);
             });
         })
     }
@@ -1518,7 +1518,7 @@ impl Validate for Mark2Record {
 impl FromObjRef<read_fonts::layout::gpos::Mark2Record<'_>> for Mark2Record {
     fn from_obj_ref(obj: &read_fonts::layout::gpos::Mark2Record, offset_data: FontData) -> Self {
         Mark2Record {
-            mark2_anchor_offsets: obj
+            mark2_anchors: obj
                 .mark2_anchors(offset_data)
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1535,14 +1535,14 @@ pub struct ExtensionPosFormat1<T> {
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
     /// ExtensionPosFormat1 subtable.
-    pub extension_offset: OffsetMarker<T, WIDTH_32>,
+    pub extension: OffsetMarker<T, WIDTH_32>,
 }
 
 impl<T: Validate> Validate for ExtensionPosFormat1<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ExtensionPosFormat1", |ctx| {
-            ctx.in_field("extension_offset", |ctx| {
-                self.extension_offset.validate_impl(ctx);
+            ctx.in_field("extension", |ctx| {
+                self.extension.validate_impl(ctx);
             });
         })
     }
@@ -1560,7 +1560,7 @@ where
     ) -> Self {
         ExtensionPosFormat1 {
             extension_lookup_type: obj.extension_lookup_type(),
-            extension_offset: obj.extension().to_owned_table(),
+            extension: obj.extension().to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -9,14 +9,14 @@ use crate::codegen_prelude::*;
 #[derive(Clone, Debug, Default)]
 pub struct Gsub {
     /// Offset to ScriptList table, from beginning of GSUB table
-    pub script_list_offset: OffsetMarker<ScriptList>,
+    pub script_list: OffsetMarker<ScriptList>,
     /// Offset to FeatureList table, from beginning of GSUB table
-    pub feature_list_offset: OffsetMarker<FeatureList>,
+    pub feature_list: OffsetMarker<FeatureList>,
     /// Offset to LookupList table, from beginning of GSUB table
-    pub lookup_list_offset: OffsetMarker<SubstitutionLookupList>,
+    pub lookup_list: OffsetMarker<SubstitutionLookupList>,
     /// Offset to FeatureVariations table, from beginning of the GSUB
     /// table (may be NULL)
-    pub feature_variations_offset: NullableOffsetMarker<FeatureVariations, WIDTH_32>,
+    pub feature_variations: NullableOffsetMarker<FeatureVariations, WIDTH_32>,
 }
 
 impl FontWrite for Gsub {
@@ -24,29 +24,29 @@ impl FontWrite for Gsub {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.compute_version() as MajorMinor;
         version.write_into(writer);
-        self.script_list_offset.write_into(writer);
-        self.feature_list_offset.write_into(writer);
-        self.lookup_list_offset.write_into(writer);
+        self.script_list.write_into(writer);
+        self.feature_list.write_into(writer);
+        self.lookup_list.write_into(writer);
         version
             .compatible(MajorMinor::VERSION_1_1)
-            .then(|| self.feature_variations_offset.write_into(writer));
+            .then(|| self.feature_variations.write_into(writer));
     }
 }
 
 impl Validate for Gsub {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Gsub", |ctx| {
-            ctx.in_field("script_list_offset", |ctx| {
-                self.script_list_offset.validate_impl(ctx);
+            ctx.in_field("script_list", |ctx| {
+                self.script_list.validate_impl(ctx);
             });
-            ctx.in_field("feature_list_offset", |ctx| {
-                self.feature_list_offset.validate_impl(ctx);
+            ctx.in_field("feature_list", |ctx| {
+                self.feature_list.validate_impl(ctx);
             });
-            ctx.in_field("lookup_list_offset", |ctx| {
-                self.lookup_list_offset.validate_impl(ctx);
+            ctx.in_field("lookup_list", |ctx| {
+                self.lookup_list.validate_impl(ctx);
             });
-            ctx.in_field("feature_variations_offset", |ctx| {
-                self.feature_variations_offset.validate_impl(ctx);
+            ctx.in_field("feature_variations", |ctx| {
+                self.feature_variations.validate_impl(ctx);
             });
         })
     }
@@ -55,10 +55,10 @@ impl Validate for Gsub {
 impl<'a> FromObjRef<read_fonts::layout::gsub::Gsub<'a>> for Gsub {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::Gsub<'a>, _: FontData) -> Self {
         Gsub {
-            script_list_offset: obj.script_list().to_owned_table(),
-            feature_list_offset: obj.feature_list().to_owned_table(),
-            lookup_list_offset: obj.lookup_list().to_owned_table(),
-            feature_variations_offset: obj.feature_variations().to_owned_table(),
+            script_list: obj.script_list().to_owned_table(),
+            feature_list: obj.feature_list().to_owned_table(),
+            lookup_list: obj.lookup_list().to_owned_table(),
+            feature_variations: obj.feature_variations().to_owned_table(),
         }
     }
 }
@@ -210,7 +210,7 @@ impl<'a> FontRead<'a> for SingleSubst {
 pub struct SingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Add to original glyph ID to get substitute glyph ID
     pub delta_glyph_id: i16,
 }
@@ -219,7 +219,7 @@ impl FontWrite for SingleSubstFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         self.delta_glyph_id.write_into(writer);
     }
 }
@@ -227,8 +227,8 @@ impl FontWrite for SingleSubstFormat1 {
 impl Validate for SingleSubstFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SingleSubstFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
         })
     }
@@ -237,7 +237,7 @@ impl Validate for SingleSubstFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat1<'a>> for SingleSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat1<'a>, _: FontData) -> Self {
         SingleSubstFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
+            coverage: obj.coverage().to_owned_table(),
             delta_glyph_id: obj.delta_glyph_id(),
         }
     }
@@ -257,7 +257,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat1 {
 pub struct SingleSubstFormat2 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of substitute glyph IDs — ordered by Coverage index
     pub substitute_glyph_ids: Vec<GlyphId>,
 }
@@ -266,7 +266,7 @@ impl FontWrite for SingleSubstFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
+        self.coverage.write_into(writer);
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
     }
@@ -275,8 +275,8 @@ impl FontWrite for SingleSubstFormat2 {
 impl Validate for SingleSubstFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SingleSubstFormat2", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
             ctx.in_field("substitute_glyph_ids", |ctx| {
                 if self.substitute_glyph_ids.len() > (u16::MAX as usize) {
@@ -291,7 +291,7 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::SingleSubstFormat2<'a>> for Single
     fn from_obj_ref(obj: &read_fonts::layout::gsub::SingleSubstFormat2<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SingleSubstFormat2 {
-            coverage_offset: obj.coverage().to_owned_table(),
+            coverage: obj.coverage().to_owned_table(),
             substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }
@@ -311,33 +311,33 @@ impl<'a> FontRead<'a> for SingleSubstFormat2 {
 pub struct MultipleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to Sequence tables. Offsets are from beginning
     /// of substitution subtable, ordered by Coverage index
-    pub sequence_offsets: Vec<OffsetMarker<Sequence>>,
+    pub sequences: Vec<OffsetMarker<Sequence>>,
 }
 
 impl FontWrite for MultipleSubstFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.sequence_offsets).unwrap() as u16).write_into(writer);
-        self.sequence_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.sequences).unwrap() as u16).write_into(writer);
+        self.sequences.write_into(writer);
     }
 }
 
 impl Validate for MultipleSubstFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MultipleSubstFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("sequence_offsets", |ctx| {
-                if self.sequence_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("sequences", |ctx| {
+                if self.sequences.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.sequence_offsets.validate_impl(ctx);
+                self.sequences.validate_impl(ctx);
             });
         })
     }
@@ -346,8 +346,8 @@ impl Validate for MultipleSubstFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gsub::MultipleSubstFormat1<'a>> for MultipleSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::MultipleSubstFormat1<'a>, _: FontData) -> Self {
         MultipleSubstFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            sequence_offsets: obj.sequences().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            sequences: obj.sequences().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -410,33 +410,33 @@ impl<'a> FontRead<'a> for Sequence {
 pub struct AlternateSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to AlternateSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
-    pub alternate_set_offsets: Vec<OffsetMarker<AlternateSet>>,
+    pub alternate_sets: Vec<OffsetMarker<AlternateSet>>,
 }
 
 impl FontWrite for AlternateSubstFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.alternate_set_offsets).unwrap() as u16).write_into(writer);
-        self.alternate_set_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.alternate_sets).unwrap() as u16).write_into(writer);
+        self.alternate_sets.write_into(writer);
     }
 }
 
 impl Validate for AlternateSubstFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AlternateSubstFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("alternate_set_offsets", |ctx| {
-                if self.alternate_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("alternate_sets", |ctx| {
+                if self.alternate_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.alternate_set_offsets.validate_impl(ctx);
+                self.alternate_sets.validate_impl(ctx);
             });
         })
     }
@@ -448,8 +448,8 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::AlternateSubstFormat1<'a>> for Alt
         _: FontData,
     ) -> Self {
         AlternateSubstFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            alternate_set_offsets: obj.alternate_sets().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            alternate_sets: obj.alternate_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -515,33 +515,33 @@ impl<'a> FontRead<'a> for AlternateSet {
 pub struct LigatureSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to LigatureSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
-    pub ligature_set_offsets: Vec<OffsetMarker<LigatureSet>>,
+    pub ligature_sets: Vec<OffsetMarker<LigatureSet>>,
 }
 
 impl FontWrite for LigatureSubstFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.ligature_set_offsets).unwrap() as u16).write_into(writer);
-        self.ligature_set_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.ligature_sets).unwrap() as u16).write_into(writer);
+        self.ligature_sets.write_into(writer);
     }
 }
 
 impl Validate for LigatureSubstFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigatureSubstFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("ligature_set_offsets", |ctx| {
-                if self.ligature_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("ligature_sets", |ctx| {
+                if self.ligature_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.ligature_set_offsets.validate_impl(ctx);
+                self.ligature_sets.validate_impl(ctx);
             });
         })
     }
@@ -550,8 +550,8 @@ impl Validate for LigatureSubstFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSubstFormat1<'a>> for LigatureSubstFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSubstFormat1<'a>, _: FontData) -> Self {
         LigatureSubstFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            ligature_set_offsets: obj.ligature_sets().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            ligature_sets: obj.ligature_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -570,25 +570,25 @@ impl<'a> FontRead<'a> for LigatureSubstFormat1 {
 pub struct LigatureSet {
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
-    pub ligature_offsets: Vec<OffsetMarker<Ligature>>,
+    pub ligatures: Vec<OffsetMarker<Ligature>>,
 }
 
 impl FontWrite for LigatureSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.ligature_offsets).unwrap() as u16).write_into(writer);
-        self.ligature_offsets.write_into(writer);
+        (array_len(&self.ligatures).unwrap() as u16).write_into(writer);
+        self.ligatures.write_into(writer);
     }
 }
 
 impl Validate for LigatureSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigatureSet", |ctx| {
-            ctx.in_field("ligature_offsets", |ctx| {
-                if self.ligature_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("ligatures", |ctx| {
+                if self.ligatures.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.ligature_offsets.validate_impl(ctx);
+                self.ligatures.validate_impl(ctx);
             });
         })
     }
@@ -597,7 +597,7 @@ impl Validate for LigatureSet {
 impl<'a> FromObjRef<read_fonts::layout::gsub::LigatureSet<'a>> for LigatureSet {
     fn from_obj_ref(obj: &read_fonts::layout::gsub::LigatureSet<'a>, _: FontData) -> Self {
         LigatureSet {
-            ligature_offsets: obj.ligatures().map(|x| x.to_owned_table()).collect(),
+            ligatures: obj.ligatures().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -660,14 +660,14 @@ pub struct ExtensionSubstFormat1<T> {
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
     /// ExtensionSubstFormat1 subtable.
-    pub extension_offset: OffsetMarker<T, WIDTH_32>,
+    pub extension: OffsetMarker<T, WIDTH_32>,
 }
 
 impl<T: Validate> Validate for ExtensionSubstFormat1<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ExtensionSubstFormat1", |ctx| {
-            ctx.in_field("extension_offset", |ctx| {
-                self.extension_offset.validate_impl(ctx);
+            ctx.in_field("extension", |ctx| {
+                self.extension.validate_impl(ctx);
             });
         })
     }
@@ -685,7 +685,7 @@ where
     ) -> Self {
         ExtensionSubstFormat1 {
             extension_lookup_type: obj.extension_lookup_type(),
-            extension_offset: obj.extension().to_owned_table(),
+            extension: obj.extension().to_owned_table(),
         }
     }
 }
@@ -782,13 +782,13 @@ impl FromTableRef<read_fonts::layout::gsub::ExtensionSubtable<'_>> for Extension
 pub struct ReverseChainSingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to coverage tables in backtrack sequence, in
     /// glyph sequence order.
-    pub backtrack_coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
+    pub backtrack_coverages: Vec<OffsetMarker<CoverageTable>>,
     /// Array of offsets to coverage tables in lookahead sequence, in
     /// glyph sequence order.
-    pub lookahead_coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
+    pub lookahead_coverages: Vec<OffsetMarker<CoverageTable>>,
     /// Array of substitute glyph IDs — ordered by Coverage index.
     pub substitute_glyph_ids: Vec<GlyphId>,
 }
@@ -797,11 +797,11 @@ impl FontWrite for ReverseChainSingleSubstFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.backtrack_coverage_offsets).unwrap() as u16).write_into(writer);
-        self.backtrack_coverage_offsets.write_into(writer);
-        (array_len(&self.lookahead_coverage_offsets).unwrap() as u16).write_into(writer);
-        self.lookahead_coverage_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.backtrack_coverages).unwrap() as u16).write_into(writer);
+        self.backtrack_coverages.write_into(writer);
+        (array_len(&self.lookahead_coverages).unwrap() as u16).write_into(writer);
+        self.lookahead_coverages.write_into(writer);
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
     }
@@ -810,20 +810,20 @@ impl FontWrite for ReverseChainSingleSubstFormat1 {
 impl Validate for ReverseChainSingleSubstFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ReverseChainSingleSubstFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("backtrack_coverage_offsets", |ctx| {
-                if self.backtrack_coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("backtrack_coverages", |ctx| {
+                if self.backtrack_coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.backtrack_coverage_offsets.validate_impl(ctx);
+                self.backtrack_coverages.validate_impl(ctx);
             });
-            ctx.in_field("lookahead_coverage_offsets", |ctx| {
-                if self.lookahead_coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("lookahead_coverages", |ctx| {
+                if self.lookahead_coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.lookahead_coverage_offsets.validate_impl(ctx);
+                self.lookahead_coverages.validate_impl(ctx);
             });
             ctx.in_field("substitute_glyph_ids", |ctx| {
                 if self.substitute_glyph_ids.len() > (u16::MAX as usize) {
@@ -843,12 +843,12 @@ impl<'a> FromObjRef<read_fonts::layout::gsub::ReverseChainSingleSubstFormat1<'a>
     ) -> Self {
         let offset_data = obj.offset_data();
         ReverseChainSingleSubstFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            backtrack_coverage_offsets: obj
+            coverage: obj.coverage().to_owned_table(),
+            backtrack_coverages: obj
                 .backtrack_coverages()
                 .map(|x| x.to_owned_table())
                 .collect(),
-            lookahead_coverage_offsets: obj
+            lookahead_coverages: obj
                 .lookahead_coverages()
                 .map(|x| x.to_owned_table())
                 .collect(),

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -58,21 +58,21 @@ pub struct ScriptRecord {
     /// 4-byte script tag identifier
     pub script_tag: Tag,
     /// Offset to Script table, from beginning of ScriptList
-    pub script_offset: OffsetMarker<Script>,
+    pub script: OffsetMarker<Script>,
 }
 
 impl FontWrite for ScriptRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.script_tag.write_into(writer);
-        self.script_offset.write_into(writer);
+        self.script.write_into(writer);
     }
 }
 
 impl Validate for ScriptRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ScriptRecord", |ctx| {
-            ctx.in_field("script_offset", |ctx| {
-                self.script_offset.validate_impl(ctx);
+            ctx.in_field("script", |ctx| {
+                self.script.validate_impl(ctx);
             });
         })
     }
@@ -82,7 +82,7 @@ impl FromObjRef<read_fonts::layout::ScriptRecord> for ScriptRecord {
     fn from_obj_ref(obj: &read_fonts::layout::ScriptRecord, offset_data: FontData) -> Self {
         ScriptRecord {
             script_tag: obj.script_tag(),
-            script_offset: obj.script(offset_data).to_owned_table(),
+            script: obj.script(offset_data).to_owned_table(),
         }
     }
 }
@@ -92,7 +92,7 @@ impl FromObjRef<read_fonts::layout::ScriptRecord> for ScriptRecord {
 pub struct Script {
     /// Offset to default LangSys table, from beginning of Script table
     /// — may be NULL
-    pub default_lang_sys_offset: NullableOffsetMarker<LangSys>,
+    pub default_lang_sys: NullableOffsetMarker<LangSys>,
     /// Array of LangSysRecords, listed alphabetically by LangSys tag
     pub lang_sys_records: Vec<LangSysRecord>,
 }
@@ -100,7 +100,7 @@ pub struct Script {
 impl FontWrite for Script {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        self.default_lang_sys_offset.write_into(writer);
+        self.default_lang_sys.write_into(writer);
         (array_len(&self.lang_sys_records).unwrap() as u16).write_into(writer);
         self.lang_sys_records.write_into(writer);
     }
@@ -109,8 +109,8 @@ impl FontWrite for Script {
 impl Validate for Script {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Script", |ctx| {
-            ctx.in_field("default_lang_sys_offset", |ctx| {
-                self.default_lang_sys_offset.validate_impl(ctx);
+            ctx.in_field("default_lang_sys", |ctx| {
+                self.default_lang_sys.validate_impl(ctx);
             });
             ctx.in_field("lang_sys_records", |ctx| {
                 if self.lang_sys_records.len() > (u16::MAX as usize) {
@@ -126,7 +126,7 @@ impl<'a> FromObjRef<read_fonts::layout::Script<'a>> for Script {
     fn from_obj_ref(obj: &read_fonts::layout::Script<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Script {
-            default_lang_sys_offset: obj.default_lang_sys().to_owned_table(),
+            default_lang_sys: obj.default_lang_sys().to_owned_table(),
             lang_sys_records: obj.lang_sys_records().to_owned_obj(offset_data),
         }
     }
@@ -145,21 +145,21 @@ pub struct LangSysRecord {
     /// 4-byte LangSysTag identifier
     pub lang_sys_tag: Tag,
     /// Offset to LangSys table, from beginning of Script table
-    pub lang_sys_offset: OffsetMarker<LangSys>,
+    pub lang_sys: OffsetMarker<LangSys>,
 }
 
 impl FontWrite for LangSysRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.lang_sys_tag.write_into(writer);
-        self.lang_sys_offset.write_into(writer);
+        self.lang_sys.write_into(writer);
     }
 }
 
 impl Validate for LangSysRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LangSysRecord", |ctx| {
-            ctx.in_field("lang_sys_offset", |ctx| {
-                self.lang_sys_offset.validate_impl(ctx);
+            ctx.in_field("lang_sys", |ctx| {
+                self.lang_sys.validate_impl(ctx);
             });
         })
     }
@@ -169,7 +169,7 @@ impl FromObjRef<read_fonts::layout::LangSysRecord> for LangSysRecord {
     fn from_obj_ref(obj: &read_fonts::layout::LangSysRecord, offset_data: FontData) -> Self {
         LangSysRecord {
             lang_sys_tag: obj.lang_sys_tag(),
-            lang_sys_offset: obj.lang_sys(offset_data).to_owned_table(),
+            lang_sys: obj.lang_sys(offset_data).to_owned_table(),
         }
     }
 }
@@ -276,21 +276,21 @@ pub struct FeatureRecord {
     /// 4-byte feature identification tag
     pub feature_tag: Tag,
     /// Offset to Feature table, from beginning of FeatureList
-    pub feature_offset: OffsetMarker<Feature>,
+    pub feature: OffsetMarker<Feature>,
 }
 
 impl FontWrite for FeatureRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.feature_tag.write_into(writer);
-        self.feature_offset.write_into(writer);
+        self.feature.write_into(writer);
     }
 }
 
 impl Validate for FeatureRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FeatureRecord", |ctx| {
-            ctx.in_field("feature_offset", |ctx| {
-                self.feature_offset.validate_impl(ctx);
+            ctx.in_field("feature", |ctx| {
+                self.feature.validate_impl(ctx);
             });
         })
     }
@@ -300,7 +300,7 @@ impl FromObjRef<read_fonts::layout::FeatureRecord> for FeatureRecord {
     fn from_obj_ref(obj: &read_fonts::layout::FeatureRecord, offset_data: FontData) -> Self {
         FeatureRecord {
             feature_tag: obj.feature_tag(),
-            feature_offset: obj.feature(offset_data).to_owned_table(),
+            feature: obj.feature(offset_data).to_owned_table(),
         }
     }
 }
@@ -309,7 +309,7 @@ impl FromObjRef<read_fonts::layout::FeatureRecord> for FeatureRecord {
 #[derive(Clone, Debug, Default)]
 pub struct Feature {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
-    pub feature_params_offset: NullableOffsetMarker<FeatureParams>,
+    pub feature_params: NullableOffsetMarker<FeatureParams>,
     /// Array of indices into the LookupList — zero-based (first
     /// lookup is LookupListIndex = 0)
     pub lookup_list_indices: Vec<u16>,
@@ -318,7 +318,7 @@ pub struct Feature {
 impl FontWrite for Feature {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        self.feature_params_offset.write_into(writer);
+        self.feature_params.write_into(writer);
         (array_len(&self.lookup_list_indices).unwrap() as u16).write_into(writer);
         self.lookup_list_indices.write_into(writer);
     }
@@ -327,8 +327,8 @@ impl FontWrite for Feature {
 impl Validate for Feature {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Feature", |ctx| {
-            ctx.in_field("feature_params_offset", |ctx| {
-                self.feature_params_offset.validate_impl(ctx);
+            ctx.in_field("feature_params", |ctx| {
+                self.feature_params.validate_impl(ctx);
             });
             ctx.in_field("lookup_list_indices", |ctx| {
                 if self.lookup_list_indices.len() > (u16::MAX as usize) {
@@ -343,7 +343,7 @@ impl<'a> FromObjRef<read_fonts::layout::Feature<'a>> for Feature {
     fn from_obj_ref(obj: &read_fonts::layout::Feature<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         Feature {
-            feature_params_offset: obj.feature_params().to_owned_table(),
+            feature_params: obj.feature_params().to_owned_table(),
             lookup_list_indices: obj.lookup_list_indices().to_owned_obj(offset_data),
         }
     }
@@ -356,25 +356,25 @@ impl<'a> FromTableRef<read_fonts::layout::Feature<'a>> for Feature {}
 pub struct LookupList<T> {
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
-    pub lookup_offsets: Vec<OffsetMarker<T>>,
+    pub lookups: Vec<OffsetMarker<T>>,
 }
 
 impl<T: FontWrite> FontWrite for LookupList<T> {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.lookup_offsets).unwrap() as u16).write_into(writer);
-        self.lookup_offsets.write_into(writer);
+        (array_len(&self.lookups).unwrap() as u16).write_into(writer);
+        self.lookups.write_into(writer);
     }
 }
 
 impl<T: Validate> Validate for LookupList<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LookupList", |ctx| {
-            ctx.in_field("lookup_offsets", |ctx| {
-                if self.lookup_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("lookups", |ctx| {
+                if self.lookups.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.lookup_offsets.validate_impl(ctx);
+                self.lookups.validate_impl(ctx);
             });
         })
     }
@@ -387,7 +387,7 @@ where
 {
     fn from_obj_ref(obj: &read_fonts::layout::LookupList<'a, U>, _: FontData) -> Self {
         LookupList {
-            lookup_offsets: obj.lookups().map(|x| x.to_owned_table()).collect(),
+            lookups: obj.lookups().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -406,7 +406,7 @@ pub struct Lookup<T> {
     pub lookup_flag: u16,
     /// Array of offsets to lookup subtables, from beginning of Lookup
     /// table
-    pub subtable_offsets: Vec<OffsetMarker<T>>,
+    pub subtables: Vec<OffsetMarker<T>>,
     /// Index (base 0) into GDEF mark glyph sets structure. This field
     /// is only present if the USE_MARK_FILTERING_SET lookup flag is
     /// set.
@@ -416,11 +416,11 @@ pub struct Lookup<T> {
 impl<T: Validate> Validate for Lookup<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Lookup", |ctx| {
-            ctx.in_field("subtable_offsets", |ctx| {
-                if self.subtable_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("subtables", |ctx| {
+                if self.subtables.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.subtable_offsets.validate_impl(ctx);
+                self.subtables.validate_impl(ctx);
             });
         })
     }
@@ -434,7 +434,7 @@ where
     fn from_obj_ref(obj: &read_fonts::layout::Lookup<'a, U>, _: FontData) -> Self {
         Lookup {
             lookup_flag: obj.lookup_flag(),
-            subtable_offsets: obj.subtables().map(|x| x.to_owned_table()).collect(),
+            subtables: obj.subtables().map(|x| x.to_owned_table()).collect(),
             mark_filtering_set: obj.mark_filtering_set(),
         }
     }
@@ -837,33 +837,33 @@ impl FromObjRef<read_fonts::layout::SequenceLookupRecord> for SequenceLookupReco
 pub struct SequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to SequenceRuleSet tables, from beginning of
     /// SequenceContextFormat1 table (offsets may be NULL)
-    pub seq_rule_set_offsets: Vec<NullableOffsetMarker<SequenceRuleSet>>,
+    pub seq_rule_sets: Vec<NullableOffsetMarker<SequenceRuleSet>>,
 }
 
 impl FontWrite for SequenceContextFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.seq_rule_set_offsets).unwrap() as u16).write_into(writer);
-        self.seq_rule_set_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.seq_rule_sets).unwrap() as u16).write_into(writer);
+        self.seq_rule_sets.write_into(writer);
     }
 }
 
 impl Validate for SequenceContextFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceContextFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("seq_rule_set_offsets", |ctx| {
-                if self.seq_rule_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("seq_rule_sets", |ctx| {
+                if self.seq_rule_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.seq_rule_set_offsets.validate_impl(ctx);
+                self.seq_rule_sets.validate_impl(ctx);
             });
         })
     }
@@ -872,8 +872,8 @@ impl Validate for SequenceContextFormat1 {
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat1<'a>> for SequenceContextFormat1 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat1<'a>, _: FontData) -> Self {
         SequenceContextFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            seq_rule_set_offsets: obj.seq_rule_sets().map(|x| x.to_owned_table()).collect(),
+            coverage: obj.coverage().to_owned_table(),
+            seq_rule_sets: obj.seq_rule_sets().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -892,25 +892,25 @@ impl<'a> FontRead<'a> for SequenceContextFormat1 {
 pub struct SequenceRuleSet {
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
-    pub seq_rule_offsets: Vec<OffsetMarker<SequenceRule>>,
+    pub seq_rules: Vec<OffsetMarker<SequenceRule>>,
 }
 
 impl FontWrite for SequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.seq_rule_offsets).unwrap() as u16).write_into(writer);
-        self.seq_rule_offsets.write_into(writer);
+        (array_len(&self.seq_rules).unwrap() as u16).write_into(writer);
+        self.seq_rules.write_into(writer);
     }
 }
 
 impl Validate for SequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceRuleSet", |ctx| {
-            ctx.in_field("seq_rule_offsets", |ctx| {
-                if self.seq_rule_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("seq_rules", |ctx| {
+                if self.seq_rules.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.seq_rule_offsets.validate_impl(ctx);
+                self.seq_rules.validate_impl(ctx);
             });
         })
     }
@@ -919,7 +919,7 @@ impl Validate for SequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::SequenceRuleSet<'a>> for SequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceRuleSet<'a>, _: FontData) -> Self {
         SequenceRuleSet {
-            seq_rule_offsets: obj.seq_rules().map(|x| x.to_owned_table()).collect(),
+            seq_rules: obj.seq_rules().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -987,40 +987,40 @@ impl<'a> FontRead<'a> for SequenceRule {
 pub struct SequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Offset to ClassDef table, from beginning of
     /// SequenceContextFormat2 table
-    pub class_def_offset: OffsetMarker<ClassDef>,
+    pub class_def: OffsetMarker<ClassDef>,
     /// Array of offsets to ClassSequenceRuleSet tables, from beginning
     /// of SequenceContextFormat2 table (may be NULL)
-    pub class_seq_rule_set_offsets: Vec<NullableOffsetMarker<ClassSequenceRuleSet>>,
+    pub class_seq_rule_sets: Vec<NullableOffsetMarker<ClassSequenceRuleSet>>,
 }
 
 impl FontWrite for SequenceContextFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        self.class_def_offset.write_into(writer);
-        (array_len(&self.class_seq_rule_set_offsets).unwrap() as u16).write_into(writer);
-        self.class_seq_rule_set_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        self.class_def.write_into(writer);
+        (array_len(&self.class_seq_rule_sets).unwrap() as u16).write_into(writer);
+        self.class_seq_rule_sets.write_into(writer);
     }
 }
 
 impl Validate for SequenceContextFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceContextFormat2", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("class_def_offset", |ctx| {
-                self.class_def_offset.validate_impl(ctx);
+            ctx.in_field("class_def", |ctx| {
+                self.class_def.validate_impl(ctx);
             });
-            ctx.in_field("class_seq_rule_set_offsets", |ctx| {
-                if self.class_seq_rule_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("class_seq_rule_sets", |ctx| {
+                if self.class_seq_rule_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.class_seq_rule_set_offsets.validate_impl(ctx);
+                self.class_seq_rule_sets.validate_impl(ctx);
             });
         })
     }
@@ -1029,9 +1029,9 @@ impl Validate for SequenceContextFormat2 {
 impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat2<'a>> for SequenceContextFormat2 {
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat2<'a>, _: FontData) -> Self {
         SequenceContextFormat2 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            class_def_offset: obj.class_def().to_owned_table(),
-            class_seq_rule_set_offsets: obj
+            coverage: obj.coverage().to_owned_table(),
+            class_def: obj.class_def().to_owned_table(),
+            class_seq_rule_sets: obj
                 .class_seq_rule_sets()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1053,25 +1053,25 @@ impl<'a> FontRead<'a> for SequenceContextFormat2 {
 pub struct ClassSequenceRuleSet {
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
-    pub class_seq_rule_offsets: Vec<OffsetMarker<ClassSequenceRule>>,
+    pub class_seq_rules: Vec<OffsetMarker<ClassSequenceRule>>,
 }
 
 impl FontWrite for ClassSequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.class_seq_rule_offsets).unwrap() as u16).write_into(writer);
-        self.class_seq_rule_offsets.write_into(writer);
+        (array_len(&self.class_seq_rules).unwrap() as u16).write_into(writer);
+        self.class_seq_rules.write_into(writer);
     }
 }
 
 impl Validate for ClassSequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassSequenceRuleSet", |ctx| {
-            ctx.in_field("class_seq_rule_offsets", |ctx| {
-                if self.class_seq_rule_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("class_seq_rules", |ctx| {
+                if self.class_seq_rules.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.class_seq_rule_offsets.validate_impl(ctx);
+                self.class_seq_rules.validate_impl(ctx);
             });
         })
     }
@@ -1080,7 +1080,7 @@ impl Validate for ClassSequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::ClassSequenceRuleSet<'a>> for ClassSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ClassSequenceRuleSet<'a>, _: FontData) -> Self {
         ClassSequenceRuleSet {
-            class_seq_rule_offsets: obj.class_seq_rules().map(|x| x.to_owned_table()).collect(),
+            class_seq_rules: obj.class_seq_rules().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -1150,7 +1150,7 @@ impl<'a> FontRead<'a> for ClassSequenceRule {
 pub struct SequenceContextFormat3 {
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
-    pub coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
+    pub coverages: Vec<OffsetMarker<CoverageTable>>,
     /// Array of SequenceLookupRecords
     pub seq_lookup_records: Vec<SequenceLookupRecord>,
 }
@@ -1159,9 +1159,9 @@ impl FontWrite for SequenceContextFormat3 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
-        (array_len(&self.coverage_offsets).unwrap() as u16).write_into(writer);
+        (array_len(&self.coverages).unwrap() as u16).write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
-        self.coverage_offsets.write_into(writer);
+        self.coverages.write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
 }
@@ -1169,11 +1169,11 @@ impl FontWrite for SequenceContextFormat3 {
 impl Validate for SequenceContextFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceContextFormat3", |ctx| {
-            ctx.in_field("coverage_offsets", |ctx| {
-                if self.coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("coverages", |ctx| {
+                if self.coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.coverage_offsets.validate_impl(ctx);
+                self.coverages.validate_impl(ctx);
             });
             ctx.in_field("seq_lookup_records", |ctx| {
                 if self.seq_lookup_records.len() > (u16::MAX as usize) {
@@ -1189,7 +1189,7 @@ impl<'a> FromObjRef<read_fonts::layout::SequenceContextFormat3<'a>> for Sequence
     fn from_obj_ref(obj: &read_fonts::layout::SequenceContextFormat3<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
         SequenceContextFormat3 {
-            coverage_offsets: obj.coverages().map(|x| x.to_owned_table()).collect(),
+            coverages: obj.coverages().map(|x| x.to_owned_table()).collect(),
             seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
@@ -1261,33 +1261,33 @@ impl<'a> FontRead<'a> for SequenceContext {
 pub struct ChainedSequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Array of offsets to ChainedSeqRuleSet tables, from beginning of
     /// ChainedSequenceContextFormat1 table (may be NULL)
-    pub chained_seq_rule_set_offsets: Vec<NullableOffsetMarker<ChainedSequenceRuleSet>>,
+    pub chained_seq_rule_sets: Vec<NullableOffsetMarker<ChainedSequenceRuleSet>>,
 }
 
 impl FontWrite for ChainedSequenceContextFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        (array_len(&self.chained_seq_rule_set_offsets).unwrap() as u16).write_into(writer);
-        self.chained_seq_rule_set_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        (array_len(&self.chained_seq_rule_sets).unwrap() as u16).write_into(writer);
+        self.chained_seq_rule_sets.write_into(writer);
     }
 }
 
 impl Validate for ChainedSequenceContextFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceContextFormat1", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("chained_seq_rule_set_offsets", |ctx| {
-                if self.chained_seq_rule_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("chained_seq_rule_sets", |ctx| {
+                if self.chained_seq_rule_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.chained_seq_rule_set_offsets.validate_impl(ctx);
+                self.chained_seq_rule_sets.validate_impl(ctx);
             });
         })
     }
@@ -1301,8 +1301,8 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat1<'a>>
         _: FontData,
     ) -> Self {
         ChainedSequenceContextFormat1 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            chained_seq_rule_set_offsets: obj
+            coverage: obj.coverage().to_owned_table(),
+            chained_seq_rule_sets: obj
                 .chained_seq_rule_sets()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1327,25 +1327,25 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat1 {
 pub struct ChainedSequenceRuleSet {
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
-    pub chained_seq_rule_offsets: Vec<OffsetMarker<ChainedSequenceRule>>,
+    pub chained_seq_rules: Vec<OffsetMarker<ChainedSequenceRule>>,
 }
 
 impl FontWrite for ChainedSequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.chained_seq_rule_offsets).unwrap() as u16).write_into(writer);
-        self.chained_seq_rule_offsets.write_into(writer);
+        (array_len(&self.chained_seq_rules).unwrap() as u16).write_into(writer);
+        self.chained_seq_rules.write_into(writer);
     }
 }
 
 impl Validate for ChainedSequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceRuleSet", |ctx| {
-            ctx.in_field("chained_seq_rule_offsets", |ctx| {
-                if self.chained_seq_rule_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("chained_seq_rules", |ctx| {
+                if self.chained_seq_rules.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.chained_seq_rule_offsets.validate_impl(ctx);
+                self.chained_seq_rules.validate_impl(ctx);
             });
         })
     }
@@ -1354,7 +1354,7 @@ impl Validate for ChainedSequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceRuleSet<'a>> for ChainedSequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::layout::ChainedSequenceRuleSet<'a>, _: FontData) -> Self {
         ChainedSequenceRuleSet {
-            chained_seq_rule_offsets: obj
+            chained_seq_rules: obj
                 .chained_seq_rules()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1447,54 +1447,54 @@ impl<'a> FontRead<'a> for ChainedSequenceRule {
 pub struct ChainedSequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
-    pub coverage_offset: OffsetMarker<CoverageTable>,
+    pub coverage: OffsetMarker<CoverageTable>,
     /// Offset to ClassDef table containing backtrack sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
-    pub backtrack_class_def_offset: OffsetMarker<ClassDef>,
+    pub backtrack_class_def: OffsetMarker<ClassDef>,
     /// Offset to ClassDef table containing input sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
-    pub input_class_def_offset: OffsetMarker<ClassDef>,
+    pub input_class_def: OffsetMarker<ClassDef>,
     /// Offset to ClassDef table containing lookahead sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
-    pub lookahead_class_def_offset: OffsetMarker<ClassDef>,
+    pub lookahead_class_def: OffsetMarker<ClassDef>,
     /// Array of offsets to ChainedClassSequenceRuleSet tables, from
     /// beginning of ChainedSequenceContextFormat2 table (may be NULL)
-    pub chained_class_seq_rule_set_offsets: Vec<NullableOffsetMarker<ChainedClassSequenceRuleSet>>,
+    pub chained_class_seq_rule_sets: Vec<NullableOffsetMarker<ChainedClassSequenceRuleSet>>,
 }
 
 impl FontWrite for ChainedSequenceContextFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        self.coverage_offset.write_into(writer);
-        self.backtrack_class_def_offset.write_into(writer);
-        self.input_class_def_offset.write_into(writer);
-        self.lookahead_class_def_offset.write_into(writer);
-        (array_len(&self.chained_class_seq_rule_set_offsets).unwrap() as u16).write_into(writer);
-        self.chained_class_seq_rule_set_offsets.write_into(writer);
+        self.coverage.write_into(writer);
+        self.backtrack_class_def.write_into(writer);
+        self.input_class_def.write_into(writer);
+        self.lookahead_class_def.write_into(writer);
+        (array_len(&self.chained_class_seq_rule_sets).unwrap() as u16).write_into(writer);
+        self.chained_class_seq_rule_sets.write_into(writer);
     }
 }
 
 impl Validate for ChainedSequenceContextFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceContextFormat2", |ctx| {
-            ctx.in_field("coverage_offset", |ctx| {
-                self.coverage_offset.validate_impl(ctx);
+            ctx.in_field("coverage", |ctx| {
+                self.coverage.validate_impl(ctx);
             });
-            ctx.in_field("backtrack_class_def_offset", |ctx| {
-                self.backtrack_class_def_offset.validate_impl(ctx);
+            ctx.in_field("backtrack_class_def", |ctx| {
+                self.backtrack_class_def.validate_impl(ctx);
             });
-            ctx.in_field("input_class_def_offset", |ctx| {
-                self.input_class_def_offset.validate_impl(ctx);
+            ctx.in_field("input_class_def", |ctx| {
+                self.input_class_def.validate_impl(ctx);
             });
-            ctx.in_field("lookahead_class_def_offset", |ctx| {
-                self.lookahead_class_def_offset.validate_impl(ctx);
+            ctx.in_field("lookahead_class_def", |ctx| {
+                self.lookahead_class_def.validate_impl(ctx);
             });
-            ctx.in_field("chained_class_seq_rule_set_offsets", |ctx| {
-                if self.chained_class_seq_rule_set_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("chained_class_seq_rule_sets", |ctx| {
+                if self.chained_class_seq_rule_sets.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.chained_class_seq_rule_set_offsets.validate_impl(ctx);
+                self.chained_class_seq_rule_sets.validate_impl(ctx);
             });
         })
     }
@@ -1508,11 +1508,11 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat2<'a>>
         _: FontData,
     ) -> Self {
         ChainedSequenceContextFormat2 {
-            coverage_offset: obj.coverage().to_owned_table(),
-            backtrack_class_def_offset: obj.backtrack_class_def().to_owned_table(),
-            input_class_def_offset: obj.input_class_def().to_owned_table(),
-            lookahead_class_def_offset: obj.lookahead_class_def().to_owned_table(),
-            chained_class_seq_rule_set_offsets: obj
+            coverage: obj.coverage().to_owned_table(),
+            backtrack_class_def: obj.backtrack_class_def().to_owned_table(),
+            input_class_def: obj.input_class_def().to_owned_table(),
+            lookahead_class_def: obj.lookahead_class_def().to_owned_table(),
+            chained_class_seq_rule_sets: obj
                 .chained_class_seq_rule_sets()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1537,25 +1537,25 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat2 {
 pub struct ChainedClassSequenceRuleSet {
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
-    pub chained_class_seq_rule_offsets: Vec<OffsetMarker<ChainedClassSequenceRule>>,
+    pub chained_class_seq_rules: Vec<OffsetMarker<ChainedClassSequenceRule>>,
 }
 
 impl FontWrite for ChainedClassSequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.chained_class_seq_rule_offsets).unwrap() as u16).write_into(writer);
-        self.chained_class_seq_rule_offsets.write_into(writer);
+        (array_len(&self.chained_class_seq_rules).unwrap() as u16).write_into(writer);
+        self.chained_class_seq_rules.write_into(writer);
     }
 }
 
 impl Validate for ChainedClassSequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedClassSequenceRuleSet", |ctx| {
-            ctx.in_field("chained_class_seq_rule_offsets", |ctx| {
-                if self.chained_class_seq_rule_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("chained_class_seq_rules", |ctx| {
+                if self.chained_class_seq_rules.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.chained_class_seq_rule_offsets.validate_impl(ctx);
+                self.chained_class_seq_rules.validate_impl(ctx);
             });
         })
     }
@@ -1569,7 +1569,7 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedClassSequenceRuleSet<'a>>
         _: FontData,
     ) -> Self {
         ChainedClassSequenceRuleSet {
-            chained_class_seq_rule_offsets: obj
+            chained_class_seq_rules: obj
                 .chained_class_seq_rules()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1668,11 +1668,11 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule {
 #[derive(Clone, Debug, Default)]
 pub struct ChainedSequenceContextFormat3 {
     /// Array of offsets to coverage tables for the backtrack sequence
-    pub backtrack_coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
+    pub backtrack_coverages: Vec<OffsetMarker<CoverageTable>>,
     /// Array of offsets to coverage tables for the input sequence
-    pub input_coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
+    pub input_coverages: Vec<OffsetMarker<CoverageTable>>,
     /// Array of offsets to coverage tables for the lookahead sequence
-    pub lookahead_coverage_offsets: Vec<OffsetMarker<CoverageTable>>,
+    pub lookahead_coverages: Vec<OffsetMarker<CoverageTable>>,
     /// Array of SequenceLookupRecords
     pub seq_lookup_records: Vec<SequenceLookupRecord>,
 }
@@ -1681,12 +1681,12 @@ impl FontWrite for ChainedSequenceContextFormat3 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
-        (array_len(&self.backtrack_coverage_offsets).unwrap() as u16).write_into(writer);
-        self.backtrack_coverage_offsets.write_into(writer);
-        (array_len(&self.input_coverage_offsets).unwrap() as u16).write_into(writer);
-        self.input_coverage_offsets.write_into(writer);
-        (array_len(&self.lookahead_coverage_offsets).unwrap() as u16).write_into(writer);
-        self.lookahead_coverage_offsets.write_into(writer);
+        (array_len(&self.backtrack_coverages).unwrap() as u16).write_into(writer);
+        self.backtrack_coverages.write_into(writer);
+        (array_len(&self.input_coverages).unwrap() as u16).write_into(writer);
+        self.input_coverages.write_into(writer);
+        (array_len(&self.lookahead_coverages).unwrap() as u16).write_into(writer);
+        self.lookahead_coverages.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
@@ -1695,23 +1695,23 @@ impl FontWrite for ChainedSequenceContextFormat3 {
 impl Validate for ChainedSequenceContextFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceContextFormat3", |ctx| {
-            ctx.in_field("backtrack_coverage_offsets", |ctx| {
-                if self.backtrack_coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("backtrack_coverages", |ctx| {
+                if self.backtrack_coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.backtrack_coverage_offsets.validate_impl(ctx);
+                self.backtrack_coverages.validate_impl(ctx);
             });
-            ctx.in_field("input_coverage_offsets", |ctx| {
-                if self.input_coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("input_coverages", |ctx| {
+                if self.input_coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.input_coverage_offsets.validate_impl(ctx);
+                self.input_coverages.validate_impl(ctx);
             });
-            ctx.in_field("lookahead_coverage_offsets", |ctx| {
-                if self.lookahead_coverage_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("lookahead_coverages", |ctx| {
+                if self.lookahead_coverages.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.lookahead_coverage_offsets.validate_impl(ctx);
+                self.lookahead_coverages.validate_impl(ctx);
             });
             ctx.in_field("seq_lookup_records", |ctx| {
                 if self.seq_lookup_records.len() > (u16::MAX as usize) {
@@ -1732,12 +1732,12 @@ impl<'a> FromObjRef<read_fonts::layout::ChainedSequenceContextFormat3<'a>>
     ) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceContextFormat3 {
-            backtrack_coverage_offsets: obj
+            backtrack_coverages: obj
                 .backtrack_coverages()
                 .map(|x| x.to_owned_table())
                 .collect(),
-            input_coverage_offsets: obj.input_coverages().map(|x| x.to_owned_table()).collect(),
-            lookahead_coverage_offsets: obj
+            input_coverages: obj.input_coverages().map(|x| x.to_owned_table()).collect(),
+            lookahead_coverages: obj
                 .lookahead_coverages()
                 .map(|x| x.to_owned_table())
                 .collect(),
@@ -1958,27 +1958,27 @@ impl<'a> FontRead<'a> for FeatureVariations {
 pub struct FeatureVariationRecord {
     /// Offset to a condition set table, from beginning of
     /// FeatureVariations table.
-    pub condition_set_offset: OffsetMarker<ConditionSet, WIDTH_32>,
+    pub condition_set: OffsetMarker<ConditionSet, WIDTH_32>,
     /// Offset to a feature table substitution table, from beginning of
     /// the FeatureVariations table.
-    pub feature_table_substitution_offset: OffsetMarker<FeatureTableSubstitution, WIDTH_32>,
+    pub feature_table_substitution: OffsetMarker<FeatureTableSubstitution, WIDTH_32>,
 }
 
 impl FontWrite for FeatureVariationRecord {
     fn write_into(&self, writer: &mut TableWriter) {
-        self.condition_set_offset.write_into(writer);
-        self.feature_table_substitution_offset.write_into(writer);
+        self.condition_set.write_into(writer);
+        self.feature_table_substitution.write_into(writer);
     }
 }
 
 impl Validate for FeatureVariationRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FeatureVariationRecord", |ctx| {
-            ctx.in_field("condition_set_offset", |ctx| {
-                self.condition_set_offset.validate_impl(ctx);
+            ctx.in_field("condition_set", |ctx| {
+                self.condition_set.validate_impl(ctx);
             });
-            ctx.in_field("feature_table_substitution_offset", |ctx| {
-                self.feature_table_substitution_offset.validate_impl(ctx);
+            ctx.in_field("feature_table_substitution", |ctx| {
+                self.feature_table_substitution.validate_impl(ctx);
             });
         })
     }
@@ -1990,8 +1990,8 @@ impl FromObjRef<read_fonts::layout::FeatureVariationRecord> for FeatureVariation
         offset_data: FontData,
     ) -> Self {
         FeatureVariationRecord {
-            condition_set_offset: obj.condition_set(offset_data).to_owned_table(),
-            feature_table_substitution_offset: obj
+            condition_set: obj.condition_set(offset_data).to_owned_table(),
+            feature_table_substitution: obj
                 .feature_table_substitution(offset_data)
                 .to_owned_table(),
         }
@@ -2003,25 +2003,25 @@ impl FromObjRef<read_fonts::layout::FeatureVariationRecord> for FeatureVariation
 pub struct ConditionSet {
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
-    pub condition_offsets: Vec<OffsetMarker<ConditionFormat1, WIDTH_32>>,
+    pub conditions: Vec<OffsetMarker<ConditionFormat1, WIDTH_32>>,
 }
 
 impl FontWrite for ConditionSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.condition_offsets).unwrap() as u16).write_into(writer);
-        self.condition_offsets.write_into(writer);
+        (array_len(&self.conditions).unwrap() as u16).write_into(writer);
+        self.conditions.write_into(writer);
     }
 }
 
 impl Validate for ConditionSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ConditionSet", |ctx| {
-            ctx.in_field("condition_offsets", |ctx| {
-                if self.condition_offsets.len() > (u16::MAX as usize) {
+            ctx.in_field("conditions", |ctx| {
+                if self.conditions.len() > (u16::MAX as usize) {
                     ctx.report("array excedes max length");
                 }
-                self.condition_offsets.validate_impl(ctx);
+                self.conditions.validate_impl(ctx);
             });
         })
     }
@@ -2030,7 +2030,7 @@ impl Validate for ConditionSet {
 impl<'a> FromObjRef<read_fonts::layout::ConditionSet<'a>> for ConditionSet {
     fn from_obj_ref(obj: &read_fonts::layout::ConditionSet<'a>, _: FontData) -> Self {
         ConditionSet {
-            condition_offsets: obj.conditions().map(|x| x.to_owned_table()).collect(),
+            conditions: obj.conditions().map(|x| x.to_owned_table()).collect(),
         }
     }
 }
@@ -2146,21 +2146,21 @@ pub struct FeatureTableSubstitutionRecord {
     pub feature_index: u16,
     /// Offset to an alternate feature table, from start of the
     /// FeatureTableSubstitution table.
-    pub alternate_feature_offset: OffsetMarker<Feature, WIDTH_32>,
+    pub alternate_feature: OffsetMarker<Feature, WIDTH_32>,
 }
 
 impl FontWrite for FeatureTableSubstitutionRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.feature_index.write_into(writer);
-        self.alternate_feature_offset.write_into(writer);
+        self.alternate_feature.write_into(writer);
     }
 }
 
 impl Validate for FeatureTableSubstitutionRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FeatureTableSubstitutionRecord", |ctx| {
-            ctx.in_field("alternate_feature_offset", |ctx| {
-                self.alternate_feature_offset.validate_impl(ctx);
+            ctx.in_field("alternate_feature", |ctx| {
+                self.alternate_feature.validate_impl(ctx);
             });
         })
     }
@@ -2175,7 +2175,7 @@ impl FromObjRef<read_fonts::layout::FeatureTableSubstitutionRecord>
     ) -> Self {
         FeatureTableSubstitutionRecord {
             feature_index: obj.feature_index(),
-            alternate_feature_offset: obj.alternate_feature(offset_data).to_owned_table(),
+            alternate_feature: obj.alternate_feature(offset_data).to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -86,7 +86,7 @@ impl<'a> FontRead<'a> for Name {
 pub struct LangTagRecord {
     /// Language-tag string offset from start of storage area (in
     /// bytes).
-    pub lang_tag_offset: OffsetMarker<String>,
+    pub lang_tag: OffsetMarker<String>,
 }
 
 impl Validate for LangTagRecord {
@@ -96,7 +96,7 @@ impl Validate for LangTagRecord {
 impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
     fn from_obj_ref(obj: &read_fonts::tables::name::LangTagRecord, offset_data: FontData) -> Self {
         LangTagRecord {
-            lang_tag_offset: obj.lang_tag(offset_data).to_owned_table(),
+            lang_tag: obj.lang_tag(offset_data).to_owned_table(),
         }
     }
 }
@@ -113,13 +113,13 @@ pub struct NameRecord {
     /// Name ID.
     pub name_id: u16,
     /// String offset from start of storage area (in bytes).
-    pub string_offset: OffsetMarker<String>,
+    pub string: OffsetMarker<String>,
 }
 
 impl Validate for NameRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("NameRecord", |ctx| {
-            ctx.in_field("string_offset", |ctx| {
+            ctx.in_field("string", |ctx| {
                 self.validate_string_data(ctx);
             });
         })
@@ -133,7 +133,7 @@ impl FromObjRef<read_fonts::tables::name::NameRecord> for NameRecord {
             encoding_id: obj.encoding_id(),
             language_id: obj.language_id(),
             name_id: obj.name_id(),
-            string_offset: obj.string(offset_data).to_owned_table(),
+            string: obj.string(offset_data).to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -141,26 +141,26 @@ impl FromObjRef<read_fonts::codegen_test::records::ContainsArrays<'_>> for Conta
 #[derive(Clone, Debug, Default)]
 pub struct ContainsOffests {
     pub off_array_count: u16,
-    pub array_offset: OffsetMarker<Vec<SimpleRecord>>,
-    pub other_offset: OffsetMarker<BasicTable, WIDTH_32>,
+    pub array: OffsetMarker<Vec<SimpleRecord>>,
+    pub other: OffsetMarker<BasicTable, WIDTH_32>,
 }
 
 impl FontWrite for ContainsOffests {
     fn write_into(&self, writer: &mut TableWriter) {
         self.off_array_count.write_into(writer);
-        self.array_offset.write_into(writer);
-        self.other_offset.write_into(writer);
+        self.array.write_into(writer);
+        self.other.write_into(writer);
     }
 }
 
 impl Validate for ContainsOffests {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ContainsOffests", |ctx| {
-            ctx.in_field("array_offset", |ctx| {
-                self.array_offset.validate_impl(ctx);
+            ctx.in_field("array", |ctx| {
+                self.array.validate_impl(ctx);
             });
-            ctx.in_field("other_offset", |ctx| {
-                self.other_offset.validate_impl(ctx);
+            ctx.in_field("other", |ctx| {
+                self.other.validate_impl(ctx);
             });
         })
     }
@@ -173,8 +173,8 @@ impl FromObjRef<read_fonts::codegen_test::records::ContainsOffests> for Contains
     ) -> Self {
         ContainsOffests {
             off_array_count: obj.off_array_count(),
-            array_offset: obj.array(offset_data).to_owned_obj(offset_data),
-            other_offset: obj.other(offset_data).to_owned_table(),
+            array: obj.array(offset_data).to_owned_obj(offset_data),
+            other: obj.other(offset_data).to_owned_table(),
         }
     }
 }

--- a/write-fonts/src/layout.rs
+++ b/write-fonts/src/layout.rs
@@ -76,10 +76,10 @@ impl<T: LookupType + FontWrite> FontWrite for Lookup<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         T::TYPE.write_into(writer);
         self.lookup_flag.write_into(writer);
-        u16::try_from(self.subtable_offsets.len())
+        u16::try_from(self.subtables.len())
             .unwrap()
             .write_into(writer);
-        self.subtable_offsets.write_into(writer);
+        self.subtables.write_into(writer);
         self.mark_filtering_set.write_into(writer);
     }
 }
@@ -440,11 +440,11 @@ mod tests {
         let table = ScriptList {
             script_records: vec![ScriptRecord {
                 script_tag: Tag::new(b"hihi"),
-                script_offset: OffsetMarker::new(Script {
-                    default_lang_sys_offset: NullableOffsetMarker::new(None),
+                script: OffsetMarker::new(Script {
+                    default_lang_sys: NullableOffsetMarker::new(None),
                     lang_sys_records: vec![LangSysRecord {
                         lang_sys_tag: Tag::new(b"coco"),
-                        lang_sys_offset: OffsetMarker::new(LangSys {
+                        lang_sys: OffsetMarker::new(LangSys {
                             required_feature_index: 0xffff,
                             feature_indices: vec![69; (u16::MAX) as usize + 5],
                         }),

--- a/write-fonts/src/layout/gdef.rs
+++ b/write-fonts/src/layout/gdef.rs
@@ -10,9 +10,9 @@ include!("../../generated/generated_gdef.rs");
 
 impl Gdef {
     fn compute_version(&self) -> MajorMinor {
-        if self.item_var_store_offset.is_some() {
+        if self.item_var_store.is_some() {
             MajorMinor::VERSION_1_3
-        } else if self.mark_glyph_sets_def_offset.is_some() {
+        } else if self.mark_glyph_sets_def.is_some() {
             MajorMinor::VERSION_1_2
         } else {
             MajorMinor::VERSION_1_0
@@ -28,7 +28,7 @@ mod tests {
     fn var_store_without_glyph_sets() {
         // this should compile, and version should be 1.3
         let gdef = Gdef {
-            item_var_store_offset: NullableOffsetMarker::new(Some(ClassDef::Format1(
+            item_var_store: NullableOffsetMarker::new(Some(ClassDef::Format1(
                 crate::layout::ClassDefFormat1 {
                     start_glyph_id: GlyphId::new(2),
                     class_value_array: vec![1, 2, 0],

--- a/write-fonts/src/layout/gpos.rs
+++ b/write-fonts/src/layout/gpos.rs
@@ -33,7 +33,7 @@ table_newtype!(
 
 impl Gpos {
     fn compute_version(&self) -> MajorMinor {
-        if self.feature_variations_offset.is_none() {
+        if self.feature_variations.is_none() {
             MajorMinor::VERSION_1_0
         } else {
             MajorMinor::VERSION_1_1
@@ -55,7 +55,7 @@ impl<T: LookupType + FontWrite> FontWrite for ExtensionPosFormat1<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         1u16.write_into(writer);
         T::TYPE.write_into(writer);
-        self.extension_offset.write_into(writer);
+        self.extension.write_into(writer);
     }
 }
 
@@ -108,7 +108,7 @@ impl SinglePosFormat2 {
 
 impl PairPosFormat1 {
     fn compute_value_format1(&self) -> ValueFormat {
-        self.pair_set_offsets
+        self.pair_sets
             .first()
             .and_then(|pairset| pairset.pair_value_records.first())
             .map(|rec| rec.value_record1.format())
@@ -116,7 +116,7 @@ impl PairPosFormat1 {
     }
 
     fn compute_value_format2(&self) -> ValueFormat {
-        self.pair_set_offsets
+        self.pair_sets
             .first()
             .and_then(|pairset| pairset.pair_value_records.first())
             .map(|rec| rec.value_record2.format())
@@ -142,29 +142,29 @@ impl PairPosFormat2 {
     }
 
     fn compute_class1_count(&self) -> u16 {
-        self.class_def1_offset.class_count()
+        self.class_def1.class_count()
     }
 
     fn compute_class2_count(&self) -> u16 {
-        self.class_def2_offset.class_count()
+        self.class_def2.class_count()
     }
 }
 
 impl MarkBasePosFormat1 {
     fn compute_mark_class_count(&self) -> u16 {
-        self.mark_array_offset.class_count()
+        self.mark_array.class_count()
     }
 }
 
 impl MarkMarkPosFormat1 {
     fn compute_mark_class_count(&self) -> u16 {
-        self.mark1_array_offset.class_count()
+        self.mark1_array.class_count()
     }
 }
 
 impl MarkLigPosFormat1 {
     fn compute_mark_class_count(&self) -> u16 {
-        self.mark_array_offset.class_count()
+        self.mark_array.class_count()
     }
 }
 

--- a/write-fonts/src/layout/gsub.rs
+++ b/write-fonts/src/layout/gsub.rs
@@ -30,7 +30,7 @@ table_newtype!(
 
 impl Gsub {
     fn compute_version(&self) -> MajorMinor {
-        if self.feature_variations_offset.is_none() {
+        if self.feature_variations.is_none() {
             MajorMinor::VERSION_1_0
         } else {
             MajorMinor::VERSION_1_1
@@ -51,7 +51,7 @@ impl<T: LookupType + FontWrite> FontWrite for ExtensionSubstFormat1<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         1u16.write_into(writer);
         T::TYPE.write_into(writer);
-        self.extension_offset.write_into(writer);
+        self.extension.write_into(writer);
     }
 }
 

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -23,7 +23,7 @@ impl Name {
 
 impl NameRecord {
     fn string(&self) -> &str {
-        self.string_offset.as_str()
+        self.string.as_str()
     }
 
     fn string_writer(&self) -> NameStringWriter {
@@ -69,7 +69,7 @@ impl FontWrite for NameRecord {
 
 impl LangTagRecord {
     fn lang_tag(&self) -> &str {
-        self.lang_tag_offset.as_str()
+        self.lang_tag.as_str()
     }
 
     fn string_writer(&self) -> NameStringWriter {
@@ -140,7 +140,7 @@ impl PartialEq for NameRecord {
             && self.encoding_id == other.encoding_id
             && self.language_id == other.language_id
             && self.name_id == other.name_id
-            && self.string_offset == other.string_offset
+            && self.string == other.string
     }
 }
 
@@ -198,21 +198,21 @@ mod tests {
             encoding_id: 1,
             language_id: 0,
             name_id: 1030,
-            string_offset: OffsetMarker::new("Ordinær".into()),
+            string: OffsetMarker::new("Ordinær".into()),
         });
         table.name_record.insert(NameRecord {
             platform_id: 0,
             encoding_id: 4,
             language_id: 0,
             name_id: 4,
-            string_offset: OffsetMarker::new("oh".into()),
+            string: OffsetMarker::new("oh".into()),
         });
         table.name_record.insert(NameRecord {
             platform_id: 3,
             encoding_id: 1,
             language_id: 0,
             name_id: 1029,
-            string_offset: OffsetMarker::new("Regular".into()),
+            string: OffsetMarker::new("Regular".into()),
         });
 
         let _dumped = crate::dump_table(&table).unwrap();

--- a/write-fonts/src/tests/gpos.rs
+++ b/write-fonts/src/tests/gpos.rs
@@ -58,7 +58,7 @@ fn markbaseposformat1() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#example-7-markbaseposformat1-subtable
 
     let table = MarkBasePosFormat1::read(test_data::MARKBASEPOSFORMAT1).unwrap();
-    assert_eq!(table.mark_array_offset.mark_records.len(), 2);
+    assert_eq!(table.mark_array.mark_records.len(), 2);
     let dumped = crate::write::dump_table(&table).unwrap();
 
     assert_hex_eq!(test_data::MARKBASEPOSFORMAT1.as_ref(), &dumped);
@@ -69,7 +69,7 @@ fn markligposformat1() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#example-8-markligposformat1-subtable
 
     let table = MarkLigPosFormat1::read(test_data::MARKLIGPOSFORMAT1).unwrap();
-    assert_eq!(table.mark_array_offset.mark_records.len(), 2);
+    assert_eq!(table.mark_array.mark_records.len(), 2);
     let dumped = crate::write::dump_table(&table).unwrap();
 
     assert_hex_eq!(test_data::MARKLIGPOSFORMAT1.as_ref(), &dumped);
@@ -80,10 +80,10 @@ fn markmarkposformat1() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#example-9-markmarkposformat1-subtable
 
     let table = MarkMarkPosFormat1::read(test_data::MARKMARKPOSFORMAT1).unwrap();
-    assert_eq!(table.mark2_array_offset.mark2_records.len(), 1);
-    let record = &table.mark2_array_offset.mark2_records[0];
-    assert_eq!(record.mark2_anchor_offsets.len(), 1);
-    let anchor = &record.mark2_anchor_offsets[0].as_ref().unwrap();
+    assert_eq!(table.mark2_array.mark2_records.len(), 1);
+    let record = &table.mark2_array.mark2_records[0];
+    assert_eq!(record.mark2_anchors.len(), 1);
+    let anchor = &record.mark2_anchors[0].as_ref().unwrap();
     let anchor = match anchor {
         AnchorTable::Format1(table) => table,
         _ => panic!("wrong table format"),
@@ -197,9 +197,7 @@ fn no_write_versioned_fields() {
     let dumped = crate::write::dump_table(&gpos).unwrap();
     assert_eq!(dumped.len(), 12);
 
-    gpos.feature_variations_offset.set(FeatureVariations {
-        feature_variation_records: Vec::new(),
-    });
+    gpos.feature_variations.set(FeatureVariations::default());
 
     let dumped = crate::write::dump_table(&gpos).unwrap();
     assert_eq!(dumped.len(), 12 + 12); // 4byte offset, 4byte version, 4byte record count


### PR DESCRIPTION
Speculative, but I think this is a good change.

Before this patch, types in `write-fonts` used the field names in the spec (snake-cased) which means that all offset fields were suffixed with `_offset`, and arrays of offsets were suffixed with `_offsets`. With this patch, we now use the same name for these fields as we do for the getters in read fonts which resolve the offsets; basically we convert `thing_offset` to `thing`, and `thing_offsets` to `things`, with a few special-cases to cover nouns with irregular pluralization.

This makes using `write-fonts` both a bit less verbose but also generally *less confusing*; in `write-fonts` these fields are concrete, and the new names reflect this.