### PR TITLE
[codegen] Make #[count] not accept expressions

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -178,8 +178,13 @@ The following annotations are supported on top-level objects:
   fields.
 - `#[format = x]`: Indicates that this field is the format field of a
   multi-format table, and that it has the provided format value.
-- `#[count(arg)]`: Only valid (and required) on arrays: the argument is either a literal,
-  an expression, or a field on the type (preceded with a `$`).
+- `#[count(arg)]` and `#[count(fn_name(arg, +))]`: This annotation has two
+  forms. The simple form accepts a single argument, which can be either
+  the token `..` (meaning all remaining data, and only valid on the last field
+  in a table), the name of a field (preceded by the `$` token) or a literal
+  integer. The less-simple form begins with a function identifier, and then one
+  or more arguments, comma separated. Currently accepted function identifiers
+  are 'subtract', 'half', 'map_delta_size', and 'delta_value_count'.
 - `#[compile(arg)]`: If present, this field will not be included in the compile
   type. The value may be either the literal 'skip', or an expression that
   evalutes to the field's type: the skip case is only expected in cases where

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -305,7 +305,7 @@ impl<'a> FontRead<'a> for Cmap0<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let glyph_id_array_byte_len = 256 * u8::RAW_BYTE_LEN;
+        let glyph_id_array_byte_len = 256_usize * u8::RAW_BYTE_LEN;
         cursor.advance_by(glyph_id_array_byte_len);
         cursor.finish(Cmap0Marker {
             glyph_id_array_byte_len,
@@ -402,7 +402,7 @@ impl<'a> FontRead<'a> for Cmap2<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let sub_header_keys_byte_len = 256 * u16::RAW_BYTE_LEN;
+        let sub_header_keys_byte_len = 256_usize * u16::RAW_BYTE_LEN;
         cursor.advance_by(sub_header_keys_byte_len);
         cursor.finish(Cmap2Marker {
             sub_header_keys_byte_len,
@@ -603,14 +603,14 @@ impl<'a> FontRead<'a> for Cmap4<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let end_code_byte_len = seg_count_x2 as usize / 2 * u16::RAW_BYTE_LEN;
+        let end_code_byte_len = transforms::half(seg_count_x2) * u16::RAW_BYTE_LEN;
         cursor.advance_by(end_code_byte_len);
         cursor.advance::<u16>();
-        let start_code_byte_len = seg_count_x2 as usize / 2 * u16::RAW_BYTE_LEN;
+        let start_code_byte_len = transforms::half(seg_count_x2) * u16::RAW_BYTE_LEN;
         cursor.advance_by(start_code_byte_len);
-        let id_delta_byte_len = seg_count_x2 as usize / 2 * i16::RAW_BYTE_LEN;
+        let id_delta_byte_len = transforms::half(seg_count_x2) * i16::RAW_BYTE_LEN;
         cursor.advance_by(id_delta_byte_len);
-        let id_range_offsets_byte_len = seg_count_x2 as usize / 2 * u16::RAW_BYTE_LEN;
+        let id_range_offsets_byte_len = transforms::half(seg_count_x2) * u16::RAW_BYTE_LEN;
         cursor.advance_by(id_range_offsets_byte_len);
         let glyph_id_array_byte_len = cursor.remaining_bytes();
         cursor.advance_by(glyph_id_array_byte_len);
@@ -908,7 +908,7 @@ impl<'a> FontRead<'a> for Cmap8<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u32>();
         cursor.advance::<u32>();
-        let is32_byte_len = 8192 * u8::RAW_BYTE_LEN;
+        let is32_byte_len = 8192_usize * u8::RAW_BYTE_LEN;
         cursor.advance_by(is32_byte_len);
         let num_groups: u32 = cursor.read()?;
         let groups_byte_len = num_groups as usize * SequentialMapGroup::RAW_BYTE_LEN;

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -107,7 +107,7 @@ impl<'a> FontRead<'a> for SimpleGlyph<'a> {
         cursor.advance::<i16>();
         cursor.advance::<i16>();
         cursor.advance::<i16>();
-        let end_pts_of_contours_byte_len = number_of_contours.max(0) as usize * u16::RAW_BYTE_LEN;
+        let end_pts_of_contours_byte_len = number_of_contours as usize * u16::RAW_BYTE_LEN;
         cursor.advance_by(end_pts_of_contours_byte_len);
         let instruction_length: u16 = cursor.read()?;
         let instructions_byte_len = instruction_length as usize * u8::RAW_BYTE_LEN;

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -1104,7 +1104,8 @@ impl<'a> FontRead<'a> for Ligature<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<GlyphId>();
         let component_count: u16 = cursor.read()?;
-        let component_glyph_ids_byte_len = minus_one(component_count) * GlyphId::RAW_BYTE_LEN;
+        let component_glyph_ids_byte_len =
+            transforms::subtract(component_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(component_glyph_ids_byte_len);
         cursor.finish(LigatureMarker {
             component_glyph_ids_byte_len,

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -40,7 +40,7 @@ impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
         let h_metrics_byte_len = number_of_h_metrics as usize * LongMetric::RAW_BYTE_LEN;
         cursor.advance_by(h_metrics_byte_len);
         let left_side_bearings_byte_len =
-            num_glyphs.saturating_sub(number_of_h_metrics) as usize * i16::RAW_BYTE_LEN;
+            transforms::subtract(num_glyphs, number_of_h_metrics) * i16::RAW_BYTE_LEN;
         cursor.advance_by(left_side_bearings_byte_len);
         cursor.finish(HmtxMarker {
             h_metrics_byte_len,

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1728,7 +1728,8 @@ impl<'a> FontRead<'a> for SequenceRule<'a> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = minus_one(glyph_count) * GlyphId::RAW_BYTE_LEN;
+        let input_sequence_byte_len =
+            transforms::subtract(glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(input_sequence_byte_len);
         let seq_lookup_records_byte_len =
             seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
@@ -2083,7 +2084,8 @@ impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = minus_one(glyph_count) * GlyphId::RAW_BYTE_LEN;
+        let input_sequence_byte_len =
+            transforms::subtract(glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(input_sequence_byte_len);
         let seq_lookup_records_byte_len =
             seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
@@ -2624,7 +2626,8 @@ impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
         let backtrack_sequence_byte_len = backtrack_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(backtrack_sequence_byte_len);
         let input_glyph_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = minus_one(input_glyph_count) * GlyphId::RAW_BYTE_LEN;
+        let input_sequence_byte_len =
+            transforms::subtract(input_glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(input_sequence_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
         let lookahead_sequence_byte_len = lookahead_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
@@ -3089,7 +3092,8 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
         let backtrack_sequence_byte_len = backtrack_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(backtrack_sequence_byte_len);
         let input_glyph_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = minus_one(input_glyph_count) * GlyphId::RAW_BYTE_LEN;
+        let input_sequence_byte_len =
+            transforms::subtract(input_glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
         cursor.advance_by(input_sequence_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
         let lookahead_sequence_byte_len = lookahead_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
@@ -3580,7 +3584,7 @@ impl<'a> FontRead<'a> for Device<'a> {
         let end_size: u16 = cursor.read()?;
         let delta_format: DeltaFormat = cursor.read()?;
         let delta_value_byte_len =
-            delta_value_count(start_size, end_size, delta_format) * u16::RAW_BYTE_LEN;
+            DeltaFormat::value_count(delta_format, start_size, end_size) * u16::RAW_BYTE_LEN;
         cursor.advance_by(delta_value_byte_len);
         cursor.finish(DeviceMarker {
             delta_value_byte_len,

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -204,7 +204,7 @@ impl<'a> FontRead<'a> for Os2<'a> {
         cursor.advance::<i16>();
         cursor.advance::<i16>();
         cursor.advance::<i16>();
-        let panose_10_byte_len = 10 * u8::RAW_BYTE_LEN;
+        let panose_10_byte_len = 10_usize * u8::RAW_BYTE_LEN;
         cursor.advance_by(panose_10_byte_len);
         cursor.advance::<u32>();
         cursor.advance::<u32>();

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -41,7 +41,7 @@ impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
         cursor.advance::<u8>();
         let entry_format: EntryFormat = cursor.read()?;
         let map_count: u16 = cursor.read()?;
-        let map_data_byte_len = map_data_size(entry_format, map_count as u32) * u8::RAW_BYTE_LEN;
+        let map_data_byte_len = EntryFormat::map_size(entry_format, map_count) * u8::RAW_BYTE_LEN;
         cursor.advance_by(map_data_byte_len);
         cursor.finish(DeltaSetIndexMapFormat0Marker { map_data_byte_len })
     }
@@ -136,7 +136,7 @@ impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
         cursor.advance::<u8>();
         let entry_format: EntryFormat = cursor.read()?;
         let map_count: u32 = cursor.read()?;
-        let map_data_byte_len = map_data_size(entry_format, map_count) * u8::RAW_BYTE_LEN;
+        let map_data_byte_len = EntryFormat::map_size(entry_format, map_count) * u8::RAW_BYTE_LEN;
         cursor.advance_by(map_data_byte_len);
         cursor.finish(DeltaSetIndexMapFormat1Marker { map_data_byte_len })
     }

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -40,7 +40,7 @@ impl<'a> FontReadWithArgs<'a> for Vmtx<'a> {
         let v_metrics_byte_len = number_of_long_ver_metrics as usize * LongMetric::RAW_BYTE_LEN;
         cursor.advance_by(v_metrics_byte_len);
         let top_side_bearings_byte_len =
-            num_glyphs.saturating_sub(number_of_long_ver_metrics) as usize * i16::RAW_BYTE_LEN;
+            transforms::subtract(num_glyphs, number_of_long_ver_metrics) * i16::RAW_BYTE_LEN;
         cursor.advance_by(top_side_bearings_byte_len);
         cursor.finish(VmtxMarker {
             v_metrics_byte_len,

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -67,9 +67,17 @@ pub(crate) mod codegen_prelude {
         last.trim_end_matches("Marker>")
     }
 
-    /// used in generated code
-    pub fn minus_one(val: impl Into<usize>) -> usize {
-        val.into().saturating_sub(1)
+    /// named transforms used in 'count', e.g
+    pub(crate) mod transforms {
+        pub fn subtract<T: TryInto<usize>, U: TryInto<usize>>(lhs: T, rhs: U) -> usize {
+            lhs.try_into()
+                .unwrap_or_default()
+                .saturating_sub(rhs.try_into().unwrap_or_default())
+        }
+
+        pub fn half<T: TryInto<usize>>(val: T) -> usize {
+            val.try_into().unwrap_or_default() / 2
+        }
     }
 }
 

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -119,16 +119,18 @@ impl PartialOrd for DeltaFormat {
     }
 }
 
-fn delta_value_count(start_size: u16, end_size: u16, delta_format: DeltaFormat) -> usize {
-    let range_len = end_size.saturating_add(1).saturating_sub(start_size) as usize;
-    let val_per_word = match delta_format {
-        DeltaFormat::Local2BitDeltas => 8,
-        DeltaFormat::Local4BitDeltas => 4,
-        DeltaFormat::Local8BitDeltas => 2,
-        _ => return 0,
-    };
+impl DeltaFormat {
+    pub(crate) fn value_count(self, start_size: u16, end_size: u16) -> usize {
+        let range_len = end_size.saturating_add(1).saturating_sub(start_size) as usize;
+        let val_per_word = match self {
+            DeltaFormat::Local2BitDeltas => 8,
+            DeltaFormat::Local4BitDeltas => 4,
+            DeltaFormat::Local8BitDeltas => 2,
+            _ => return 0,
+        };
 
-    let count = range_len / val_per_word;
-    let extra = (range_len % val_per_word).min(1);
-    count + extra
+        let count = range_len / val_per_word;
+        let extra = (range_len % val_per_word).min(1);
+        count + extra
+    }
 }

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -19,6 +19,11 @@ impl EntryFormat {
     pub fn bit_count(self) -> u8 {
         (self.bits() & Self::INNER_INDEX_BIT_COUNT_MASK.bits()) + 1
     }
+
+    // called from codegen
+    pub(crate) fn map_size(self, map_count: impl Into<u32>) -> usize {
+        self.entry_size() as usize * map_count.into() as usize
+    }
 }
 
 impl<'a> DeltaSetIndexMap<'a> {
@@ -48,10 +53,6 @@ impl<'a> DeltaSetIndexMap<'a> {
             inner: (entry & ((1 << bit_count) - 1)) as u16,
         })
     }
-}
-
-fn map_data_size(entry_format: EntryFormat, map_count: u32) -> usize {
-    entry_format.entry_size() as usize * map_count as usize
 }
 
 impl<'a> ItemVariationStore<'a> {

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -123,19 +123,19 @@ table Cmap4 {
     /// searchRange)
     range_shift: u16,
     /// End characterCode for each segment, last=0xFFFF.
-    #[count($seg_count_x2 as usize / 2)]
+    #[count(half($seg_count_x2))]
     end_code: [u16],
     /// Set to 0.
     #[skip_getter]
     reserved_pad: u16,
     /// Start character code for each segment.
-    #[count($seg_count_x2 as usize / 2)]
+    #[count(half($seg_count_x2))]
     start_code: [u16],
     /// Delta for all character codes in segment.
-    #[count($seg_count_x2 as usize / 2)]
+    #[count(half($seg_count_x2))]
     id_delta: [i16],
     /// Offsets into glyphIdArray or 0
-    #[count($seg_count_x2 as usize / 2)]
+    #[count(half($seg_count_x2))]
     id_range_offsets: [u16],
     /// Glyph index array (arbitrary length)
     #[count(..)]

--- a/resources/codegen_inputs/glyf.rs
+++ b/resources/codegen_inputs/glyf.rs
@@ -36,7 +36,7 @@ table SimpleGlyph {
     y_max: i16,
     /// Array of point indices for the last point of each contour,
     /// in increasing numeric order
-    #[count($number_of_contours.max(0) as usize)]
+    #[count($number_of_contours)]
     end_pts_of_contours: [u16],
     /// Total number of bytes for instructions. If instructionLength is
     /// zero, no instructions are present for this glyph, and this

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -159,7 +159,7 @@ table Ligature {
     component_count: u16,
     /// Array of component glyph IDs — start with the second
     /// component, ordered in writing direction
-    #[count(minus_one($component_count))]
+    #[count(subtract($component_count, 1))]
     component_glyph_ids: [GlyphId],
 }
 

--- a/resources/codegen_inputs/hmtx.rs
+++ b/resources/codegen_inputs/hmtx.rs
@@ -10,7 +10,7 @@ table Hmtx {
     h_metrics: [LongMetric],
     /// Leading (left/top) side bearings for glyph IDs greater than or equal to
     /// numberOfLongMetrics.
-    #[count($num_glyphs.saturating_sub($number_of_h_metrics) as usize)]
+    #[count(subtract($num_glyphs, $number_of_h_metrics))]
     left_side_bearings: [i16],
 }
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -265,7 +265,7 @@ table SequenceRule {
     #[compile(array_len($seq_lookup_records))]
     seq_lookup_count: u16,
     /// Array of input glyph IDs—starting with the second glyph
-    #[count(minus_one($glyph_count))]
+    #[count(subtract($glyph_count, 1))]
     input_sequence: [GlyphId],
     /// Array of Sequence lookup records
     #[count($seq_lookup_count)]
@@ -314,7 +314,7 @@ table ClassSequenceRule {
     seq_lookup_count: u16,
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
-    #[count(minus_one($glyph_count))]
+    #[count(subtract($glyph_count, 1))]
     input_sequence: [GlyphId],
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
@@ -388,7 +388,7 @@ table ChainedSequenceRule {
     #[compile(plus_one($input_sequence.len()))]
     input_glyph_count: u16,
     /// Array of input glyph IDs—start with second glyph
-    #[count(minus_one($input_glyph_count))]
+    #[count(subtract($input_glyph_count, 1))]
     input_sequence: [GlyphId],
     /// Number of glyphs in the lookahead sequence
     #[compile(array_len($lookahead_sequence))]
@@ -455,7 +455,7 @@ table ChainedClassSequenceRule {
     input_glyph_count: u16,
     /// Array of input sequence classes, beginning with the second
     /// glyph position
-    #[count(minus_one($input_glyph_count))]
+    #[count(subtract($input_glyph_count, 1))]
     input_sequence: [GlyphId],
     /// Number of glyphs in the lookahead sequence
     #[compile(array_len($lookahead_sequence))]
@@ -532,7 +532,7 @@ table Device {
     /// Format of deltaValue array data: 0x0001, 0x0002, or 0x0003
     delta_format: DeltaFormat,
     /// Array of compressed data
-    #[count(delta_value_count($start_size, $end_size, $delta_format))]
+    #[count(delta_value_count($delta_format, $start_size, $end_size))]
     delta_value: [u16],
 }
 

--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -11,7 +11,7 @@ table DeltaSetIndexMapFormat0 {
     /// The number of mapping entries.
     map_count: u16,
     /// The delta-set index mapping data. See details below.
-    #[count(map_data_size($entry_format, $map_count as u32))]
+    #[count(map_data_size($entry_format, $map_count))]
     map_data: [u8],
 }
 

--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -11,7 +11,7 @@ table DeltaSetIndexMapFormat0 {
     /// The number of mapping entries.
     map_count: u16,
     /// The delta-set index mapping data. See details below.
-    #[count(map_data_size($entry_format, $map_count))]
+    #[count(delta_set_index_data($entry_format, $map_count))]
     map_data: [u8],
 }
 
@@ -26,7 +26,7 @@ table DeltaSetIndexMapFormat1 {
     /// The number of mapping entries.
     map_count: u32,
     /// The delta-set index mapping data. See details below.
-    #[count(map_data_size($entry_format, $map_count))]
+    #[count(delta_set_index_data($entry_format, $map_count))]
     map_data: [u8],
 }
 

--- a/resources/codegen_inputs/vmtx.rs
+++ b/resources/codegen_inputs/vmtx.rs
@@ -11,6 +11,6 @@ table Vmtx {
     #[count($number_of_long_ver_metrics)]
     v_metrics: [LongMetric],
     /// Top side bearings for glyph IDs greater than or equal to numberOfLongMetrics.
-    #[count($num_glyphs.saturating_sub($number_of_long_ver_metrics) as usize)]
+    #[count(subtract($num_glyphs, $number_of_long_ver_metrics))]
     top_side_bearings: [i16],
 }


### PR DESCRIPTION
This introduces a new, more constrained grammar for this attribute, supporting two forms.

In the simple form, it accepts a single argument, which may be either a `$field`, a literal integer (`52`) or the special token `..`, which means "all remaining data", and is only valid for the last field in a table.

In the non-simple form, it accepts a function like syntax, where the 'function' is one of a small set of predefined options. These functions expect some set number of pre-defined arguments, which may be either `$field`s or literals.

supported 'functions' are currently `subtract`, `half`, `delta_value_count` and `map_data_size`.

----

This actually wasn't too bad? It's a lot more code to do what we want, but it does have a nice conceptual clarity, and it makes it much more possible to imagine things like 'computing the inverse of a function', when the range of possible functions is discrete and known ahead of time. I also think the syntax ends up being quite reasonable.

I'm going to have to perform similar surgery in a few other locations, but I hope that this was one of the larger ones.