### PR TITLE
Fix version type in vhea table

### DIFF
--- a/font-types/src/version.rs
+++ b/font-types/src/version.rs
@@ -35,6 +35,8 @@ impl Version16Dot16 {
     pub const VERSION_0_5: Version16Dot16 = Version16Dot16::new(0, 5);
     /// Version 1.0
     pub const VERSION_1_0: Version16Dot16 = Version16Dot16::new(1, 0);
+    /// Version 1.1
+    pub const VERSION_1_1: Version16Dot16 = Version16Dot16::new(1, 1);
     /// Version 2.0
     pub const VERSION_2_0: Version16Dot16 = Version16Dot16::new(2, 0);
     /// Version 2.5

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -13,7 +13,7 @@ pub struct VheaMarker {}
 impl VheaMarker {
     fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        start..start + Version16Dot16::RAW_BYTE_LEN
     }
     fn ascender_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
@@ -89,7 +89,7 @@ impl TopLevelTable for Vhea<'_> {
 impl<'a> FontRead<'a> for Vhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
+        cursor.advance::<Version16Dot16>();
         cursor.advance::<FWord>();
         cursor.advance::<FWord>();
         cursor.advance::<FWord>();
@@ -114,8 +114,8 @@ impl<'a> FontRead<'a> for Vhea<'a> {
 pub type Vhea<'a> = TableRef<'a, VheaMarker>;
 
 impl<'a> Vhea<'a> {
-    /// The major/minor version (1, 0)
-    pub fn version(&self) -> MajorMinor {
+    /// The major/minor version (1, 1)
+    pub fn version(&self) -> Version16Dot16 {
         let range = self.shape.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }

--- a/resources/codegen_inputs/vhea.rs
+++ b/resources/codegen_inputs/vhea.rs
@@ -3,9 +3,9 @@
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 #[tag = "vhea"]
 table Vhea {
-    /// The major/minor version (1, 0)
-    #[compile(MajorMinor::VERSION_1_1)]
-    version: MajorMinor,
+    /// The major/minor version (1, 1)
+    #[compile(Version16Dot16::VERSION_1_1)]
+    version: Version16Dot16,
     /// Typographic ascent.
     ascender: FWord,
     /// Typographic descent.

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -72,7 +72,7 @@ impl Vhea {
 impl FontWrite for Vhea {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (MajorMinor::VERSION_1_1 as MajorMinor).write_into(writer);
+        (Version16Dot16::VERSION_1_1 as Version16Dot16).write_into(writer);
         self.ascender.write_into(writer);
         self.descender.write_into(writer);
         self.line_gap.write_into(writer);

--- a/write-fonts/src/tables/vhea.rs
+++ b/write-fonts/src/tables/vhea.rs
@@ -1,3 +1,18 @@
 //! the [vhea (Horizontal Header)](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) table
 
 include!("../../generated/generated_vhea.rs");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_serialization() {
+        let table = Vhea::default();
+        let dumped = crate::dump_table(&table).unwrap();
+        let raw_version = u32::from_be_bytes(dumped[..4].try_into().unwrap());
+        // this is not a (u16, u16) pair, but a Version16Dot16, which has its own
+        // weird representation
+        assert_eq!(raw_version, 0x00011000);
+    }
+}


### PR DESCRIPTION
We had specified this as MajorMinor (essentially a packed pair of u16s) but the type in the spec is Version16Dot16, which has its own special representation.