### PR TITLE
[write-fonts] Small ValueRecord additions

### DIFF
--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -13,7 +13,7 @@ pub const WIDTH_32: usize = 4;
 /// An offset subtable.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
     obj: T,
     //error: Option<Box<ReadError>>,
@@ -22,7 +22,7 @@ pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
 /// An offset subtable which may be null.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NullableOffsetMarker<T, const N: usize = WIDTH_16> {
     obj: Option<T>,
 }

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -1,6 +1,9 @@
 //! OpenType layout.
 
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    hash::Hash,
+};
 
 pub use read_fonts::tables::layout::LookupFlag;
 use read_fonts::FontRead;
@@ -537,6 +540,16 @@ impl PartialEq for Device {
 }
 
 impl Eq for Device {}
+
+//FIXME: ditto
+impl Hash for Device {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.start_size.hash(state);
+        self.end_size.hash(state);
+        (self.delta_format as u16).hash(state);
+        self.delta_value.hash(state);
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -11,7 +11,7 @@ use crate::{
     write::{FontWrite, TableWriter},
 };
 
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq, Hash)]
 pub struct ValueRecord {
     pub x_placement: Option<i16>,
     pub y_placement: Option<i16>,
@@ -43,6 +43,11 @@ impl ValueRecord {
             | flag_if_true!(self.y_placement_device, ValueFormat::Y_PLACEMENT_DEVICE)
             | flag_if_true!(self.x_advance_device, ValueFormat::X_ADVANCE_DEVICE)
             | flag_if_true!(self.y_advance_device, ValueFormat::Y_ADVANCE_DEVICE)
+    }
+
+    /// Return the number of bytes required to encode this value record
+    pub fn encoded_size(&self) -> usize {
+        self.format().bits().count_ones() as usize * 2
     }
 }
 


### PR DESCRIPTION
This makes ValueRecord hashable, and also adds a method to ValueFormat for computing the byte size of the record.

This has again highlighted one annoyance of this tool, which is there's no way to change or augment the set of traits that we derive for a given object; it would be nice if we could add support in codegen for this. (I am mentioning it here so that I can reference this in a new issue.)