### PR TITLE
[ci] Migrate from actions-rs, update checkout

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo doc
-        run: cargo doc --all-features --document-private-items
+        run: cargo doc --all-features --document-private-items --no-deps
 
   clippy-lint:
     name: Clippy lints

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
 
@@ -29,7 +29,7 @@ jobs:
     name: Clippy lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -43,7 +43,7 @@ jobs:
     name: cargo test stable
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
     name: check codegen is up-to-date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -72,7 +72,7 @@ jobs:
     name: cargo check no std
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -87,7 +87,7 @@ jobs:
     name: cargo check wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,51 +16,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
 
       - name: rustfmt check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all-features --document-private-items
+        run: cargo doc --all-features --document-private-items
 
   clippy-lint:
     name: Clippy lints
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          profile: minimal
-          override: true
-
-      #- run: git submodule update --init --recursive
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo clippy --all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets -- -D warnings
+        run: cargo clippy --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --no-default-features -- -D warnings
+      - name: cargo clippy --no-default-features
+        run: cargo clippy --all-targets --no-default-features -- -D warnings
 
   test-stable:
     name: cargo test stable
@@ -69,17 +46,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets --all-features
+        run: cargo test --all-targets --all-features
 
   ensure-clean-codegen:
     name: check codegen is up-to-date
@@ -88,17 +58,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: run codegen
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin=codegen resources/codegen_plan.toml
+        run: cargo run --bin=codegen resources/codegen_plan.toml
       - name: ensure no unstaged changes
         run: |
           git add .
@@ -112,39 +75,23 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo check font-types
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path=font-types/Cargo.toml --no-default-features
+        run: cargo check --manifest-path=font-types/Cargo.toml --no-default-features
 
       - name: cargo check read-fonts
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path=read-fonts/Cargo.toml --no-default-features
+        run: cargo check --manifest-path=read-fonts/Cargo.toml --no-default-features
 
   check-wasm:
     name: cargo check wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - run: rustup target add wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path=write-fonts/Cargo.toml --target wasm32-unknown-unknown
+      - name: cargo check wasm target
+        run: cargo check --manifest-path=write-fonts/Cargo.toml --target wasm32-unknown-unknown
 


### PR DESCRIPTION
There were a bunch of deprecation warnings in the CI logs, which raised two issues:

- we need to update any actions that we call from CI to [versions using node 16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- the actions-rs actions we've been using to install the toolchain and run cargo [are unmaintained](https://github.com/actions-rs/toolchain/issues/216), so we move over to another action from dtolonay 