### PR TITLE
Change class sequence rules to use u16

### DIFF
--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -2085,7 +2085,7 @@ impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
         let input_sequence_byte_len =
-            transforms::subtract(glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
+            transforms::subtract(glyph_count, 1_usize) * u16::RAW_BYTE_LEN;
         cursor.advance_by(input_sequence_byte_len);
         let seq_lookup_records_byte_len =
             seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
@@ -2115,7 +2115,7 @@ impl<'a> ClassSequenceRule<'a> {
 
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
-    pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId>] {
+    pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.input_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
@@ -3089,14 +3089,14 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_sequence_byte_len = backtrack_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let backtrack_sequence_byte_len = backtrack_glyph_count as usize * u16::RAW_BYTE_LEN;
         cursor.advance_by(backtrack_sequence_byte_len);
         let input_glyph_count: u16 = cursor.read()?;
         let input_sequence_byte_len =
-            transforms::subtract(input_glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
+            transforms::subtract(input_glyph_count, 1_usize) * u16::RAW_BYTE_LEN;
         cursor.advance_by(input_sequence_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_sequence_byte_len = lookahead_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let lookahead_sequence_byte_len = lookahead_glyph_count as usize * u16::RAW_BYTE_LEN;
         cursor.advance_by(lookahead_sequence_byte_len);
         let seq_lookup_count: u16 = cursor.read()?;
         let seq_lookup_records_byte_len =
@@ -3122,7 +3122,7 @@ impl<'a> ChainedClassSequenceRule<'a> {
     }
 
     /// Array of backtrack-sequence classes
-    pub fn backtrack_sequence(&self) -> &'a [BigEndian<GlyphId>] {
+    pub fn backtrack_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.backtrack_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
@@ -3135,7 +3135,7 @@ impl<'a> ChainedClassSequenceRule<'a> {
 
     /// Array of input sequence classes, beginning with the second
     /// glyph position
-    pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId>] {
+    pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.input_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
@@ -3147,7 +3147,7 @@ impl<'a> ChainedClassSequenceRule<'a> {
     }
 
     /// Array of lookahead-sequence classes
-    pub fn lookahead_sequence(&self) -> &'a [BigEndian<GlyphId>] {
+    pub fn lookahead_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.lookahead_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -316,7 +316,7 @@ table ClassSequenceRule {
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
     #[count(subtract($glyph_count, 1))]
-    input_sequence: [GlyphId],
+    input_sequence: [u16],
     /// Array of SequenceLookupRecords
     #[count($seq_lookup_count)]
     seq_lookup_records: [SequenceLookupRecord],
@@ -450,20 +450,20 @@ table ChainedClassSequenceRule {
     backtrack_glyph_count: u16,
     /// Array of backtrack-sequence classes
     #[count($backtrack_glyph_count)]
-    backtrack_sequence: [GlyphId],
+    backtrack_sequence: [u16],
     /// Total number of glyphs in the input sequence
     #[compile(plus_one($input_sequence.len()))]
     input_glyph_count: u16,
     /// Array of input sequence classes, beginning with the second
     /// glyph position
     #[count(subtract($input_glyph_count, 1))]
-    input_sequence: [GlyphId],
+    input_sequence: [u16],
     /// Number of glyphs in the lookahead sequence
     #[compile(array_len($lookahead_sequence))]
     lookahead_glyph_count: u16,
     /// Array of lookahead-sequence classes
     #[count($lookahead_glyph_count)]
-    lookahead_sequence: [GlyphId],
+    lookahead_sequence: [u16],
     /// Number of SequenceLookupRecords
     #[compile(array_len($seq_lookup_records))]
     seq_lookup_count: u16,

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -1391,17 +1391,14 @@ impl<'a> FontRead<'a> for ClassSequenceRuleSet {
 pub struct ClassSequenceRule {
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
-    pub input_sequence: Vec<GlyphId>,
+    pub input_sequence: Vec<u16>,
     /// Array of SequenceLookupRecords
     pub seq_lookup_records: Vec<SequenceLookupRecord>,
 }
 
 impl ClassSequenceRule {
     /// Construct a new `ClassSequenceRule`
-    pub fn new(
-        input_sequence: Vec<GlyphId>,
-        seq_lookup_records: Vec<SequenceLookupRecord>,
-    ) -> Self {
+    pub fn new(input_sequence: Vec<u16>, seq_lookup_records: Vec<SequenceLookupRecord>) -> Self {
         Self {
             input_sequence: input_sequence.into_iter().map(Into::into).collect(),
             seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
@@ -2033,12 +2030,12 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet {
 #[derive(Clone, Debug, Default)]
 pub struct ChainedClassSequenceRule {
     /// Array of backtrack-sequence classes
-    pub backtrack_sequence: Vec<GlyphId>,
+    pub backtrack_sequence: Vec<u16>,
     /// Array of input sequence classes, beginning with the second
     /// glyph position
-    pub input_sequence: Vec<GlyphId>,
+    pub input_sequence: Vec<u16>,
     /// Array of lookahead-sequence classes
-    pub lookahead_sequence: Vec<GlyphId>,
+    pub lookahead_sequence: Vec<u16>,
     /// Array of SequenceLookupRecords
     pub seq_lookup_records: Vec<SequenceLookupRecord>,
 }
@@ -2046,9 +2043,9 @@ pub struct ChainedClassSequenceRule {
 impl ChainedClassSequenceRule {
     /// Construct a new `ChainedClassSequenceRule`
     pub fn new(
-        backtrack_sequence: Vec<GlyphId>,
-        input_sequence: Vec<GlyphId>,
-        lookahead_sequence: Vec<GlyphId>,
+        backtrack_sequence: Vec<u16>,
+        input_sequence: Vec<u16>,
+        lookahead_sequence: Vec<u16>,
         seq_lookup_records: Vec<SequenceLookupRecord>,
     ) -> Self {
         Self {


### PR DESCRIPTION
These are currently defined as sequences of `GlyphId` but should actually be arbitrary `u16` class values as stored in a `ClassDef`.