### PR TITLE
Compile Device tables, including in ValueRecord

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -394,8 +394,10 @@ fn traversal_arm_for_field(
         }
         // HACK: who wouldn't want to hard-code ValueRecord handling
         FieldType::Struct { typ } if typ == "ValueRecord" => {
-            let clone = in_record.then(|| quote!(.clone()));
-            quote!(Field::new(#name_str, self.#name() #clone #maybe_unwrap))
+            let offset_data = pass_data
+                .cloned()
+                .unwrap_or_else(|| fld.offset_getter_data_src());
+            quote!(Field::new(#name_str, self.#name() #maybe_unwrap .traversal_type(#offset_data)))
         }
         FieldType::Struct { .. } => {
             quote!(compile_error!(concat!("another weird type: ", #name_str)))

--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -224,15 +224,6 @@ impl<'a> PrettyPrinter<'a> {
                 })?;
             }
             FieldType::Record(record) => self.print_fields(record)?,
-            FieldType::ValueRecord(record) if record.get_field(0).is_none() => {
-                self.write_all(b"Null")?;
-                self.print_hex(&[])?
-            }
-            FieldType::ValueRecord(record) => self.indented(|this| {
-                this.print_hex(&[])?;
-                this.print_newline()?;
-                this.print_fields(record)
-            })?,
             FieldType::Array(array) => self.print_array(array)?,
         }
 

--- a/otexplorer/src/query.rs
+++ b/otexplorer/src/query.rs
@@ -173,7 +173,6 @@ fn field_type_name(field_type: &FieldType) -> Cow<'static, str> {
         FieldType::GlyphId(_) => "GlyphId".into(),
         FieldType::Array(arr) => format!("[{}]", arr.type_name()).into(),
         FieldType::Record(record) => record.type_name().to_string().into(),
-        FieldType::ValueRecord(_) => "ValueRecord".into(),
         FieldType::ResolvedOffset(ResolvedOffset {
             target: Ok(table), ..
         }) => table.type_name().to_string().into(),

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -866,7 +866,10 @@ impl<'a> SomeTable<'a> for SinglePosFormat1<'a> {
                 FieldType::offset(self.coverage_offset(), self.coverage()),
             )),
             2usize => Some(Field::new("value_format", self.value_format())),
-            3usize => Some(Field::new("value_record", self.value_record())),
+            3usize => Some(Field::new(
+                "value_record",
+                self.value_record().traversal_type(self.offset_data()),
+            )),
             _ => None,
         }
     }
@@ -1370,8 +1373,14 @@ impl<'a> SomeRecord<'a> for PairValueRecord {
             name: "PairValueRecord",
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("second_glyph", self.second_glyph())),
-                1usize => Some(Field::new("value_record1", self.value_record1().clone())),
-                2usize => Some(Field::new("value_record2", self.value_record2().clone())),
+                1usize => Some(Field::new(
+                    "value_record1",
+                    self.value_record1().traversal_type(_data),
+                )),
+                2usize => Some(Field::new(
+                    "value_record2",
+                    self.value_record2().traversal_type(_data),
+                )),
                 _ => None,
             }),
             data,
@@ -1701,8 +1710,14 @@ impl<'a> SomeRecord<'a> for Class2Record {
         RecordResolver {
             name: "Class2Record",
             get_field: Box::new(move |idx, _data| match idx {
-                0usize => Some(Field::new("value_record1", self.value_record1().clone())),
-                1usize => Some(Field::new("value_record2", self.value_record2().clone())),
+                0usize => Some(Field::new(
+                    "value_record1",
+                    self.value_record1().traversal_type(_data),
+                )),
+                1usize => Some(Field::new(
+                    "value_record2",
+                    self.value_record2().traversal_type(_data),
+                )),
                 _ => None,
             }),
             data,

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -107,6 +107,18 @@ impl Default for DeltaFormat {
     }
 }
 
+impl Ord for DeltaFormat {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (*self as u16).cmp(&(*other as u16))
+    }
+}
+
+impl PartialOrd for DeltaFormat {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(Ord::cmp(self, other))
+    }
+}
+
 fn delta_value_count(start_size: u16, end_size: u16, delta_format: DeltaFormat) -> usize {
     let range_len = end_size.saturating_add(1).saturating_sub(start_size) as usize;
     let val_per_word = match delta_format {

--- a/read-fonts/src/traversal.rs
+++ b/read-fonts/src/traversal.rs
@@ -18,7 +18,6 @@ use types::{
 use crate::{
     array::{ComputedArray, VarLenArray},
     read::{ComputeSize, ReadArgs},
-    tables::gpos::ValueRecord,
     FontData, FontRead, FontReadWithArgs, ReadError, VarSize,
 };
 
@@ -49,7 +48,6 @@ pub enum FieldType<'a> {
     /// Used in COLR/CPAL
     ArrayOffset(ArrayOffset<'a>),
     Record(RecordResolver<'a>),
-    ValueRecord(ValueRecord),
     Array(Box<dyn SomeArray<'a> + 'a>),
 }
 
@@ -547,8 +545,6 @@ impl<'a> Debug for FieldType<'a> {
             }) => arg0.fmt(f),
             Self::ResolvedOffset(arg0) => arg0.target.fmt(f),
             Self::Record(arg0) => (arg0 as &(dyn SomeTable<'a> + 'a)).fmt(f),
-            Self::ValueRecord(arg0) if arg0.get_field(0).is_none() => write!(f, "NullValueRecord"),
-            Self::ValueRecord(arg0) => (arg0 as &(dyn SomeTable<'a> + 'a)).fmt(f),
             Self::Array(arg0) => arg0.fmt(f),
         }
     }
@@ -708,12 +704,6 @@ impl<'a> From<Version16Dot16> for FieldType<'a> {
 impl<'a> From<GlyphId> for FieldType<'a> {
     fn from(src: GlyphId) -> FieldType<'a> {
         FieldType::GlyphId(src)
-    }
-}
-
-impl<'a> From<ValueRecord> for FieldType<'a> {
-    fn from(src: ValueRecord) -> Self {
-        Self::ValueRecord(src)
     }
 }
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -523,6 +523,7 @@ enum u16 DeltaFormat {
 }
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
+#[skip_constructor]
 table Device {
     /// Smallest size to correct, in ppem
     start_size: u16,

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -2349,23 +2349,6 @@ pub struct Device {
     pub delta_value: Vec<u16>,
 }
 
-impl Device {
-    /// Construct a new `Device`
-    pub fn new(
-        start_size: u16,
-        end_size: u16,
-        delta_format: DeltaFormat,
-        delta_value: Vec<u16>,
-    ) -> Self {
-        Self {
-            start_size,
-            end_size,
-            delta_format,
-            delta_value: delta_value.into_iter().map(Into::into).collect(),
-        }
-    }
-}
-
 impl FontWrite for Device {
     fn write_into(&self, writer: &mut TableWriter) {
         self.start_size.write_into(writer);

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -478,6 +478,18 @@ fn are_sequential(gid1: GlyphId, gid2: GlyphId) -> bool {
     gid2.to_u16().saturating_sub(gid1.to_u16()) == 1
 }
 
+//FIXME: we should derive this in codegen
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        self.start_size == other.start_size
+            && self.end_size == other.end_size
+            && self.delta_format == other.delta_format
+            && self.delta_value == other.delta_value
+    }
+}
+
+impl Eq for Device {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This is a bit annoying because ValueRecord is hand-rolled, and so I had to rework a bunch of it to make it actually contain device tables.

My understanding is that this isn't really used much, but it's in the `feaLib` tests so that's enough for me 😅 