### PR TITLE
[ci] Treat rustdoc warnings as errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: cargo doc
         run: cargo doc --all-features --document-private-items --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
 
       - name: check no println! or eprintln! statements
         run: resources/scripts/check_no_println.sh

--- a/resources/githooks/pre-push
+++ b/resources/githooks/pre-push
@@ -13,7 +13,7 @@ set -o xtrace
 # ensure rustfmt has been run
 cargo fmt --all -- --check
 # ensure we don't have broken links in docs
-cargo doc --all-features --document-private-items
+RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items
 
 # ensure we at least compile without default features
 cargo check --manifest-path=font-types/Cargo.toml --no-default-features

--- a/skrifa/src/meta/strings.rs
+++ b/skrifa/src/meta/strings.rs
@@ -234,7 +234,7 @@ fn language_id_to_bcp47(language_id: u16) -> Option<&'static str> {
 }
 
 /// Mapping of OpenType name table language identifier to BCP-47 language tag.
-/// Borrowed from Skia: https://skia.googlesource.com/skia/+/refs/heads/main/src/sfnt/SkOTTable_name.cpp#98
+/// Borrowed from Skia: <https://skia.googlesource.com/skia/+/refs/heads/main/src/sfnt/SkOTTable_name.cpp#98>
 const LANGUAGE_ID_TO_BCP47: &[(u16, &str)] = &[
     /* A mapping from Mac Language Designators to BCP 47 codes.
      *  The following list was constructed more or less manually.

--- a/write-fonts/src/round.rs
+++ b/write-fonts/src/round.rs
@@ -1,13 +1,13 @@
 //! Rounding whose behavior is defined by the
 //! [font specification](https://learn.microsoft.com/en-us/typography/opentype/spec/otff).
 
-/// ot_round is defined by https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization.
+/// ot_round is defined by <https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization>.
 ///
-/// https://github.com/fonttools/fonttools/issues/1248#issuecomment-383198166 captures the rationale
+/// <https://github.com/fonttools/fonttools/issues/1248#issuecomment-383198166> captures the rationale
 /// for the current implementation.
 ///
-/// Copied from https://github.com/simoncozens/rust-font-tools/blob/105436d3a617ddbebd25f790b041ff506bd90d44/otmath/src/lib.rs#L17,
-/// which is in turn copied from https://github.com/fonttools/fonttools/blob/a55a545b12a9735e303568a9d4c7e75fe6dbd2be/Lib/fontTools/misc/roundTools.py#L23.
+/// Copied from <https://github.com/simoncozens/rust-font-tools/blob/105436d3a617ddbebd25f790b041ff506bd90d44/otmath/src/lib.rs#L17>,
+/// which is in turn copied from <https://github.com/fonttools/fonttools/blob/a55a545b12a9735e303568a9d4c7e75fe6dbd2be/Lib/fontTools/misc/roundTools.py#L23>.
 pub trait OtRound<U, T = Self> {
     fn ot_round(self) -> U;
 }


### PR DESCRIPTION
As far as I can tell these tend to generally be useful, and with this off it's easy to commit bare hyperlinks that rustdoc yells at me for, locally.

~(currently checking that this actually fails, then I will fix the existing problems)~

JMM