### PR TITLE
Helpers for compiling shared layout tables

### DIFF
--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -79,6 +79,11 @@ impl<const N: usize, T> OffsetMarker<T, N> {
     pub fn set(&mut self, obj: T) {
         self.obj = obj;
     }
+
+    /// Convert into the inner type
+    pub fn into_inner(self) -> T {
+        self.obj
+    }
 }
 
 impl<const N: usize, T> NullableOffsetMarker<T, N> {
@@ -90,6 +95,11 @@ impl<const N: usize, T> NullableOffsetMarker<T, N> {
     /// Set the contents of the marker, replacing any existing contents.
     pub fn set(&mut self, obj: impl Into<Option<T>>) {
         self.obj = obj.into()
+    }
+
+    /// Convert into the inner type
+    pub fn into_inner(self) -> Option<T> {
+        self.obj
     }
 }
 

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -62,6 +62,12 @@ macro_rules! table_newtype {
         }
 
         impl<'a> FromTableRef<$read_type> for $name {}
+
+        impl From<$inner> for $name {
+            fn from(src: $inner) -> $name {
+                $name(src)
+            }
+        }
     };
 }
 
@@ -83,6 +89,46 @@ impl<T: LookupType + FontWrite> FontWrite for Lookup<T> {
             .write_into(writer);
         self.subtables.write_into(writer);
         self.mark_filtering_set.write_into(writer);
+    }
+}
+
+impl Lookup<SequenceContext> {
+    /// Convert this untyped SequenceContext into its GSUB or GPOS specific version
+    pub fn into_concrete<T: From<SequenceContext>>(self) -> Lookup<T> {
+        let Lookup {
+            lookup_flag,
+            subtables,
+            mark_filtering_set,
+        } = self;
+        let subtables = subtables
+            .into_iter()
+            .map(|offset| OffsetMarker::new(offset.into_inner().into()))
+            .collect();
+        Lookup {
+            lookup_flag,
+            subtables,
+            mark_filtering_set,
+        }
+    }
+}
+
+impl Lookup<ChainedSequenceContext> {
+    /// Convert this untyped SequenceContext into its GSUB or GPOS specific version
+    pub fn into_concrete<T: From<ChainedSequenceContext>>(self) -> Lookup<T> {
+        let Lookup {
+            lookup_flag,
+            subtables,
+            mark_filtering_set,
+        } = self;
+        let subtables = subtables
+            .into_iter()
+            .map(|offset| OffsetMarker::new(offset.into_inner().into()))
+            .collect();
+        Lookup {
+            lookup_flag,
+            subtables,
+            mark_filtering_set,
+        }
     }
 }
 


### PR DESCRIPTION
We use a newtype pattern so we can differentiate between the GPOS and GSUB uses of certain common tables, but that is challange during compilation, where we don't really care about this distinction until the very end. This patch lets us work with the common tables while we build them up, and then cast them into the appropriate concrete type when we're done.