### PR TITLE
add pre-push git hook to check for accidental println! statements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
       - name: cargo doc
         run: cargo doc --all-features --document-private-items --no-deps
 
+      - name: check no println! or eprintln! statements
+        run: resources/scripts/check_no_println.sh
+
   clippy-lint:
     name: Clippy lints
     runs-on: ubuntu-latest

--- a/resources/githooks/pre-push
+++ b/resources/githooks/pre-push
@@ -3,6 +3,10 @@
 # Local check that we are likely to pass CI
 # CI is quite slow so it's nice to be able to run locally
 
+
+GITHOOKS_DIR=$(dirname "$(realpath "$0")")
+SCRIPTS_DIR="$GITHOOKS_DIR/../scripts"
+
 set -o errexit
 set -o xtrace
 
@@ -19,3 +23,22 @@ cargo clippy --all-features --all-targets -- -D warnings
 
 cargo test --all-features
 cargo test --no-default-features
+
+# shut up xtrace
+{ set +x; } 2>/dev/null
+
+# Check against println! or eprintln! in the Rust files about to be pushed.
+# The pre-push git hook receives info about what is to be pushed from stdin, see:
+# https://git-scm.com/docs/githooks#_pre_push
+# The `test` Unix command -t NUM option returns true if the given file descriptor (0 for stdin)
+# is open and associated with a terminal, and false if the input is piped.
+# When this is run as a regular script (input is a terminal), all the git-tracked *.rs files
+# are searched. When it's run as a hook (input is a pipe) only the added lines from the diff
+# between local and remote refs are searched.
+if [ -t 0 ]; then
+    "$SCRIPTS_DIR/check_no_println.sh"
+else
+    while read -r _local_ref local_sha _remote_ref remote_sha; do
+        "$SCRIPTS_DIR/check_no_println.sh" --from-ref "$remote_sha" --to-ref "$local_sha"
+    done
+fi

--- a/resources/scripts/check_no_println.sh
+++ b/resources/scripts/check_no_println.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Script to check for println! or eprintln! in Rust files, ignoring comments.
+#
+# When no args are provided, all the git-tracked *.rs files are searched,
+# except those listed in the 'println_ignore.txt' file next to the script.
+# When run with two args, respectively --from-ref <ref> and --to-ref <ref>,
+# only the added lines from the git diff between the two refs are searched.
+# The latter is useful when running this as a pre-push git hook.
+
+SCRIPTS_DIR=$(dirname "$(realpath "$0")")
+PRINTLN_IGNORE_LIST="$SCRIPTS_DIR/println_ignore.txt"
+
+
+grep_rust_lines_with_prints() {
+    for file in $(git ls-files '*.rs'); do
+        # skip files listed in the ignore list
+        if ! grep -q -F -x "$file" "$PRINTLN_IGNORE_LIST"; then
+            # Strip all inline comments
+            sed -e 's://.*$::' "$file" | \
+            # Prepend the file name and line number to each line, with colors
+            awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
+            # Grep for print statements
+            grep --color=always -E '\b(println!|eprintln!)' || true
+        fi
+    done
+}
+
+diff_rust_lines_with_prints() {
+    local from_ref="$1"
+    local to_ref="${2:-HEAD}"
+    # --diff-filter=A is to list only added files, excluding modified/deleted
+    git diff "$from_ref" "$to_ref" --name-only --diff-filter=A | \
+    grep '\.rs$' | \
+    while read -r file; do
+        # skip files listed in the ignore list
+        if ! grep -q -F -x "$file" "$PRINTLN_IGNORE_LIST"; then
+            # For each file, get a unified diff with no context (-U0)
+            git diff "$from_ref" "$to_ref" -U0 -- "$file" | \
+            # Strip lines starting with '+++' containing the file name
+            grep -v -E '^\+\+\+' | \
+            # Select only the added lines, i.e. starting with a plus sign
+            grep -E '^\+' | \
+            # Strip the '+' prefix and the inline comments
+            sed -e 's/^\+//' -e 's://.*$::' | \
+            # Prepend the file name and line number to each line, with colors
+            awk -v file="$file" '{ printf "\033[35m%s\033[0m:\033[32m%s\033[0m: %s\n", file, FNR, $0 }' | \
+            # Grep for print statements
+            grep --color=always -E '\b(println!|eprintln!)' || true
+        fi
+    done
+}
+
+
+opt_error() {
+    local message="$1"
+    echo "Error: $message"
+    echo "Usage: $0 [--from-ref <ref>] [--to-ref <ref>]"
+    exit 1
+}
+
+
+if [ $# -eq 0 ]; then
+    # when no arguments are passed, search all git-tracked files
+    matches=$(grep_rust_lines_with_prints)
+else
+    from_ref=""
+    to_ref=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --from-ref)
+                from_ref="$2"
+                shift 2
+                ;;
+            --to-ref)
+                to_ref="${2:-HEAD}"
+                shift 2
+                ;;
+            *)
+                opt_error "Unknown option: $1"
+                ;;
+        esac
+    done
+
+    if [ -z "$from_ref" ] || [ -z "$to_ref" ]; then
+        opt_error "both --from-ref and --to-ref must be provided, or none at all."
+    fi
+
+    matches=$(diff_rust_lines_with_prints "$from_ref" "$to_ref")
+fi
+
+if [ ! -z "$matches" ]; then
+    echo "Error: The following Rust source files contain println! or eprintln! statements:"
+    echo "$matches"
+    echo "Please remove or comment out the println! and eprintln! statements before pushing."
+    echo "You may also add the files to 'println_ignore.txt' if you want to keep as is."
+    exit 1
+fi
+exit 0

--- a/resources/scripts/println_ignore.txt
+++ b/resources/scripts/println_ignore.txt
@@ -1,0 +1,3 @@
+font-codegen/src/bin/preprocessor.rs
+otexplorer/src/main.rs
+otexplorer/src/query.rs

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -20,3 +20,5 @@ kurbo = "0.9.1"
 diff = "0.1.12"
 ansi_term = "0.12.1"
 read-fonts = { version = "0.1.3", path = "../read-fonts", features = ["test_data"] }
+log = "0.4"
+env_logger = "0.10.0"

--- a/write-fonts/src/tables/name.rs
+++ b/write-fonts/src/tables/name.rs
@@ -162,6 +162,12 @@ impl PartialOrd for NameRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use env_logger;
+    use log::debug;
+
+    fn init() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
 
     #[test]
     fn encoding() {
@@ -227,6 +233,8 @@ mod tests {
 
     #[test]
     fn roundtrip() {
+        init();
+
         #[rustfmt::skip]
         static COLINS_BESPOKE_DATA: &[u8] = &[
             0x0, 0x0, // version
@@ -274,7 +282,7 @@ mod tests {
 
         for rec in raw_table.name_record() {
             let raw_str = rec.string(raw_table.string_data()).unwrap();
-            eprintln!("{raw_str}");
+            debug!("{raw_str}");
         }
 
         assert_eq!(raw_table.version(), reloaded.version());
@@ -292,11 +300,11 @@ mod tests {
             assert_eq!(old.language_id(), new.language_id());
             assert_eq!(old.name_id(), new.name_id());
             assert_eq!(old.length(), new.length());
-            eprintln!("{:?} {:?}", old.string_offset(), new.string_offset());
+            debug!("{:?} {:?}", old.string_offset(), new.string_offset());
             let old_str = old.string(raw_table.string_data()).unwrap();
             let new_str = new.string(reloaded.string_data()).unwrap();
             if old_str != new_str {
-                eprintln!("'{old_str}' != '{new_str}'");
+                debug!("'{old_str}' != '{new_str}'");
                 fail = true;
             }
         }


### PR DESCRIPTION
similar to https://github.com/googlefonts/fontmake-rs/pull/204, with the only difference that in the case of fontations there are a couple of files where the use of `println!` is intentional and legitimate (font-codegen::preprocessor or otexplorer) so I added an allow-list to be able to exclude those from the check.