### PR TITLE
write-fonts => 0.1.10

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
So I can release #351, #353, #354 as these make it impossible for fontmake-rs to encode an interesting gvar.

JMM.