### PR TITLE
[codegen] Remove support for unspecified offset targets

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -276,7 +276,7 @@ fn traversal_arm_for_field(
     }
     match &fld.typ {
         FieldType::Offset {
-            target: Some(OffsetTarget::Array(inner)),
+            target: OffsetTarget::Array(inner),
             ..
         } if matches!(inner.deref(), FieldType::Struct { .. }) => {
             let typ = inner.cooked_type_tokens();
@@ -294,19 +294,13 @@ fn traversal_arm_for_field(
                     )
             ))
         }
-        FieldType::Offset {
-            target: Some(target),
-            ..
-        } => {
+        FieldType::Offset { target, .. } => {
             let constructor_name = match target {
                 OffsetTarget::Table(_) => quote!(offset),
                 OffsetTarget::Array(_) => quote!(offset_to_array_of_scalars),
             };
             let getter = fld.offset_getter_name();
             quote!(Field::new(#name_str, FieldType::#constructor_name(self.#name()#maybe_unwrap, self.#getter(#pass_data)#maybe_unwrap)))
-        }
-        FieldType::Offset { .. } => {
-            quote!(Field::new(#name_str, FieldType::unknown_offset(self.#name()#maybe_unwrap)))
         }
         FieldType::Scalar { .. } => quote!(Field::new(#name_str, self.#name()#maybe_unwrap)),
 
@@ -331,7 +325,7 @@ fn traversal_arm_for_field(
             }
 
             FieldType::Offset {
-                target: Some(OffsetTarget::Table(target)),
+                target: OffsetTarget::Table(target),
                 ..
             } => {
                 let maybe_data = pass_data.is_none().then(|| quote!(let data = self.data;));
@@ -359,13 +353,12 @@ fn traversal_arm_for_field(
                 }}
             }
             FieldType::Offset {
-                target: Some(OffsetTarget::Array(_)),
+                target: OffsetTarget::Array(_),
                 ..
             } => panic!(
                 "achievement unlocked: 'added arrays of offsets to arrays to OpenType spec' {:#?}",
                 fld
             ),
-            FieldType::Offset { .. } => quote!(Field::new(#name_str, self.#name()#maybe_unwrap)),
             _ => quote!(compile_error!("unhandled traversal case")),
         },
         FieldType::ComputedArray(arr) => {
@@ -511,7 +504,7 @@ impl Field {
             check_resolution(phase, inner_typ)?;
         }
         if let FieldType::Offset {
-            target: Some(OffsetTarget::Array(inner_typ)),
+            target: OffsetTarget::Array(inner_typ),
             ..
         } = &self.typ
         {
@@ -764,15 +757,9 @@ impl Field {
     ) -> Option<TokenStream> {
         let (_, target) = match &self.typ {
             _ if self.attrs.offset_getter.is_some() => return None,
-            FieldType::Offset {
-                typ,
-                target: Some(target),
-            } => (typ, target),
+            FieldType::Offset { typ, target } => (typ, target),
             FieldType::Array { inner_typ, .. } => match inner_typ.as_ref() {
-                FieldType::Offset {
-                    typ,
-                    target: Some(target),
-                } => (typ, target),
+                FieldType::Offset { typ, target } => (typ, target),
                 _ => return None,
             },
             _ => return None,
@@ -1152,9 +1139,8 @@ impl Field {
     fn gets_recursive_validation(&self) -> bool {
         match &self.typ {
             FieldType::Scalar { .. } | FieldType::Struct { .. } => false,
-            FieldType::Offset { target: None, .. } => false,
             FieldType::Offset {
-                target: Some(OffsetTarget::Array(elem)),
+                target: OffsetTarget::Array(elem),
                 ..
             } if matches!(elem.deref(), FieldType::Scalar { .. }) => false,
             FieldType::Offset { .. }
@@ -1175,7 +1161,7 @@ impl Field {
         match &self.typ {
             _ if self.attrs.to_owned.is_some() => false,
             FieldType::Offset {
-                target: Some(OffsetTarget::Array(_)),
+                target: OffsetTarget::Array(_),
                 ..
             } => true,
             FieldType::Offset { .. } => in_record,
@@ -1204,10 +1190,7 @@ impl Field {
             }
             FieldType::Scalar { .. } => quote!(obj.#name()),
             FieldType::Struct { .. } => quote!(obj.#name().to_owned_obj(offset_data)),
-            FieldType::Offset {
-                target: Some(target),
-                ..
-            } => {
+            FieldType::Offset { target, .. } => {
                 let offset_getter = self.offset_getter_name().unwrap();
                 match target {
                     // in this case it is possible that this is an array of
@@ -1287,20 +1270,12 @@ impl FieldType {
     }
 
     // impl code reused for the two calls above
-    fn compile_type_impl(
-        &self,
-        nullable: bool,
-        //version_dependent: bool,
-        for_constructor: bool,
-    ) -> TokenStream {
-        let raw_type = match self {
+    fn compile_type_impl(&self, nullable: bool, for_constructor: bool) -> TokenStream {
+        match self {
             FieldType::Scalar { typ } => typ.into_token_stream(),
             FieldType::Struct { typ } => typ.into_token_stream(),
             FieldType::Offset { typ, target } => {
-                let target = target
-                    .as_ref()
-                    .map(OffsetTarget::compile_type)
-                    .unwrap_or_else(|| quote!(Box<dyn FontWrite>));
+                let target = target.compile_type();
                 if for_constructor {
                     if nullable {
                         return quote!(Option<#target>);
@@ -1312,7 +1287,7 @@ impl FieldType {
                 if nullable {
                     // we don't bother wrapping this in an Option if versioned,
                     // since it already acts like an Option
-                    return quote!(NullableOffsetMarker<#target, #width>);
+                    quote!(NullableOffsetMarker<#target, #width>)
                 } else {
                     quote!(OffsetMarker<#target, #width>)
                 }
@@ -1327,13 +1302,7 @@ impl FieldType {
             }
             FieldType::ComputedArray(array) | FieldType::VarLenArray(array) => array.compile_type(),
             FieldType::PendingResolution { .. } => panic!("Should have resolved {:?}", self),
-        };
-        raw_type
-        //if version_dependent {
-        //quote!( Option<#raw_type> )
-        //} else {
-        //raw_type
-        //}
+        }
     }
 }
 

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -288,7 +288,7 @@ impl InlineExpr {
 pub(crate) enum FieldType {
     Offset {
         typ: syn::Ident,
-        target: Option<OffsetTarget>,
+        target: OffsetTarget,
     },
     Scalar {
         typ: syn::Ident,
@@ -766,7 +766,7 @@ impl FieldType {
         }
 
         if ["Offset16", "Offset24", "Offset32"].contains(&last.ident.to_string().as_str()) {
-            let target = get_offset_target(&last.arguments)?;
+            let target = get_offset_target(last)?;
             return Ok(FieldType::Offset {
                 typ: last.ident.clone(),
                 target,
@@ -792,8 +792,8 @@ fn get_single_path_segment(path: &syn::Path) -> syn::Result<&syn::PathSegment> {
 }
 
 // either a single ident or an array
-fn get_offset_target(input: &syn::PathArguments) -> syn::Result<Option<OffsetTarget>> {
-    match get_single_generic_arg(input)? {
+fn get_offset_target(input: &syn::PathSegment) -> syn::Result<OffsetTarget> {
+    match get_single_generic_arg(&input.arguments)? {
         Some(syn::GenericArgument::Type(syn::Type::Slice(t))) => {
             let inner = FieldType::from_syn_type(&t.elem)?;
             if matches!(
@@ -802,7 +802,7 @@ fn get_offset_target(input: &syn::PathArguments) -> syn::Result<Option<OffsetTar
                     | FieldType::Struct { .. }
                     | FieldType::PendingResolution { .. }
             ) {
-                Ok(Some(OffsetTarget::Array(Box::new(inner))))
+                Ok(OffsetTarget::Array(Box::new(inner)))
             } else {
                 Err(logged_syn_error(
                     t.elem.span(),
@@ -813,12 +813,10 @@ fn get_offset_target(input: &syn::PathArguments) -> syn::Result<Option<OffsetTar
         Some(syn::GenericArgument::Type(syn::Type::Path(t)))
             if t.path.segments.len() == 1 && t.path.get_ident().is_some() =>
         {
-            Ok(Some(OffsetTarget::Table(
-                t.path.get_ident().unwrap().clone(),
-            )))
+            Ok(OffsetTarget::Table(t.path.get_ident().unwrap().clone()))
         }
         Some(_) => Err(logged_syn_error(input.span(), "expected path or slice")),
-        None => Ok(None),
+        None => Err(logged_syn_error(input.span(), "expected offset target")),
     }
 }
 
@@ -1070,13 +1068,13 @@ fn resolve_field(
 
     if let FieldType::Offset { typ, target } = &field.typ {
         let offset_typ = typ;
-        if let Some(OffsetTarget::Array(array_of)) = target {
+        if let OffsetTarget::Array(array_of) = target {
             if let FieldType::PendingResolution { typ } = array_of.as_ref() {
                 let resolved_typ = resolve_ident(known, &field.name, typ)?;
                 *field = Field {
                     typ: FieldType::Offset {
                         typ: offset_typ.clone(),
-                        target: Some(OffsetTarget::Array(Box::new(resolved_typ.clone()))),
+                        target: OffsetTarget::Array(Box::new(resolved_typ.clone())),
                     },
                     ..field.clone()
                 }
@@ -1479,17 +1477,15 @@ mod tests {
     #[test]
     fn offset_target() {
         let array_target = make_path_seg("Offset16<[u16]>");
-        assert!(get_offset_target(&array_target.arguments)
-            .unwrap()
-            .is_some());
+        assert!(get_offset_target(&array_target).is_ok());
 
         let path_target = make_path_seg("Offset16<SomeType>");
-        assert!(get_offset_target(&path_target.arguments).unwrap().is_some());
+        assert!(get_offset_target(&path_target).is_ok());
 
         let non_target = make_path_seg("Offset16");
-        assert!(get_offset_target(&non_target.arguments).unwrap().is_none());
+        assert!(get_offset_target(&non_target).is_err());
 
         let tuple_target = make_path_seg("Offset16<(u16, u16)>");
-        assert!(get_offset_target(&tuple_target.arguments).is_err());
+        assert!(get_offset_target(&tuple_target).is_err());
     }
 }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -135,7 +135,7 @@ pub struct TableRecord {
     /// Checksum for the table.
     pub checksum: BigEndian<u32>,
     /// Offset from the beginning of the font data.
-    pub offset: BigEndian<Offset32>,
+    pub offset: BigEndian<u32>,
     /// Length of the table.
     pub length: BigEndian<u32>,
 }
@@ -151,11 +151,6 @@ impl TableRecord {
         self.checksum.get()
     }
 
-    /// Offset from the beginning of the font data.
-    pub fn offset(&self) -> Offset32 {
-        self.offset.get()
-    }
-
     /// Length of the table.
     pub fn length(&self) -> u32 {
         self.length.get()
@@ -164,7 +159,7 @@ impl TableRecord {
 
 impl FixedSize for TableRecord {
     const RAW_BYTE_LEN: usize =
-        Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+        Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 #[cfg(feature = "traversal")]
@@ -175,11 +170,7 @@ impl<'a> SomeRecord<'a> for TableRecord {
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("tag", self.tag())),
                 1usize => Some(Field::new("checksum", self.checksum())),
-                2usize => Some(Field::new(
-                    "offset",
-                    FieldType::unknown_offset(self.offset()),
-                )),
-                3usize => Some(Field::new("length", self.length())),
+                2usize => Some(Field::new("length", self.length())),
                 _ => None,
             }),
             data,

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -200,3 +200,9 @@ impl<'a> TableProvider<'a> for FontRef<'a> {
         self.table_data(tag)
     }
 }
+
+impl TableRecord {
+    pub fn offset(&self) -> Offset32 {
+        Offset32::new(self.offset.get())
+    }
+}

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -293,10 +293,12 @@ record VariationSelector {
     var_selector: Uint24,
     /// Offset from the start of the format 14 subtable to Default UVS
     /// Table. May be 0.
-    default_uvs_offset: Offset32,
+    #[nullable]
+    default_uvs_offset: Offset32<DefaultUvs>,
     /// Offset from the start of the format 14 subtable to Non-Default
     /// UVS Table. May be 0.
-    non_default_uvs_offset: Offset32,
+    #[nullable]
+    non_default_uvs_offset: Offset32<NonDefaultUvs>,
 }
 
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
@@ -308,8 +310,16 @@ table DefaultUvs {
     ranges: [UnicodeRange],
 }
 
+/// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
+table NonDefaultUvs {
+    num_uvs_mappings: u32,
+    #[count($num_uvs_mappings)]
+    uvs_mapping: [UvsMapping]
+
+}
+
 /// Part of [Cmap14]
-record UVSMapping {
+record UvsMapping {
     /// Base Unicode value of the UVS
     unicode_value: Uint24,
     /// Glyph ID of the UVS

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -24,8 +24,9 @@ record TableRecord {
     /// Checksum for the table.
     checksum: u32,
     /// Offset from the beginning of the font data.
-    #[compile_type(u32)] // we set these manually
-    offset: Offset32,
+    // we handle this offset manually, since we can't always know the type
+    #[skip_getter]
+    offset: u32,
     /// Length of the table.
     length: u32,
 }

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -76,12 +76,11 @@ pub struct TableRecord {
 
 impl TableRecord {
     /// Construct a new `TableRecord`
-    #[allow(clippy::useless_conversion)]
     pub fn new(tag: Tag, checksum: u32, offset: u32, length: u32) -> Self {
         Self {
             tag,
             checksum,
-            offset: offset.into(),
+            offset,
             length,
         }
     }


### PR DESCRIPTION
This might have made sense at some point, but it is no longer used and adds unnecessary complexity.

Getting this to work involves fixing the two remaining places where we
use untyped offsets:

- in the root TableRecord, where there may be arbitrary tags and
  arbitrary tables, we just encode the offset as a u32.
- in cmap, we hadn't declared format 14 subtables correctly.

Just Merge Me™️