### PR TITLE
[codegen] Remove :Default bound on constructor generics

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -266,7 +266,7 @@ pub(crate) fn generate_compile_impl(
             .any(|info| info.manual_compile_type))
         .then(|| quote!( #[allow(clippy::useless_conversion)] ));
         quote! {
-            impl #default_impl_params #name <#generic_param> {
+            impl <#generic_param> #name <#generic_param> {
                 #[doc = #docstring]
                 #too_many_args
                 #useless_conversion

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -1886,7 +1886,7 @@ pub struct ExtensionPosFormat1<T> {
     pub extension: OffsetMarker<T, WIDTH_32>,
 }
 
-impl<T: Default> ExtensionPosFormat1<T> {
+impl<T> ExtensionPosFormat1<T> {
     /// Construct a new `ExtensionPosFormat1`
     pub fn new(extension_lookup_type: u16, extension: T) -> Self {
         Self {

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -778,7 +778,7 @@ pub struct ExtensionSubstFormat1<T> {
     pub extension: OffsetMarker<T, WIDTH_32>,
 }
 
-impl<T: Default> ExtensionSubstFormat1<T> {
+impl<T> ExtensionSubstFormat1<T> {
     /// Construct a new `ExtensionSubstFormat1`
     pub fn new(extension_lookup_type: u16, extension: T) -> Self {
         Self {

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -444,7 +444,7 @@ pub struct LookupList<T> {
     pub lookups: Vec<OffsetMarker<T>>,
 }
 
-impl<T: Default> LookupList<T> {
+impl<T> LookupList<T> {
     /// Construct a new `LookupList`
     pub fn new(lookups: Vec<T>) -> Self {
         Self {
@@ -507,7 +507,7 @@ pub struct Lookup<T> {
     pub mark_filtering_set: u16,
 }
 
-impl<T: Default> Lookup<T> {
+impl<T> Lookup<T> {
     /// Construct a new `Lookup`
     pub fn new(lookup_flag: LookupFlag, subtables: Vec<T>, mark_filtering_set: u16) -> Self {
         Self {


### PR DESCRIPTION
This is a minor fixup; this bound is overly constrictive and not relevant in any of the code that we generate so far. We can always get more constrictive later, as needed.