### PR TITLE
Improve diagnostics when table packing fails

### DIFF
--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -203,7 +203,8 @@ impl Graph {
         }
     }
 
-    pub(crate) fn topological_sort(&mut self) {
+    /// returns `true` if a solution is found, `false` otherwise
+    pub(crate) fn topological_sort(&mut self) -> bool {
         self.sort_kahn();
         if !self.find_overflows().is_empty() {
             self.sort_shortest_distance();
@@ -212,6 +213,7 @@ impl Graph {
             self.assign_32bit_spaces();
             self.sort_shortest_distance();
         }
+        self.find_overflows().is_empty()
     }
 
     fn find_overflows(&self) -> Vec<(ObjectId, ObjectId)> {


### PR DESCRIPTION
This would previously just hit an unwrap and provide very little information. We still provide very little information, but we now do it earlier and in a controlled way.

This should at least explain what happens in cases like #303.