### PR TITLE
Add #[compile_with] attribute

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -197,6 +197,11 @@ The following annotations are supported on top-level objects:
   evalutes to the field's type: the skip case is only expected in cases where
   there is a manual `FontWrite` impl, and the field does not make sense on the
   compile type.
+- `#[compile_with(method_name)]`: Specify custom compilation behaviour. This
+  attribute lets you name a method that will be called to get some type that
+  will be used to compile this field. This may be any type that implements the
+  `FontWrite` trait; this can be used in cases where the logic to compile a
+  given type requires some custom implementation.
 - `#[compile_type(type)]`: specify an alternate type to be used in the struct
   generated for this type.
 - `#[default(expr)]`: specify a value that will be used in the implementation of

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -548,6 +548,15 @@ impl Field {
             }
         }
 
+        if let Some(comp_attr) = &self.attrs.compile_with {
+            if self.attrs.compile.is_some() {
+                return Err(logged_syn_error(
+                    comp_attr.span(),
+                    "cannot have both 'compile' and 'compile_with'",
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -1117,6 +1126,9 @@ impl Field {
                 // noop
                 CustomCompile::Skip => return Default::default(),
             }
+        } else if let Some(attr) = self.attrs.compile_with.as_ref() {
+            let method = &attr.attr;
+            quote!( self.#method() )
         } else {
             computed = false;
             let name = self.name_for_compile();

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -189,6 +189,7 @@ pub(crate) struct FieldAttrs {
     pub(crate) format: Option<Attr<syn::LitInt>>,
     pub(crate) count: Option<Attr<Count>>,
     pub(crate) compile: Option<Attr<CustomCompile>>,
+    pub(crate) compile_with: Option<Attr<syn::Ident>>,
     pub(crate) default: Option<Attr<syn::Expr>>,
     pub(crate) compile_type: Option<Attr<syn::Type>>,
     pub(crate) read_with_args: Option<Attr<FieldReadArgs>>,
@@ -933,6 +934,7 @@ static OFFSET_GETTER: &str = "offset_getter";
 static OFFSET_DATA: &str = "offset_data_method";
 static OFFSET_ADJUSTMENT: &str = "offset_adjustment";
 static COMPILE: &str = "compile";
+static COMPILE_WITH: &str = "compile_with";
 static COMPILE_TYPE: &str = "compile_type";
 static DEFAULT: &str = "default";
 static READ_WITH: &str = "read_with";
@@ -969,6 +971,8 @@ impl Parse for FieldAttrs {
                 this.count = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == COMPILE {
                 this.compile = Some(Attr::new(ident.clone(), attr.parse_args()?));
+            } else if ident == COMPILE_WITH {
+                this.compile_with = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == COMPILE_TYPE {
                 this.compile_type = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == DEFAULT {

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -32,7 +32,6 @@ table Name {
 }
 
 /// Part of [Name]
-#[skip_font_write]
 record LangTagRecord {
     /// Language-tag string length (in bytes)
     #[compile(skip)]
@@ -42,12 +41,12 @@ record LangTagRecord {
     #[offset_getter(lang_tag)]
     #[traverse_with(traverse_lang_tag)]
     #[compile_type(OffsetMarker<String>)]
+    #[compile_with(compile_name_string)]
     #[validate(skip)]
     lang_tag_offset: Offset16<NameString>,
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[skip_font_write]
 record NameRecord {
     /// Platform ID.
     platform_id: u16,
@@ -64,6 +63,7 @@ record NameRecord {
     #[traverse_with(traverse_string)]
     #[offset_getter(string)]
     #[compile_type(OffsetMarker<String>)]
+    #[compile_with(compile_name_string)]
     #[validate(validate_string_data)]
     string_offset: Offset16<NameString>,
 }

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -22,6 +22,7 @@ table BasicTable {
 
 record SimpleRecord {
     val1: u16,
+    #[compile_with(compile_va2)]
     va2: u32,
 }
 

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -114,6 +114,13 @@ impl LangTagRecord {
     }
 }
 
+impl FontWrite for LangTagRecord {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (self.compile_name_string()).write_into(writer);
+    }
+}
+
 impl Validate for LangTagRecord {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
@@ -158,6 +165,17 @@ impl NameRecord {
             name_id,
             string: string.into(),
         }
+    }
+}
+
+impl FontWrite for NameRecord {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.platform_id.write_into(writer);
+        self.encoding_id.write_into(writer);
+        self.language_id.write_into(writer);
+        self.name_id.write_into(writer);
+        (self.compile_name_string()).write_into(writer);
     }
 }
 

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -90,7 +90,7 @@ impl SimpleRecord {
 impl FontWrite for SimpleRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.val1.write_into(writer);
-        self.va2.write_into(writer);
+        (self.compile_va2()).write_into(writer);
     }
 }
 

--- a/write-fonts/src/codegen_test.rs
+++ b/write-fonts/src/codegen_test.rs
@@ -20,6 +20,21 @@ mod records {
         }
     }
 
+    impl SimpleRecord {
+        // the [compile_with] attribute specifies this method, which returns
+        // a different type than the one declared in the table.
+        fn compile_va2(&self) -> [u8; 4] {
+            [0xde, 0xad, 0xbe, 0xef]
+        }
+    }
+
+    #[test]
+    fn compile_with() {
+        let record = SimpleRecord::new(69, 16);
+        let bytes = crate::dump_table(&record).unwrap();
+        assert_eq!(bytes, [0, 69, 0xde, 0xad, 0xbe, 0xef])
+    }
+
     #[test]
     fn constructors() {
         let simple = vec![SimpleRecord::new(6, 32)];


### PR DESCRIPTION
This closes #190, by providing a way to fully customize the compilation behaviour for a given field.

This differs from the `#[compile]` attribute in two important ways:
- `#[compile]` implies that this field is fully computed, which means we do not even include the field on the struct (since it would be ignored). `#[compile_with]` implies that the field exists, but that it requires special logic when compiled.
- with `#[compile]`, you must provide a value with the same type as the declared type of the field. With `#[compile_with]`, you name a method that will be called, and which can return *any* type that implements `FontWrite`.

This PR includes a commit that uses this new attribute to improve how we compile the strings in the `name` table.

Once this is merged, I will be able to also fix #189.