### PR TITLE
Change top level read-fonts type constructors to take a byte slice

### DIFF
--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, str::FromStr};
 
 use font_types::Tag;
-use read_fonts::{traversal::SomeTable, FileRef, FontData, FontRef, ReadError, TableProvider};
+use read_fonts::{traversal::SomeTable, FileRef, FontRef, ReadError, TableProvider};
 
 mod print;
 mod query;
@@ -17,8 +17,7 @@ use query::Query;
 fn main() -> Result<(), Error> {
     let args = flags::Args::from_env().map_err(|e| Error(e.to_string()))?;
     let bytes = std::fs::read(&args.input).unwrap();
-    let data = FontData::new(&bytes);
-    let font = FileRef::new(data)
+    let font = FileRef::new(&bytes)
         .unwrap()
         .fonts()
         .nth(args.index.unwrap_or(0) as usize)

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -84,7 +84,7 @@ pub enum FileRef<'a> {
 
 impl<'a> FileRef<'a> {
     /// Creates a new reference to a file representing a font or font collection.
-    pub fn new(data: FontData<'a>) -> Result<Self, ReadError> {
+    pub fn new(data: &'a [u8]) -> Result<Self, ReadError> {
         Ok(if let Ok(collection) = CollectionRef::new(data) {
             Self::Collection(collection)
         } else {
@@ -111,7 +111,8 @@ pub struct CollectionRef<'a> {
 
 impl<'a> CollectionRef<'a> {
     /// Creates a new reference to a font collection.
-    pub fn new(data: FontData<'a>) -> Result<Self, ReadError> {
+    pub fn new(data: &'a [u8]) -> Result<Self, ReadError> {
+        let data = FontData::new(data);
         let header = TTCHeader::read(data)?;
         if header.ttc_tag() != TTC_HEADER_TAG {
             Err(ReadError::InvalidTtc(header.ttc_tag()))
@@ -158,7 +159,8 @@ pub struct FontRef<'a> {
 
 impl<'a> FontRef<'a> {
     /// Creates a new reference to a font.
-    pub fn new(data: FontData<'a>) -> Result<Self, ReadError> {
+    pub fn new(data: &'a [u8]) -> Result<Self, ReadError> {
+        let data = FontData::new(data);
         Self::with_table_directory(data, TableDirectory::read(data)?)
     }
 

--- a/read-fonts/src/tests/test_data.rs
+++ b/read-fonts/src/tests/test_data.rs
@@ -361,17 +361,12 @@ pub mod stat {
 }
 
 pub mod test_fonts {
-    use crate::FontData;
+    pub static COLR_GRADIENT_RECT: &[u8] =
+        include_bytes!("../../../resources/test_fonts/ttf/linear_gradient_rect_colr_1.ttf");
 
-    pub static COLR_GRADIENT_RECT: FontData<'static> = FontData::new(include_bytes!(
-        "../../../resources/test_fonts/ttf/linear_gradient_rect_colr_1.ttf"
-    ));
+    pub static VAZIRMATN_VAR: &[u8] =
+        include_bytes!("../../../resources/test_fonts/ttf/vazirmatn_var_trimmed.ttf");
 
-    pub static VAZIRMATN_VAR: FontData<'static> = FontData::new(include_bytes!(
-        "../../../resources/test_fonts/ttf/vazirmatn_var_trimmed.ttf"
-    ));
-
-    pub static SIMPLE_GLYF: FontData<'static> = FontData::new(include_bytes!(
-        "../../../resources/test_fonts/ttf/simple_glyf.ttf"
-    ));
+    pub static SIMPLE_GLYF: &[u8] =
+        include_bytes!("../../../resources/test_fonts/ttf/simple_glyf.ttf");
 }


### PR DESCRIPTION
This changes `FontRef`, `FileRef`, and `CollectionRef` constructors to take `&'a [u8]` rather than `FontData<'a>`.

These types are useful as public interfaces in other crates, but the `FontData` parameter makes them cumbersome to construct and is mostly an implementation detail of read-fonts.

The changes here are all fairly simple. Ok to merge if it looks good.