### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 

--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.1.0", path = "../font-types" }
+font-types = { version = "0.1.1", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 xflags = "0.2.4"
-read-fonts = { path = "../read-fonts",version = "0.1.0"}
-font-types = { path = "../font-types",version = "0.1.0"}
+read-fonts = { path = "../read-fonts",version = "0.1.1"}
+font-types = { path = "../font-types",version = "0.1.1"}
 ansi_term = "0.12.1"
 atty = "0.2"

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -15,4 +15,4 @@ traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { version = "0.1.0", path = "../font-types" }
+font-types = { version = "0.1.1", path = "../font-types" }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -14,7 +14,7 @@ scale = []
 hinting = []
 
 [dependencies]
-read-fonts = { version = "0.1.0", path = "../read-fonts" }
+read-fonts = { version = "0.1.1", path = "../read-fonts" }
 
 [dev-dependencies]
-read-fonts = { version = "0.1.0", path = "../read-fonts", features = ["test_data"] }
+read-fonts = { version = "0.1.1", path = "../read-fonts", features = ["test_data"] }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -11,12 +11,12 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { version = "0.1.0", path = "../font-types" }
-read-fonts = { version = "0.1.0", path = "../read-fonts" }
+font-types = { version = "0.1.1", path = "../font-types" }
+read-fonts = { version = "0.1.1", path = "../read-fonts" }
 bitflags = "1.3"
 kurbo = "0.9.1"
 
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
-read-fonts = { version = "0.1.0", path = "../read-fonts", features = ["test_data"] }
+read-fonts = { version = "0.1.1", path = "../read-fonts", features = ["test_data"] }


### PR DESCRIPTION
It does feel weird to me that we're going to end up in situations where we have, say, versions [0.1, 0.1.1, 0.2, 0.3] for font-types, where all of those versions point to the same commit? Especially if anyone else is using font-types?