### PR TITLE
Add LookupFlag type

### DIFF
--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -737,7 +737,7 @@ impl<T> LookupMarker<T> {
     }
     fn lookup_flag_byte_range(&self) -> Range<usize> {
         let start = self.lookup_type_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        start..start + LookupFlag::RAW_BYTE_LEN
     }
     fn sub_table_count_byte_range(&self) -> Range<usize> {
         let start = self.lookup_flag_byte_range().end;
@@ -768,7 +768,7 @@ impl<'a, T> FontRead<'a> for Lookup<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
-        cursor.advance::<u16>();
+        cursor.advance::<LookupFlag>();
         let sub_table_count: u16 = cursor.read()?;
         let subtable_offsets_byte_len = sub_table_count as usize * Offset16::RAW_BYTE_LEN;
         cursor.advance_by(subtable_offsets_byte_len);
@@ -805,7 +805,7 @@ impl<'a, T> Lookup<'a, T> {
     }
 
     /// Lookup qualifiers
-    pub fn lookup_flag(&self) -> u16 {
+    pub fn lookup_flag(&self) -> LookupFlag {
         let range = self.shape.lookup_flag_byte_range();
         self.data.read_at(range.start).unwrap()
     }
@@ -851,7 +851,7 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("lookup_type", self.lookup_type())),
-            1usize => Some(Field::new("lookup_flag", self.lookup_flag())),
+            1usize => Some(Field::new("lookup_flag", self.traverse_lookup_flag())),
             2usize => Some(Field::new("sub_table_count", self.sub_table_count())),
             3usize => Some({
                 let data = self.data;

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -1,5 +1,10 @@
 //! OpenType Layout common table formats
 
+#[path = "./lookupflag.rs"]
+mod lookupflag;
+
+pub use lookupflag::LookupFlag;
+
 #[cfg(test)]
 #[path = "../tests/layout.rs"]
 mod tests;
@@ -9,6 +14,11 @@ include!("../../generated/generated_layout.rs");
 impl<'a, T: FontRead<'a>> Lookup<'a, T> {
     pub fn get_subtable(&self, offset: Offset16) -> Result<T, ReadError> {
         self.resolve_offset(offset)
+    }
+
+    #[cfg(feature = "traversal")]
+    fn traverse_lookup_flag(&self) -> traversal::FieldType<'a> {
+        self.lookup_flag().to_bits().into()
     }
 }
 

--- a/read-fonts/src/tables/lookupflag.rs
+++ b/read-fonts/src/tables/lookupflag.rs
@@ -1,0 +1,139 @@
+//! The lookup flag type.
+//!
+//! This is kind-of-but-not-quite-exactly a bit enumeration, and so we implement
+//! it manually.
+
+/// The [LookupFlag](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#lookupFlag) bit enumeration.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LookupFlag(u16);
+
+impl LookupFlag {
+    /// Return new, empty flags
+    pub fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Construct a LookupFlag from a raw value, discarding invalid bits
+    pub fn from_bits_truncate(bits: u16) -> Self {
+        const VALID_BITS: u16 = !0x00E0;
+        Self(bits & VALID_BITS)
+    }
+
+    /// Raw transmutation to u16.
+    pub fn to_bits(self) -> u16 {
+        self.0
+    }
+
+    /// This bit relates only to the correct processing of the cursive attachment
+    /// lookup type (GPOS lookup type 3).
+    ///
+    /// When this bit is set, the last glyph in a given sequence to which the
+    /// cursive attachment lookup is applied, will be positioned on the baseline.
+    pub fn right_to_left(self) -> bool {
+        (self.0 & 0x0001) != 0
+    }
+
+    /// This bit relates only to the correct processing of the cursive attachment
+    /// lookup type (GPOS lookup type 3).
+    ///
+    /// When this bit is set, the last glyph in a given sequence to which the
+    /// cursive attachment lookup is applied, will be positioned on the baseline.
+    pub fn set_right_to_left(&mut self, val: bool) {
+        if val {
+            self.0 |= 0x0001
+        } else {
+            self.0 &= !0x0001
+        }
+    }
+
+    /// If set, skips over base glyphs
+    pub fn ignore_base_glyphs(self) -> bool {
+        (self.0 & 0x0002) != 0
+    }
+
+    /// If set, skips over base glyphs
+    pub fn set_ignore_base_glyphs(&mut self, val: bool) {
+        if val {
+            self.0 |= 0x0002
+        } else {
+            self.0 &= !0x0002
+        }
+    }
+
+    /// If set, skips over ligatures
+    pub fn ignore_ligatures(self) -> bool {
+        (self.0 & 0x0004) != 0
+    }
+
+    /// If set, skips over ligatures
+    pub fn set_ignore_ligatures(&mut self, val: bool) {
+        if val {
+            self.0 |= 0x0004
+        } else {
+            self.0 &= !0x0004
+        }
+    }
+
+    /// If set, skips over all combining marks
+    pub fn ignore_marks(self) -> bool {
+        (self.0 & 0x0008) != 0
+    }
+
+    /// If set, skips over all combining marks
+    pub fn set_ignore_marks(&mut self, val: bool) {
+        if val {
+            self.0 |= 0x0008
+        } else {
+            self.0 &= !0x0008
+        }
+    }
+
+    /// If set, indicates that the lookup table structure is followed by a
+    /// MarkFilteringSet field.
+    ///
+    /// The layout engine skips over all mark glyphs not in the mark filtering set
+    /// indicated.
+    pub fn use_mark_filtering_set(self) -> bool {
+        (self.0 & 0x0010) != 0
+    }
+
+    /// If set, indicates that the lookup table structure is followed by a
+    /// MarkFilteringSet field.
+    ///
+    /// The layout engine skips over all mark glyphs not in the mark filtering set
+    /// indicated.
+    pub fn set_use_mark_filtering_set(&mut self, val: bool) {
+        if val {
+            self.0 |= 0x0010
+        } else {
+            self.0 &= !0x0010
+        }
+    }
+
+    /// If not zero, skips over all marks of attachment type different from specified.
+    pub fn mark_attachment_type_mask(self) -> Option<u16> {
+        let val = self.0 & 0xff00;
+        if val == 0 {
+            None
+        } else {
+            Some(val >> 8)
+        }
+    }
+
+    /// If not zero, skips over all marks of attachment type different from specified.
+    pub fn set_mark_attachment_type(&mut self, val: u16) {
+        let val = (val & 0xff) << 8;
+        self.0 = (self.0 & 0xff) | val;
+    }
+}
+
+impl font_types::Scalar for LookupFlag {
+    type Raw = <u16 as font_types::Scalar>::Raw;
+    fn to_raw(self) -> Self::Raw {
+        self.0.to_raw()
+    }
+    fn from_raw(raw: Self::Raw) -> Self {
+        let t = <u16>::from_raw(raw);
+        Self(t)
+    }
+}

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -1,6 +1,8 @@
 // path (from compile crate) to the generated parse module for this table.
 #![parse_module(read_fonts::tables::layout)]
 
+extern scalar LookupFlag;
+
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 table ScriptList {
     /// Number of ScriptRecords
@@ -115,7 +117,8 @@ table Lookup {
     #[compile(skip)]
     lookup_type: u16,
     /// Lookup qualifiers
-    lookup_flag: u16,
+    #[traverse_with(traverse_lookup_flag)]
+    lookup_flag: LookupFlag,
     /// Number of subtables for this lookup
     #[compile(array_len($subtable_offsets))]
     sub_table_count: u16,

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -497,7 +497,7 @@ where
 #[derive(Clone, Debug, Default)]
 pub struct Lookup<T> {
     /// Lookup qualifiers
-    pub lookup_flag: u16,
+    pub lookup_flag: LookupFlag,
     /// Array of offsets to lookup subtables, from beginning of Lookup
     /// table
     pub subtables: Vec<OffsetMarker<T>>,
@@ -509,7 +509,7 @@ pub struct Lookup<T> {
 
 impl<T: Default> Lookup<T> {
     /// Construct a new `Lookup`
-    pub fn new(lookup_flag: u16, subtables: Vec<T>, mark_filtering_set: u16) -> Self {
+    pub fn new(lookup_flag: LookupFlag, subtables: Vec<T>, mark_filtering_set: u16) -> Self {
         Self {
             lookup_flag,
             subtables: subtables.into_iter().map(Into::into).collect(),

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+pub use read_fonts::tables::layout::LookupFlag;
 use read_fonts::FontRead;
 
 #[cfg(test)]
@@ -66,6 +67,12 @@ macro_rules! table_newtype {
 
 pub(crate) use lookup_type;
 pub(crate) use table_newtype;
+
+impl FontWrite for LookupFlag {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.to_bits().write_into(writer)
+    }
+}
 
 impl<T: LookupType + FontWrite> FontWrite for Lookup<T> {
     fn write_into(&self, writer: &mut TableWriter) {


### PR DESCRIPTION
This can be shared between the two crates. Was blocked on 'extern scalar', which now exists.

Requires custom traversal logic, because traversal has know way of knowing about this type, and I'd like to avoid special-casing it in that code.

This will conflict with #142, and I don't have strong opinions about which should go in first.