### PR TITLE
make structs for types that impl FontReadWithArgs

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -70,12 +70,15 @@ fn generate_read_with_args(item: &Record) -> TokenStream {
     let anon_lifetime = lifetime.is_some().then(|| quote!(<'_>));
 
     let args = item.attrs.read_args.as_ref().unwrap();
-    let args_type = args.args_type();
-    let destructure_pattern = args.destructure_pattern();
+    let args_type = super::table::make_args_type_name(name);
+    let args_type_decl = args.type_declaration(name);
+    let destructure_pattern = args.destructure_pattern(&args_type);
     let field_size_expr = item.fields.iter().map(Field::record_len_expr);
     let field_inits = item.fields.iter().map(Field::record_init_stmt);
 
     quote! {
+        #args_type_decl
+
         impl ReadArgs for #name #anon_lifetime {
             type Args = #args_type;
         }

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -132,7 +132,9 @@ impl<'a> Colr<'a> {
     /// Attempt to resolve [`base_glyph_records_offset`][Self::base_glyph_records_offset].
     pub fn base_glyph_records(&self) -> Option<Result<&'a [BaseGlyph], ReadError>> {
         let data = self.data;
-        let args = self.num_base_glyph_records();
+        let args = ArrayArgs {
+            count: self.num_base_glyph_records(),
+        };
         self.base_glyph_records_offset()
             .resolve_with_args(data, &args)
     }
@@ -146,7 +148,9 @@ impl<'a> Colr<'a> {
     /// Attempt to resolve [`layer_records_offset`][Self::layer_records_offset].
     pub fn layer_records(&self) -> Option<Result<&'a [Layer], ReadError>> {
         let data = self.data;
-        let args = self.num_layer_records();
+        let args = ArrayArgs {
+            count: self.num_layer_records(),
+        };
         self.layer_records_offset().resolve_with_args(data, &args)
     }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -131,7 +131,9 @@ impl<'a> Cpal<'a> {
     /// Attempt to resolve [`color_records_array_offset`][Self::color_records_array_offset].
     pub fn color_records_array(&self) -> Option<Result<&'a [ColorRecord], ReadError>> {
         let data = self.data;
-        let args = self.num_color_records();
+        let args = ArrayArgs {
+            count: self.num_color_records(),
+        };
         self.color_records_array_offset()
             .resolve_with_args(data, &args)
     }
@@ -156,7 +158,9 @@ impl<'a> Cpal<'a> {
     /// Attempt to resolve [`palette_types_array_offset`][Self::palette_types_array_offset].
     pub fn palette_types_array(&self) -> Option<Result<&'a [BigEndian<u32>], ReadError>> {
         let data = self.data;
-        let args = self.num_palettes();
+        let args = ArrayArgs {
+            count: self.num_palettes(),
+        };
         self.palette_types_array_offset()
             .map(|x| x.resolve_with_args(data, &args))?
     }
@@ -176,7 +180,9 @@ impl<'a> Cpal<'a> {
     /// Attempt to resolve [`palette_labels_array_offset`][Self::palette_labels_array_offset].
     pub fn palette_labels_array(&self) -> Option<Result<&'a [BigEndian<u16>], ReadError>> {
         let data = self.data;
-        let args = self.num_palettes();
+        let args = ArrayArgs {
+            count: self.num_palettes(),
+        };
         self.palette_labels_array_offset()
             .map(|x| x.resolve_with_args(data, &args))?
     }
@@ -198,7 +204,9 @@ impl<'a> Cpal<'a> {
     /// Attempt to resolve [`palette_entry_labels_array_offset`][Self::palette_entry_labels_array_offset].
     pub fn palette_entry_labels_array(&self) -> Option<Result<&'a [BigEndian<u16>], ReadError>> {
         let data = self.data;
-        let args = self.num_palette_entries();
+        let args = ArrayArgs {
+            count: self.num_palette_entries(),
+        };
         self.palette_entry_labels_array_offset()
             .map(|x| x.resolve_with_args(data, &args))?
     }

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -29,13 +29,23 @@ impl TopLevelTable for Hmtx<'_> {
     const TAG: Tag = Tag::new(b"hmtx");
 }
 
+///The [ReadArgs] type for [Hmtx].
+#[derive(Clone, Copy, Debug)]
+pub struct HmtxArgs {
+    pub number_of_h_metrics: u16,
+    pub num_glyphs: u16,
+}
+
 impl ReadArgs for Hmtx<'_> {
-    type Args = (u16, u16);
+    type Args = HmtxArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
-    fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
-        let (number_of_h_metrics, num_glyphs) = *args;
+    fn read_with_args(data: FontData<'a>, args: &HmtxArgs) -> Result<Self, ReadError> {
+        let HmtxArgs {
+            number_of_h_metrics,
+            num_glyphs,
+        } = *args;
         let mut cursor = data.cursor();
         let h_metrics_byte_len = number_of_h_metrics as usize * LongMetric::RAW_BYTE_LEN;
         cursor.advance_by(h_metrics_byte_len);

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -470,7 +470,9 @@ impl FeatureRecord {
 
     /// Attempt to resolve [`feature_offset`][Self::feature_offset].
     pub fn feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
-        let args = self.feature_tag();
+        let args = FeatureArgs {
+            feature_tag: self.feature_tag(),
+        };
         self.feature_offset().resolve_with_args(data, &args)
     }
 }
@@ -520,13 +522,19 @@ impl FeatureMarker {
     }
 }
 
+///The [ReadArgs] type for [Feature].
+#[derive(Clone, Copy, Debug)]
+pub struct FeatureArgs {
+    pub feature_tag: Tag,
+}
+
 impl ReadArgs for Feature<'_> {
-    type Args = Tag;
+    type Args = FeatureArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for Feature<'a> {
-    fn read_with_args(data: FontData<'a>, args: &Tag) -> Result<Self, ReadError> {
-        let feature_tag = *args;
+    fn read_with_args(data: FontData<'a>, args: &FeatureArgs) -> Result<Self, ReadError> {
+        let FeatureArgs { feature_tag } = *args;
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let lookup_index_count: u16 = cursor.read()?;
@@ -552,7 +560,9 @@ impl<'a> Feature<'a> {
     /// Attempt to resolve [`feature_params_offset`][Self::feature_params_offset].
     pub fn feature_params(&self) -> Option<Result<FeatureParams<'a>, ReadError>> {
         let data = self.data;
-        let args = self.feature_tag();
+        let args = FeatureParamsArgs {
+            feature_tag: self.feature_tag(),
+        };
         self.feature_params_offset().resolve_with_args(data, &args)
     }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -105,7 +105,9 @@ impl<'a> Stat<'a> {
     /// Attempt to resolve [`design_axes_offset`][Self::design_axes_offset].
     pub fn design_axes(&self) -> Result<&'a [AxisRecord], ReadError> {
         let data = self.data;
-        let args = self.design_axis_count();
+        let args = ArrayArgs {
+            count: self.design_axis_count(),
+        };
         self.design_axes_offset().resolve_with_args(data, &args)
     }
 
@@ -127,7 +129,9 @@ impl<'a> Stat<'a> {
     /// Attempt to resolve [`offset_to_axis_value_offsets`][Self::offset_to_axis_value_offsets].
     pub fn offset_to_axis_values(&self) -> Result<AxisValueArray<'a>, ReadError> {
         let data = self.data;
-        let args = self.axis_value_count();
+        let args = AxisValueArrayArgs {
+            axis_value_count: self.axis_value_count(),
+        };
         self.offset_to_axis_value_offsets()
             .resolve_with_args(data, &args)
     }
@@ -255,13 +259,19 @@ impl AxisValueArrayMarker {
     }
 }
 
+///The [ReadArgs] type for [AxisValueArray].
+#[derive(Clone, Copy, Debug)]
+pub struct AxisValueArrayArgs {
+    pub axis_value_count: u16,
+}
+
 impl ReadArgs for AxisValueArray<'_> {
-    type Args = u16;
+    type Args = AxisValueArrayArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for AxisValueArray<'a> {
-    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let axis_value_count = *args;
+    fn read_with_args(data: FontData<'a>, args: &AxisValueArrayArgs) -> Result<Self, ReadError> {
+        let AxisValueArrayArgs { axis_value_count } = *args;
         let mut cursor = data.cursor();
         let axis_value_offsets_byte_len = axis_value_count as usize * Offset16::RAW_BYTE_LEN;
         cursor.advance_by(axis_value_offsets_byte_len);

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -159,7 +159,10 @@ impl<'a> KindsOfOffsets<'a> {
     /// Attempt to resolve [`read_args_offset`][Self::read_args_offset].
     pub fn read_args(&self) -> Result<HasArgsTable<'a>, ReadError> {
         let data = self.data;
-        let args = (self.array_offset_count(), self._brightness());
+        let args = HasArgsTableArgs {
+            count: self.array_offset_count(),
+            _brightness: self._brightness(),
+        };
         self.read_args_offset().resolve_with_args(data, &args)
     }
 
@@ -172,7 +175,10 @@ impl<'a> KindsOfOffsets<'a> {
     /// Attempt to resolve [`nullable_read_args_offset`][Self::nullable_read_args_offset].
     pub fn nullable_read_args(&self) -> Option<Result<HasArgsTable<'a>, ReadError>> {
         let data = self.data;
-        let args = (self.array_offset_count(), self._brightness());
+        let args = HasArgsTableArgs {
+            count: self.array_offset_count(),
+            _brightness: self._brightness(),
+        };
         self.nullable_read_args_offset()
             .resolve_with_args(data, &args)
     }
@@ -186,7 +192,9 @@ impl<'a> KindsOfOffsets<'a> {
     /// Attempt to resolve [`array_offset`][Self::array_offset].
     pub fn array(&self) -> Result<&'a [BigEndian<u16>], ReadError> {
         let data = self.data;
-        let args = self.array_offset_count();
+        let args = ArrayArgs {
+            count: self.array_offset_count(),
+        };
         self.array_offset().resolve_with_args(data, &args)
     }
 
@@ -199,7 +207,9 @@ impl<'a> KindsOfOffsets<'a> {
     /// Attempt to resolve [`record_array_offset`][Self::record_array_offset].
     pub fn record_array(&self) -> Result<&'a [Shmecord], ReadError> {
         let data = self.data;
-        let args = self.array_offset_count();
+        let args = ArrayArgs {
+            count: self.array_offset_count(),
+        };
         self.record_array_offset().resolve_with_args(data, &args)
     }
 
@@ -214,7 +224,9 @@ impl<'a> KindsOfOffsets<'a> {
     /// Attempt to resolve [`versioned_nullable_record_array_offset`][Self::versioned_nullable_record_array_offset].
     pub fn versioned_nullable_record_array(&self) -> Option<Result<&'a [Shmecord], ReadError>> {
         let data = self.data;
-        let args = self.array_offset_count();
+        let args = ArrayArgs {
+            count: self.array_offset_count(),
+        };
         self.versioned_nullable_record_array_offset()
             .map(|x| x.resolve_with_args(data, &args))?
     }
@@ -779,13 +791,20 @@ impl HasArgsTableMarker {
     }
 }
 
+///The [ReadArgs] type for [HasArgsTable].
+#[derive(Clone, Copy, Debug)]
+pub struct HasArgsTableArgs {
+    pub count: u16,
+    pub _brightness: i16,
+}
+
 impl ReadArgs for HasArgsTable<'_> {
-    type Args = (u16, i16);
+    type Args = HasArgsTableArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for HasArgsTable<'a> {
-    fn read_with_args(data: FontData<'a>, args: &(u16, i16)) -> Result<Self, ReadError> {
-        let (count, _brightness) = *args;
+    fn read_with_args(data: FontData<'a>, args: &HasArgsTableArgs) -> Result<Self, ReadError> {
+        let HasArgsTableArgs { count, _brightness } = *args;
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let things_byte_len = count as usize * u16::RAW_BYTE_LEN;

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -29,13 +29,23 @@ impl TopLevelTable for Vmtx<'_> {
     const TAG: Tag = Tag::new(b"vmtx");
 }
 
+///The [ReadArgs] type for [Vmtx].
+#[derive(Clone, Copy, Debug)]
+pub struct VmtxArgs {
+    pub number_of_long_ver_metrics: u16,
+    pub num_glyphs: u16,
+}
+
 impl ReadArgs for Vmtx<'_> {
-    type Args = (u16, u16);
+    type Args = VmtxArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for Vmtx<'a> {
-    fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
-        let (number_of_long_ver_metrics, num_glyphs) = *args;
+    fn read_with_args(data: FontData<'a>, args: &VmtxArgs) -> Result<Self, ReadError> {
+        let VmtxArgs {
+            number_of_long_ver_metrics,
+            num_glyphs,
+        } = *args;
         let mut cursor = data.cursor();
         let v_metrics_byte_len = number_of_long_ver_metrics as usize * LongMetric::RAW_BYTE_LEN;
         cursor.advance_by(v_metrics_byte_len);

--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -144,13 +144,21 @@ impl<'a, T> FontRead<'a> for VarLenArray<'a, T> {
     }
 }
 
+/// The [ReadArgs] args for array types.
+#[derive(Clone, Copy, Debug)]
+pub struct ArrayArgs {
+    /// The number of items in the array
+    pub count: u16,
+}
+
 impl<'a, T: FixedSize> ReadArgs for &'a [T] {
-    type Args = u16;
+    type Args = ArrayArgs;
 }
 
 impl<'a, T: FixedSize> FontReadWithArgs<'a> for &'a [T] {
-    fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let len = *args as usize * T::RAW_BYTE_LEN;
+    fn read_with_args(data: FontData<'a>, args: &ArrayArgs) -> Result<Self, ReadError> {
+        let ArrayArgs { count } = *args;
+        let len = count as usize * T::RAW_BYTE_LEN;
         data.read_array(0..len)
     }
 }

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -23,10 +23,13 @@ pub mod offsets_arrays {
     fn array_offsets() {
         let builder = crate::test_helpers::BeBuffer::new()
             .push(MajorMinor::VERSION_1_0)
-            .push(12_u16) // offset to 0xdead
+            .push(18_u16) // offset to 0xdead
             .push(0u16) // nullable
             .push(2u16) // array len
-            .push(12u16) // array offset
+            .push(69i16) // brightness
+            .push(18u16)
+            .push(0u16) // nullable
+            .push(18u16) // array offset
             .extend([0xdead_u16, 0xbeef]);
 
         let table = KindsOfOffsets::read(builder.font_data()).unwrap();

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -42,7 +42,7 @@ pub extern crate font_types as types;
 /// All the types that may be referenced in auto-generated code.
 #[doc(hidden)]
 pub(crate) mod codegen_prelude {
-    pub use crate::array::{ComputedArray, VarLenArray};
+    pub use crate::array::{ArrayArgs, ComputedArray, VarLenArray};
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::read::{

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -27,6 +27,11 @@ pub trait FontRead<'a>: Sized {
 
 /// A trait for a type that needs additional arguments to be read.
 pub trait ReadArgs {
+    /// The arguments required to read this type.
+    ///
+    /// By convention, this is a struct that is the name of the implementing type,
+    /// suffixed with "Args". For example, the `Args` for the type `VeryBadTable`
+    /// would be `VeryBadTableArgs`
     type Args: Copy;
 }
 
@@ -36,10 +41,6 @@ pub trait FontReadWithArgs<'a>: Sized + ReadArgs {
     ///
     /// If successful, returns a new item of this type, and the number of bytes
     /// used to construct it.
-    ///
-    /// If a type requires multiple arguments, they will be passed as a tuple.
-    //TODO: split up the 'takes args' and 'reports size' parts of this into
-    // separate traits
     fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError>;
 }
 

--- a/read-fonts/src/table_provider.rs
+++ b/read-fonts/src/table_provider.rs
@@ -52,14 +52,23 @@ pub trait TableProvider<'a> {
         //FIXME: should we make the user pass these in?
         let num_glyphs = self.maxp().map(|maxp| maxp.num_glyphs())?;
         let number_of_h_metrics = self.hhea().map(|hhea| hhea.number_of_long_metrics())?;
-        self.expect_table_args(&(number_of_h_metrics, num_glyphs))
+        let args = tables::hmtx::HmtxArgs {
+            num_glyphs,
+            number_of_h_metrics,
+        };
+        self.expect_table_args(&args)
     }
 
     fn vmtx(&self) -> Result<tables::vmtx::Vmtx<'a>, ReadError> {
         //FIXME: should we make the user pass these in?
         let num_glyphs = self.maxp().map(|maxp| maxp.num_glyphs())?;
-        let number_of_v_metrics = self.vhea().map(|vhea| vhea.number_of_long_ver_metrics())?;
-        self.expect_table_args(&(number_of_v_metrics, num_glyphs))
+        let number_of_long_ver_metrics =
+            self.vhea().map(|vhea| vhea.number_of_long_ver_metrics())?;
+        let args = tables::vmtx::VmtxArgs {
+            num_glyphs,
+            number_of_long_ver_metrics,
+        };
+        self.expect_table_args(&args)
     }
 
     fn fvar(&self) -> Result<tables::fvar::Fvar<'a>, ReadError> {
@@ -182,8 +191,8 @@ mod tests {
             }
         }
 
-        let number_of_h_metrics = DummyProvider.hhea().unwrap().number_of_long_metrics();
-        let num_glyphs = DummyProvider.maxp().unwrap().num_glyphs();
+        let number_of_h_metrics = dbg!(DummyProvider.hhea().unwrap().number_of_long_metrics());
+        let num_glyphs = dbg!(DummyProvider.maxp()).unwrap().num_glyphs();
         let hmtx = DummyProvider.hmtx().unwrap();
 
         assert_eq!(number_of_h_metrics, 1);

--- a/read-fonts/src/tables/fvar.rs
+++ b/read-fonts/src/tables/fvar.rs
@@ -5,7 +5,7 @@ include!("../../generated/generated_fvar.rs");
 #[path = "./instance_record.rs"]
 mod instance_record;
 
-pub use instance_record::InstanceRecord;
+pub use instance_record::{InstanceRecord, InstanceRecordArgs};
 
 impl<'a> Fvar<'a> {
     /// Returns the array of variation axis records.

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -11,7 +11,7 @@ use crate::array::ComputedArray;
 pub use super::layout::{
     ClassDef, CoverageTable, Device, FeatureList, FeatureVariations, Lookup, ScriptList,
 };
-pub use value_record::ValueRecord;
+pub use value_record::{ValueRecord, ValueRecordArgs};
 
 #[cfg(test)]
 #[path = "../tests/gpos.rs"]

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -29,13 +29,22 @@ pub enum FeatureParams<'a> {
     CharacterVariant(CharacterVariantParams<'a>),
 }
 
+/// The [ReadArgs] args for [FeatureParams]
+#[derive(Clone, Copy, Debug)]
+pub struct FeatureParamsArgs {
+    pub feature_tag: Tag,
+}
+
 impl ReadArgs for FeatureParams<'_> {
-    type Args = Tag;
+    type Args = FeatureParamsArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for FeatureParams<'a> {
-    fn read_with_args(bytes: FontData<'a>, args: &Tag) -> Result<FeatureParams<'a>, ReadError> {
-        match *args {
+    fn read_with_args(
+        bytes: FontData<'a>,
+        args: &FeatureParamsArgs,
+    ) -> Result<FeatureParams<'a>, ReadError> {
+        match args.feature_tag {
             t if t == Tag::new(b"size") => SizeParams::read(bytes).map(Self::Size),
             // to whoever is debugging this dumb bug I wrote: I'm sorry.
             t if &t.to_raw()[..2] == b"ss" => {
@@ -72,8 +81,12 @@ impl<'a> SomeTable<'a> for FeatureParams<'a> {
 
 impl FeatureTableSubstitutionRecord {
     pub fn alternate_feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
-        self.alternate_feature_offset()
-            .resolve_with_args(data, &Tag::new(b"NULL"))
+        self.alternate_feature_offset().resolve_with_args(
+            data,
+            &FeatureArgs {
+                feature_tag: Tag::new(b"NULL"),
+            },
+        )
     }
 }
 

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -116,13 +116,19 @@ impl ValueRecord {
     }
 }
 
+/// the [ReadArgs] args for [ValueRecord]
+#[derive(Clone, Copy, Debug)]
+pub struct ValueRecordArgs {
+    pub value_format: ValueFormat,
+}
+
 impl ReadArgs for ValueRecord {
-    type Args = ValueFormat;
+    type Args = ValueRecordArgs;
 }
 
 impl<'a> FontReadWithArgs<'a> for ValueRecord {
     fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError> {
-        ValueRecord::read(data, *args)
+        ValueRecord::read(data, args.value_format)
     }
 }
 
@@ -147,8 +153,8 @@ impl std::fmt::Debug for ValueRecord {
 
 impl ComputeSize for ValueRecord {
     #[inline]
-    fn compute_size(args: &ValueFormat) -> usize {
-        args.record_byte_len()
+    fn compute_size(args: &ValueRecordArgs) -> usize {
+        args.value_format.record_byte_len()
     }
 }
 

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -474,7 +474,12 @@ impl<'a> Iterator for TupleVariationHeaderIter<'a> {
             return None;
         }
         self.current += 1;
-        let next = TupleVariationHeader::read_with_args(self.data, &self.axis_count);
+        let next = TupleVariationHeader::read_with_args(
+            self.data,
+            &TupleVariationHeaderArgs {
+                axis_count: self.axis_count,
+            },
+        );
         let next_len = next
             .as_ref()
             .map(|table| table.byte_len(self.axis_count))

--- a/resources/codegen_inputs/colr.rs
+++ b/resources/codegen_inputs/colr.rs
@@ -11,11 +11,11 @@ table Colr {
     num_base_glyph_records: u16,
     /// Offset to baseGlyphRecords array (may be NULL).
     #[nullable]
-    #[read_offset_with($num_base_glyph_records)]
+    #[read_offset_with(count: $num_base_glyph_records)]
     base_glyph_records_offset: Offset32<[BaseGlyph]>,
     /// Offset to layerRecords array (may be NULL).
     #[nullable]
-    #[read_offset_with($num_layer_records)]
+    #[read_offset_with(count: $num_layer_records)]
     layer_records_offset: Offset32<[Layer]>,
     /// Number of Layer records; may be 0 in a version 1 table.
     num_layer_records: u16,

--- a/resources/codegen_inputs/cpal.rs
+++ b/resources/codegen_inputs/cpal.rs
@@ -16,7 +16,7 @@ table Cpal {
     /// Offset from the beginning of CPAL table to the first
     /// ColorRecord.
     #[nullable]
-    #[read_offset_with($num_color_records)]
+    #[read_offset_with(count: $num_color_records)]
     color_records_array_offset: Offset32<[ColorRecord]>,
     /// Index of each palette’s first color record in the combined
     /// color record array.
@@ -30,7 +30,7 @@ table Cpal {
     /// [Palette Types Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-type-array
     #[since_version(1)]
     #[nullable]
-    #[read_offset_with($num_palettes)]
+    #[read_offset_with(count: $num_palettes)]
     palette_types_array_offset: Offset32<[u32]>,
     /// Offset from the beginning of CPAL table to the [Palette Labels Array][].
     ///
@@ -41,7 +41,7 @@ table Cpal {
     /// [Palette Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-labels-array
     #[since_version(1)]
     #[nullable]
-    #[read_offset_with($num_palettes)]
+    #[read_offset_with(count: $num_palettes)]
     palette_labels_array_offset: Offset32<[u16]>,
     /// Offset from the beginning of CPAL table to the [Palette Entry Labels Array][].
     ///
@@ -54,7 +54,7 @@ table Cpal {
     /// [Palette Entry Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entry-label-array
     #[since_version(1)]
     #[nullable]
-    #[read_offset_with($num_palette_entries)]
+    #[read_offset_with(count: $num_palette_entries)]
     palette_entry_labels_array_offset: Offset32<[u16]>,
 }
 

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -224,10 +224,10 @@ record PairValueRecord {
     /// the Coverage table).
     second_glyph: GlyphId,
     /// Positioning data for the first glyph in the pair.
-    #[read_with($value_format1)]
+    #[read_with(value_format: $value_format1)]
     value_record1: ValueRecord,
     /// Positioning data for the second glyph in the pair.
-    #[read_with($value_format2)]
+    #[read_with(value_format: $value_format2)]
     value_record2: ValueRecord,
 }
 
@@ -277,10 +277,10 @@ record Class1Record<'a> {
 #[read_args(value_format1: ValueFormat, value_format2: ValueFormat)]
 record Class2Record {
     /// Positioning for first glyph — empty if valueFormat1 = 0.
-    #[read_with($value_format1)]
+    #[read_with(value_format: $value_format1)]
     value_record1: ValueRecord,
     /// Positioning for second glyph — empty if valueFormat2 = 0.
-    #[read_with($value_format2)]
+    #[read_with(value_format: $value_format2)]
     value_record2: ValueRecord,
 }
 

--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -21,7 +21,7 @@ table Stat {
     /// start of the design axes array. If designAxisCount is zero, set
     /// to zero; if designAxisCount is greater than zero, must be
     /// greater than zero.
-    #[read_offset_with($design_axis_count)]
+    #[read_offset_with(count: $design_axis_count)]
     design_axes_offset: Offset32<[AxisRecord]>,
     /// The number of axis value tables.
     #[compile(array_len($offset_to_axis_value_offsets))]

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -20,14 +20,23 @@ table KindsOfOffsets {
     /// count of the array at array_offset
     #[compile(array_len($array_offset))]
     array_offset_count: u16,
+    /// Another field
+    _brightness: i16,
+    /// An offset with read_args:
+    #[read_offset_with(count: $array_offset_count, $_brightness)]
+    read_args_offset: Offset16<HasArgsTable>,
+    /// A nullable offset with read_args:
+    #[nullable]
+    #[read_offset_with(count: $array_offset_count, $_brightness)]
+    nullable_read_args_offset: Offset16<HasArgsTable>,
     /// An offset to an array:
-    #[read_offset_with($array_offset_count)]
+    #[read_offset_with(count: $array_offset_count)]
     array_offset: Offset16<[u16]>,
     /// An offset to an array of records
-    #[read_offset_with($array_offset_count)]
+    #[read_offset_with(count: $array_offset_count)]
     record_array_offset: Offset16<[Shmecord]>,
     /// A nullable, versioned offset to an array of records
-    #[read_offset_with($array_offset_count)]
+    #[read_offset_with(count: $array_offset_count)]
     #[nullable]
     #[since_version(1,1)]
     versioned_nullable_record_array_offset: Offset16<[Shmecord]>,
@@ -104,6 +113,13 @@ table Dummy {
     // #[skip_getter]
     // #[user_computed]
     // offset: u32,
+}
+
+#[read_args(count: u16, _brightness: i16)]
+table HasArgsTable {
+    hmm: u16,
+    #[count($count)]
+    things: [u16],
 }
 
 #[skip_constructor]

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -16,7 +16,7 @@ table BasicTable {
     #[compile(array_len($array_records))]
     array_records_count: u32,
     #[count($array_records_count)]
-    #[read_with($arrays_inner_count)]
+    #[read_with(array_len: $arrays_inner_count)]
     array_records: ComputedArray<ContainsArrays<'a>>,
 }
 
@@ -36,7 +36,7 @@ record ContainsArrays<'a> {
 record ContainsOffests {
     #[compile(array_len($array_offset))]
     off_array_count: u16,
-    #[read_offset_with($off_array_count)]
+    #[read_offset_with(count: $off_array_count)]
     array_offset: Offset16<[SimpleRecord]>,
     other_offset: Offset32<BasicTable>,
 }

--- a/write-fonts/src/codegen_test.rs
+++ b/write-fonts/src/codegen_test.rs
@@ -50,7 +50,7 @@ mod formats {
     }
 }
 
-mod offsets_arrays {
+pub mod offsets_arrays {
     include!("../generated/generated_test_offsets_arrays.rs");
 }
 

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -11,7 +11,7 @@ pub mod validate;
 mod write;
 
 #[cfg(test)]
-mod codegen_test;
+pub mod codegen_test;
 #[cfg(test)]
 mod hex_diff;
 

--- a/write-fonts/src/tables/hmtx.rs
+++ b/write-fonts/src/tables/hmtx.rs
@@ -19,7 +19,11 @@ mod tests {
         let _dumped = crate::write::dump_table(&hmtx).unwrap();
 
         let data = FontData::new(&_dumped);
-        let loaded = read_fonts::tables::hmtx::Hmtx::read_with_args(data, &(1, 5)).unwrap();
+        let args = read_fonts::tables::hmtx::HmtxArgs {
+            number_of_h_metrics: 1,
+            num_glyphs: 5,
+        };
+        let loaded = read_fonts::tables::hmtx::Hmtx::read_with_args(data, &args).unwrap();
         assert_eq!(loaded.h_metrics()[0].advance(), 602);
         assert_eq!(loaded.h_metrics()[0].side_bearing(), -214);
         assert_eq!(loaded.left_side_bearings(), &hmtx.left_side_bearings);


### PR DESCRIPTION
Previously we passed around untyped tuples, which has caused some confusion.

Honestly: this was a bit of a hassle, and I'm not sure I love it? The main downside is that it adds a bunch of code to the codegen crate. It also complicates the syntax in our codgen inputs for specifying arguments, as you need to be able to specify the name of the argument for which you are providing a value, unless the value and the argument already share a name.

If we keep it, I need to go clean up some docs.

(I do have an idea for how this might be improved, by using the `fn pick_speed(Opts { go_fast, how_fast }: Opts) -> ()` syntax, but this involves changing the API so we always pass arguments by value. This is probably fine, and I'll explore it separately, probably tomorrow)