### PR TITLE
Make Component friendlier to compiler

### DIFF
--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -32,7 +32,7 @@ pub struct Bbox {
 /// A simple (without components) glyph
 #[derive(Clone, Debug)]
 pub struct SimpleGlyph {
-    bbox: Bbox,
+    pub bbox: Bbox,
     contours: Vec<Contour>,
     _instructions: Vec<u8>,
 }
@@ -40,7 +40,7 @@ pub struct SimpleGlyph {
 /// A glyph consisting of multiple component sub-glyphs
 #[derive(Clone, Debug)]
 pub struct CompositeGlyph {
-    bbox: Bbox,
+    pub bbox: Bbox,
     components: Vec<Component>,
     _instructions: Vec<u8>,
 }
@@ -48,10 +48,10 @@ pub struct CompositeGlyph {
 /// A single component glyph (part of a [`CompositeGlyph`]).
 #[derive(Clone, Debug)]
 pub struct Component {
-    glyph: GlyphId,
-    anchor: Anchor,
+    pub glyph: GlyphId,
+    pub anchor: Anchor,
     pub flags: ComponentFlags,
-    transform: Transform,
+    pub transform: Transform,
 }
 
 /// Options that can be manually set for a given component.
@@ -513,6 +513,10 @@ impl CompositeGlyph {
                 _instructions: Default::default(),
             })
         }
+    }
+
+    pub fn components(&self) -> impl Iterator<Item = &Component> {
+        self.components.iter()
     }
 }
 

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -515,8 +515,8 @@ impl CompositeGlyph {
         }
     }
 
-    pub fn components(&self) -> impl Iterator<Item = &Component> {
-        self.components.iter()
+    pub fn components(&self) -> &[Component] {
+        &self.components
     }
 }
 


### PR DESCRIPTION
Things I learned trying to compile glyphs: I want to see more of the fields of Component.

This is a blocker for completing the merge of https://github.com/googlefonts/fontmake-rs/pull/120.