### PR TITLE
TopLevelTable trait + codegen attribute

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,6 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
+font-types = { version = "0.0.3", path = "../font-types" }
 rustfmt-wrapper = "0.1"
 regex = "1.5"
 miette = { version =  "4.6", features = ["fancy"] }

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, str::FromStr};
 
 use font_types::Tag;
-use read_fonts::{traversal::SomeTable, FileRef, FontRef, ReadError, TableProvider};
+use read_fonts::{traversal::SomeTable, FileRef, FontRef, ReadError, TableProvider, TopLevelTable};
 
 mod print;
 mod query;
@@ -101,23 +101,24 @@ fn get_some_table<'a>(
     font: &FontRef<'a>,
     tag: Tag,
 ) -> Result<Box<dyn SomeTable<'a> + 'a>, ReadError> {
+    use read_fonts::tables;
     match tag {
-        read_fonts::tables::gpos::TAG => font.gpos().map(|x| Box::new(x) as _),
-        read_fonts::tables::gsub::TAG => font.gsub().map(|x| Box::new(x) as _),
-        read_fonts::tables::cmap::TAG => font.cmap().map(|x| Box::new(x) as _),
-        read_fonts::tables::gdef::TAG => font.gdef().map(|x| Box::new(x) as _),
-        read_fonts::tables::glyf::TAG => font.glyf().map(|x| Box::new(x) as _),
-        read_fonts::tables::head::TAG => font.head().map(|x| Box::new(x) as _),
-        read_fonts::tables::hhea::TAG => font.hhea().map(|x| Box::new(x) as _),
-        read_fonts::tables::hmtx::TAG => font.hmtx().map(|x| Box::new(x) as _),
-        read_fonts::tables::loca::TAG => font.loca(None).map(|x| Box::new(x) as _),
-        read_fonts::tables::maxp::TAG => font.maxp().map(|x| Box::new(x) as _),
-        read_fonts::tables::name::TAG => font.name().map(|x| Box::new(x) as _),
-        read_fonts::tables::post::TAG => font.post().map(|x| Box::new(x) as _),
-        read_fonts::tables::colr::TAG => font.colr().map(|x| Box::new(x) as _),
-        read_fonts::tables::stat::TAG => font.stat().map(|x| Box::new(x) as _),
-        read_fonts::tables::vhea::TAG => font.vhea().map(|x| Box::new(x) as _),
-        read_fonts::tables::vmtx::TAG => font.vmtx().map(|x| Box::new(x) as _),
+        tables::gpos::Gpos::TAG => font.gpos().map(|x| Box::new(x) as _),
+        tables::gsub::Gsub::TAG => font.gsub().map(|x| Box::new(x) as _),
+        tables::cmap::Cmap::TAG => font.cmap().map(|x| Box::new(x) as _),
+        tables::gdef::Gdef::TAG => font.gdef().map(|x| Box::new(x) as _),
+        tables::glyf::Glyf::TAG => font.glyf().map(|x| Box::new(x) as _),
+        tables::head::Head::TAG => font.head().map(|x| Box::new(x) as _),
+        tables::hhea::Hhea::TAG => font.hhea().map(|x| Box::new(x) as _),
+        tables::hmtx::Hmtx::TAG => font.hmtx().map(|x| Box::new(x) as _),
+        tables::loca::Loca::TAG => font.loca(None).map(|x| Box::new(x) as _),
+        tables::maxp::Maxp::TAG => font.maxp().map(|x| Box::new(x) as _),
+        tables::name::Name::TAG => font.name().map(|x| Box::new(x) as _),
+        tables::post::Post::TAG => font.post().map(|x| Box::new(x) as _),
+        tables::colr::Colr::TAG => font.colr().map(|x| Box::new(x) as _),
+        tables::stat::Stat::TAG => font.stat().map(|x| Box::new(x) as _),
+        tables::vhea::Vhea::TAG => font.vhea().map(|x| Box::new(x) as _),
+        tables::vmtx::Vmtx::TAG => font.vmtx().map(|x| Box::new(x) as _),
         _ => Err(ReadError::TableIsMissing(tag)),
     }
 }

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -31,6 +31,11 @@ impl AvarMarker {
     }
 }
 
+impl TopLevelTable for Avar<'_> {
+    /// `avar`
+    const TAG: Tag = Tag::new(b"avar");
+}
+
 impl<'a> FontRead<'a> for Avar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -27,6 +27,11 @@ impl CmapMarker {
     }
 }
 
+impl TopLevelTable for Cmap<'_> {
+    /// `cmap`
+    const TAG: Tag = Tag::new(b"cmap");
+}
+
 impl<'a> FontRead<'a> for Cmap<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -59,6 +59,11 @@ impl ColrMarker {
     }
 }
 
+impl TopLevelTable for Colr<'_> {
+    /// `COLR`
+    const TAG: Tag = Tag::new(b"COLR");
+}
+
 impl<'a> FontRead<'a> for Colr<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -54,6 +54,11 @@ impl CpalMarker {
     }
 }
 
+impl TopLevelTable for Cpal<'_> {
+    /// `CPAL`
+    const TAG: Tag = Tag::new(b"CPAL");
+}
+
 impl<'a> FontRead<'a> for Cpal<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -44,6 +44,11 @@ impl GdefMarker {
     }
 }
 
+impl TopLevelTable for Gdef<'_> {
+    /// `GDEF`
+    const TAG: Tag = Tag::new(b"GDEF");
+}
+
 impl<'a> FontRead<'a> for Gdef<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -12,6 +12,11 @@ pub struct GlyfMarker {}
 
 impl GlyfMarker {}
 
+impl TopLevelTable for Glyf<'_> {
+    /// `glyf`
+    const TAG: Tag = Tag::new(b"glyf");
+}
+
 impl<'a> FontRead<'a> for Glyf<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let cursor = data.cursor();

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -36,6 +36,11 @@ impl GposMarker {
     }
 }
 
+impl TopLevelTable for Gpos<'_> {
+    /// `GPOS`
+    const TAG: Tag = Tag::new(b"GPOS");
+}
+
 impl<'a> FontRead<'a> for Gpos<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -35,6 +35,11 @@ impl GsubMarker {
     }
 }
 
+impl TopLevelTable for Gsub<'_> {
+    /// `GSUB`
+    const TAG: Tag = Tag::new(b"GSUB");
+}
+
 impl<'a> FontRead<'a> for Gsub<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -81,6 +81,11 @@ impl HeadMarker {
     }
 }
 
+impl TopLevelTable for Head<'_> {
+    /// `head`
+    const TAG: Tag = Tag::new(b"head");
+}
+
 impl<'a> FontRead<'a> for Head<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -6,7 +6,6 @@
 use crate::codegen_prelude::*;
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-/// [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct HheaMarker {}
@@ -82,6 +81,11 @@ impl HheaMarker {
     }
 }
 
+impl TopLevelTable for Hhea<'_> {
+    /// `hhea`
+    const TAG: Tag = Tag::new(b"hhea");
+}
+
 impl<'a> FontRead<'a> for Hhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
@@ -107,7 +111,6 @@ impl<'a> FontRead<'a> for Hhea<'a> {
 }
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-/// [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 pub type Hhea<'a> = TableRef<'a, HheaMarker>;
 
 impl<'a> Hhea<'a> {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -24,6 +24,11 @@ impl HmtxMarker {
     }
 }
 
+impl TopLevelTable for Hmtx<'_> {
+    /// `hmtx`
+    const TAG: Tag = Tag::new(b"hmtx");
+}
+
 impl ReadArgs for Hmtx<'_> {
     type Args = (u16, u16);
 }

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -33,6 +33,11 @@ impl HvarMarker {
     }
 }
 
+impl TopLevelTable for Hvar<'_> {
+    /// `HVAR`
+    const TAG: Tag = Tag::new(b"HVAR");
+}
+
 impl<'a> FontRead<'a> for Hvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -87,6 +87,11 @@ impl MaxpMarker {
     }
 }
 
+impl TopLevelTable for Maxp<'_> {
+    /// `maxp`
+    const TAG: Tag = Tag::new(b"maxp");
+}
+
 impl<'a> FontRead<'a> for Maxp<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -39,6 +39,11 @@ impl MvarMarker {
     }
 }
 
+impl TopLevelTable for Mvar<'_> {
+    /// `MVAR`
+    const TAG: Tag = Tag::new(b"MVAR");
+}
+
 impl<'a> FontRead<'a> for Mvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -42,6 +42,11 @@ impl NameMarker {
     }
 }
 
+impl TopLevelTable for Name<'_> {
+    /// `name`
+    const TAG: Tag = Tag::new(b"name");
+}
+
 impl<'a> FontRead<'a> for Name<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-/// [`OS2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
+/// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct Os2Marker {
@@ -180,6 +180,11 @@ impl Os2Marker {
     }
 }
 
+impl TopLevelTable for Os2<'_> {
+    /// `OS/2`
+    const TAG: Tag = Tag::new(b"OS/2");
+}
+
 impl<'a> FontRead<'a> for Os2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
@@ -274,7 +279,7 @@ impl<'a> FontRead<'a> for Os2<'a> {
     }
 }
 
-/// [`OS2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
+/// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
 pub type Os2<'a> = TableRef<'a, Os2Marker>;
 
 impl<'a> Os2<'a> {

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -67,6 +67,11 @@ impl PostMarker {
     }
 }
 
+impl TopLevelTable for Post<'_> {
+    /// `post`
+    const TAG: Tag = Tag::new(b"post");
+}
+
 impl<'a> FontRead<'a> for Post<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -43,6 +43,11 @@ impl StatMarker {
     }
 }
 
+impl TopLevelTable for Stat<'_> {
+    /// `STAT`
+    const TAG: Tag = Tag::new(b"STAT");
+}
+
 impl<'a> FontRead<'a> for Stat<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -81,6 +81,11 @@ impl VheaMarker {
     }
 }
 
+impl TopLevelTable for Vhea<'_> {
+    /// `vhea`
+    const TAG: Tag = Tag::new(b"vhea");
+}
+
 impl<'a> FontRead<'a> for Vhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -24,6 +24,11 @@ impl VmtxMarker {
     }
 }
 
+impl TopLevelTable for Vmtx<'_> {
+    /// `vmtx`
+    const TAG: Tag = Tag::new(b"vmtx");
+}
+
 impl ReadArgs for Vmtx<'_> {
     type Args = (u16, u16);
 }

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -37,6 +37,11 @@ impl VvarMarker {
     }
 }
 
+impl TopLevelTable for Vvar<'_> {
+    /// `VVAR`
+    const TAG: Tag = Tag::new(b"VVAR");
+}
+
 impl<'a> FontRead<'a> for Vvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -33,7 +33,7 @@ pub mod test_helpers;
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
 pub use read::{ComputeSize, FontRead, FontReadWithArgs, ReadArgs, ReadError, VarSize};
-pub use table_provider::TableProvider;
+pub use table_provider::{TableProvider, TopLevelTable};
 pub use table_ref::TableRef;
 
 /// Public re-export of the font-types crate.
@@ -48,8 +48,10 @@ pub(crate) mod codegen_prelude {
     pub use crate::read::{
         ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
     };
+    pub use crate::table_provider::TopLevelTable;
     pub use crate::table_ref::TableRef;
     pub use std::ops::Range;
+
     pub use types::*;
 
     #[cfg(feature = "traversal")]

--- a/read-fonts/src/tables/avar.rs
+++ b/read-fonts/src/tables/avar.rs
@@ -1,10 +1,5 @@
 //! The [Axis Variations](https://docs.microsoft.com/en-us/typography/opentype/spec/avar) table
 
-use types::Tag;
-
-/// 'avar'
-pub const TAG: Tag = Tag::new(b"avar");
-
 include!("../../generated/generated_avar.rs");
 
 impl<'a> SegmentMaps<'a> {

--- a/read-fonts/src/tables/cmap.rs
+++ b/read-fonts/src/tables/cmap.rs
@@ -1,10 +1,5 @@
 //! The [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap) table
 
-use types::Tag;
-
-/// 'cmap'
-pub const TAG: Tag = Tag::new(b"cmap");
-
 include!("../../generated/generated_cmap.rs");
 
 impl<'a> Cmap<'a> {

--- a/read-fonts/src/tables/colr.rs
+++ b/read-fonts/src/tables/colr.rs
@@ -1,9 +1,5 @@
 //! The [COLR](https://docs.microsoft.com/en-us/typography/opentype/spec/colr) table
 
 use super::variations::{DeltaSetIndexMap, ItemVariationStore};
-use types::Tag;
-
-/// 'COLR'
-pub const TAG: Tag = Tag::new(b"COLR");
 
 include!("../../generated/generated_colr.rs");

--- a/read-fonts/src/tables/cpal.rs
+++ b/read-fonts/src/tables/cpal.rs
@@ -1,10 +1,5 @@
 //! The [CPAL](https://docs.microsoft.com/en-us/typography/opentype/spec/cpal) table
 
-use types::Tag;
-
-/// 'CPAL'
-pub const TAG: Tag = Tag::new(b"CPAL");
-
 include!("../../generated/generated_cpal.rs");
 
 #[cfg(test)]

--- a/read-fonts/src/tables/gdef.rs
+++ b/read-fonts/src/tables/gdef.rs
@@ -6,14 +6,10 @@ pub use super::layout::{
     ChainedSequenceContext, ClassDef, CoverageTable, Device, FeatureList, FeatureVariations,
     Lookup, LookupList, ScriptList, SequenceContext,
 };
-use types::Tag;
 
 #[cfg(test)]
 #[path = "../tests/test_gdef.rs"]
 mod tests;
-
-/// 'GDEF'
-pub const TAG: Tag = Tag::new(b"GDEF");
 
 include!("../../generated/generated_gdef.rs");
 

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -1,10 +1,5 @@
 //! The [glyf (Glyph Data)](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf) table
 
-use crate::{FontData, ReadError};
-
-/// 'glyf'
-pub const TAG: Tag = Tag::new(b"glyf");
-
 include!("../../generated/generated_glyf.rs");
 
 macro_rules! field_getter {

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -17,9 +17,6 @@ pub use value_record::ValueRecord;
 #[path = "../tests/gpos.rs"]
 mod tests;
 
-/// 'GPOS'
-pub const TAG: Tag = Tag::new(b"GPOS");
-
 include!("../../generated/generated_gpos.rs");
 
 /// A typed GPOS [LookupList](super::layout::LookupList) table

--- a/read-fonts/src/tables/gsub.rs
+++ b/read-fonts/src/tables/gsub.rs
@@ -2,8 +2,6 @@
 //!
 //! [GSUB]: https://docs.microsoft.com/en-us/typography/opentype/spec/gsub
 
-use types::Tag;
-
 pub use super::layout::{
     ChainedSequenceContext, ClassDef, CoverageTable, Device, FeatureList, FeatureVariations,
     Lookup, LookupList, ScriptList, SequenceContext,
@@ -12,9 +10,6 @@ pub use super::layout::{
 #[cfg(test)]
 #[path = "../tests/test_gsub.rs"]
 mod tests;
-
-/// 'GSUB'
-pub const TAG: Tag = Tag::new(b"GSUB");
 
 include!("../../generated/generated_gsub.rs");
 

--- a/read-fonts/src/tables/head.rs
+++ b/read-fonts/src/tables/head.rs
@@ -1,10 +1,5 @@
 //! The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head) table
 
-use types::Tag;
-
-/// 'head'
-pub const TAG: Tag = Tag::new(b"head");
-
 include!("../../generated/generated_head.rs");
 
 #[cfg(test)]

--- a/read-fonts/src/tables/hhea.rs
+++ b/read-fonts/src/tables/hhea.rs
@@ -1,8 +1,3 @@
 //! the [hhea (Horizontal Header)](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) table
 
-use types::Tag;
-
-/// 'hhea'
-pub const TAG: Tag = Tag::new(b"hhea");
-
 include!("../../generated/generated_hhea.rs");

--- a/read-fonts/src/tables/hmtx.rs
+++ b/read-fonts/src/tables/hmtx.rs
@@ -1,8 +1,3 @@
 //! The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
 
-use types::Tag;
-
-/// 'hmtx'
-pub const TAG: Tag = Tag::new(b"hmtx");
-
 include!("../../generated/generated_hmtx.rs");

--- a/read-fonts/src/tables/hvar.rs
+++ b/read-fonts/src/tables/hvar.rs
@@ -1,10 +1,6 @@
 //! The [HVAR (Horizontal Metrics Variation)](https://docs.microsoft.com/en-us/typography/opentype/spec/hvar) table
 
 use super::variations::{self, DeltaSetIndexMap, ItemVariationStore};
-use types::Tag;
-
-/// 'HVAR'
-pub const TAG: Tag = Tag::new(b"HVAR");
 
 include!("../../generated/generated_hvar.rs");
 

--- a/read-fonts/src/tables/loca.rs
+++ b/read-fonts/src/tables/loca.rs
@@ -11,9 +11,6 @@ use types::{BigEndian, GlyphId, Tag};
 #[cfg(feature = "traversal")]
 use crate::traversal;
 
-/// 'loca'
-pub const TAG: Tag = Tag::new(b"loca");
-
 /// The [loca] table.
 ///
 /// [loca]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca

--- a/read-fonts/src/tables/loca.rs
+++ b/read-fonts/src/tables/loca.rs
@@ -2,7 +2,10 @@
 //!
 //! [loca]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca
 
-use crate::read::{FontRead, FontReadWithArgs, ReadArgs, ReadError};
+use crate::{
+    read::{FontRead, FontReadWithArgs, ReadArgs, ReadError},
+    table_provider::TopLevelTable,
+};
 use types::{BigEndian, GlyphId, Tag};
 
 #[cfg(feature = "traversal")]
@@ -18,6 +21,10 @@ pub const TAG: Tag = Tag::new(b"loca");
 pub enum Loca<'a> {
     Short(&'a [BigEndian<u16>]),
     Long(&'a [BigEndian<u32>]),
+}
+
+impl TopLevelTable for Loca<'_> {
+    const TAG: Tag = Tag::new(b"loca");
 }
 
 impl<'a> Loca<'a> {

--- a/read-fonts/src/tables/maxp.rs
+++ b/read-fonts/src/tables/maxp.rs
@@ -1,8 +1,3 @@
 //! The [maxp](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp) table
 
-use types::Tag;
-
-/// 'maxp'
-pub const TAG: Tag = Tag::new(b"maxp");
-
 include!("../../generated/generated_maxp.rs");

--- a/read-fonts/src/tables/mvar.rs
+++ b/read-fonts/src/tables/mvar.rs
@@ -1,14 +1,10 @@
 //! The [MVAR (Metrics Variation)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
 
 use super::variations::{DeltaSetIndex, ItemVariationStore};
-use types::Tag;
-
-/// 'MVAR'
-pub const TAG: Tag = Tag::new(b"MVAR");
 
 /// Four-byte tags used to represent particular metric or other values.
 pub mod tags {
-    use super::Tag;
+    use font_types::Tag;
 
     /// Horizontal ascender.
     pub const HASC: Tag = Tag::new(b"hasc");

--- a/read-fonts/src/tables/name.rs
+++ b/read-fonts/src/tables/name.rs
@@ -1,10 +1,5 @@
 //! The [name (Naming)](https://docs.microsoft.com/en-us/typography/opentype/spec/name) table
 
-use crate::FontData;
-
-/// 'name'
-pub const TAG: Tag = Tag::new(b"name");
-
 include!("../../generated/generated_name.rs");
 
 impl<'a> Name<'a> {

--- a/read-fonts/src/tables/os2.rs
+++ b/read-fonts/src/tables/os2.rs
@@ -1,10 +1,5 @@
 //! The [os2](https://docs.microsoft.com/en-us/typography/opentype/spec/os2) table
 
-use types::Tag;
-
-/// 'OS/2'
-pub const TAG: Tag = Tag::new(b"OS/2");
-
 include!("../../generated/generated_os2.rs");
 
 #[cfg(test)]

--- a/read-fonts/src/tables/post.rs
+++ b/read-fonts/src/tables/post.rs
@@ -1,10 +1,5 @@
 //! the [post (PostScript)](https://docs.microsoft.com/en-us/typography/opentype/spec/post#header) table
 
-use types::{GlyphId, Tag, Version16Dot16};
-
-/// 'post'
-pub const TAG: Tag = Tag::new(b"post");
-
 include!("../../generated/generated_post.rs");
 
 impl<'a> Post<'a> {

--- a/read-fonts/src/tables/stat.rs
+++ b/read-fonts/src/tables/stat.rs
@@ -1,10 +1,5 @@
 //! The [STAT](https://learn.microsoft.com/en-us/typography/opentype/spec/stat) table
 
-use types::Tag;
-
-/// 'STAT'
-pub const TAG: Tag = Tag::new(b"STAT");
-
 include!("../../generated/generated_stat.rs");
 
 #[cfg(test)]

--- a/read-fonts/src/tables/vhea.rs
+++ b/read-fonts/src/tables/vhea.rs
@@ -1,8 +1,3 @@
 //! the [vhea (Horizontal Header)](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) table
 
-use types::Tag;
-
-/// 'vhea'
-pub const TAG: Tag = Tag::new(b"vhea");
-
 include!("../../generated/generated_vhea.rs");

--- a/read-fonts/src/tables/vmtx.rs
+++ b/read-fonts/src/tables/vmtx.rs
@@ -1,10 +1,5 @@
 //! The [vmtx (Vertical Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/vmtx) table
 
-use types::Tag;
-
 pub use super::hmtx::LongMetric;
-
-/// 'vmtx'
-pub const TAG: Tag = Tag::new(b"vmtx");
 
 include!("../../generated/generated_vmtx.rs");

--- a/read-fonts/src/tables/vvar.rs
+++ b/read-fonts/src/tables/vvar.rs
@@ -1,10 +1,6 @@
 //! The [VVAR (Vertical Metrics Variation)](https://docs.microsoft.com/en-us/typography/opentype/spec/vvar) table
 
 use super::variations::{self, DeltaSetIndexMap, ItemVariationStore};
-use types::Tag;
-
-/// 'VVAR'
-pub const TAG: Tag = Tag::new(b"VVAR");
 
 include!("../../generated/generated_vvar.rs");
 

--- a/resources/codegen_inputs/avar.rs
+++ b/resources/codegen_inputs/avar.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::avar)]
 
 /// The [avar (Axis Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/avar) table
+#[tag = "avar"]
 table Avar {
     /// Major version number of the axis variations table — set to 1.
     /// Minor version number of the axis variations table — set to 0.

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::cmap)]
 
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
+#[tag = "cmap"]
 table Cmap {
     /// Table version number (0).
     version: u16,

--- a/resources/codegen_inputs/colr.rs
+++ b/resources/codegen_inputs/colr.rs
@@ -2,6 +2,7 @@
 #![parse_module(read_fonts::tables::colr)]
 
 /// [COLR (Color)](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#colr-header) table
+#[tag = "COLR"]
 table Colr {
     /// Table version number - set to 0 or 1.
     #[version]

--- a/resources/codegen_inputs/cpal.rs
+++ b/resources/codegen_inputs/cpal.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::cpal)]
 
 /// [CPAL (Color Palette Table)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-table-header) table
+#[tag = "CPAL"]
 table Cpal {
     /// Table version number (=0).
     #[version]

--- a/resources/codegen_inputs/gdef.rs
+++ b/resources/codegen_inputs/gdef.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::gdef)]
 
 /// [GDEF](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#gdef-header) 1.0
+#[tag = "GDEF"]
 table Gdef {
     /// The major/minor version of the GDEF table
     #[version]

--- a/resources/codegen_inputs/glyf.rs
+++ b/resources/codegen_inputs/glyf.rs
@@ -1,5 +1,6 @@
 #![parse_module(read_fonts::tables::glyf)]
 /// The [glyf (Glyph Data)](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf) table
+#[tag = "glyf"]
 table Glyf {}
 
 ///// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -5,6 +5,7 @@ extern record ValueRecord;
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
+#[tag = "GPOS"]
 table Gpos {
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
     #[version]

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -2,6 +2,7 @@
 #![parse_module(read_fonts::tables::gsub)]
 
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
+#[tag = "GSUB"]
 table Gsub {
     /// The major and minor version of the GSUB table, as a tuple (u16, u16)
     #[version]

--- a/resources/codegen_inputs/head.rs
+++ b/resources/codegen_inputs/head.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::head)]
 
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/head>
+#[tag = "head"]
 table Head {
     /// Version number of the font header table, set to (1, 0)
     #[compile(MajorMinor::VERSION_1_0)]

--- a/resources/codegen_inputs/hhea.rs
+++ b/resources/codegen_inputs/hhea.rs
@@ -1,7 +1,7 @@
 #![parse_module(read_fonts::tables::hhea)]
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-/// [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
+#[tag = "hhea"]
 table Hhea {
     /// The major/minor version (1, 0)
     #[compile(MajorMinor::VERSION_1_0)]

--- a/resources/codegen_inputs/hmtx.rs
+++ b/resources/codegen_inputs/hmtx.rs
@@ -2,6 +2,7 @@
 
 /// The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
 #[read_args(number_of_h_metrics: u16, num_glyphs: u16)]
+#[tag = "hmtx"]
 table Hmtx {
     /// Paired advance width/height and left/top side bearing values for each
     /// glyph. Records are indexed by glyph ID.

--- a/resources/codegen_inputs/hvar.rs
+++ b/resources/codegen_inputs/hvar.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::hvar)]
 
 /// The [HVAR (Horizontal Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/hvar) table
+#[tag = "HVAR"]
 table Hvar {
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.

--- a/resources/codegen_inputs/maxp.rs
+++ b/resources/codegen_inputs/maxp.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::maxp)]
 
 /// [`maxp`](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
+#[tag = "maxp"]
 table Maxp {
     /// The version: 0x00005000 for version 0.5, 0x00010000 for version 1.0.
     #[version]

--- a/resources/codegen_inputs/mvar.rs
+++ b/resources/codegen_inputs/mvar.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::mvar)]
 
 /// The [MVAR (Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
+#[tag = "MVAR"]
 table Mvar {
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::name)]
 
 /// [Naming table version 1](https://docs.microsoft.com/en-us/typography/opentype/spec/name#naming-table-version-1)
+#[tag = "name"]
 table Name {
     /// Table version number (0 or 1)
     #[version]

--- a/resources/codegen_inputs/os2.rs
+++ b/resources/codegen_inputs/os2.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::os2)]
 
-/// [`OS2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
+/// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
+#[tag = "OS/2"]
 table Os2 {
     #[version]
     #[compile(self.compute_version())]

--- a/resources/codegen_inputs/post.rs
+++ b/resources/codegen_inputs/post.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::post)]
 
 /// [post (PostScript)](https://docs.microsoft.com/en-us/typography/opentype/spec/post#header) table
+#[tag = "post"]
 table Post {
     /// 0x00010000 for version 1.0 0x00020000 for version 2.0
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version

--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -2,6 +2,7 @@
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
 #[skip_constructor]
+#[tag = "STAT"]
 table Stat {
     /// Major/minor version number. Set to 1.2 for new fonts.
     #[version]

--- a/resources/codegen_inputs/vhea.rs
+++ b/resources/codegen_inputs/vhea.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::vhea)]
 
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
+#[tag = "vhea"]
 table Vhea {
     /// The major/minor version (1, 0)
     #[compile(MajorMinor::VERSION_1_1)]

--- a/resources/codegen_inputs/vmtx.rs
+++ b/resources/codegen_inputs/vmtx.rs
@@ -4,6 +4,7 @@ extern record LongMetric;
 
 /// The [vmtx (Vertical Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/vmtx) table
 #[read_args(number_of_long_ver_metrics: u16, num_glyphs: u16)]
+#[tag = "vmtx"]
 table Vmtx {
     /// Paired advance height and top side bearing values for each
     /// glyph. Records are indexed by glyph ID.

--- a/resources/codegen_inputs/vvar.rs
+++ b/resources/codegen_inputs/vvar.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::vvar)]
 
 /// The [VVAR (Vertical Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/vvar) table
+#[tag = "VVAR"]
 table Vvar {
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -103,6 +103,10 @@ impl Validate for Cpal {
     }
 }
 
+impl TopLevelTable for Cpal {
+    const TAG: Tag = Tag::new(b"CPAL");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::cpal::Cpal<'a>> for Cpal {
     fn from_obj_ref(obj: &read_fonts::tables::cpal::Cpal<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -91,6 +91,10 @@ impl Validate for Gdef {
     }
 }
 
+impl TopLevelTable for Gdef {
+    const TAG: Tag = Tag::new(b"GDEF");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::gdef::Gdef<'a>> for Gdef {
     fn from_obj_ref(obj: &read_fonts::tables::gdef::Gdef<'a>, _: FontData) -> Self {
         Gdef {

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -69,6 +69,10 @@ impl Validate for Gpos {
     }
 }
 
+impl TopLevelTable for Gpos {
+    const TAG: Tag = Tag::new(b"GPOS");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::gpos::Gpos<'a>> for Gpos {
     fn from_obj_ref(obj: &read_fonts::tables::gpos::Gpos<'a>, _: FontData) -> Self {
         Gpos {

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -68,6 +68,10 @@ impl Validate for Gsub {
     }
 }
 
+impl TopLevelTable for Gsub {
+    const TAG: Tag = Tag::new(b"GSUB");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::gsub::Gsub<'a>> for Gsub {
     fn from_obj_ref(obj: &read_fonts::tables::gsub::Gsub<'a>, _: FontData) -> Self {
         Gsub {

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -135,6 +135,10 @@ impl Validate for Head {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
+impl TopLevelTable for Head {
+    const TAG: Tag = Tag::new(b"head");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::head::Head<'a>> for Head {
     fn from_obj_ref(obj: &read_fonts::tables::head::Head<'a>, _: FontData) -> Self {
         Head {

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -6,7 +6,6 @@
 use crate::codegen_prelude::*;
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-/// [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 #[derive(Clone, Debug, Default)]
 pub struct Hhea {
     /// Typographic ascent.
@@ -96,6 +95,10 @@ impl FontWrite for Hhea {
 
 impl Validate for Hhea {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
+}
+
+impl TopLevelTable for Hhea {
+    const TAG: Tag = Tag::new(b"hhea");
 }
 
 impl<'a> FromObjRef<read_fonts::tables::hhea::Hhea<'a>> for Hhea {

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -46,6 +46,10 @@ impl Validate for Hmtx {
     }
 }
 
+impl TopLevelTable for Hmtx {
+    const TAG: Tag = Tag::new(b"hmtx");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
     fn from_obj_ref(obj: &read_fonts::tables::hmtx::Hmtx<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -230,6 +230,10 @@ impl Validate for Maxp {
     }
 }
 
+impl TopLevelTable for Maxp {
+    const TAG: Tag = Tag::new(b"maxp");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::maxp::Maxp<'a>> for Maxp {
     fn from_obj_ref(obj: &read_fonts::tables::maxp::Maxp<'a>, _: FontData) -> Self {
         Maxp {

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -74,6 +74,10 @@ impl Validate for Name {
     }
 }
 
+impl TopLevelTable for Name {
+    const TAG: Tag = Tag::new(b"name");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::name::Name<'a>> for Name {
     fn from_obj_ref(obj: &read_fonts::tables::name::Name<'a>, _: FontData) -> Self {
         let offset_data = obj.string_data();

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -155,6 +155,10 @@ impl Validate for Post {
     }
 }
 
+impl TopLevelTable for Post {
+    const TAG: Tag = Tag::new(b"post");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::post::Post<'a>> for Post {
     fn from_obj_ref(obj: &read_fonts::tables::post::Post<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -66,6 +66,10 @@ impl Validate for Stat {
     }
 }
 
+impl TopLevelTable for Stat {
+    const TAG: Tag = Tag::new(b"STAT");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::stat::Stat<'a>> for Stat {
     fn from_obj_ref(obj: &read_fonts::tables::stat::Stat<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -96,6 +96,10 @@ impl Validate for Vhea {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
+impl TopLevelTable for Vhea {
+    const TAG: Tag = Tag::new(b"vhea");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::vhea::Vhea<'a>> for Vhea {
     fn from_obj_ref(obj: &read_fonts::tables::vhea::Vhea<'a>, _: FontData) -> Self {
         Vhea {

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -45,6 +45,10 @@ impl Validate for Vmtx {
     }
 }
 
+impl TopLevelTable for Vmtx {
+    const TAG: Tag = Tag::new(b"vmtx");
+}
+
 impl<'a> FromObjRef<read_fonts::tables::vmtx::Vmtx<'a>> for Vmtx {
     fn from_obj_ref(obj: &read_fonts::tables::vmtx::Vmtx<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -34,7 +34,9 @@ pub(crate) mod codegen_prelude {
     pub use std::collections::BTreeSet;
     pub use types::*;
 
-    pub use read::{FontData, FontRead, FontReadWithArgs, ReadArgs, ReadError, ResolveOffset};
+    pub use read::{
+        FontData, FontRead, FontReadWithArgs, ReadArgs, ReadError, ResolveOffset, TopLevelTable,
+    };
 
     /// checked conversion to u16
     pub fn array_len<T: super::collections::HasLen>(s: &T) -> Result<u16, TryFromIntError> {


### PR DESCRIPTION
This adds the `#[tag = "sfnt"]` attribute in codegen, and uses that to implement the `TopLevelTable` trait, which just associates a const with an item.

The big annoyance here is with hmtx/vmtx and hhea/vhea; because these share an implementation, we need to create new types to hang this trait off of, and we can't use the attribute.

I'm personally coming back to the opinion that our lives would be simpler if we just let there be duplicate codegen for these types; i'm not convinced that we will actually ever want to share code between them, and it would reduce the amount of boilerplate we need to implement on our own.

There are a few things missing from this:
- we still have the TAG constants in each table module
- I haven't dealt with hmtx/vmtx etc in `write-fonts`, since I want to see what the consensus is on this before hand.