### PR TITLE
[codegen] Add #[derive_traits(..)] attribute

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -157,8 +157,9 @@ The following annotations are supported on top-level objects:
   common tables that contain offsets which point to different concrete types
   depending on the containing table, such as the `Layout` subtable shared
   between GPOS and GSUB.
-- `#[derive_traits(Trait, OtherTrait)]` Provide a list of additional traits to
-  be derived for this type. In the case of records, the trait will be derived
+- `#[capabilites(equality, order, hash)]` Provide a list of additional
+  functionality to be implemented for this type. In Rust this means deriving 
+  additional traits. In the case of records, the trait will be derived
   in both `read-fonts` and `write-fonts`, but in the case of tables only for
   `write-fonts` (since tables in `read-fonts` are just byte slices, without
   semantic information)

--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -157,6 +157,11 @@ The following annotations are supported on top-level objects:
   common tables that contain offsets which point to different concrete types
   depending on the containing table, such as the `Layout` subtable shared
   between GPOS and GSUB.
+- `#[derive_traits(Trait, OtherTrait)]` Provide a list of additional traits to
+  be derived for this type. In the case of records, the trait will be derived
+  in both `read-fonts` and `write-fonts`, but in the case of tables only for
+  `write-fonts` (since tables in `read-fonts` are just byte slices, without
+  semantic information)
 
 
 #### field attributes

--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -338,7 +338,7 @@ pub(crate) fn generate_raw_enum(raw: &RawEnum) -> TokenStream {
 
     quote! {
         #( #docs )*
-        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
         #[repr(#typ)]
         pub enum #name {
             #( #variants )*

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -43,10 +43,11 @@ pub(crate) fn generate(item: &Record) -> syn::Result<TokenStream> {
         }
     });
     let maybe_impl_read_with_args = (has_read_args).then(|| generate_read_with_args(item));
-    let maybe_extra_traits = item.attrs.extra_traits.as_ref().map(|args| {
-        let traits = &args.traits;
-        quote!( #( #traits, )* )
-    });
+    let maybe_extra_traits = item
+        .attrs
+        .capabilities
+        .as_ref()
+        .map(|cap| cap.extra_traits());
 
     Ok(quote! {
     #( #docs )*
@@ -248,11 +249,8 @@ pub(crate) fn generate_compile_impl(
         }
         }
     });
-    let maybe_extra_traits = attrs.extra_traits.as_ref().map(|args| {
-        let traits = &args.traits;
-        quote!( #( #traits, )* )
-    });
 
+    let maybe_extra_traits = attrs.capabilities.as_ref().map(|cap| cap.extra_traits());
     let constructor_args_raw = fields.iter_constructor_info().collect::<Vec<_>>();
     let constructor_args = constructor_args_raw.iter().map(
         |FieldConstructorInfo {

--- a/font-types/src/raw.rs
+++ b/font-types/src/raw.rs
@@ -91,6 +91,24 @@ impl<T: Scalar + Copy + PartialEq> PartialEq<T> for BigEndian<T> {
     }
 }
 
+impl<T: Scalar + Copy + PartialOrd + PartialEq> PartialOrd for BigEndian<T>
+where
+    <T as Scalar>::Raw: PartialEq,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.get().partial_cmp(&other.get())
+    }
+}
+
+impl<T: Scalar + Copy + Ord + Eq> Ord for BigEndian<T>
+where
+    <T as Scalar>::Raw: Eq,
+{
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.get().cmp(&other.get())
+    }
+}
+
 // these following impls are an elaborate way to impl ReadScalar for BigEndian<T>
 impl<const N: usize> FixedSize for [u8; N] {
     const RAW_BYTE_LEN: usize = N;

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -158,7 +158,7 @@ impl<'a> SomeRecord<'a> for EncodingRecord {
 }
 
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#platform-ids>
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum PlatformId {
     #[default]

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -1382,7 +1382,7 @@ impl<'a> std::fmt::Debug for VarColorLine<'a> {
 }
 
 /// [Extend](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) enumeration
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum Extend {
     #[default]
@@ -5454,7 +5454,7 @@ impl<'a> std::fmt::Debug for PaintComposite<'a> {
 }
 
 /// [CompositeMode](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite) enumeration
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum CompositeMode {
     Clear = 0,

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -222,7 +222,7 @@ impl<'a> std::fmt::Debug for Gdef<'a> {
 }
 
 /// Used in the [Glyph Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table)
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum GlyphClassDef {
     #[default]

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -3514,7 +3514,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContext<'a> {
 
 /// [Device](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 /// delta formats
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum DeltaFormat {
     /// Signed 2-bit value, 8 values per uint16

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -211,7 +211,7 @@ impl<'a> SomeRecord<'a> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
 #[repr(C)]
 #[repr(packed)]
 pub struct NameRecord {

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -211,7 +211,7 @@ impl<'a> SomeRecord<'a> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(C)]
 #[repr(packed)]
 pub struct NameRecord {

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum MyEnum1 {
     /// doc me baby
@@ -48,7 +48,7 @@ impl<'a> From<MyEnum1> for FieldType<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u16)]
 pub enum MyEnum2 {
     ItsATwo = 2,

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -101,18 +101,6 @@ impl RangeRecord {
     }
 }
 
-impl Ord for DeltaFormat {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (*self as u16).cmp(&(*other as u16))
-    }
-}
-
-impl PartialOrd for DeltaFormat {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(Ord::cmp(self, other))
-    }
-}
-
 impl DeltaFormat {
     pub(crate) fn value_count(self, start_size: u16, end_size: u16) -> usize {
         let range_len = end_size.saturating_add(1).saturating_sub(start_size) as usize;

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -526,6 +526,7 @@ enum u16 DeltaFormat {
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 #[skip_constructor]
+#[derive_traits(PartialEq, Eq, Hash)]
 table Device {
     /// Smallest size to correct, in ppem
     start_size: u16,

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -526,7 +526,7 @@ enum u16 DeltaFormat {
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 #[skip_constructor]
-#[derive_traits(PartialEq, Eq, Hash)]
+#[capabilites(equality, hash)]
 table Device {
     /// Smallest size to correct, in ppem
     start_size: u16,

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -47,6 +47,7 @@ record LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
+#[derive_traits(PartialEq, Eq, PartialOrd, Ord)]
 record NameRecord {
     /// Platform ID.
     platform_id: u16,

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -47,7 +47,7 @@ record LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive_traits(PartialEq, Eq, PartialOrd, Ord)]
+#[capabilites(equality, order)]
 record NameRecord {
     /// Platform ID.
     platform_id: u16,

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -2343,7 +2343,7 @@ impl FontWrite for DeltaFormat {
 }
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Device {
     /// Smallest size to correct, in ppem
     pub start_size: u16,

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -134,7 +134,7 @@ impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NameRecord {
     /// Platform ID.
     pub platform_id: u16,

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -134,7 +134,7 @@ impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq)]
 pub struct NameRecord {
     /// Platform ID.
     pub platform_id: u16,

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -13,7 +13,7 @@ pub const WIDTH_32: usize = 4;
 /// An offset subtable.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
     obj: T,
     //error: Option<Box<ReadError>>,
@@ -22,7 +22,7 @@ pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
 /// An offset subtable which may be null.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NullableOffsetMarker<T, const N: usize = WIDTH_16> {
     obj: Option<T>,
 }

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -551,28 +551,6 @@ fn encode_chunk(chunk: &[i8], mask: u8, bits: usize) -> u16 {
     out
 }
 
-//FIXME: we should derive this in codegen
-impl PartialEq for Device {
-    fn eq(&self, other: &Self) -> bool {
-        self.start_size == other.start_size
-            && self.end_size == other.end_size
-            && self.delta_format == other.delta_format
-            && self.delta_value == other.delta_value
-    }
-}
-
-impl Eq for Device {}
-
-//FIXME: ditto
-impl Hash for Device {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.start_size.hash(state);
-        self.end_size.hash(state);
-        (self.delta_format as u16).hash(state);
-        self.delta_value.hash(state);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -124,41 +124,6 @@ impl FromObjRef<read_fonts::tables::name::NameString<'_>> for String {
 
 impl FromTableRef<read_fonts::tables::name::NameString<'_>> for String {}
 
-impl PartialEq for NameRecord {
-    fn eq(&self, other: &Self) -> bool {
-        self.platform_id == other.platform_id
-            && self.encoding_id == other.encoding_id
-            && self.language_id == other.language_id
-            && self.name_id == other.name_id
-            && self.string == other.string
-    }
-}
-
-impl Eq for NameRecord {}
-
-impl Ord for NameRecord {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (
-            self.platform_id,
-            self.encoding_id,
-            self.language_id,
-            self.name_id,
-        )
-            .cmp(&(
-                other.platform_id,
-                other.encoding_id,
-                other.language_id,
-                other.name_id,
-            ))
-    }
-}
-
-impl PartialOrd for NameRecord {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This was an old todo that I hit again when working on gvar; sometimes we want some particular table/record to implement a specific trait, on a case-by-case basis. This adds support for a new table-level attribute where you can provide a list of traits that will be derived for the type.

While getting this to work I ran into a few existing cases where we were not deriving traits that we could be, so I added those as well (for instance, we will now derive Ord/PartialOrd for generated flags as well as BigEndian<T>).

closes #186 