### PR TITLE
[codegen] Make #[available] not accept expressions

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -159,7 +159,9 @@ The following annotations are supported on top-level objects:
   that this field is allowed to be null. This changes the behaviour of getters,
   as well as validation and compilation code.
 - `#[available(version)]`: indicates that a field only exists in a given version
-  of the table.
+  of the table. The `version` may be either a single integer literal
+  (`#[available(1)]`), or a comma-separated pair of integer literals
+  (`#[available(1,1)]`).
 - `#[skip_getter]`: if present, we will not generate a getter for this field.
   Used on things like padding fields.
 - `#[offset_getter(method name)]`: only allowed on offsets or arrays of offsets.

--- a/font-types/src/version.rs
+++ b/font-types/src/version.rs
@@ -121,10 +121,22 @@ impl Compatible for Version16Dot16 {
     }
 }
 
+impl Compatible<(u16, u16)> for Version16Dot16 {
+    fn compatible(&self, other: (u16, u16)) -> bool {
+        self.compatible(Version16Dot16::new(other.0, other.1))
+    }
+}
+
 impl Compatible for MajorMinor {
     #[inline]
     fn compatible(&self, other: Self) -> bool {
         self.major == other.major && self.minor >= other.minor
+    }
+}
+
+impl Compatible<(u16, u16)> for MajorMinor {
+    fn compatible(&self, other: (u16, u16)) -> bool {
+        self.compatible(MajorMinor::new(other.0, other.1))
     }
 }
 

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -237,26 +237,20 @@ impl<'a> FontRead<'a> for TTCHeader<'a> {
         let table_directory_offsets_byte_len = num_fonts as usize * u32::RAW_BYTE_LEN;
         cursor.advance_by(table_directory_offsets_byte_len);
         let dsig_tag_byte_start = version
-            .compatible(MajorMinor::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(MajorMinor::VERSION_2_0)
-            .then(|| cursor.advance::<u32>());
+        version.compatible((2, 0)).then(|| cursor.advance::<u32>());
         let dsig_length_byte_start = version
-            .compatible(MajorMinor::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(MajorMinor::VERSION_2_0)
-            .then(|| cursor.advance::<u32>());
+        version.compatible((2, 0)).then(|| cursor.advance::<u32>());
         let dsig_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(MajorMinor::VERSION_2_0)
-            .then(|| cursor.advance::<u32>());
+        version.compatible((2, 0)).then(|| cursor.advance::<u32>());
         cursor.finish(TTCHeaderMarker {
             table_directory_offsets_byte_len,
             dsig_tag_byte_start,
@@ -328,13 +322,13 @@ impl<'a> SomeTable<'a> for TTCHeader<'a> {
                 "table_directory_offsets",
                 self.table_directory_offsets(),
             )),
-            4usize if version.compatible(MajorMinor::VERSION_2_0) => {
+            4usize if version.compatible((2, 0)) => {
                 Some(Field::new("dsig_tag", self.dsig_tag().unwrap()))
             }
-            5usize if version.compatible(MajorMinor::VERSION_2_0) => {
+            5usize if version.compatible((2, 0)) => {
                 Some(Field::new("dsig_length", self.dsig_length().unwrap()))
             }
-            6usize if version.compatible(MajorMinor::VERSION_2_0) => {
+            6usize if version.compatible((2, 0)) => {
                 Some(Field::new("dsig_offset", self.dsig_offset().unwrap()))
             }
             _ => None,

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -43,11 +43,11 @@ impl<'a> FontRead<'a> for Base<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let item_var_store_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(BaseMarker {
             item_var_store_offset_byte_start,
@@ -119,7 +119,7 @@ impl<'a> SomeTable<'a> for Base<'a> {
                 "vert_axis_offset",
                 FieldType::offset(self.vert_axis_offset(), self.vert_axis()),
             )),
-            3usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            3usize if version.compatible((1, 1)) => Some(Field::new(
                 "item_var_store_offset",
                 FieldType::offset(
                     self.item_var_store_offset().unwrap(),

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -58,18 +58,18 @@ impl<'a> FontRead<'a> for Gdef<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let mark_glyph_sets_def_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_2)
+            .compatible((1, 2))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_2)
+            .compatible((1, 2))
             .then(|| cursor.advance::<Offset16>());
         let item_var_store_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_3)
+            .compatible((1, 3))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_3)
+            .compatible((1, 3))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(GdefMarker {
             mark_glyph_sets_def_offset_byte_start,
@@ -195,14 +195,14 @@ impl<'a> SomeTable<'a> for Gdef<'a> {
                     self.mark_attach_class_def(),
                 ),
             )),
-            5usize if version.compatible(MajorMinor::VERSION_1_2) => Some(Field::new(
+            5usize if version.compatible((1, 2)) => Some(Field::new(
                 "mark_glyph_sets_def_offset",
                 FieldType::offset(
                     self.mark_glyph_sets_def_offset().unwrap(),
                     self.mark_glyph_sets_def().unwrap(),
                 ),
             )),
-            6usize if version.compatible(MajorMinor::VERSION_1_3) => Some(Field::new(
+            6usize if version.compatible((1, 3)) => Some(Field::new(
                 "item_var_store_offset",
                 FieldType::offset(
                     self.item_var_store_offset().unwrap(),

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -49,11 +49,11 @@ impl<'a> FontRead<'a> for Gpos<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let feature_variations_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(GposMarker {
             feature_variations_offset_byte_start,
@@ -141,7 +141,7 @@ impl<'a> SomeTable<'a> for Gpos<'a> {
                 "lookup_list_offset",
                 FieldType::offset(self.lookup_list_offset(), self.lookup_list()),
             )),
-            4usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            4usize if version.compatible((1, 1)) => Some(Field::new(
                 "feature_variations_offset",
                 FieldType::offset(
                     self.feature_variations_offset().unwrap(),

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -48,11 +48,11 @@ impl<'a> FontRead<'a> for Gsub<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let feature_variations_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(GsubMarker {
             feature_variations_offset_byte_start,
@@ -141,7 +141,7 @@ impl<'a> SomeTable<'a> for Gsub<'a> {
                 "lookup_list_offset",
                 FieldType::offset(self.lookup_list_offset(), self.lookup_list()),
             )),
-            4usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            4usize if version.compatible((1, 1)) => Some(Field::new(
                 "feature_variations_offset",
                 FieldType::offset(
                     self.feature_variations_offset().unwrap(),

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -98,96 +98,70 @@ impl<'a> FontRead<'a> for Maxp<'a> {
         let version: Version16Dot16 = cursor.read()?;
         cursor.advance::<u16>();
         let max_points_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_contours_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_composite_points_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_composite_contours_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_zones_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_twilight_points_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_storage_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_function_defs_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_instruction_defs_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_stack_elements_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_size_of_instructions_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_component_elements_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         let max_component_depth_byte_start = version
-            .compatible(Version16Dot16::VERSION_1_0)
+            .compatible((1, 0))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(Version16Dot16::VERSION_1_0)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
         cursor.finish(MaxpMarker {
             max_points_byte_start,
             max_contours_byte_start,
@@ -315,51 +289,51 @@ impl<'a> SomeTable<'a> for Maxp<'a> {
         match idx {
             0usize => Some(Field::new("version", self.version())),
             1usize => Some(Field::new("num_glyphs", self.num_glyphs())),
-            2usize if version.compatible(Version16Dot16::VERSION_1_0) => {
+            2usize if version.compatible((1, 0)) => {
                 Some(Field::new("max_points", self.max_points().unwrap()))
             }
-            3usize if version.compatible(Version16Dot16::VERSION_1_0) => {
+            3usize if version.compatible((1, 0)) => {
                 Some(Field::new("max_contours", self.max_contours().unwrap()))
             }
-            4usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            4usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_composite_points",
                 self.max_composite_points().unwrap(),
             )),
-            5usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            5usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_composite_contours",
                 self.max_composite_contours().unwrap(),
             )),
-            6usize if version.compatible(Version16Dot16::VERSION_1_0) => {
+            6usize if version.compatible((1, 0)) => {
                 Some(Field::new("max_zones", self.max_zones().unwrap()))
             }
-            7usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            7usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_twilight_points",
                 self.max_twilight_points().unwrap(),
             )),
-            8usize if version.compatible(Version16Dot16::VERSION_1_0) => {
+            8usize if version.compatible((1, 0)) => {
                 Some(Field::new("max_storage", self.max_storage().unwrap()))
             }
-            9usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            9usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_function_defs",
                 self.max_function_defs().unwrap(),
             )),
-            10usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            10usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_instruction_defs",
                 self.max_instruction_defs().unwrap(),
             )),
-            11usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            11usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_stack_elements",
                 self.max_stack_elements().unwrap(),
             )),
-            12usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            12usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_size_of_instructions",
                 self.max_size_of_instructions().unwrap(),
             )),
-            13usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            13usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_component_elements",
                 self.max_component_elements().unwrap(),
             )),
-            14usize if version.compatible(Version16Dot16::VERSION_1_0) => Some(Field::new(
+            14usize if version.compatible((1, 0)) => Some(Field::new(
                 "max_component_depth",
                 self.max_component_depth().unwrap(),
             )),

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -85,30 +85,30 @@ impl<'a> FontRead<'a> for Post<'a> {
         cursor.advance::<u32>();
         cursor.advance::<u32>();
         let num_glyphs_byte_start = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.position())
             .transpose()?;
         let num_glyphs = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.read::<u16>())
             .transpose()?
             .unwrap_or(0);
         let glyph_name_index_byte_start = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.position())
             .transpose()?;
         let glyph_name_index_byte_len = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible((2, 0))
             .then_some(num_glyphs as usize * u16::RAW_BYTE_LEN);
         if let Some(value) = glyph_name_index_byte_len {
             cursor.advance_by(value);
         }
         let string_data_byte_start = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible((2, 0))
             .then(|| cursor.position())
             .transpose()?;
         let string_data_byte_len = version
-            .compatible(Version16Dot16::VERSION_2_0)
+            .compatible((2, 0))
             .then_some(cursor.remaining_bytes());
         if let Some(value) = string_data_byte_len {
             cursor.advance_by(value);
@@ -237,14 +237,14 @@ impl<'a> SomeTable<'a> for Post<'a> {
             6usize => Some(Field::new("max_mem_type42", self.max_mem_type42())),
             7usize => Some(Field::new("min_mem_type1", self.min_mem_type1())),
             8usize => Some(Field::new("max_mem_type1", self.max_mem_type1())),
-            9usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+            9usize if version.compatible((2, 0)) => {
                 Some(Field::new("num_glyphs", self.num_glyphs().unwrap()))
             }
-            10usize if version.compatible(Version16Dot16::VERSION_2_0) => Some(Field::new(
+            10usize if version.compatible((2, 0)) => Some(Field::new(
                 "glyph_name_index",
                 self.glyph_name_index().unwrap(),
             )),
-            11usize if version.compatible(Version16Dot16::VERSION_2_0) => {
+            11usize if version.compatible((2, 0)) => {
                 Some(Field::new("string_data", self.traverse_string_data()))
             }
             _ => None,

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -58,12 +58,10 @@ impl<'a> FontRead<'a> for Stat<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset32>();
         let elided_fallback_name_id_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
-        version
-            .compatible(MajorMinor::VERSION_1_1)
-            .then(|| cursor.advance::<u16>());
+        version.compatible((1, 1)).then(|| cursor.advance::<u16>());
         cursor.finish(StatMarker {
             elided_fallback_name_id_byte_start,
         })
@@ -171,7 +169,7 @@ impl<'a> SomeTable<'a> for Stat<'a> {
                     self.offset_to_axis_values(),
                 ),
             )),
-            6usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            6usize if version.compatible((1, 1)) => Some(Field::new(
                 "elided_fallback_name_id",
                 self.elided_fallback_name_id().unwrap(),
             )),

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -62,25 +62,25 @@ impl<'a> FontRead<'a> for KindsOfOffsets<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let versioned_nullable_record_array_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.advance::<Offset16>());
         let versioned_nonnullable_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.advance::<Offset16>());
         let versioned_nullable_offset_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(KindsOfOffsetsMarker {
             versioned_nullable_record_array_offset_byte_start,
@@ -227,7 +227,7 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
                     self.offset_data(),
                 ),
             )),
-            6usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            6usize if version.compatible((1, 1)) => Some(Field::new(
                 "versioned_nullable_record_array_offset",
                 traversal::FieldType::offset_to_array_of_records(
                     self.versioned_nullable_record_array_offset().unwrap(),
@@ -236,14 +236,14 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
                     self.offset_data(),
                 ),
             )),
-            7usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            7usize if version.compatible((1, 1)) => Some(Field::new(
                 "versioned_nonnullable_offset",
                 FieldType::offset(
                     self.versioned_nonnullable_offset().unwrap(),
                     self.versioned_nonnullable().unwrap(),
                 ),
             )),
-            8usize if version.compatible(MajorMinor::VERSION_1_1) => Some(Field::new(
+            8usize if version.compatible((1, 1)) => Some(Field::new(
                 "versioned_nullable_offset",
                 FieldType::offset(
                     self.versioned_nullable_offset().unwrap(),
@@ -310,21 +310,21 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets<'a> {
         let nullable_offsets_byte_len = count as usize * Offset16::RAW_BYTE_LEN;
         cursor.advance_by(nullable_offsets_byte_len);
         let versioned_nonnullable_offsets_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         let versioned_nonnullable_offsets_byte_len = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then_some(count as usize * Offset16::RAW_BYTE_LEN);
         if let Some(value) = versioned_nonnullable_offsets_byte_len {
             cursor.advance_by(value);
         }
         let versioned_nullable_offsets_byte_start = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| cursor.position())
             .transpose()?;
         let versioned_nullable_offsets_byte_len = version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then_some(count as usize * Offset16::RAW_BYTE_LEN);
         if let Some(value) = versioned_nullable_offsets_byte_len {
             cursor.advance_by(value);
@@ -452,7 +452,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                     ),
                 )
             }),
-            4usize if version.compatible(MajorMinor::VERSION_1_1) => Some({
+            4usize if version.compatible((1, 1)) => Some({
                 let data = self.data;
                 Field::new(
                     "versioned_nonnullable_offsets",
@@ -466,7 +466,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                     ),
                 )
             }),
-            5usize if version.compatible(MajorMinor::VERSION_1_1) => Some({
+            5usize if version.compatible((1, 1)) => Some({
                 let data = self.data;
                 Field::new(
                     "versioned_nullable_offsets",

--- a/resources/codegen_inputs/base.rs
+++ b/resources/codegen_inputs/base.rs
@@ -14,7 +14,7 @@ table Base {
     #[nullable]
     vert_axis_offset: Offset16<Axis>,
     /// Offset to Item Variation Store table, from beginning of BASE table (may be null)
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     #[nullable]
     item_var_store_offset: Offset32<ItemVariationStore>,
 }

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -48,12 +48,12 @@ table TTCHeader {
     table_directory_offsets: [u32],
 
     /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
-    #[available(MajorMinor::VERSION_2_0)]
+    #[available(2,0)]
     dsig_tag: u32,
     /// The length (in bytes) of the DSIG table (null if no signature)
-    #[available(MajorMinor::VERSION_2_0)]
+    #[available(2,0)]
     dsig_length: u32,
     /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
-    #[available(MajorMinor::VERSION_2_0)]
+    #[available(2,0)]
     dsig_offset: u32,
 }

--- a/resources/codegen_inputs/gdef.rs
+++ b/resources/codegen_inputs/gdef.rs
@@ -25,12 +25,12 @@ table Gdef {
     mark_attach_class_def_offset: Offset16<ClassDef>,
     /// Offset to the table of mark glyph set definitions, from
     /// beginning of GDEF header (may be NULL)
-    #[available(MajorMinor::VERSION_1_2)]
+    #[available(1,2)]
     #[nullable]
     mark_glyph_sets_def_offset: Offset16<MarkGlyphSets>,
     /// Offset to the Item Variation Store table, from beginning of
     /// GDEF header (may be NULL)
-    #[available(MajorMinor::VERSION_1_3)]
+    #[available(1,3)]
     #[nullable]
     item_var_store_offset: Offset32<ItemVariationStore>,
 }

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -17,7 +17,7 @@ table Gpos {
     feature_list_offset: Offset16<FeatureList>,
     /// Offset to LookupList table, from beginning of GPOS table
     lookup_list_offset: Offset16<PositionLookupList>,
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     #[nullable]
     feature_variations_offset: Offset32<FeatureVariations>,
 }

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -16,7 +16,7 @@ table Gsub {
     lookup_list_offset: Offset16<SubstitutionLookupList>,
     /// Offset to FeatureVariations table, from beginning of the GSUB
     /// table (may be NULL)
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     #[nullable]
     feature_variations_offset: Offset32<FeatureVariations>,
 }

--- a/resources/codegen_inputs/maxp.rs
+++ b/resources/codegen_inputs/maxp.rs
@@ -10,46 +10,46 @@ table Maxp {
     /// The number of glyphs in the font.
     num_glyphs: u16,
     /// Maximum points in a non-composite glyph.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_points: u16,
     /// Maximum contours in a non-composite glyph.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_contours: u16,
     /// Maximum points in a composite glyph.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_composite_points: u16,
     /// Maximum contours in a composite glyph.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_composite_contours: u16,
     /// 1 if instructions do not use the twilight zone (Z0), or 2 if
     /// instructions do use Z0; should be set to 2 in most cases.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_zones: u16,
     /// Maximum points used in Z0.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_twilight_points: u16,
     /// Number of Storage Area locations.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_storage: u16,
     /// Number of FDEFs, equal to the highest function number + 1.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_function_defs: u16,
     /// Number of IDEFs.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_instruction_defs: u16,
     /// Maximum stack depth across Font Program ('fpgm' table), CVT
     /// Program ('prep' table) and all glyph instructions (in the
     /// 'glyf' table).
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_stack_elements: u16,
     /// Maximum byte count for glyph instructions.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_size_of_instructions: u16,
     /// Maximum number of components referenced at “top level” for
     /// any composite glyph.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_component_elements: u16,
     /// Maximum levels of recursion; 1 for simple components.
-    #[available(Version16Dot16::VERSION_1_0)]
+    #[available(1,0)]
     max_component_depth: u16,
 }

--- a/resources/codegen_inputs/post.rs
+++ b/resources/codegen_inputs/post.rs
@@ -43,16 +43,16 @@ table Post {
     max_mem_type1: u32,
     /// Number of glyphs (this should be the same as numGlyphs in
     /// 'maxp' table).
-    #[available(Version16Dot16::VERSION_2_0)]
+    #[available(2,0)]
     num_glyphs: u16,
     /// Array of indices into the string data. See below for details.
     #[count($num_glyphs)]
-    #[available(Version16Dot16::VERSION_2_0)]
+    #[available(2,0)]
     glyph_name_index: [u16],
     /// Storage for the string data.
     #[count(..)]
     #[validate(skip)]
-    #[available(Version16Dot16::VERSION_2_0)]
+    #[available(2,0)]
     #[traverse_with(traverse_string_data)]
     string_data: VarLenArray<PString<'a>>,
 }

--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -37,7 +37,7 @@ table Stat {
     /// Name ID used as fallback when projection of names into a
     /// particular font model produces a subfamily name containing only
     /// elidable elements.
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     elided_fallback_name_id: u16,
 }
 

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -29,13 +29,13 @@ table KindsOfOffsets {
     /// A nullable, versioned offset to an array of records
     #[read_offset_with($array_offset_count)]
     #[nullable]
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     versioned_nullable_record_array_offset: Offset16<[Shmecord]>,
     /// A normal offset that is versioned
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     versioned_nonnullable_offset: Offset16<Dummy>,
     /// An offset that is nullable and versioned
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     #[nullable]
     versioned_nullable_offset: Offset32<Dummy>,
 }
@@ -57,11 +57,11 @@ table KindsOfArraysOfOffsets {
     #[count($count)]
     nullable_offsets: [Offset16<Dummy>],
     /// A normal offset that is versioned
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     #[count($count)]
     versioned_nonnullable_offsets: [Offset16<Dummy>],
     /// An offset that is nullable and versioned
-    #[available(MajorMinor::VERSION_1_1)]
+    #[available(1,1)]
     #[nullable]
     #[count($count)]
     versioned_nullable_offsets: [Offset16<Dummy>],

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -35,7 +35,7 @@ impl FontWrite for Base {
         self.horiz_axis.write_into(writer);
         self.vert_axis.write_into(writer);
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| self.item_var_store.write_into(writer));
     }
 }

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -127,17 +127,17 @@ impl Validate for TTCHeader {
                 }
             });
             ctx.in_field("dsig_tag", |ctx| {
-                if version.compatible(MajorMinor::VERSION_2_0) && self.dsig_tag.is_none() {
+                if version.compatible((2, 0)) && self.dsig_tag.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("dsig_length", |ctx| {
-                if version.compatible(MajorMinor::VERSION_2_0) && self.dsig_length.is_none() {
+                if version.compatible((2, 0)) && self.dsig_length.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("dsig_offset", |ctx| {
-                if version.compatible(MajorMinor::VERSION_2_0) && self.dsig_offset.is_none() {
+                if version.compatible((2, 0)) && self.dsig_offset.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -58,10 +58,10 @@ impl FontWrite for Gdef {
         self.lig_caret_list.write_into(writer);
         self.mark_attach_class_def.write_into(writer);
         version
-            .compatible(MajorMinor::VERSION_1_2)
+            .compatible((1, 2))
             .then(|| self.mark_glyph_sets_def.write_into(writer));
         version
-            .compatible(MajorMinor::VERSION_1_3)
+            .compatible((1, 3))
             .then(|| self.item_var_store.write_into(writer));
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -45,7 +45,7 @@ impl FontWrite for Gpos {
         self.feature_list.write_into(writer);
         self.lookup_list.write_into(writer);
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| self.feature_variations.write_into(writer));
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -44,7 +44,7 @@ impl FontWrite for Gsub {
         self.feature_list.write_into(writer);
         self.lookup_list.write_into(writer);
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| self.feature_variations.write_into(writer));
     }
 }

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -58,79 +58,79 @@ impl FontWrite for Maxp {
         let version = self.compute_version() as Version16Dot16;
         version.write_into(writer);
         self.num_glyphs.write_into(writer);
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_points
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_contours
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_composite_points
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_composite_contours
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_zones
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_twilight_points
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_storage
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_function_defs
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_instruction_defs
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_stack_elements
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_size_of_instructions
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_component_elements
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_1_0).then(|| {
+        version.compatible((1, 0)).then(|| {
             self.max_component_depth
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -144,85 +144,67 @@ impl Validate for Maxp {
         ctx.in_table("Maxp", |ctx| {
             let version: Version16Dot16 = self.compute_version();
             ctx.in_field("max_points", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0) && self.max_points.is_none() {
+                if version.compatible((1, 0)) && self.max_points.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_contours", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0) && self.max_contours.is_none() {
+                if version.compatible((1, 0)) && self.max_contours.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_composite_points", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_composite_points.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_composite_points.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_composite_contours", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_composite_contours.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_composite_contours.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_zones", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0) && self.max_zones.is_none() {
+                if version.compatible((1, 0)) && self.max_zones.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_twilight_points", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_twilight_points.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_twilight_points.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_storage", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0) && self.max_storage.is_none() {
+                if version.compatible((1, 0)) && self.max_storage.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_function_defs", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_function_defs.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_function_defs.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_instruction_defs", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_instruction_defs.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_instruction_defs.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_stack_elements", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_stack_elements.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_stack_elements.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_size_of_instructions", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_size_of_instructions.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_size_of_instructions.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_component_elements", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_component_elements.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_component_elements.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_component_depth", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_1_0)
-                    && self.max_component_depth.is_none()
-                {
+                if version.compatible((1, 0)) && self.max_component_depth.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -109,19 +109,19 @@ impl FontWrite for Post {
         self.max_mem_type42.write_into(writer);
         self.min_mem_type1.write_into(writer);
         self.max_mem_type1.write_into(writer);
-        version.compatible(Version16Dot16::VERSION_2_0).then(|| {
+        version.compatible((2, 0)).then(|| {
             self.num_glyphs
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_2_0).then(|| {
+        version.compatible((2, 0)).then(|| {
             self.glyph_name_index
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(Version16Dot16::VERSION_2_0).then(|| {
+        version.compatible((2, 0)).then(|| {
             self.string_data
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -135,14 +135,12 @@ impl Validate for Post {
         ctx.in_table("Post", |ctx| {
             let version = self.version;
             ctx.in_field("num_glyphs", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_2_0) && self.num_glyphs.is_none() {
+                if version.compatible((2, 0)) && self.num_glyphs.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("glyph_name_index", |ctx| {
-                if version.compatible(Version16Dot16::VERSION_2_0)
-                    && self.glyph_name_index.is_none()
-                {
+                if version.compatible((2, 0)) && self.glyph_name_index.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.glyph_name_index.is_some()

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -36,7 +36,7 @@ impl FontWrite for Stat {
         self.design_axes.write_into(writer);
         (array_len(&self.offset_to_axis_values).unwrap() as u16).write_into(writer);
         self.offset_to_axis_values.write_into(writer);
-        version.compatible(MajorMinor::VERSION_1_1).then(|| {
+        version.compatible((1, 1)).then(|| {
             self.elided_fallback_name_id
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -56,9 +56,7 @@ impl Validate for Stat {
                 self.offset_to_axis_values.validate_impl(ctx);
             });
             ctx.in_field("elided_fallback_name_id", |ctx| {
-                if version.compatible(MajorMinor::VERSION_1_1)
-                    && self.elided_fallback_name_id.is_none()
-                {
+                if version.compatible((1, 1)) && self.elided_fallback_name_id.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -51,16 +51,16 @@ impl FontWrite for KindsOfOffsets {
         self.array.write_into(writer);
         self.record_array.write_into(writer);
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| self.versioned_nullable_record_array.write_into(writer));
-        version.compatible(MajorMinor::VERSION_1_1).then(|| {
+        version.compatible((1, 1)).then(|| {
             self.versioned_nonnullable
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
         version
-            .compatible(MajorMinor::VERSION_1_1)
+            .compatible((1, 1))
             .then(|| self.versioned_nullable.write_into(writer));
     }
 }
@@ -82,9 +82,7 @@ impl Validate for KindsOfOffsets {
                 self.versioned_nullable_record_array.validate_impl(ctx);
             });
             ctx.in_field("versioned_nonnullable", |ctx| {
-                if version.compatible(MajorMinor::VERSION_1_1)
-                    && self.versioned_nonnullable.is_none()
-                {
+                if version.compatible((1, 1)) && self.versioned_nonnullable.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 self.versioned_nonnullable.validate_impl(ctx);
@@ -151,13 +149,13 @@ impl FontWrite for KindsOfArraysOfOffsets {
         (array_len(&self.nonnullables).unwrap() as u16).write_into(writer);
         self.nonnullables.write_into(writer);
         self.nullables.write_into(writer);
-        version.compatible(MajorMinor::VERSION_1_1).then(|| {
+        version.compatible((1, 1)).then(|| {
             self.versioned_nonnullables
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(MajorMinor::VERSION_1_1).then(|| {
+        version.compatible((1, 1)).then(|| {
             self.versioned_nullables
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -183,9 +181,7 @@ impl Validate for KindsOfArraysOfOffsets {
                 self.nullables.validate_impl(ctx);
             });
             ctx.in_field("versioned_nonnullables", |ctx| {
-                if version.compatible(MajorMinor::VERSION_1_1)
-                    && self.versioned_nonnullables.is_none()
-                {
+                if version.compatible((1, 1)) && self.versioned_nonnullables.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_nonnullables.is_some()
@@ -196,8 +192,7 @@ impl Validate for KindsOfArraysOfOffsets {
                 self.versioned_nonnullables.validate_impl(ctx);
             });
             ctx.in_field("versioned_nullables", |ctx| {
-                if version.compatible(MajorMinor::VERSION_1_1) && self.versioned_nullables.is_none()
-                {
+                if version.compatible((1, 1)) && self.versioned_nullables.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_nullables.is_some()


### PR DESCRIPTION
Further work on making us schema-ready. Previously this attribute accepted any expression that evaluated to something which implemented the 'Comparable' trait, for the appropriate version type. In practice, this was so that we could provide both literal integers as well as named constants, such as `MajorMinor::VERSION_1_1`.

The schema will not support the concept of an arbitrary expression, however, and so this needs a more constrained representation.

With this patch, we no longer support the use of named constants in this attribute; instead the argument must be either a single integer literal, or a comma-separated major/minor pair of literal integers, which we will convert to the appropriate type when comparing.