### PR TITLE
Fix error span alignment, update deps

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/main.rs"
 
 [dependencies]
 font-types = { version = "0.0.5", path = "../font-types" }
-rustfmt-wrapper = "0.1"
+rustfmt-wrapper = "0.2"
 regex = "1.5"
-miette = { version =  "4.6", features = ["fancy"] }
+miette = { version =  "5.0", features = ["fancy"] }
 syn =  { version = "1.0", features = ["parsing",  "extra-traits", "full"] }
 proc-macro2 =  { version = "1.0", features = ["span-locations"]}
 quote = "1.0"
@@ -23,6 +23,6 @@ toml = "0.5"
 serde = {version = "1.0", features = ["derive"] }
 xflags = "0.2.4"
 log = "0.4"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 rayon = "1.5.3"
 indexmap = "1.9.1"

--- a/font-codegen/src/error.rs
+++ b/font-codegen/src/error.rs
@@ -42,9 +42,11 @@ impl ErrorReport {
         let message = error.to_string();
         let span = error.span();
         let start = span.start();
-        let start = SourceOffset::from_location(&text, start.line, start.column);
+        // we add + 1 to these offsets because of weird upstream behaviour I'm too lazy
+        // to try and land a fix for. If spans are off-by-one, delete these + 1s :)
+        let start = SourceOffset::from_location(&text, start.line, start.column + 1);
         let end = span.end();
-        let end = SourceOffset::from_location(&text, end.line, end.column);
+        let end = SourceOffset::from_location(&text, end.line, end.column + 1);
         let start_off = start.offset();
         let len = end.offset() - start_off;
         let location = LabeledSpan::new(Some(message), start_off, len);


### PR DESCRIPTION
The upstream logic for mapping line/col to offset seems broken; as far as I can tell it is attempting to handle both 0-index and 1-indexed columns? In any case this patch seems to work, and this is not a safety critical situation.