### PR TITLE
[skrifa] cleanup and better encapsulate hinting

### DIFF
--- a/skrifa/src/scale/glyf/hint/mod.rs
+++ b/skrifa/src/scale/glyf/hint/mod.rs
@@ -1,0 +1,73 @@
+use super::scaler::ScalerFont;
+use crate::scale::Hinting;
+
+use read_fonts::{
+    tables::glyf::PointFlags,
+    types::{F26Dot6, Point},
+};
+
+/// Slot for the hinting cache.
+#[derive(Copy, Clone, Default, Debug)]
+enum Slot {
+    /// Uncached font.
+    #[default]
+    Uncached,
+    /// Font and size cache indices.
+    Cached {
+        font_index: usize,
+        size_index: usize,
+    },
+}
+
+#[derive(Copy, Clone, Default, Debug)]
+pub struct HintConfig {
+    hinting: Option<Hinting>,
+    is_enabled: bool,
+    slot: Option<Slot>,
+}
+
+impl HintConfig {
+    pub fn new(hinting: Option<Hinting>) -> Self {
+        Self {
+            hinting,
+            is_enabled: hinting.is_some(),
+            slot: None,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.is_enabled
+    }
+
+    pub fn reset(&mut self) {
+        self.is_enabled = self.hinting.is_some();
+    }
+}
+
+/// Aggregate state from the scaler that is necessary for hinting
+/// a glyph.
+pub struct HintGlyph<'a> {
+    pub font: &'a ScalerFont<'a>,
+    pub config: &'a mut HintConfig,
+    pub points: &'a mut [Point<F26Dot6>],
+    pub original: &'a mut [Point<F26Dot6>],
+    pub unscaled: &'a mut [Point<i32>],
+    pub flags: &'a mut [PointFlags],
+    pub contours: &'a [u16],
+    pub point_base: usize,
+    pub contour_base: usize,
+    pub phantom: &'a mut [Point<F26Dot6>],
+    pub ins: &'a [u8],
+    pub is_composite: bool,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct HintContext {
+    // TODO
+}
+
+impl HintContext {
+    pub fn hint(&mut self, glyph: HintGlyph) -> bool {
+        true
+    }
+}

--- a/skrifa/src/scale/glyf/mod.rs
+++ b/skrifa/src/scale/glyf/mod.rs
@@ -7,15 +7,13 @@ mod deltas;
 mod outline;
 mod scaler;
 
-pub use outline::Outline;
-pub use scaler::Scaler;
+#[cfg(feature = "hinting")]
+mod hint;
 
 pub use read_fonts::types::Point;
+pub use {outline::Outline, scaler::Scaler};
 
-use read_fonts::types::{F26Dot6, Fixed};
-
-use super::{Error, Pen, Result, Variation};
-use crate::NormalizedCoord;
+use read_fonts::types::{F26Dot6, Fixed, Pen};
 
 /// Point that actually represents a vector holding a variation delta.
 pub type Delta = Point<Fixed>;
@@ -34,6 +32,9 @@ pub struct Context {
     /// Temporary point storage that is used for storing intermediate
     /// interpolated values while computing deltas.
     working_points: Vec<Point<Fixed>>,
+    /// Cache and retained state for executing TrueType bytecode.
+    #[cfg(feature = "hinting")]
+    hint_context: hint::HintContext,
 }
 
 impl Context {
@@ -46,11 +47,7 @@ impl Context {
 #[cfg(test)]
 mod tests {
     use super::{super::test, Context, Outline, Scaler};
-    use read_fonts::{
-        test_data::test_fonts,
-        types::{F26Dot6, GlyphId},
-        FontRef,
-    };
+    use read_fonts::{test_data::test_fonts, FontRef};
 
     #[test]
     fn vazirmatin_var() {


### PR DESCRIPTION
This patch doesn't have any functional changes. Just a bit of code shuffling:
* Removes the unnecessary intermediate `GlyphScaler` type (and the double lifetime!)
* Moves font "instance" parameters (size, scale and coords) to the `ScalerFont` type
* Encapsulates hinting state in a new module

This is mostly so I can maintain the bytecode interpreter in a fork (for now!) without requiring changes to the main scaler code. It's also just better organized all around.