### PR TITLE
Fix missing Ord impl for flag types

### DIFF
--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -24,7 +24,7 @@ pub(crate) fn generate_flags(raw: &BitFlags) -> proc_macro2::TokenStream {
 
     quote! {
         #( #docs )*
-        #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct #name { bits: #typ }
         impl #name {
             #( #variant_decls )*

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -218,7 +218,7 @@ impl<'a> std::fmt::Debug for SimpleGlyph<'a> {
 }
 
 /// Flags used in [SimpleGlyph]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SimpleGlyphFlags {
     bits: u8,
 }
@@ -725,7 +725,7 @@ impl<'a> std::fmt::Debug for CompositeGlyph<'a> {
 }
 
 /// Flags used in [CompositeGlyph]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompositeGlyphFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -219,7 +219,7 @@ impl<'a> SomeTable<'a> for PositionLookup<'a> {
 }
 
 /// See [ValueRecord]
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValueFormat {
     bits: u16,
 }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -176,7 +176,7 @@ impl<'a> std::fmt::Debug for Gvar<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GvarFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -893,7 +893,7 @@ impl<'a> SomeRecord<'a> for AxisValueRecord {
 }
 
 /// [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags).
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueTableFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_test_flags.rs
+++ b/read-fonts/generated/generated_test_flags.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// Some flags!
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValueFormat {
     bits: u16,
 }

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -401,7 +401,7 @@ impl<'a> SomeTable<'a> for DeltaSetIndexMap<'a> {
 }
 
 /// Entry format for a [DeltaSetIndexMap].
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntryFormat {
     bits: u8,
 }

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -60,4 +60,11 @@ pub mod flags {
         let xplace = ValueFormat::X_PLACEMENT;
         assert_eq!(format!("{xplace:?}"), "X_PLACEMENT");
     }
+
+    // not exactly a test, but this will fail to compile if these are missing
+    #[test]
+    fn impl_traits() {
+        fn impl_check<T: Copy + std::hash::Hash + Eq + Ord>() {}
+        impl_check::<ValueFormat>();
+    }
 }


### PR DESCRIPTION
This was overlooked when we stopped using bitflags.

fixes #233

(just merge me)