### PR TITLE
Make ot_round more widely accessible and comment it

### DIFF
--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -6,6 +6,7 @@ pub mod from_obj;
 mod graph;
 mod offsets;
 pub mod pens;
+mod round;
 pub mod tables;
 pub mod validate;
 mod write;
@@ -17,6 +18,7 @@ mod hex_diff;
 
 pub use font_builder::FontBuilder;
 pub use offsets::{NullableOffsetMarker, OffsetMarker};
+pub use round::OtRound;
 pub use write::{dump_table, FontWrite, TableWriter};
 
 /// Rexport of the common font types

--- a/write-fonts/src/round.rs
+++ b/write-fonts/src/round.rs
@@ -1,0 +1,27 @@
+//! Rounding whose behavior is defined by the
+//! [font specification](https://learn.microsoft.com/en-us/typography/opentype/spec/otff).
+
+/// ot_round is defined by https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization.
+///
+/// https://github.com/fonttools/fonttools/issues/1248#issuecomment-383198166 captures the rationale
+/// for the current implementation.
+///
+/// Copied from https://github.com/simoncozens/rust-font-tools/blob/105436d3a617ddbebd25f790b041ff506bd90d44/otmath/src/lib.rs#L17,
+/// which is in turn copied from https://github.com/fonttools/fonttools/blob/a55a545b12a9735e303568a9d4c7e75fe6dbd2be/Lib/fontTools/misc/roundTools.py#L23.
+pub trait OtRound<U, T = Self> {
+    fn ot_round(self) -> U;
+}
+
+impl OtRound<i16> for f64 {
+    #[inline]
+    fn ot_round(self) -> i16 {
+        (self + 0.5).floor() as i16
+    }
+}
+
+impl OtRound<i16> for f32 {
+    #[inline]
+    fn ot_round(self) -> i16 {
+        (self + 0.5).floor() as i16
+    }
+}

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -1,5 +1,6 @@
 //! The [glyf (Glyph Data)](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf) table
 
+use crate::OtRound;
 use kurbo::{BezPath, Rect, Shape};
 
 use read_fonts::{
@@ -94,7 +95,7 @@ pub trait OtPoint {
 
 impl OtPoint for kurbo::Point {
     fn get(self) -> (i16, i16) {
-        (ot_round(self.x as f32), ot_round(self.y as f32))
+        (self.x.ot_round(), self.y.ot_round())
     }
 }
 
@@ -102,12 +103,6 @@ impl OtPoint for (i16, i16) {
     fn get(self) -> (i16, i16) {
         self
     }
-}
-
-// adapted from simon:
-// https://github.com/simoncozens/rust-font-tools/blob/105436d3a617ddbebd25f790b041ff506bd90d44/otmath/src/lib.rs#L17
-fn ot_round(val: f32) -> i16 {
-    (val + 0.5).floor() as i16
 }
 
 impl Contour {
@@ -638,10 +633,10 @@ impl Bbox {
 impl From<Rect> for Bbox {
     fn from(value: Rect) -> Self {
         Bbox {
-            x_min: ot_round(value.min_x() as f32),
-            y_min: ot_round(value.min_y() as f32),
-            x_max: ot_round(value.max_x() as f32),
-            y_max: ot_round(value.max_y() as f32),
+            x_min: value.min_x().ot_round(),
+            y_min: value.min_y().ot_round(),
+            x_max: value.max_x().ot_round(),
+            y_max: value.max_y().ot_round(),
         }
     }
 }


### PR DESCRIPTION
Put it in write-fonts because `floor()` is not available in font-types. Modelled on std::ops, e.g. https://doc.rust-lang.org/std/ops/trait.Sub.html.