### PR TITLE
Better read arg constructors

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -74,6 +74,8 @@ fn generate_read_with_args(item: &Record) -> TokenStream {
     let destructure_pattern = args.destructure_pattern();
     let field_size_expr = item.fields.iter().map(Field::record_len_expr);
     let field_inits = item.fields.iter().map(Field::record_init_stmt);
+    let constructor_args = args.constructor_args();
+    let args_from_constructor_args = args.read_args_from_constructor_args();
 
     quote! {
         impl ReadArgs for #name #anon_lifetime {
@@ -95,6 +97,17 @@ fn generate_read_with_args(item: &Record) -> TokenStream {
                     #( #field_inits, )*
                 })
 
+            }
+        }
+
+        impl<'a> #name #lifetime {
+            /// A constructor that requires additional arguments.
+            ///
+            /// This type requires some external state in order to be
+            /// parsed.
+            pub fn read(data: FontData<'a>, #( #constructor_args, )* ) -> Result<Self, ReadError> {
+                let args = #args_from_constructor_args;
+                Self::read_with_args(data, &args)
             }
         }
     }

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -189,6 +189,22 @@ impl<'a> FontReadWithArgs<'a> for AxisInstanceArrays<'a> {
     }
 }
 
+impl<'a> AxisInstanceArrays<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        axis_count: u16,
+        instance_count: u16,
+        instance_size: u16,
+    ) -> Result<Self, ReadError> {
+        let args = (axis_count, instance_count, instance_size);
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Shim table to handle combined axis and instance arrays.
 pub type AxisInstanceArrays<'a> = TableRef<'a, AxisInstanceArraysMarker>;
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1553,6 +1553,21 @@ impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
     }
 }
 
+impl<'a> PairSet<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        value_format1: ValueFormat,
+        value_format2: ValueFormat,
+    ) -> Result<Self, ReadError> {
+        let args = (value_format1, value_format2);
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Part of [PairPosFormat1]
 pub type PairSet<'a> = TableRef<'a, PairSetMarker>;
 
@@ -1664,6 +1679,21 @@ impl<'a> FontReadWithArgs<'a> for PairValueRecord {
             value_record1: cursor.read_with_args(&value_format1)?,
             value_record2: cursor.read_with_args(&value_format2)?,
         })
+    }
+}
+
+impl<'a> PairValueRecord {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        value_format1: ValueFormat,
+        value_format2: ValueFormat,
+    ) -> Result<Self, ReadError> {
+        let args = (value_format1, value_format2);
+        Self::read_with_args(data, &args)
     }
 }
 
@@ -1937,6 +1967,22 @@ impl<'a> FontReadWithArgs<'a> for Class1Record<'a> {
     }
 }
 
+impl<'a> Class1Record<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        class2_count: u16,
+        value_format1: ValueFormat,
+        value_format2: ValueFormat,
+    ) -> Result<Self, ReadError> {
+        let args = (class2_count, value_format1, value_format2);
+        Self::read_with_args(data, &args)
+    }
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for Class1Record<'a> {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -2002,6 +2048,21 @@ impl<'a> FontReadWithArgs<'a> for Class2Record {
             value_record1: cursor.read_with_args(&value_format1)?,
             value_record2: cursor.read_with_args(&value_format2)?,
         })
+    }
+}
+
+impl<'a> Class2Record {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        value_format1: ValueFormat,
+        value_format2: ValueFormat,
+    ) -> Result<Self, ReadError> {
+        let args = (value_format1, value_format2);
+        Self::read_with_args(data, &args)
     }
 }
 
@@ -2400,6 +2461,17 @@ impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
     }
 }
 
+impl<'a> BaseArray<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Part of [MarkBasePosFormat1]
 pub type BaseArray<'a> = TableRef<'a, BaseArrayMarker>;
 
@@ -2497,6 +2569,17 @@ impl<'a> FontReadWithArgs<'a> for BaseRecord<'a> {
         Ok(Self {
             base_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
         })
+    }
+}
+
+impl<'a> BaseRecord<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
     }
 }
 
@@ -2719,6 +2802,17 @@ impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
     }
 }
 
+impl<'a> LigatureArray<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Part of [MarkLigPosFormat1]
 pub type LigatureArray<'a> = TableRef<'a, LigatureArrayMarker>;
 
@@ -2826,6 +2920,17 @@ impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
     }
 }
 
+impl<'a> LigatureAttach<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Part of [MarkLigPosFormat1]
 pub type LigatureAttach<'a> = TableRef<'a, LigatureAttachMarker>;
 
@@ -2923,6 +3028,17 @@ impl<'a> FontReadWithArgs<'a> for ComponentRecord<'a> {
         Ok(Self {
             ligature_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
         })
+    }
+}
+
+impl<'a> ComponentRecord<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
     }
 }
 
@@ -3146,6 +3262,17 @@ impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
     }
 }
 
+impl<'a> Mark2Array<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Part of [MarkMarkPosFormat1]Class2Record
 pub type Mark2Array<'a> = TableRef<'a, Mark2ArrayMarker>;
 
@@ -3243,6 +3370,17 @@ impl<'a> FontReadWithArgs<'a> for Mark2Record<'a> {
         Ok(Self {
             mark2_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
         })
+    }
+}
+
+impl<'a> Mark2Record<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
+        let args = mark_class_count;
+        Self::read_with_args(data, &args)
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -508,6 +508,21 @@ impl<'a> FontReadWithArgs<'a> for SharedTuples<'a> {
     }
 }
 
+impl<'a> SharedTuples<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        shared_tuple_count: u16,
+        axis_count: u16,
+    ) -> Result<Self, ReadError> {
+        let args = (shared_tuple_count, axis_count);
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// Array of tuple records shared across all glyph variation data tables.
 pub type SharedTuples<'a> = TableRef<'a, SharedTuplesMarker>;
 

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -49,6 +49,21 @@ impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
     }
 }
 
+impl<'a> Hmtx<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        number_of_h_metrics: u16,
+        num_glyphs: u16,
+    ) -> Result<Self, ReadError> {
+        let args = (number_of_h_metrics, num_glyphs);
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
 pub type Hmtx<'a> = TableRef<'a, HmtxMarker>;
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -539,6 +539,17 @@ impl<'a> FontReadWithArgs<'a> for Feature<'a> {
     }
 }
 
+impl<'a> Feature<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, feature_tag: Tag) -> Result<Self, ReadError> {
+        let args = feature_tag;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
 pub type Feature<'a> = TableRef<'a, FeatureMarker>;
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -271,6 +271,17 @@ impl<'a> FontReadWithArgs<'a> for AxisValueArray<'a> {
     }
 }
 
+impl<'a> AxisValueArray<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, axis_value_count: u16) -> Result<Self, ReadError> {
+        let args = axis_value_count;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// An array of [AxisValue] tables.
 pub type AxisValueArray<'a> = TableRef<'a, AxisValueArrayMarker>;
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -200,6 +200,17 @@ impl<'a> FontReadWithArgs<'a> for ContainsArrays<'a> {
     }
 }
 
+impl<'a> ContainsArrays<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, array_len: u16) -> Result<Self, ReadError> {
+        let args = array_len;
+        Self::read_with_args(data, &args)
+    }
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ContainsArrays<'a> {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -64,6 +64,17 @@ impl<'a> FontReadWithArgs<'a> for TupleVariationHeader<'a> {
     }
 }
 
+impl<'a> TupleVariationHeader<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, axis_count: u16) -> Result<Self, ReadError> {
+        let args = axis_count;
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
 pub type TupleVariationHeader<'a> = TableRef<'a, TupleVariationHeaderMarker>;
 
@@ -149,6 +160,17 @@ impl<'a> FontReadWithArgs<'a> for Tuple<'a> {
         Ok(Self {
             values: cursor.read_array(axis_count as usize)?,
         })
+    }
+}
+
+impl<'a> Tuple<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, axis_count: u16) -> Result<Self, ReadError> {
+        let args = axis_count;
+        Self::read_with_args(data, &args)
     }
 }
 
@@ -833,6 +855,17 @@ impl<'a> FontReadWithArgs<'a> for VariationRegion<'a> {
         Ok(Self {
             region_axes: cursor.read_array(axis_count as usize)?,
         })
+    }
+}
+
+impl<'a> VariationRegion<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(data: FontData<'a>, axis_count: u16) -> Result<Self, ReadError> {
+        let args = axis_count;
+        Self::read_with_args(data, &args)
     }
 }
 

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -49,6 +49,21 @@ impl<'a> FontReadWithArgs<'a> for Vmtx<'a> {
     }
 }
 
+impl<'a> Vmtx<'a> {
+    /// A constructor that requires additional arguments.
+    ///
+    /// This type requires some external state in order to be
+    /// parsed.
+    pub fn read(
+        data: FontData<'a>,
+        number_of_long_ver_metrics: u16,
+        num_glyphs: u16,
+    ) -> Result<Self, ReadError> {
+        let args = (number_of_long_ver_metrics, num_glyphs);
+        Self::read_with_args(data, &args)
+    }
+}
+
 /// The [vmtx (Vertical Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/vmtx) table
 pub type Vmtx<'a> = TableRef<'a, VmtxMarker>;
 

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -31,6 +31,10 @@ pub trait ReadArgs {
 }
 
 /// A trait for types that require external data in order to be constructed.
+///
+/// You should not need to use this directly; it is intended to be used from
+/// generated code. Any type that requires external arguments also has a custom
+/// `read` constructor where you can pass those arguments like normal.
 pub trait FontReadWithArgs<'a>: Sized + ReadArgs {
     /// read an item, using the provided args.
     ///
@@ -38,8 +42,6 @@ pub trait FontReadWithArgs<'a>: Sized + ReadArgs {
     /// used to construct it.
     ///
     /// If a type requires multiple arguments, they will be passed as a tuple.
-    //TODO: split up the 'takes args' and 'reports size' parts of this into
-    // separate traits
     fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError>;
 }
 

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -388,9 +388,9 @@ mod tests {
 
         const N_AXES: u16 = 2;
 
-        let read_args = (EXPECTED.len() as u16, N_AXES);
         let tuples =
-            SharedTuples::read_with_args(SKIA_GVAR_SHARED_TUPLES_DATA, &read_args).unwrap();
+            SharedTuples::read(SKIA_GVAR_SHARED_TUPLES_DATA, EXPECTED.len() as u16, N_AXES)
+                .unwrap();
         let tuple_vec: Vec<_> = tuples
             .tuples()
             .iter()
@@ -410,8 +410,7 @@ mod tests {
         let header = GlyphVariationDataHeader::read(SKIA_GVAR_I_DATA).unwrap();
         assert_eq!(header.serialized_data_offset(), 36);
         assert_eq!(header.tuple_variation_count().count(), 8);
-        let shared_tuples =
-            SharedTuples::read_with_args(SKIA_GVAR_SHARED_TUPLES_DATA, &(8, 2)).unwrap();
+        let shared_tuples = SharedTuples::read(SKIA_GVAR_SHARED_TUPLES_DATA, 8, 2).unwrap();
 
         let vardata = GlyphVariationData::new(SKIA_GVAR_I_DATA, 2, shared_tuples).unwrap();
         assert_eq!(vardata.tuple_count(), 8);

--- a/read-fonts/src/tables/instance_record.rs
+++ b/read-fonts/src/tables/instance_record.rs
@@ -23,6 +23,18 @@ impl ReadArgs for InstanceRecord<'_> {
     type Args = (u16, u16);
 }
 
+impl<'a> InstanceRecord<'a> {
+    /// Parse an instance record with a known axis_count and instance_size
+    pub fn read(
+        data: FontData<'a>,
+        axis_count: u16,
+        instance_size: u16,
+    ) -> Result<Self, ReadError> {
+        let args = (axis_count, instance_size);
+        Self::read_with_args(data, &args)
+    }
+}
+
 impl<'a> FontReadWithArgs<'a> for InstanceRecord<'a> {
     fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError> {
         let axis_count = args.0 as usize;

--- a/read-fonts/src/tables/loca.rs
+++ b/read-fonts/src/tables/loca.rs
@@ -5,6 +5,7 @@
 use crate::{
     read::{FontRead, FontReadWithArgs, ReadArgs, ReadError},
     table_provider::TopLevelTable,
+    FontData,
 };
 use types::{BigEndian, GlyphId, Tag};
 
@@ -25,6 +26,10 @@ impl TopLevelTable for Loca<'_> {
 }
 
 impl<'a> Loca<'a> {
+    pub fn read(data: FontData<'a>, is_long: bool) -> Result<Self, crate::ReadError> {
+        Self::read_with_args(data, &is_long)
+    }
+
     pub fn len(&self) -> usize {
         match self {
             Loca::Short(data) => data.len().saturating_sub(1),
@@ -71,10 +76,7 @@ impl ReadArgs for Loca<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Loca<'a> {
-    fn read_with_args(
-        data: crate::FontData<'a>,
-        args: &Self::Args,
-    ) -> Result<Self, crate::ReadError> {
+    fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, crate::ReadError> {
         let is_long = *args;
         if is_long {
             data.read_array(0..data.len()).map(Loca::Long)

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -474,7 +474,7 @@ impl<'a> Iterator for TupleVariationHeaderIter<'a> {
             return None;
         }
         self.current += 1;
-        let next = TupleVariationHeader::read_with_args(self.data, &self.axis_count);
+        let next = TupleVariationHeader::read(self.data, self.axis_count);
         let next_len = next
             .as_ref()
             .map(|table| table.byte_len(self.axis_count))

--- a/write-fonts/src/tables/hmtx.rs
+++ b/write-fonts/src/tables/hmtx.rs
@@ -19,7 +19,7 @@ mod tests {
         let _dumped = crate::write::dump_table(&hmtx).unwrap();
 
         let data = FontData::new(&_dumped);
-        let loaded = read_fonts::tables::hmtx::Hmtx::read_with_args(data, &(1, 5)).unwrap();
+        let loaded = read_fonts::tables::hmtx::Hmtx::read(data, 1, 5).unwrap();
         assert_eq!(loaded.h_metrics()[0].advance(), 602);
         assert_eq!(loaded.h_metrics()[0].side_bearing(), -214);
         assert_eq!(loaded.left_side_bearings(), &hmtx.left_side_bearings);


### PR DESCRIPTION
I wanted to write this separately from #284, since maybe it is actually just a better solution overall? With this, the user should never need to interact with `FontReadWithArgs` at all, and can use the generated methods, where the arguments get names.

I used `read` instead of `new` for the method name because that's the name we generally use for constructors in `read-fonts`, otherwise I would prefer `new`.