### PR TITLE
Unblock cmap compile type

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -44,6 +44,17 @@ impl Fields {
                 normal_offset_data_fld = Some(fld);
             }
 
+            // Ideally we'd map is_offset => _offset and array of offsets => _offsets but STAT::offsetToAxisValueOffsets breaks the rule
+            if fld.is_offset_or_array_of_offsets() {
+                let name = fld.name.to_string();
+                if !name.ends_with("_offset") && !name.ends_with("_offsets") {
+                    return Err(logged_syn_error(
+                        fld.name.span(),
+                        "name must end in _offset or _offsets",
+                    ));
+                }
+            }
+
             if (matches!(fld.typ, FieldType::VarLenArray(_))
                 || fld.attrs.count.as_deref().map(Count::all).unwrap_or(false))
                 && i != self.fields.len() - 1
@@ -824,16 +835,19 @@ impl Field {
         })
     }
 
+    fn is_offset(&self) -> bool {
+        matches!(self.typ, FieldType::Offset { .. })
+    }
+
+    fn is_array_of_offsets(&self) -> bool {
+        let FieldType::Array { inner_typ } = &self.typ else {
+            return false;
+        };
+        matches!(inner_typ.as_ref(), FieldType::Offset { .. })
+    }
+
     fn is_offset_or_array_of_offsets(&self) -> bool {
-        match &self.typ {
-            FieldType::Offset { .. } => true,
-            FieldType::Array { inner_typ }
-                if matches!(inner_typ.as_ref(), FieldType::Offset { .. }) =>
-            {
-                true
-            }
-            _ => false,
-        }
+        self.is_offset() || self.is_array_of_offsets()
     }
 
     pub(crate) fn offset_getter_name(&self) -> Option<syn::Ident> {

--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -67,6 +67,7 @@ pub fn generate_code(code_str: &str, mode: Mode) -> Result<String, syn::Error> {
 pub(crate) fn generate_parse_module(items: &Items) -> Result<proc_macro2::TokenStream, syn::Error> {
     let mut code = Vec::new();
     for item in items.iter() {
+        debug!("Generate {}", item.name());
         let item_code = match item {
             Item::Record(item) => record::generate(item)?,
             Item::Table(item) => table::generate(item)?,

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -199,6 +199,8 @@ pub(crate) struct FieldAttrs {
     pub(crate) to_owned: Option<Attr<InlineExpr>>,
     /// Custom validation behaviour
     pub(crate) validation: Option<Attr<FieldValidation>>,
+    /// Whether the value is computed by the user
+    pub(crate) user_computed: Option<syn::Path>,
 }
 
 #[derive(Debug, Clone)]
@@ -958,6 +960,7 @@ static READ_OFFSET_WITH: &str = "read_offset_with";
 static TRAVERSE_WITH: &str = "traverse_with";
 static TO_OWNED: &str = "to_owned";
 static VALIDATE: &str = "validate";
+static USER_COMPUTED: &str = "user_computed";
 
 impl Parse for FieldAttrs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -1005,6 +1008,8 @@ impl Parse for FieldAttrs {
                 this.traverse_with = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == FORMAT {
                 this.format = Some(Attr::new(ident.clone(), parse_attr_eq_value(attr.tokens)?))
+            } else if ident == USER_COMPUTED {
+                this.user_computed = Some(attr.path);
             } else {
                 return Err(logged_syn_error(
                     ident.span(),

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -1237,7 +1237,7 @@ impl Items {
 }
 
 impl Item {
-    fn name(&self) -> &syn::Ident {
+    pub(crate) fn name(&self) -> &syn::Ident {
         match self {
             Item::Table(table) => &table.name,
             Item::Record(record) => &record.name,

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -526,8 +526,12 @@ fn generate_format_constructors(item: &TableFormat, items: &Items) -> syn::Resul
         let constructor_ident = make_snake_case_ident(var_name);
 
         let docstring = format!(" Construct a new `{}` subtable", variant.type_name());
+        // judiciously allow this lint
+        let too_many_args =
+            (constructor_args.len() > 7).then(|| quote!(#[allow(clippy::too_many_arguments)]));
         constructors.push(quote! {
-            #[doc = #docstring]
+             #[doc = #docstring]
+            #too_many_args
             pub fn #constructor_ident ( #( #constructor_args,)*  ) -> Self {
                 Self::#var_name( #var_type::new( #( #constructor_arg_names, )* ))
             }

--- a/font-types/src/uint24.rs
+++ b/font-types/src/uint24.rs
@@ -1,5 +1,5 @@
 /// 24-bit unsigned integer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Uint24(u32);
 
 impl Uint24 {

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -13,12 +13,12 @@ pub struct BasicTableMarker {
 }
 
 impl BasicTableMarker {
-    fn padded_byte_range(&self) -> Range<usize> {
+    fn padded_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset32::RAW_BYTE_LEN
     }
     fn simple_count_byte_range(&self) -> Range<usize> {
-        let start = self.padded_byte_range().end;
+        let start = self.padded_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
     fn simple_records_byte_range(&self) -> Range<usize> {
@@ -61,15 +61,15 @@ impl<'a> FontRead<'a> for BasicTable<'a> {
 pub type BasicTable<'a> = TableRef<'a, BasicTableMarker>;
 
 impl<'a> BasicTable<'a> {
-    pub fn padded(&self) -> Offset32 {
-        let range = self.shape.padded_byte_range();
+    pub fn padded_offset(&self) -> Offset32 {
+        let range = self.shape.padded_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
-    /// Attempt to resolve [`padded`][Self::padded].
+    /// Attempt to resolve [`padded_offset`][Self::padded_offset].
     pub fn padded(&self) -> Result<PadLikeCmap<'a>, ReadError> {
         let data = self.data;
-        self.padded().resolve(data)
+        self.padded_offset().resolve(data)
     }
 
     pub fn simple_count(&self) -> u16 {
@@ -108,8 +108,8 @@ impl<'a> SomeTable<'a> for BasicTable<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new(
-                "padded",
-                FieldType::offset(self.padded(), self.padded()),
+                "padded_offset",
+                FieldType::offset(self.padded_offset(), self.padded()),
             )),
             1usize => Some(Field::new("simple_count", self.simple_count())),
             2usize => Some(Field::new(

--- a/resources/codegen_inputs/avar.rs
+++ b/resources/codegen_inputs/avar.rs
@@ -8,6 +8,7 @@ table Avar {
     version: MajorMinor,
     /// Permanently reserved; set to zero.
     #[skip_getter]
+    #[compile(0)]
     _reserved: u16,
     /// The number of variation axes for this font. This must be the same number as axisCount in the 'fvar' table.
     axis_count: u16,

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -127,6 +127,7 @@ table Cmap4 {
     end_code: [u16],
     /// Set to 0.
     #[skip_getter]
+    #[compile(0)]
     reserved_pad: u16,
     /// Start character code for each segment.
     #[count(half($seg_count_x2))]
@@ -168,6 +169,7 @@ table Cmap8 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,
@@ -207,6 +209,7 @@ table Cmap10 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,
@@ -229,6 +232,7 @@ table Cmap12 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,
@@ -249,6 +253,7 @@ table Cmap13 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -26,6 +26,7 @@ record TableRecord {
     /// Offset from the beginning of the font data.
     // we handle this offset manually, since we can't always know the type
     #[skip_getter]
+    #[user_computed]
     offset: u32,
     /// Length of the table.
     length: u32,

--- a/resources/codegen_inputs/mvar.rs
+++ b/resources/codegen_inputs/mvar.rs
@@ -8,6 +8,7 @@ table Mvar {
     version: MajorMinor,
     /// Not used; set to 0.
     #[skip_getter]
+    #[compile(0)]
     _reserved: u16,
     /// The size in bytes of each value record — must be greater than zero.
     value_record_size: u16,

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -7,10 +7,11 @@
 #![parse_module(read_fonts::codegen_test::records)]
 
 table BasicTable {
+    padded: Offset32<PadLikeCmap>,
     #[compile(array_len($simple_records))]
     simple_count: u16,
     #[count($simple_count)]
-    simple_records: [SimpleRecord],
+    simple_records: [SimpleRecord],    
     #[compile(self.compute_arrays_inner_count())]
     arrays_inner_count: u16,
     #[compile(array_len($array_records))]
@@ -22,7 +23,14 @@ table BasicTable {
 
 record SimpleRecord {
     val1: u16,
-    va2: u32,
+    va2: u32,        
+}
+
+table PadLikeCmap {
+    /// Set to 0.
+    #[skip_getter]
+    reserved: u16,
+    val: Uint24,
 }
 
 #[read_args(array_len: u16)]

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -29,6 +29,7 @@ record SimpleRecord {
 table PadLikeCmap {
     /// Set to 0.
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     val: Uint24,
 }

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -7,7 +7,7 @@
 #![parse_module(read_fonts::codegen_test::records)]
 
 table BasicTable {
-    padded: Offset32<PadLikeCmap>,
+    padded_offset: Offset32<PadLikeCmap>,
     #[compile(array_len($simple_records))]
     simple_count: u16,
     #[count($simple_count)]

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -120,21 +120,20 @@ impl FromObjRef<read_fonts::codegen_test::records::SimpleRecord> for SimpleRecor
 
 #[derive(Clone, Debug, Default)]
 pub struct PadLikeCmap {
-    /// Set to 0.
-    pub reserved: u16,
     pub val: Uint24,
 }
 
 impl PadLikeCmap {
     /// Construct a new `PadLikeCmap`
-    pub fn new(reserved: u16, val: Uint24) -> Self {
-        Self { reserved, val }
+    pub fn new(val: Uint24) -> Self {
+        Self { val }
     }
 }
 
 impl FontWrite for PadLikeCmap {
+    #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        self.reserved.write_into(writer);
+        (0 as u16).write_into(writer);
         self.val.write_into(writer);
     }
 }
@@ -145,10 +144,7 @@ impl Validate for PadLikeCmap {
 
 impl<'a> FromObjRef<read_fonts::codegen_test::records::PadLikeCmap<'a>> for PadLikeCmap {
     fn from_obj_ref(obj: &read_fonts::codegen_test::records::PadLikeCmap<'a>, _: FontData) -> Self {
-        PadLikeCmap {
-            reserved: obj.reserved(),
-            val: obj.val(),
-        }
+        PadLikeCmap { val: obj.val() }
     }
 }
 

--- a/write-fonts/src/codegen_test.rs
+++ b/write-fonts/src/codegen_test.rs
@@ -22,9 +22,10 @@ mod records {
 
     #[test]
     fn constructors() {
+        let padded = PadLikeCmap::new(Uint24::new(42));
         let simple = vec![SimpleRecord::new(6, 32)];
         let contains_arrays = ContainsArrays::new(vec![1, 2, 3], simple.clone());
-        let basic = BasicTable::new(simple.clone(), vec![contains_arrays]);
+        let basic = BasicTable::new(padded, simple.clone(), vec![contains_arrays]);
         let contains_offsets = ContainsOffests::new(simple, basic);
         assert_eq!(contains_offsets.other.simple_records.len(), 1);
     }


### PR DESCRIPTION
Fix issues blocking cmap compile type. Fixes #269. Fixes #270. Fixes #273.

Names that violate _offset(s) naming convention now get nice errors instead of compile issues in generated code:

```shell
Error: 
  × parsing failed
    ╭─[resources/codegen_inputs/test_records.rs:9:1]
  9 │ table BasicTable {
 10 │     padded: Offset32<PadLikeCmap>,
    ·     ───┬──
    ·        ╰── name must end in _offset
 11 │     #[compile(array_len($simple_records))]
    ╰────
```

Skip getter will complain if no way to acquire a value is defined, such as when applied to a reserved field:

```shell
 10 │     #[skip_getter]
 11 │     _reserved: u16,
    ·     ────┬────
    ·         ╰── There is no getter and no defined way to get a value. Perhaps you need ...?
```