### PR TITLE
Tag tweaks

### DIFF
--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -25,46 +25,44 @@ impl Tag {
     ///
     /// This method panics if the tag is not valid per the requirements above.
     pub const fn new(src: &[u8]) -> Tag {
-        assert!(
-            !src.is_empty() && src.len() < 5,
-            "input must be 1-4 bytes in length"
-        );
-        let mut raw = [b' '; 4];
-        let mut i = 0;
-        while i < src.len() {
-            if src[i] <= 0x20 || src[i] > 0x7e {
-                panic!("all bytes must be in range (0x20, 0x7E)");
-            }
-            raw[i] = src[i];
-            i += 1;
+        match Tag::new_checked(src) {
+            Ok(tag) => tag,
+            Err(InvalidTag::InvalidLength(_)) => panic!("invalid length for tag"),
+            Err(InvalidTag::InvalidByte { .. }) => panic!("tag contains invalid byte"),
         }
-        Tag(raw)
     }
 
     /// Attempt to create a `Tag` from raw bytes.
     ///
-    /// The argument may be a slice of bytes, a `&str`, or any other type that
-    /// impls `AsRef<[u8]>`.
-    ///
     /// The slice must contain between 1 and 4 bytes, each in the printable
     /// ascii range (`0x20..=0x7E`).
     ///
-    /// If the input has fewer than four bytes, spaces will be appended.
-    pub fn new_checked(src: &[u8]) -> Result<Self, InvalidTag> {
+    /// If the input has fewer than four bytes, it will be padded with spaces.
+    pub const fn new_checked(src: &[u8]) -> Result<Self, InvalidTag> {
         if src.is_empty() || src.len() > 4 {
             return Err(InvalidTag::InvalidLength(src.len()));
         }
-        if let Some(pos) = src.iter().position(|b| !(0x20..=0x7E).contains(b)) {
-            let byte = src[pos];
+        let mut raw = [0x20; 4];
+        let mut i = 0;
+        let mut seen_space = false;
+        while i < src.len() {
+            let byte = match src[i] {
+                byte @ 0x20 if i == 0 => return Err(InvalidTag::InvalidByte { pos: i, byte }),
+                byte @ 0..=0x1F | byte @ 0x7f.. => {
+                    return Err(InvalidTag::InvalidByte { pos: i, byte })
+                }
+                byte @ 0x21..=0x7e if seen_space => {
+                    return Err(InvalidTag::InvalidByte { pos: i, byte })
+                }
+                byte => byte,
+            };
 
-            return Err(InvalidTag::InvalidByte { pos, byte });
+            seen_space |= byte == 0x20;
+
+            raw[i] = byte;
+            i += 1;
         }
-        let mut out = [b' '; 4];
-        out[..src.len()].copy_from_slice(src);
-
-        // I think this is all fine but I'm also frequently wrong, so
-        debug_assert!(std::str::from_utf8(&out).is_ok());
-        Ok(Tag(out))
+        Ok(Tag(raw))
     }
 
     // for symmetry with integer types / other things we encode/decode
@@ -83,10 +81,15 @@ impl Tag {
     pub const fn from_be_bytes(bytes: [u8; 4]) -> Self {
         Self(bytes)
     }
+
+    /// Return the raw byte array representing this tag.
+    pub fn into_bytes(self) -> [u8; 4] {
+        self.0
+    }
 }
 
 /// An error representing an invalid tag.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InvalidTag {
     InvalidLength(usize),
     InvalidByte { pos: usize, byte: u8 },
@@ -139,6 +142,12 @@ impl PartialEq<&str> for Tag {
 impl PartialEq<&[u8]> for Tag {
     fn eq(&self, other: &&[u8]) -> bool {
         self.0.as_ref() == *other
+    }
+}
+
+impl AsRef<[u8]> for Tag {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -198,15 +207,19 @@ mod tests {
     fn smoke_test() {
         Tag::new(b"head");
         assert!(Tag::new_checked(b"").is_err());
+        assert!(Tag::new_checked(b" ").is_err());
         assert!(Tag::new_checked(b"a").is_ok());
         assert!(Tag::new_checked(b"ab").is_ok());
         assert!(Tag::new_checked(b"abc").is_ok());
         assert!(Tag::new_checked(b"abcd").is_ok());
         assert!(Tag::new_checked(b"abcde").is_err());
+        assert!(Tag::new_checked(b" bc").is_err()); // space invalid in first position
+        assert!(Tag::new_checked(b"b c").is_err()); // non-space cannot follow space
+        assert_eq!(Tag::new_checked(b"bc  "), Ok(Tag::new(b"bc")));
 
         // ascii only:
         assert!(Tag::new_checked(&[0x19]).is_err());
-        assert!(Tag::new_checked(&[0x20]).is_ok());
+        assert!(Tag::new_checked(&[0x21]).is_ok());
         assert!(Tag::new_checked(&[0x7E]).is_ok());
         assert!(Tag::new_checked(&[0x7F]).is_err());
     }


### PR DESCRIPTION
This improves the validation logic around tags to fix a few issues:

- tags cannot begin with spaces, but can contain trailing spaces
- validation logic was different between new and new_checked

In addition it adds an AsRef<[u8]> impl and a to_bytes method, for accessing the raw bytes.