### PR TITLE
Enhancements to the Fixed type

### DIFF
--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -124,7 +124,7 @@ macro_rules! float_conv {
                 //what matters is that we are rounding *away from zero*.
                 #[cfg(all(not(feature = "std"), not(test)))]
                 Self(
-                    (x * Self::ONE as $ty + (0.5 * (-1.0 * x.is_sign_negative() as u8 as $ty)))
+                    (x * Self::ONE.0 as $ty + (0.5 * (-1.0 * x.is_sign_negative() as u8 as $ty)))
                         as _,
                 )
             }

--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -18,9 +18,14 @@ macro_rules! fixed_impl {
             /// This type's smallest representable value
             pub const EPSILON: Self = Self(1);
 
+            /// Representation of 0.0.
+            pub const ZERO: Self = Self(0);
+
+            /// Representation of 1.0.
+            pub const ONE: Self = Self(1 << $fract_bits);
+
             const INT_MASK: $ty = !0 << $fract_bits;
             const ROUND: $ty = 1 << ($fract_bits - 1);
-            const ONE: $ty = 1 << $fract_bits;
             const FRACT_BITS: usize = $fract_bits;
 
             //TODO: is this actually useful?
@@ -114,7 +119,7 @@ macro_rules! float_conv {
             /// representable value.
             pub fn $from(x: $ty) -> Self {
                 #[cfg(any(feature = "std", test))]
-                return Self((x * Self::ONE as $ty).round() as _);
+                return Self((x * Self::ONE.0 as $ty).round() as _);
                 //NOTE: this behaviour is not exactly equivalent, but should be okay?
                 //what matters is that we are rounding *away from zero*.
                 #[cfg(all(not(feature = "std"), not(test)))]
@@ -130,7 +135,7 @@ macro_rules! float_conv {
             /// round-tripped.
             pub fn $to(self) -> $ty {
                 let int = ((self.0 & Self::INT_MASK) >> Self::FRACT_BITS) as $ty;
-                let fract = (self.0 & !Self::INT_MASK) as $ty / Self::ONE as $ty;
+                let fract = (self.0 & !Self::INT_MASK) as $ty / Self::ONE.0 as $ty;
                 int + fract
             }
         }

--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -1,6 +1,6 @@
 //! fixed-point numerical types
 
-use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 // shared between Fixed and F2Dot14
 macro_rules! fixed_impl {
@@ -281,5 +281,17 @@ mod tests {
             Fixed::from_f64(-0.000015259)
         );
         assert_eq!(Fixed(0x7fff_ffff), Fixed::from_f64(32768.0));
+    }
+
+    #[test]
+    fn fixed_muldiv() {
+        assert_eq!(
+            Fixed::from_f64(0.5) * Fixed::from_f64(2.0),
+            Fixed::from_f64(1.0)
+        );
+        assert_eq!(
+            Fixed::from_f64(0.5) / Fixed::from_f64(2.0),
+            Fixed::from_f64(0.25)
+        );
     }
 }

--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -169,7 +169,7 @@ impl Mul for Fixed {
     #[inline(always)]
     fn mul(self, other: Self) -> Self::Output {
         let ab = self.0 as i64 * other.0 as i64;
-        Self(((ab + 0x8000 - if ab < 0 { 1 } else { 0 }) >> 16) as i32)
+        Self(((ab + 0x8000 - i64::from(ab < 0)) >> 16) as i32)
     }
 }
 


### PR DESCRIPTION
I've run into some friction when using the fixed point types for computing things like deltas and variation region scalars. This adds `Mul`, `Div` and `Neg` impls for `Fixed` along with exposed associated constants for 0 and 1. Also adds a `to_fixed` conversion for `F2dot14`.

Ok to merge if there are no issues.