### PR TITLE
Update write-fonts to 0.1.8

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
To release #322 so fontmake-rs can build a trivial font that is OTS-clean.

JMM.