### PR TITLE
Additional docs for skrifa

### DIFF
--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "skrifa"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
-description = "Metadata and glyph loading for OpenType fonts."
+description = "Metadata reader and glyph scaler for OpenType fonts."
 repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
-publish = false
 
 [features]
 default = ["scale"]
@@ -19,7 +18,3 @@ read-fonts = { version = "0.1.4", path = "../read-fonts" }
 
 [dev-dependencies]
 read-fonts = { version = "0.1.4", path = "../read-fonts", features = ["test_data"] }
-
-# cargo-release settings
-[package.metadata.release]
-release = false

--- a/skrifa/README.md
+++ b/skrifa/README.md
@@ -1,22 +1,40 @@
 # skrifa
 
-This is a library for high level loading of glyph outlines (and eventually color outlines and bitmaps)
-from font files. The intention is fully featured (e.g. variations and hinting) support for all glyph sources
-except for the SVG table.
-
-This is part of the [oxidize](https://github.com/googlefonts/oxidize) project.
+This crate aims to be a robust, ergonomic, high performance library for reading OpenType fonts. It
+is built on top of the [read-fonts](https://github.com/googlefonts/fontations/tree/main/read-fonts) low level
+parsing library and is also part of the [oxidize](https://github.com/googlefonts/oxidize) project.
 
 ## Features
 
+### Metadata
+
+The following information is currently exposed:
+
+* Global font metrics with variation support (units per em, ascender, descender, etc)
+* Glyph metrics with variation support (advance width, left side-bearing, etc)
+* Codepoint to nominal glyph identifier mapping
+    * Unicode variation sequences
+* Localized strings
+
+Future goals include:
+
+* Attributes (stretch, style and weight)
+* Variation axes and named instances
+    * Conversion from user coordinates to normalized design coordinates
+* Color palettes
+* Embedded bitmap strikes
+
+### Glyph scaling
+
 Current (✔️), near term (🔜) and planned (⌛) feature matrix:
 
-| Source | Loading | Variations | Hinting |
+| Source | Decoding | Variations | Hinting |
 |--------|---------|------------|---------|
 | glyf   | ✔️     |  ✔️        | ⌛*    |
 | CFF    | ⌛     | ⌛         | ⌛     |
 | CFF2   | ⌛     | ⌛         | ⌛     |
-| COLRv0 | 🔜     | 🔜         | *      |
-| COLRv1 | 🔜     | 🔜         | *      |
+| COLRv0 | 🔜     | 🔜         | **      |
+| COLRv1 | 🔜     | 🔜         | **      |
 | EBDT   | 🔜     | -          | -      |
 | CBDT   | 🔜     | -          | -      |
 | sbix   | 🔜     | -          | -      |

--- a/skrifa/README.md
+++ b/skrifa/README.md
@@ -1,8 +1,14 @@
 # skrifa
 
-This crate aims to be a robust, ergonomic, high performance library for reading OpenType fonts. It
-is built on top of the [read-fonts](https://github.com/googlefonts/fontations/tree/main/read-fonts) low level
-parsing library and is also part of the [oxidize](https://github.com/googlefonts/oxidize) project.
+[![Crates.io](https://img.shields.io/crates/v/skrifa.svg?maxAge=2592000)](https://crates.io/crates/skrifa)
+[![Docs](https://docs.rs/skrifa/badge.svg)](https://docs.rs/skrifa)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
+This crate aims to be a robust, ergonomic, high performance library for reading
+OpenType fonts. It is built on top of the
+[read-fonts](https://github.com/googlefonts/fontations/tree/main/read-fonts)
+low level parsing library and is also part of the
+[oxidize](https://github.com/googlefonts/oxidize) project.
 
 ## Features
 
@@ -10,7 +16,8 @@ parsing library and is also part of the [oxidize](https://github.com/googlefonts
 
 The following information is currently exposed:
 
-* Global font metrics with variation support (units per em, ascender, descender, etc)
+* Global font metrics with variation support (units per em, ascender,
+descender, etc)
 * Glyph metrics with variation support (advance width, left side-bearing, etc)
 * Codepoint to nominal glyph identifier mapping
     * Unicode variation sequences
@@ -41,10 +48,20 @@ Current (✔️), near term (🔜) and planned (⌛) feature matrix:
 
 \* A working implementation exists for hinting but is not yet merged.
 
-\*\* This will be supported but is probably not desirable due the general affine transforms
-present in the paint graph.
+\*\* This will be supported but is probably not desirable due the general
+affine transforms present in the paint graph.
+
+## Safety
+
+Unsafe code is forbidden by a `#![forbid(unsafe_code)]` attribute in the root
+of the library.
+
+## Panicking
+
+This library should not panic regardless of API misuse or use of
+corrupted/malicious font files. Please file an issue if this occurs.
 
 ## The name?
 
-Following along with our theme, *skrifa* is Old Norse for "write" or "it is written." And
-so it is named.
+Following along with our theme, *skrifa* is Old Norse for "write" or "it is
+written." And so it is named.

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -1,3 +1,16 @@
+//! A robust, ergonomic, high performance crate for OpenType fonts.
+//!  
+//! Skrifa is a mid level library that provides access to various types
+//! of [`metadata`](meta) contained in a font as well as support for
+//! [`scaling`](scale) of glyph outlines.
+//!
+//! It is described as "mid level" because the library is designed to sit
+//! above low level font parsing (provided by [`read-fonts`](https://crates.io/crates/read-fonts))
+//! and below a higher level text layout engine.
+//!
+//! See the [readme](https://github.com/dfrg/fontations/blob/main/skrifa/README.md) for additional
+//! details.
+
 #![forbid(unsafe_code)]
 // TODO: this is temporary-- remove when hinting is added.
 #![allow(dead_code, unused_imports, unused_variables)]

--- a/skrifa/src/meta/mod.rs
+++ b/skrifa/src/meta/mod.rs
@@ -1,4 +1,4 @@
-//! High level interface to font metadata.
+//! Accessors for various types of font metadata.
 
 pub mod charmap;
 pub mod metrics;

--- a/skrifa/src/scale/error.rs
+++ b/skrifa/src/scale/error.rs
@@ -2,7 +2,7 @@ use read_fonts::{tables::glyf::ToPathError, types::GlyphId, ReadError};
 
 use std::fmt;
 
-/// Errors that may occur when loading glyphs.
+/// Errors that may occur when scaling glyphs.
 #[derive(Clone, Debug)]
 pub enum Error {
     /// No viable sources were available.

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -1,24 +1,49 @@
 //! Extraction of glyph outlines.
 //!
 //! Scaling is the process of decoding an outline, applying variation deltas,
-//! and executing [hinting](https://en.wikipedia.org/wiki/Font_hinting) instructions
-//! for a glyph of a particular size.
+//! and executing [hinting](https://en.wikipedia.org/wiki/Font_hinting)
+//! instructions for a glyph of a particular size.
 //!
-//! The process starts with construction of a [`Context`] that can be used to build
-//! and configure a [`Scaler`] which can generate scaled paths for glyphs.
+//! ## It all starts with a context
 //!
-//! Read on for more detail.
+//! The scaling process generally requires dynamic memory allocations to hold
+//! intermediate results. In addition, TrueType hinting requires execution
+//! of a set of programs to generate state for any instance of a font before
+//! applying glyph instructions.
+//!
+//! To amortize the cost of memory allocations and support caching of hinting
+//! state, we use the [`Context`] type. This type is opaque and contains
+//! internal buffers and caches that can be reused by subsequent scaling
+//! operations.
+//!
+//! Contexts exist purely as a performance optimization and management of them
+//! is up to the user. There are several reasonable strategies of varying
+//! complexity:
+//!
+//! * If performance and heap traffic are not significant concerns, creating
+//! a context per glyph (or glyph run) works in a pinch.
+//! * When making use of a single shared glyph cache, this is an ideal place to
+//! store a context.
+//! * Multithreaded code can use thread locals or a global pool of contexts.
+//!
+//! Regardless of how you manage them, creating a context is trivial:
+//! ```
+//! use skrifa::scale::Context;
+//!
+//! let mut context = Context::new();
+//! ```
+//!
+//! For simplicity, the examples below will use a local context.
 //!
 //! ## Building a scaler
 //!
-//! Scaling requires temporary memory allocations and, in the case of hinting,
-//! also benefits from caching the state of the hinting setup programs. To amortize the
-//! cost of heap allocations and support caching, the [`Context`] type is provided.
-//! This type is opaque and offers a single method called [`new_scaler`](Context::new_scaler)
-//! that produces a [`ScalerBuilder`] to configure and build a [`Scaler`].
+//! Now that we have a [`Context`], we can use the
+//! [`new_scaler`](Context::new_scaler) method to generate an instance of the
+//! [`ScalerBuilder`] type that allows us to configure and build a [`Scaler`].
 //!
-//! Assuming you have some `font` (any type that implements [`TableProvider`](read_fonts::TableProvider)),
-//! this will build a scaler for a size of 16px:
+//! Assuming you have some `font` (any type that implements
+//! [`TableProvider`](read_fonts::TableProvider)), this will build a scaler for
+//! a size of 16px:
 //!
 //! ```
 //! # use skrifa::{scale::*, Size};
@@ -30,7 +55,8 @@
 //! # }
 //! ```
 //!
-//! For variable fonts, the [`variation_settings`](ScalerBuilder::variation_settings) method can
+//! For variable fonts, the
+//! [`variation_settings`](ScalerBuilder::variation_settings) method can
 //! be used to specify user coordinates for selecting an instance:
 //!
 //! ```
@@ -44,19 +70,21 @@
 //! # }
 //! ```
 //!
-//! If you already have coordinates in normalized design space, you can specify those directly
-//! with the [`normalized_coords`](ScalerBuilder::normalized_coords) method.
+//! If you already have coordinates in normalized design space, you can specify
+//! those directly with the
+//! [`normalized_coords`](ScalerBuilder::normalized_coords) method.
 //!
 //! See the [`ScalerBuilder`] type for all available configuration options.
 //!
 //! ## Getting an outline
 //!
-//! Once we have a configured scaler, extracting an outline is fairly simple. The
-//! [`Scaler::outline`] method uses a callback approach where the user
-//! provides an implementation of the [`Pen`] trait and the appropriate methods are invoked for
-//! each resulting path element of the scaled outline.
+//! Once we have a configured scaler, extracting an outline is fairly simple.
+//! The [`Scaler::outline`] method uses a callback approach where the user
+//! provides an implementation of the [`Pen`] trait and the appropriate methods
+//! are invoked for each resulting path element of the scaled outline.
 //!
-//! Assuming we constructed a scaler as above, let's load a glyph and convert it into an SVG path:
+//! Assuming we constructed a scaler as above, let's load a glyph and convert
+//! it into an SVG path:
 //!
 //! ```
 //! # use skrifa::{scale::*, GlyphId, Size};
@@ -107,12 +135,14 @@
 //! # }
 //! ```
 //!
-//! The pen based interface is designed to be flexible. Output can be sent directly to a
-//! software rasterizer for scan conversion, converted to an owned path representation (such as
-//! a kurbo [`BezPath`](https://docs.rs/kurbo/latest/kurbo/struct.BezPath.html)) for further
-//! analysis and transformation, or fed into other crates like [vello](https://github.com/linebender/vello),
-//! [lyon](https://github.com/nical/lyon) or [pathfinder](https://github.com/servo/pathfinder)
-//! for GPU rendering.
+//! The pen based interface is designed to be flexible. Output can be sent
+//! directly to a software rasterizer for scan conversion, converted to an
+//! owned path representation (such as a kurbo
+//! [`BezPath`](https://docs.rs/kurbo/latest/kurbo/struct.BezPath.html)) for
+//! further analysis and transformation, or fed into other crates like
+//! [vello](https://github.com/linebender/vello),
+//! [lyon](https://github.com/nical/lyon) or
+//! [pathfinder](https://github.com/servo/pathfinder) for GPU rendering.
 
 mod error;
 mod scaler;
@@ -146,13 +176,14 @@ pub enum Hinting {
     /// "Full" hinting mode. May generate rough outlines and poor horizontal
     /// spacing.
     Full,
-    /// Light hinting mode. This prevents most movement in the horizontal direction
-    /// with the exception of a per-font backward compatibility opt in.
+    /// Light hinting mode. This prevents most movement in the horizontal
+    /// direction with the exception of a per-font backward compatibility
+    /// opt in.
     Light,
     /// Same as light, but with additional support for RGB subpixel rendering.
     LightSubpixel,
-    /// Same as light subpixel, but always prevents adjustment in the horizontal
-    /// direction. This is the default mode.
+    /// Same as light subpixel, but always prevents adjustment in the
+    /// horizontal direction. This is the default mode.
     #[default]
     VerticalSubpixel,
 }
@@ -160,9 +191,10 @@ pub enum Hinting {
 /// Context for scaling glyphs.
 ///
 /// This type contains temporary memory buffers and various internal caches to
-/// accelerate the glyph scaling process. You'll generally want to keep one
-/// (or more, in the multi-threaded case) of these around and reuse them for
-/// scaling batches of glyphs.
+/// accelerate the glyph scaling process.
+///
+/// See the [module level documentation](crate::scale#it-all-starts-with-a-context)
+/// for more detail.
 #[derive(Clone, Default, Debug)]
 pub struct Context {
     /// Inner context for loading TrueType outlines.

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -15,7 +15,7 @@
 //! also benefits from caching the state of the hinting setup programs. To amortize the
 //! cost of heap allocations and support caching, the [`Context`] type is provided.
 //! This type is opaque and offers a single method called [`new_scaler`](Context::new_scaler)
-//! that produces a [`ScalerBuilder`] to configure and builder a [`Scaler`].
+//! that produces a [`ScalerBuilder`] to configure and build a [`Scaler`].
 //!
 //! Assuming you have some `font` (any type that implements [`TableProvider`](read_fonts::TableProvider)),
 //! this will build a scaler for a size of 16px:
@@ -52,7 +52,7 @@
 //! ## Getting an outline
 //!
 //! Once we have a configured scaler, extracting an outline is fairly simple. The
-//! [`outline`](Scaler::outline) method on scaler uses a callback approach where the user
+//! [`Scaler::outline`] method uses a callback approach where the user
 //! provides an implementation of the [`Pen`] trait and the appropriate methods are invoked for
 //! each resulting path element of the scaled outline.
 //!

--- a/skrifa/src/scale/scaler.rs
+++ b/skrifa/src/scale/scaler.rs
@@ -11,6 +11,9 @@ use read_fonts::{
 };
 
 /// Builder for configuring a glyph scaler.
+///
+/// See the [module level documentation](crate::scale#building-a-scaler)
+/// for more detail.
 pub struct ScalerBuilder<'a> {
     context: &'a mut Context,
     cache_key: Option<UniqueId>,
@@ -74,9 +77,35 @@ impl<'a> ScalerBuilder<'a> {
         self
     }
 
-    /// Adds the sequence of variation settings.
+    /// Appends the given sequence of variation settings. This will clear any
+    /// variations specified as normalized coordinates.
     ///
-    /// This will clear any variations specified as normalized coordinates.
+    /// This methods accepts any type which can be converted into an iterator
+    /// that yields a sequence of values that are convertible to
+    /// [`VariationSetting`]. Various conversions from tuples are provided.
+    ///
+    /// The following are all equivalent:
+    ///
+    /// ```
+    /// # use skrifa::{scale::*, Tag, VariationSetting};
+    /// # let mut context = Context::new();
+    /// # let builder = context.new_scaler();
+    /// // slice of VariationSetting
+    /// builder.variation_settings(&[
+    ///     VariationSetting::new(Tag::new(b"wgth"), 720.0),
+    ///     VariationSetting::new(Tag::new(b"wdth"), 50.0),
+    /// ])
+    /// # ; let builder = context.new_scaler();
+    /// // slice of (Tag, f32)
+    /// builder.variation_settings(&[(Tag::new(b"wght"), 720.0), (Tag::new(b"wdth"), 50.0)])
+    /// # ; let builder = context.new_scaler();
+    /// // slice of (&str, f32)
+    /// builder.variation_settings(&[("wght", 720.0), ("wdth", 50.0)])
+    /// # ;
+    ///
+    /// ```
+    ///
+    /// Iterators that yield the above types are also accepted.
     pub fn variation_settings<I>(self, settings: I) -> Self
     where
         I: IntoIterator,
@@ -154,6 +183,9 @@ impl<'a> ScalerBuilder<'a> {
 }
 
 /// Glyph scaler for a specific font and configuration.
+///
+/// See the [module level documentation](crate::scale#getting-an-outline)
+/// for more detail.
 pub struct Scaler<'a> {
     coords: &'a [NormalizedCoord],
     outlines: Outlines<'a>,

--- a/skrifa/src/scale/scaler.rs
+++ b/skrifa/src/scale/scaler.rs
@@ -74,8 +74,9 @@ impl<'a> ScalerBuilder<'a> {
         self
     }
 
-    /// Adds the sequence of variation settings. This will clear any variations
-    /// specified as normalized coordinates.
+    /// Adds the sequence of variation settings.
+    ///
+    /// This will clear any variations specified as normalized coordinates.
     pub fn variation_settings<I>(self, settings: I) -> Self
     where
         I: IntoIterator,

--- a/skrifa/src/setting.rs
+++ b/skrifa/src/setting.rs
@@ -34,6 +34,14 @@ impl<T> Setting<T> {
     }
 }
 
+// This is provided so that &[VariationSetting] can be passed to the
+// variation_settings() method of ScalerBuilder.
+impl<T: Copy> From<&'_ Setting<T>> for Setting<T> {
+    fn from(value: &'_ Setting<T>) -> Self {
+        *value
+    }
+}
+
 impl<T> From<(Tag, T)> for Setting<T> {
     fn from(s: (Tag, T)) -> Self {
         Self {
@@ -65,24 +73,6 @@ impl<T: Copy> From<&(&str, T)> for Setting<T> {
     fn from(s: &(&str, T)) -> Self {
         Self {
             selector: Tag::from_str(s.0).unwrap_or_default(),
-            value: s.1,
-        }
-    }
-}
-
-impl<T> From<([u8; 4], T)> for Setting<T> {
-    fn from(s: ([u8; 4], T)) -> Self {
-        Self {
-            selector: Tag::new_checked(&s.0[..]).unwrap_or_default(),
-            value: s.1,
-        }
-    }
-}
-
-impl<T: Copy> From<&([u8; 4], T)> for Setting<T> {
-    fn from(s: &([u8; 4], T)) -> Self {
-        Self {
-            selector: Tag::new_checked(&s.0[..]).unwrap_or_default(),
             value: s.1,
         }
     }

--- a/skrifa/src/setting.rs
+++ b/skrifa/src/setting.rs
@@ -43,6 +43,15 @@ impl<T> From<(Tag, T)> for Setting<T> {
     }
 }
 
+impl<T: Copy> From<&(Tag, T)> for Setting<T> {
+    fn from(s: &(Tag, T)) -> Self {
+        Self {
+            selector: s.0,
+            value: s.1,
+        }
+    }
+}
+
 impl<T> From<(&str, T)> for Setting<T> {
     fn from(s: (&str, T)) -> Self {
         Self {
@@ -52,8 +61,26 @@ impl<T> From<(&str, T)> for Setting<T> {
     }
 }
 
+impl<T: Copy> From<&(&str, T)> for Setting<T> {
+    fn from(s: &(&str, T)) -> Self {
+        Self {
+            selector: Tag::from_str(s.0).unwrap_or_default(),
+            value: s.1,
+        }
+    }
+}
+
 impl<T> From<([u8; 4], T)> for Setting<T> {
     fn from(s: ([u8; 4], T)) -> Self {
+        Self {
+            selector: Tag::new_checked(&s.0[..]).unwrap_or_default(),
+            value: s.1,
+        }
+    }
+}
+
+impl<T: Copy> From<&([u8; 4], T)> for Setting<T> {
+    fn from(s: &([u8; 4], T)) -> Self {
         Self {
             selector: Tag::new_checked(&s.0[..]).unwrap_or_default(),
             value: s.1,


### PR DESCRIPTION
This provides some more detailed documentation with a focus on the scale module. Also updates the readme to describe supported metadata.

[Readme rendered](https://github.com/dfrg/fontations/blob/skrifa-docs/skrifa/README.md)

No functional changes, but additional `From` impls for `Setting` were added because writing docs exposed that the shape of the `ScalerBuilder::variation_settings` API wasn't quite what I intended.

Closes #209