### PR TITLE
Require fields have some means of acquiring a value

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -59,7 +59,7 @@ impl Fields {
             if !fld.has_defined_value() {
                 return Err(logged_syn_error(
                     fld.name.span(),
-                    "There is no defined way to get a value. If you are skipping getter then perhaps you need #[compile(const)], such as for a reserved field that should be set to 0, or #[user_computed] for a field write-fonts users need to set directly?",
+                    "There is no defined way to get a value. If you are skipping getter then perhaps you have a fixed value, such as for a reserved field that should be set to 0? - if so please use #[compile(0)]",
                 ));
             }
 

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -55,6 +55,14 @@ impl Fields {
                 }
             }
 
+            // We can't generate a compile type if don't define a way to have value
+            if !fld.has_defined_value() {
+                return Err(logged_syn_error(
+                    fld.name.span(),
+                    "There is no defined way to get a value. If you are skipping getter then perhaps you need #[compile(const)], such as for a reserved field that should be set to 0, or #[user_computed] for a field write-fonts users need to set directly?",
+                ));
+            }
+
             if (matches!(fld.typ, FieldType::VarLenArray(_))
                 || fld.attrs.count.as_deref().map(Count::all).unwrap_or(false))
                 && i != self.fields.len() - 1
@@ -835,6 +843,10 @@ impl Field {
         })
     }
 
+    fn is_count(&self) -> bool {
+        self.attrs.count.is_some()
+    }
+
     fn is_offset_or_array_of_offsets(&self) -> bool {
         match &self.typ {
             FieldType::Offset { .. } => true,
@@ -845,6 +857,13 @@ impl Field {
             }
             _ => false,
         }
+    }
+
+    fn has_defined_value(&self) -> bool {
+        if self.attrs.skip_getter.is_none() {
+            return true;
+        }
+        self.is_computed() || self.is_count()
     }
 
     pub(crate) fn offset_getter_name(&self) -> Option<syn::Ident> {

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -199,6 +199,10 @@ pub(crate) struct FieldAttrs {
     pub(crate) to_owned: Option<Attr<InlineExpr>>,
     /// Custom validation behaviour
     pub(crate) validation: Option<Attr<FieldValidation>>,
+    /// Whether the value is computed by the user. This occurs for fields that
+    /// lack getters *and* don't have a fixed value known at compile time. That is,
+    /// their value must be set by the user.
+    pub(crate) user_computed: Option<syn::Path>,
 }
 
 #[derive(Debug, Clone)]
@@ -940,6 +944,7 @@ static READ_OFFSET_WITH: &str = "read_offset_with";
 static TRAVERSE_WITH: &str = "traverse_with";
 static TO_OWNED: &str = "to_owned";
 static VALIDATE: &str = "validate";
+static USER_COMPUTED: &str = "user_computed";
 
 impl Parse for FieldAttrs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -987,6 +992,8 @@ impl Parse for FieldAttrs {
                 this.traverse_with = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == FORMAT {
                 this.format = Some(Attr::new(ident.clone(), parse_attr_eq_value(attr.tokens)?))
+            } else if ident == USER_COMPUTED {
+                this.user_computed = Some(attr.path);
             } else {
                 return Err(logged_syn_error(
                     ident.span(),

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -199,10 +199,6 @@ pub(crate) struct FieldAttrs {
     pub(crate) to_owned: Option<Attr<InlineExpr>>,
     /// Custom validation behaviour
     pub(crate) validation: Option<Attr<FieldValidation>>,
-    /// Whether the value is computed by the user. This occurs for fields that
-    /// lack getters *and* don't have a fixed value known at compile time. That is,
-    /// their value must be set by the user.
-    pub(crate) user_computed: Option<syn::Path>,
 }
 
 #[derive(Debug, Clone)]
@@ -944,7 +940,6 @@ static READ_OFFSET_WITH: &str = "read_offset_with";
 static TRAVERSE_WITH: &str = "traverse_with";
 static TO_OWNED: &str = "to_owned";
 static VALIDATE: &str = "validate";
-static USER_COMPUTED: &str = "user_computed";
 
 impl Parse for FieldAttrs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -992,8 +987,6 @@ impl Parse for FieldAttrs {
                 this.traverse_with = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == FORMAT {
                 this.format = Some(Attr::new(ident.clone(), parse_attr_eq_value(attr.tokens)?))
-            } else if ident == USER_COMPUTED {
-                this.user_computed = Some(attr.path);
             } else {
                 return Err(logged_syn_error(
                     ident.span(),

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -47,7 +47,7 @@ fn list_tables(font: &FontRef) {
         println!(
             "{0} 0x{1:02$X} {3:8} 0x{4:08X} ",
             record.tag(),
-            record.offset().to_u32(),
+            record.offset(),
             offset_pad,
             record.length(),
             record.checksum()
@@ -81,7 +81,7 @@ fn get_offset_width(font: &FontRef) -> usize {
         .table_directory
         .table_records()
         .iter()
-        .map(|rec| rec.offset().to_u32())
+        .map(|rec| rec.offset())
         .max()
         .unwrap_or_default();
     hex_width(max_off)

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -151,6 +151,11 @@ impl TableRecord {
         self.checksum.get()
     }
 
+    /// Offset from the beginning of the font data.
+    pub fn offset(&self) -> u32 {
+        self.offset.get()
+    }
+
     /// Length of the table.
     pub fn length(&self) -> u32 {
         self.length.get()
@@ -170,7 +175,8 @@ impl<'a> SomeRecord<'a> for TableRecord {
             get_field: Box::new(move |idx, _data| match idx {
                 0usize => Some(Field::new("tag", self.tag())),
                 1usize => Some(Field::new("checksum", self.checksum())),
-                2usize => Some(Field::new("length", self.length())),
+                2usize => Some(Field::new("offset", self.offset())),
+                3usize => Some(Field::new("length", self.length())),
                 _ => None,
             }),
             data,

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -661,12 +661,22 @@ impl DummyMarker {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
+    fn reserved_byte_range(&self) -> Range<usize> {
+        let start = self.value_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn offset_byte_range(&self) -> Range<usize> {
+        let start = self.reserved_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
 }
 
 impl<'a> FontRead<'a> for Dummy<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
         cursor.finish(DummyMarker {})
     }
 }

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -661,13 +661,9 @@ impl DummyMarker {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn reserved_byte_range(&self) -> Range<usize> {
+    fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
-    }
-    fn offset_byte_range(&self) -> Range<usize> {
-        let start = self.reserved_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
     }
 }
 
@@ -676,7 +672,6 @@ impl<'a> FontRead<'a> for Dummy<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        cursor.advance::<u32>();
         cursor.finish(DummyMarker {})
     }
 }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -188,7 +188,7 @@ impl<'a> FontRef<'a> {
             .ok()
             .and_then(|idx| self.table_directory.table_records().get(idx))
             .and_then(|record| {
-                let start = record.offset().non_null()?;
+                let start = Offset32::new(record.offset()).non_null()?;
                 let len = record.length() as usize;
                 self.data.slice(start..start + len)
             })
@@ -212,11 +212,5 @@ impl<'a> FontRef<'a> {
 impl<'a> TableProvider<'a> for FontRef<'a> {
     fn data_for_tag(&self, tag: Tag) -> Option<FontData<'a>> {
         self.table_data(tag)
-    }
-}
-
-impl TableRecord {
-    pub fn offset(&self) -> Offset32 {
-        Offset32::new(self.offset.get())
     }
 }

--- a/resources/codegen_inputs/avar.rs
+++ b/resources/codegen_inputs/avar.rs
@@ -8,6 +8,7 @@ table Avar {
     version: MajorMinor,
     /// Permanently reserved; set to zero.
     #[skip_getter]
+    #[compile(0)]
     _reserved: u16,
     /// The number of variation axes for this font. This must be the same number as axisCount in the 'fvar' table.
     axis_count: u16,

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -128,6 +128,7 @@ table Cmap4 {
     end_code: [u16],
     /// Set to 0.
     #[skip_getter]
+    #[compile(0)]
     reserved_pad: u16,
     /// Start character code for each segment.
     #[count(half($seg_count_x2))]
@@ -169,6 +170,7 @@ table Cmap8 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,
@@ -208,6 +210,7 @@ table Cmap10 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,
@@ -230,6 +233,7 @@ table Cmap12 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,
@@ -250,6 +254,7 @@ table Cmap13 {
     format: u16,
     /// Reserved; set to 0
     #[skip_getter]
+    #[compile(0)]
     reserved: u16,
     /// Byte length of this subtable (including the header)
     length: u32,

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -26,6 +26,7 @@ record TableRecord {
     /// Offset from the beginning of the font data.
     // we handle this offset manually, since we can't always know the type
     #[skip_getter]
+    #[user_computed]
     offset: u32,
     /// Length of the table.
     length: u32,

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -25,8 +25,6 @@ record TableRecord {
     checksum: u32,
     /// Offset from the beginning of the font data.
     // we handle this offset manually, since we can't always know the type
-    #[skip_getter]
-    #[user_computed]
     offset: u32,
     /// Length of the table.
     length: u32,

--- a/resources/codegen_inputs/mvar.rs
+++ b/resources/codegen_inputs/mvar.rs
@@ -8,6 +8,7 @@ table Mvar {
     version: MajorMinor,
     /// Not used; set to 0.
     #[skip_getter]
+    #[compile(0)]
     _reserved: u16,
     /// The size in bytes of each value record — must be greater than zero.
     value_record_size: u16,

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -94,6 +94,16 @@ table KindsOfArrays {
 #[skip_constructor]
 table Dummy {
     value: u16,
+    /// Set to 0.
+    // If we didn't set compile(0) there would be no way for write-fonts to have a value.
+    #[skip_getter]
+    #[compile(0)]
+    reserved: u16,
+    // Has no getter, but isn't a compile time const.
+    // write-fonts users need to set this themselves.
+    #[skip_getter]
+    #[user_computed]
+    offset: u32,
 }
 
 #[skip_constructor]

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -98,12 +98,12 @@ table Dummy {
     // If we didn't set compile(0) there would be no way for write-fonts to have a value.
     #[skip_getter]
     #[compile(0)]
-    reserved: u16,
+    _reserved: u16,
     // Has no getter, but isn't a compile time const.
     // write-fonts users need to set this themselves.
-    #[skip_getter]
-    #[user_computed]
-    offset: u32,
+    // #[skip_getter]
+    // #[user_computed]
+    // offset: u32,
 }
 
 #[skip_constructor]

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -357,11 +357,15 @@ impl<'a> FontRead<'a> for KindsOfArrays {
 #[derive(Clone, Debug, Default)]
 pub struct Dummy {
     pub value: u16,
+    pub offset: u32,
 }
 
 impl FontWrite for Dummy {
+    #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.value.write_into(writer);
+        (0 as u16).write_into(writer);
+        self.offset.write_into(writer);
     }
 }
 
@@ -374,7 +378,10 @@ impl<'a> FromObjRef<read_fonts::codegen_test::offsets_arrays::Dummy<'a>> for Dum
         obj: &read_fonts::codegen_test::offsets_arrays::Dummy<'a>,
         _: FontData,
     ) -> Self {
-        Dummy { value: obj.value() }
+        Dummy {
+            value: obj.value(),
+            offset: obj.offset(),
+        }
     }
 }
 

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -357,7 +357,6 @@ impl<'a> FontRead<'a> for KindsOfArrays {
 #[derive(Clone, Debug, Default)]
 pub struct Dummy {
     pub value: u16,
-    pub offset: u32,
 }
 
 impl FontWrite for Dummy {
@@ -365,7 +364,6 @@ impl FontWrite for Dummy {
     fn write_into(&self, writer: &mut TableWriter) {
         self.value.write_into(writer);
         (0 as u16).write_into(writer);
-        self.offset.write_into(writer);
     }
 }
 
@@ -378,10 +376,7 @@ impl<'a> FromObjRef<read_fonts::codegen_test::offsets_arrays::Dummy<'a>> for Dum
         obj: &read_fonts::codegen_test::offsets_arrays::Dummy<'a>,
         _: FontData,
     ) -> Self {
-        Dummy {
-            value: obj.value(),
-            offset: obj.offset(),
-        }
+        Dummy { value: obj.value() }
     }
 }
 


### PR DESCRIPTION
When they don't, such as when a reserved field is marked `#[skip_getter]` the write types get confused.

Most of the time the source of definition for a getter-less field should be a const, typically a  `#[compile(0]`:

```rust
    /// Set to 0.
    #[skip_getter]
    #[compile(0)]
    reserved_pad: u16,
```

Sometimes not, such as font.rs:

```rust
    #[skip_getter]
    offset: u32,
```

Hoisted out of #271. In #271 attribute `user_computed` was added to allow codegen to report errors when this is done by accident while still letting special butterfly fields exist. Here I have chosen to remove the skip getter from offset instead. That required tweaks to lib.rs.