### PR TITLE
patch bump font-types and write-fonts

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.1.2", path = "../font-types" }
+font-types = { version = "0.1.3", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 xflags = "0.2.4"
 read-fonts = { path = "../read-fonts",version = "0.1.3" }
-font-types = { path = "../font-types",version = "0.1.2" }
+font-types = { path = "../font-types",version = "0.1.3" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -15,4 +15,4 @@ traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { version = "0.1.2", path = "../font-types" }
+font-types = { version = "0.1.3", path = "../font-types" }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { version = "0.1.2", path = "../font-types" }
+font-types = { version = "0.1.3", path = "../font-types" }
 read-fonts = { version = "0.1.3", path = "../read-fonts" }
 bitflags = "1.3"
 kurbo = "0.9.1"


### PR DESCRIPTION
So I can release write support for avar, fvar, and hvar