### PR TITLE
Enforce the offset naming scheme.

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -44,6 +44,17 @@ impl Fields {
                 normal_offset_data_fld = Some(fld);
             }
 
+            // Ideally we'd map is_offset => _offset and array of offsets => _offsets but STAT::offsetToAxisValueOffsets breaks the rule
+            if fld.is_offset_or_array_of_offsets() {
+                let name = fld.name.to_string();
+                if !name.ends_with("_offset") && !name.ends_with("_offsets") {
+                    return Err(logged_syn_error(
+                        fld.name.span(),
+                        "name must end in _offset or _offsets",
+                    ));
+                }
+            }
+
             if (matches!(fld.typ, FieldType::VarLenArray(_))
                 || fld.attrs.count.as_deref().map(Count::all).unwrap_or(false))
                 && i != self.fields.len() - 1


### PR DESCRIPTION
It's quite confusing if you name an offset to blah as blah as the codegen will emit two definitions of `blah()`. Enforce the naming convention - which we are already following - of a suffix on an offset field.

Hoisted out of https://github.com/googlefonts/fontations/pull/271

Fixes #270. Just merge me.