### PR TITLE
Bump write-fonts to 0.1.7

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
So I can release #315 for https://github.com/googlefonts/fontmake-rs/issues/223