### PR TITLE
[skrifa] replace raw u64 with UniqueId

### DIFF
--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -12,10 +12,12 @@ pub mod scale;
 mod coords;
 mod setting;
 mod size;
+mod unique_id;
 
 pub use coords::NormalizedCoords;
 pub use setting::{Setting, VariationSetting};
 pub use size::Size;
+pub use unique_id::UniqueId;
 
 /// Type for a glyph identifier.
 pub type GlyphId = read_fonts::types::GlyphId;

--- a/skrifa/src/scale/glyf/scaler.rs
+++ b/skrifa/src/scale/glyf/scaler.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{Error, NormalizedCoord, Result, GLYF_COMPOSITE_RECURSION_LIMIT},
+    super::{Error, NormalizedCoord, Result, UniqueId, GLYF_COMPOSITE_RECURSION_LIMIT},
     Context, Outline, Point,
 };
 
@@ -44,12 +44,12 @@ impl<'a> Scaler<'a> {
     pub fn new(
         context: &'a mut Context,
         font: &impl TableProvider<'a>,
-        font_id: Option<u64>,
+        unique_id: Option<UniqueId>,
         size: f32,
         #[cfg(feature = "hinting")] hinting: Option<Hinting>,
         coords: &'a [NormalizedCoord],
     ) -> Result<Self> {
-        let font = ScalerFont::new(font, font_id, size, coords)?;
+        let font = ScalerFont::new(font, unique_id, size, coords)?;
         Ok(Self {
             context,
             font,
@@ -545,7 +545,7 @@ impl<'a> Scaler<'a> {
 /// table references for loading, scaling and hinting a glyph outline.
 #[derive(Clone)]
 pub struct ScalerFont<'a> {
-    pub id: Option<u64>,
+    pub id: Option<UniqueId>,
     pub is_scaled: bool,
     pub ppem: u16,
     pub scale: F26Dot6,
@@ -572,7 +572,7 @@ pub struct ScalerFont<'a> {
 impl<'a> ScalerFont<'a> {
     fn new(
         font: &impl TableProvider<'a>,
-        id: Option<u64>,
+        id: Option<UniqueId>,
         size: f32,
         coords: &'a [NormalizedCoord],
     ) -> Result<Self> {

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -15,7 +15,7 @@ pub use read_fonts::types::Pen;
 pub use error::{Error, Result};
 pub use scaler::{Scaler, ScalerBuilder};
 
-use super::{GlyphId, NormalizedCoord, VariationSetting};
+use super::{GlyphId, NormalizedCoord, UniqueId, VariationSetting};
 use core::str::FromStr;
 use read_fonts::types::Tag;
 

--- a/skrifa/src/scale/scaler.rs
+++ b/skrifa/src/scale/scaler.rs
@@ -1,5 +1,5 @@
 use super::{glyf, Context, Error, NormalizedCoord, Pen, Result, VariationSetting};
-use crate::Size;
+use crate::{Size, UniqueId};
 
 #[cfg(feature = "hinting")]
 use super::Hinting;
@@ -13,7 +13,7 @@ use read_fonts::{
 /// Builder for configuring a glyph scaler.
 pub struct ScalerBuilder<'a> {
     context: &'a mut Context,
-    font_id: Option<u64>,
+    cache_key: Option<UniqueId>,
     size: Size,
     #[cfg(feature = "hinting")]
     hint: Option<Hinting>,
@@ -26,7 +26,7 @@ impl<'a> ScalerBuilder<'a> {
         context.variations.clear();
         Self {
             context,
-            font_id: None,
+            cache_key: None,
             size: Size::unscaled(),
             #[cfg(feature = "hinting")]
             hint: None,
@@ -35,8 +35,8 @@ impl<'a> ScalerBuilder<'a> {
 
     /// Sets a unique font identifier for hint state caching. Specifying `None` will
     /// disable caching.
-    pub fn font_id(mut self, font_id: Option<u64>) -> Self {
-        self.font_id = font_id;
+    pub fn cache_key(mut self, key: Option<UniqueId>) -> Self {
+        self.cache_key = key;
         self
     }
 
@@ -96,7 +96,7 @@ impl<'a> ScalerBuilder<'a> {
         let glyf = if let Ok(glyf) = glyf::Scaler::new(
             &mut self.context.glyf,
             font,
-            self.font_id,
+            self.cache_key,
             self.size.ppem().unwrap_or_default(),
             #[cfg(feature = "hinting")]
             self.hint,

--- a/skrifa/src/unique_id.rs
+++ b/skrifa/src/unique_id.rs
@@ -1,0 +1,45 @@
+//! Unique identifier to support internal caching.
+
+/// Identifier used as a key for internal caches.
+///
+/// The representation of a font in this crate is designed to be flexible for
+/// clients (any type that implements [`TableProvider`](read_fonts::TableProvider)
+/// is supported) without imposing any strict constraints on ownership or data layout.
+///
+/// The price for this flexibility is that an additional mechanism is necessary
+/// to enable caching of state for performance sensitive operations. The chosen
+/// design stores cached data in separate contexts (see [`scale::Context`][crate::scale::Context]
+/// as an example) keyed by this type.
+///
+/// Thus, to enable caching, a client may provide an instance of this type when
+/// making use of a context. For example, [`ScalerBuilder::cache_key`][crate::scale::ScalerBuilder::cache_key] can
+/// be used when configuring a glyph scaler.
+///
+/// # Semantics
+/// Currently, the fields on this type carry no actual semantics. The `index`
+/// field, for example, is not required to match the index of a font in a collection.
+/// Types and names were chosen to accommodate the common representation of
+/// a pointer and index pair.
+///
+/// The only requirement is that the 96 bits be unique for a given font.
+///
+/// ## Uniqueness and safety
+/// Users are responsible for ensuring that a unique identifier is not used for
+/// different fonts within a single context. Violating this invariant is guaranteed
+/// to be safe, but will very likely lead to incorrect results.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct UniqueId {
+    /// Unique identifier for the data blob containing the content of
+    /// a font file.
+    pub data_id: u64,
+    /// Index of a font in a font collection file.
+    pub index: u32,
+}
+
+impl UniqueId {
+    /// Creates a new unique identifier from the given data identifier and font
+    /// collection index.
+    pub fn new(data_id: u64, index: u32) -> Self {
+        Self { data_id, index }
+    }
+}

--- a/skrifa/src/unique_id.rs
+++ b/skrifa/src/unique_id.rs
@@ -16,10 +16,10 @@
 /// be used when configuring a glyph scaler.
 ///
 /// # Semantics
-/// Currently, the fields on this type carry no actual semantics. The `index`
-/// field, for example, is not required to match the index of a font in a collection.
-/// Types and names were chosen to accommodate the common representation of
-/// a pointer and index pair.
+/// Currently, the parameters used to construct this type carry no actual semantics.
+/// The `index` parameter, for example, is not required to match the index of a font
+/// in a collection. Types and names were chosen to accommodate the common representation
+/// of a pointer and index pair.
 ///
 /// The only requirement is that the 96 bits be unique for a given font.
 ///
@@ -31,9 +31,9 @@
 pub struct UniqueId {
     /// Unique identifier for the data blob containing the content of
     /// a font file.
-    pub data_id: u64,
+    data_id: u64,
     /// Index of a font in a font collection file.
-    pub index: u32,
+    index: u32,
 }
 
 impl UniqueId {


### PR DESCRIPTION
Again, following up on #209, replaces the raw u64 used as a font identifier/cache key with a new `UniqueId` type.