### PR TITLE
Fixup new rustdoc warning

### DIFF
--- a/font-types/src/raw.rs
+++ b/font-types/src/raw.rs
@@ -52,7 +52,7 @@ pub trait ReadScalar: FixedSize {
 pub struct BigEndian<T: Scalar>(pub(crate) T::Raw);
 
 impl<T: Scalar> BigEndian<T> {
-    /// construct a new BigEndian<T> from raw bytes
+    /// construct a new `BigEndian<T>` from raw bytes
     pub fn new(raw: T::Raw) -> BigEndian<T> {
         BigEndian(raw)
     }


### PR DESCRIPTION
As of rustc 1.66, rustdoc warns if you have anything that looks like an HTML tag (e.g., a generic) that is not enclosed in backticks.

Just Merge Me™️