### PR TITLE
[skrifa] cleanup: replace Variation with generic Setting<T>

### DIFF
--- a/skrifa/src/coords.rs
+++ b/skrifa/src/coords.rs
@@ -1,0 +1,59 @@
+//! Representation of a set of normalized coordinates.
+
+use super::NormalizedCoord;
+
+/// Ordered sequence of normalized variation coordinates in design space.
+///
+/// This type represents a position in the variation space where each
+/// coordinate corresponds to an axis (in the same order as the `fvar` table)
+/// and is a normalized value in the range `[-1..1]`.
+///
+/// See [Coordinate Scales and Normalization](https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization)
+/// for further details.
+///
+/// If the array is larger in length than the number of axes, extraneous
+/// values are ignored. If it is smaller, unrepresented axes are assumed to be
+/// at their default positions (i.e. 0).
+///
+/// A value of this type constructed with `default()` represents the default
+/// position for each axis.
+///
+/// Normalized coordinates are ignored for non-variable fonts.
+#[derive(Copy, Clone, Default, Debug)]
+pub struct NormalizedCoords<'a>(&'a [NormalizedCoord]);
+
+impl<'a> NormalizedCoords<'a> {
+    /// Creates a new sequence of normalized coordinates from the given array.
+    pub fn new(coords: &'a [NormalizedCoord]) -> Self {
+        Self(coords)
+    }
+
+    /// Returns the underlying array of normalized coordinates.
+    pub fn inner(&self) -> &'a [NormalizedCoord] {
+        self.0
+    }
+}
+
+impl<'a> From<&'a [NormalizedCoord]> for NormalizedCoords<'a> {
+    fn from(value: &'a [NormalizedCoord]) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> IntoIterator for NormalizedCoords<'a> {
+    type IntoIter = core::slice::Iter<'a, NormalizedCoord>;
+    type Item = &'a NormalizedCoord;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'_ NormalizedCoords<'a> {
+    type IntoIter = core::slice::Iter<'a, NormalizedCoord>;
+    type Item = &'a NormalizedCoord;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -6,118 +6,25 @@
 pub extern crate read_fonts as raw;
 
 pub mod meta;
-
 #[cfg(feature = "scale")]
 pub mod scale;
 
-/// Type for a normalized variation coordinate.
-pub type NormalizedCoord = read_fonts::types::F2Dot14;
+mod coords;
+mod setting;
+mod size;
 
-/// Ordered sequence of normalized variation coordinates in design space.
-///
-/// This type represents a position in the variation space where each
-/// coordinate corresponds to an axis (in the same order as the `fvar` table)
-/// and is a normalized value in the range `[-1..1]`.
-///
-/// See [Coordinate Scales and Normalization](https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization)
-/// for further details.
-///
-/// If the array is larger in length than the number of axes, extraneous
-/// values are ignored. If it is smaller, unrepresented axes are assumed to be
-/// at their default positions (i.e. 0).
-///
-/// A value of this type constructed with `default()` represents the default
-/// position for each axis.
-///
-/// Normalized coordinates are ignored for non-variable fonts.
-#[derive(Copy, Clone, Default, Debug)]
-pub struct NormalizedCoords<'a>(&'a [NormalizedCoord]);
-
-impl<'a> NormalizedCoords<'a> {
-    /// Creates a new sequence of normalized coordinates from the given array.
-    pub fn new(coords: &'a [NormalizedCoord]) -> Self {
-        Self(coords)
-    }
-
-    /// Returns the underlying array of normalized coordinates.
-    pub fn inner(&self) -> &'a [NormalizedCoord] {
-        self.0
-    }
-}
-
-impl<'a> From<&'a [NormalizedCoord]> for NormalizedCoords<'a> {
-    fn from(value: &'a [NormalizedCoord]) -> Self {
-        Self(value)
-    }
-}
-
-impl<'a> IntoIterator for NormalizedCoords<'a> {
-    type IntoIter = core::slice::Iter<'a, NormalizedCoord>;
-    type Item = &'a NormalizedCoord;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl<'a> IntoIterator for &'_ NormalizedCoords<'a> {
-    type IntoIter = core::slice::Iter<'a, NormalizedCoord>;
-    type Item = &'a NormalizedCoord;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-/// Font size in pixels per em units.
-///
-/// Sizes in this crate are represented as a ratio of pixels to the size of
-/// the em square defined by the font. This is equivalent to the `px` unit
-/// in CSS (assuming a DPI scale factor of 1.0).
-///
-/// To retrieve metrics and outlines in font units, use the [unscaled](Self::unscaled)
-/// construtor on this type.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-pub struct Size(f32);
-
-impl Size {
-    /// Creates a new font size from the given value in pixels per em units.
-    ///
-    /// Providing a value `<= 0.0` is equivalent to creating an unscaled size
-    /// and will result in metrics and outlines generated in font units.
-    pub fn new(ppem: f32) -> Self {
-        Self(ppem)
-    }
-
-    /// Creates a new font size for generating unscaled metrics or outlines in
-    /// font units.
-    pub fn unscaled() -> Self {
-        Self(0.0)
-    }
-
-    /// Returns the raw size in pixels per em units.
-    ///
-    /// Results in `None` if the size is unscaled.
-    pub fn ppem(self) -> Option<f32> {
-        (self.0 > 0.0).then_some(self.0)
-    }
-
-    /// Computes a linear scale factor for this font size and the given units
-    /// per em value which can be retrieved from the [Metrics](crate::meta::metrics::Metrics)
-    /// type or from the [head](read_fonts::tables::head::Head) table.
-    ///
-    /// Returns 1.0 for an unscaled size or when `units_per_em` is 0.
-    pub fn linear_scale(self, units_per_em: u16) -> f32 {
-        if self.0 > 0.0 && units_per_em != 0 {
-            self.0 / units_per_em as f32
-        } else {
-            1.0
-        }
-    }
-}
+pub use coords::NormalizedCoords;
+pub use setting::{Setting, VariationSetting};
+pub use size::Size;
 
 /// Type for a glyph identifier.
 pub type GlyphId = read_fonts::types::GlyphId;
+
+/// Type for a 4-byte tag used to identify font tables and other resources.
+pub type Tag = read_fonts::types::Tag;
+
+/// Type for a normalized variation coordinate.
+pub type NormalizedCoord = read_fonts::types::F2Dot14;
 
 #[doc(inline)]
 pub use meta::MetadataProvider;

--- a/skrifa/src/meta/metrics.rs
+++ b/skrifa/src/meta/metrics.rs
@@ -30,6 +30,7 @@ use read_fonts::{
 
 use crate::{NormalizedCoord, NormalizedCoords, Size};
 
+/// Type for a bounding box with single precision floating point coordinates.
 pub type BoundingBox = read_fonts::types::BoundingBox<f32>;
 
 /// Metrics for a text decoration.

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -15,7 +15,7 @@ pub use read_fonts::types::Pen;
 pub use error::{Error, Result};
 pub use scaler::{Scaler, ScalerBuilder};
 
-use super::{GlyphId, NormalizedCoord};
+use super::{GlyphId, NormalizedCoord, VariationSetting};
 use core::str::FromStr;
 use read_fonts::types::Tag;
 
@@ -42,42 +42,6 @@ pub enum Hinting {
     VerticalSubpixel,
 }
 
-/// Setting for specifying a variation by tag and value.
-#[derive(Copy, Clone, Debug)]
-pub struct Variation {
-    /// Tag for the variation.
-    pub tag: Tag,
-    /// Value for the variation.
-    pub value: f32,
-}
-
-impl From<(Tag, f32)> for Variation {
-    fn from(s: (Tag, f32)) -> Self {
-        Self {
-            tag: s.0,
-            value: s.1,
-        }
-    }
-}
-
-impl From<(&str, f32)> for Variation {
-    fn from(s: (&str, f32)) -> Self {
-        Self {
-            tag: Tag::from_str(s.0).unwrap_or_default(),
-            value: s.1,
-        }
-    }
-}
-
-impl From<([u8; 4], f32)> for Variation {
-    fn from(s: ([u8; 4], f32)) -> Self {
-        Self {
-            tag: Tag::new_checked(&s.0[..]).unwrap_or_default(),
-            value: s.1,
-        }
-    }
-}
-
 /// Context for loading glyphs.
 #[derive(Clone, Default, Debug)]
 pub struct Context {
@@ -88,7 +52,7 @@ pub struct Context {
     /// Storage for normalized variation coordinates.
     coords: Vec<NormalizedCoord>,
     /// Storage for variation settings.
-    variations: Vec<Variation>,
+    variations: Vec<VariationSetting>,
 }
 
 impl Context {
@@ -120,7 +84,7 @@ mod tests {
             let mut scaler = cx
                 .new_scaler()
                 .size(Size::new(expected_outline.size))
-                .coords(&expected_outline.coords)
+                .normalized_coords(&expected_outline.coords)
                 .build(&font);
             scaler
                 .outline(expected_outline.glyph_id, &mut path)

--- a/skrifa/src/scale/scaler.rs
+++ b/skrifa/src/scale/scaler.rs
@@ -1,4 +1,4 @@
-use super::{glyf, Context, Error, NormalizedCoord, Pen, Result, Variation};
+use super::{glyf, Context, Error, NormalizedCoord, Pen, Result, VariationSetting};
 use crate::Size;
 
 #[cfg(feature = "hinting")]
@@ -61,7 +61,7 @@ impl<'a> ScalerBuilder<'a> {
     /// Specifies a variation with a set of normalized coordinates.
     ///
     /// This will clear any variations specified with the variations method.
-    pub fn coords<I>(self, coords: I) -> Self
+    pub fn normalized_coords<I>(self, coords: I) -> Self
     where
         I: IntoIterator,
         I::Item: Borrow<NormalizedCoord>,
@@ -76,15 +76,15 @@ impl<'a> ScalerBuilder<'a> {
 
     /// Adds the sequence of variation settings. This will clear any variations
     /// specified as normalized coordinates.
-    pub fn variations<I>(self, variations: I) -> Self
+    pub fn variation_settings<I>(self, settings: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<Variation>,
+        I::Item: Into<VariationSetting>,
     {
         self.context.coords.clear();
         self.context
             .variations
-            .extend(variations.into_iter().map(|v| v.into()));
+            .extend(settings.into_iter().map(|v| v.into()));
         self
     }
 
@@ -137,7 +137,7 @@ impl<'a> ScalerBuilder<'a> {
             for (i, axis) in axes
                 .iter()
                 .enumerate()
-                .filter(|(_, axis)| axis.axis_tag() == variation.tag)
+                .filter(|(_, axis)| axis.axis_tag() == variation.selector)
             {
                 let coord = axis.normalize(Fixed::from_f64(variation.value as f64));
                 let coord = avar_mappings

--- a/skrifa/src/setting.rs
+++ b/skrifa/src/setting.rs
@@ -1,0 +1,80 @@
+//! Generic type for selecting variations and features.
+
+use super::Tag;
+use core::str::FromStr;
+
+/// Setting defined by a selector tag and an associated value.
+///
+/// This type is a generic container for properties that can be activated
+/// or defined by a `(Tag, T)` pair where the tag selects the target
+/// setting and the generic value of type `T` specifies the value for that
+/// setting.
+///
+/// ## Usage
+/// Current usage is for specifying variation axis settings (similar to the
+/// CSS property [font-variation-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)).
+/// See [`VariationSetting`].
+///
+/// In the future, this will likely also be used for specifying feature settings
+/// (analogous to the CSS property [font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings))
+/// for selecting OpenType [features](https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags).
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct Setting<T> {
+    /// Tag that specifies the target setting.
+    pub selector: Tag,
+    /// The desired value for the setting.
+    pub value: T,
+}
+
+impl<T> Setting<T> {
+    /// Creates a new setting from the given selector tag and its associated
+    /// value.
+    pub fn new(selector: Tag, value: T) -> Self {
+        Self { selector, value }
+    }
+}
+
+impl<T> From<(Tag, T)> for Setting<T> {
+    fn from(s: (Tag, T)) -> Self {
+        Self {
+            selector: s.0,
+            value: s.1,
+        }
+    }
+}
+
+impl<T> From<(&str, T)> for Setting<T> {
+    fn from(s: (&str, T)) -> Self {
+        Self {
+            selector: Tag::from_str(s.0).unwrap_or_default(),
+            value: s.1,
+        }
+    }
+}
+
+impl<T> From<([u8; 4], T)> for Setting<T> {
+    fn from(s: ([u8; 4], T)) -> Self {
+        Self {
+            selector: Tag::new_checked(&s.0[..]).unwrap_or_default(),
+            value: s.1,
+        }
+    }
+}
+
+/// Type for specifying a variation axis setting in user coordinates.
+///
+/// The `selector` field should contain a tag that corresponds to a
+/// variation axis while the `value` field specifies the desired position
+/// on the axis in user coordinates (i.e. within the range defined by
+/// the mininum and maximum values of the axis).
+///
+/// # Example
+/// ```
+/// use skrifa::{Tag, VariationSetting};
+///
+/// // For convenience, a conversion from (&str, f32) is provided.
+/// let slightly_bolder: VariationSetting = ("wght", 720.0).into();
+///
+/// assert_eq!(slightly_bolder, VariationSetting::new(Tag::new(b"wght"), 720.0));
+/// ```
+pub type VariationSetting = Setting<f32>;

--- a/skrifa/src/size.rs
+++ b/skrifa/src/size.rs
@@ -1,0 +1,48 @@
+//! Strongly typed font size representation.
+
+/// Font size in pixels per em units.
+///
+/// Sizes in this crate are represented as a ratio of pixels to the size of
+/// the em square defined by the font. This is equivalent to the `px` unit
+/// in CSS (assuming a DPI scale factor of 1.0).
+///
+/// To retrieve metrics and outlines in font units, use the [unscaled](Self::unscaled)
+/// construtor on this type.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub struct Size(f32);
+
+impl Size {
+    /// Creates a new font size from the given value in pixels per em units.
+    ///
+    /// Providing a value `<= 0.0` is equivalent to creating an unscaled size
+    /// and will result in metrics and outlines generated in font units.
+    pub fn new(ppem: f32) -> Self {
+        Self(ppem)
+    }
+
+    /// Creates a new font size for generating unscaled metrics or outlines in
+    /// font units.
+    pub fn unscaled() -> Self {
+        Self(0.0)
+    }
+
+    /// Returns the raw size in pixels per em units.
+    ///
+    /// Results in `None` if the size is unscaled.
+    pub fn ppem(self) -> Option<f32> {
+        (self.0 > 0.0).then_some(self.0)
+    }
+
+    /// Computes a linear scale factor for this font size and the given units
+    /// per em value which can be retrieved from the [Metrics](crate::meta::metrics::Metrics)
+    /// type or from the [head](read_fonts::tables::head::Head) table.
+    ///
+    /// Returns 1.0 for an unscaled size or when `units_per_em` is 0.
+    pub fn linear_scale(self, units_per_em: u16) -> f32 {
+        if self.0 > 0.0 && units_per_em != 0 {
+            self.0 / units_per_em as f32
+        } else {
+            1.0
+        }
+    }
+}


### PR DESCRIPTION
No functional changes here. This is the first in a series of cleanup PRs designed to prepare skrifa for initial release.

Removes the `scale::Variation` type and replaces it with a generic `Setting<T>` type along with a type alias `VariationSetting = Setting<f32>`. Setting is generic because the same structure will also be useful for OpenType feature settings at some point in the future.

Addresses one item on the list in #209.

Also moves a few types from lib.rs to modules.