### PR TITLE
Bump font-types and read-fonts because NameId touched them

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.1.1", path = "../font-types" }
+font-types = { version = "0.1.2", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 xflags = "0.2.4"
-read-fonts = { path = "../read-fonts",version = "0.1.2" }
-font-types = { path = "../font-types",version = "0.1.1" }
+read-fonts = { path = "../read-fonts",version = "0.1.3" }
+font-types = { path = "../font-types",version = "0.1.2" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."
@@ -15,4 +15,4 @@ traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { version = "0.1.1", path = "../font-types" }
+font-types = { version = "0.1.2", path = "../font-types" }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -15,10 +15,10 @@ scale = []
 hinting = []
 
 [dependencies]
-read-fonts = { version = "0.1.2", path = "../read-fonts" }
+read-fonts = { version = "0.1.3", path = "../read-fonts" }
 
 [dev-dependencies]
-read-fonts = { version = "0.1.2", path = "../read-fonts", features = ["test_data"] }
+read-fonts = { version = "0.1.3", path = "../read-fonts", features = ["test_data"] }
 
 # cargo-release settings
 [package.metadata.release]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -11,12 +11,12 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { version = "0.1.1", path = "../font-types" }
-read-fonts = { version = "0.1.2", path = "../read-fonts" }
+font-types = { version = "0.1.2", path = "../font-types" }
+read-fonts = { version = "0.1.3", path = "../read-fonts" }
 bitflags = "1.3"
 kurbo = "0.9.1"
 
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
-read-fonts = { version = "0.1.2", path = "../read-fonts", features = ["test_data"] }
+read-fonts = { version = "0.1.3", path = "../read-fonts", features = ["test_data"] }


### PR DESCRIPTION
Currently I cannot release write-fonts 0.1.5.

Just merge. And feel free to release font-types, read-fonts, and write-fonts too.