### PR TITLE
Fix include_bytes! breakage

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."

--- a/read-fonts/build.rs
+++ b/read-fonts/build.rs
@@ -1,0 +1,28 @@
+//! build script for read-fonts.
+//!
+//! This copies certain test files into OUT_DIR if they exist, or writes
+//! empty files if they do not exist.
+//!
+//! This means that the package can still compile even if these files are
+//! missing, such as when packaged for crates.io
+
+use std::path::Path;
+
+static FILES_TO_MOVE: &[&str] = &[
+    "../resources/test_fonts/ttf/linear_gradient_rect_colr_1.ttf",
+    "../resources/test_fonts/ttf/simple_glyf.ttf",
+    "../resources/test_fonts/ttf/vazirmatn_var_trimmed.ttf",
+];
+
+fn main() {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir);
+    for path in FILES_TO_MOVE.iter().map(Path::new) {
+        let out_path = out_dir.join(path.file_name().unwrap());
+        if path.exists() {
+            std::fs::copy(path, out_path).unwrap();
+        } else {
+            std::fs::write(out_path, []).unwrap();
+        }
+    }
+}

--- a/read-fonts/src/tests/test_data.rs
+++ b/read-fonts/src/tests/test_data.rs
@@ -361,12 +361,19 @@ pub mod stat {
 }
 
 pub mod test_fonts {
+    //! statically bundled test fonts.
+    //!
+    //! These files are only present if this crate is built from the repo root,
+    //! and not when the crate is packaged.
+    //!
+    //! To add new files, you will need to add the file in resources/test_fonts,
+    //! and then update read-fonts/build.rs.
+
     pub static COLR_GRADIENT_RECT: &[u8] =
-        include_bytes!("../../../resources/test_fonts/ttf/linear_gradient_rect_colr_1.ttf");
+        include_bytes!(concat!(env!("OUT_DIR"), "/linear_gradient_rect_colr_1.ttf"));
 
     pub static VAZIRMATN_VAR: &[u8] =
-        include_bytes!("../../../resources/test_fonts/ttf/vazirmatn_var_trimmed.ttf");
+        include_bytes!(concat!(env!("OUT_DIR"), "/vazirmatn_var_trimmed.ttf"));
 
-    pub static SIMPLE_GLYF: &[u8] =
-        include_bytes!("../../../resources/test_fonts/ttf/simple_glyf.ttf");
+    pub static SIMPLE_GLYF: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/simple_glyf.ttf"));
 }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -12,10 +12,10 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 font-types = { version = "0.0.3", path = "../font-types" }
-read-fonts = { version = "0.0.3", path = "../read-fonts" }
+read-fonts = { version = "0.0.4", path = "../read-fonts" }
 bitflags = "1.3"
 
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
-read-fonts = { version = "0.0.3", path = "../read-fonts", features = ["test_data"] }
+read-fonts = { version = "0.0.4", path = "../read-fonts", features = ["test_data"] }


### PR DESCRIPTION
Instead of directly including these files, we now have a build script
that will copy the files into a build directory *if they exist*, and
will write an empty file in that location if they do not.

This ensures that include_bytes! always points to a file that exists,
which means that we will compile as a package.