### PR TITLE
Minor improvements to FontRef

### DIFF
--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -43,3 +43,5 @@ pub type NormalizedCoord = read_fonts::types::F2Dot14;
 
 #[doc(inline)]
 pub use meta::MetadataProvider;
+
+pub use read_fonts::FontRef;


### PR DESCRIPTION
This beefs up the docs for `FontRef` a bit, adds a new `from_index` constructor that can directly create fonts from a collection, and re-exports the type in skrifa.

JMM.