### PR TITLE
STAT compilation improvements

### DIFF
--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::stat)]
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
+#[skip_constructor]
 table Stat {
     /// Major/minor version number. Set to 1.2 for new fonts.
     #[version]
@@ -13,7 +14,7 @@ table Stat {
     /// this value must be greater than or equal to the axisCount value
     /// in the 'fvar' table. In all fonts, must be greater than zero if
     /// axisValueCount is greater than zero.
-    #[compile(array_len($offset_to_axis_value_offsets))]
+    #[compile(array_len($design_axes_offset))]
     design_axis_count: u16,
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes array. If designAxisCount is zero, set

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -26,28 +26,13 @@ pub struct Stat {
     pub elided_fallback_name_id: Option<u16>,
 }
 
-impl Stat {
-    /// Construct a new `Stat`
-    #[allow(clippy::useless_conversion)]
-    pub fn new(
-        design_axes: Vec<AxisRecord>,
-        offset_to_axis_values: OffsetMarker<Vec<OffsetMarker<AxisValue>>, WIDTH_32>,
-    ) -> Self {
-        Self {
-            design_axes: design_axes.into(),
-            offset_to_axis_values: offset_to_axis_values.into(),
-            ..Default::default()
-        }
-    }
-}
-
 impl FontWrite for Stat {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         let version = MajorMinor::VERSION_1_2 as MajorMinor;
         version.write_into(writer);
         (8 as u16).write_into(writer);
-        (array_len(&self.offset_to_axis_values).unwrap() as u16).write_into(writer);
+        (array_len(&self.design_axes).unwrap() as u16).write_into(writer);
         self.design_axes.write_into(writer);
         (array_len(&self.offset_to_axis_values).unwrap() as u16).write_into(writer);
         self.offset_to_axis_values.write_into(writer);


### PR DESCRIPTION
- fixed a bug where we were calculating design_axis_count incorrectly
- add a custom constructor, to ensure elided_fallback_name_id is always present
- add a basic test case