### PR TITLE
Convert read SimpleGlyph to write SimpleGlyph

### DIFF
--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -218,7 +218,7 @@ impl<'a> FromObjRef<read::tables::glyf::SimpleGlyph<'a>> for SimpleGlyph {
         for end_pt in from.end_pts_of_contours() {
             let end = end_pt.get() as usize;
             let count = end - last_end + 1;
-            last_end = end;
+            last_end = end + 1;
             contours.push(Contour(points.by_ref().take(count).collect()));
         }
         Self {

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -216,9 +216,9 @@ impl<'a> FromObjRef<read::tables::glyf::SimpleGlyph<'a>> for SimpleGlyph {
         let mut last_end = 0;
         let mut contours = vec![];
         for end_pt in from.end_pts_of_contours() {
-            let end = end_pt.get() as usize;
-            let count = end - last_end + 1;
-            last_end = end + 1;
+            let end = end_pt.get() as usize + 1;
+            let count = end - last_end;
+            last_end = end;
             contours.push(Contour(points.by_ref().take(count).collect()));
         }
         Self {


### PR DESCRIPTION
Implements `FromObjRef` and `FromTableRef` for `write_fonts::tables::glyf::SimpleGlyph` to allow conversion from the read type to the write type using the `from_table_ref` method.