### PR TITLE
Bump versions to 0.0.3

### DIFF
--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."
@@ -15,5 +15,5 @@ traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { version = "0.0.2", path = "../font-types" }
+font-types = { version = "0.0.3", path = "../font-types" }
 bitflags = "1.3"

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -11,11 +11,11 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { version = "0.0.2", path = "../font-types" }
-read-fonts = { version = "0.0.2", path = "../read-fonts" }
+font-types = { version = "0.0.3", path = "../font-types" }
+read-fonts = { version = "0.0.3", path = "../read-fonts" }
 bitflags = "1.3"
 
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
-read-fonts = { version = "0.0.2", path = "../read-fonts", features = ["test_data"] }
+read-fonts = { version = "0.0.3", path = "../read-fonts", features = ["test_data"] }


### PR DESCRIPTION
This will let me reference a stable version in fea-rs.

Also I apparently haven't been tagging releases, so will  start doing that.