### PR TITLE
Add some more flags types

### DIFF
--- a/resources/codegen_inputs/head.rs
+++ b/resources/codegen_inputs/head.rs
@@ -1,6 +1,26 @@
 #![parse_module(read_fonts::tables::head)]
 
-/// <https://docs.microsoft.com/en-us/typography/opentype/spec/head>
+/// The `macStyle` field for the head table.
+flags u16 MacStyle {
+    /// Bit 0: Bold (if set to 1)
+    BOLD = 0x0001,
+    /// Bit 1: Italic (if set to 1)
+    ITALIC = 0x0002,
+    /// Bit 2: Underline (if set to 1)
+    UNDERLINE = 0x0004,
+    /// Bit 3: Outline (if set to 1)
+    OUTLINE = 0x0008,
+    /// Bit 4: Shadow (if set to 1)
+    SHADOW = 0x0010,
+    /// Bit 5: Condensed (if set to 1)
+    CONDENSED = 0x0020,
+    /// Bit 6: Extended (if set to 1)
+    EXTENDED = 0x0040,
+    // Bits 7-15: Reserved (set to 0)    
+}
+
+/// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head) 
+/// (font header) table.
 #[tag = "head"]
 table Head {
     /// Version number of the font header table, set to (1, 0)
@@ -39,7 +59,7 @@ table Head {
     /// Maximum y coordinate across all glyph bounding boxes.
     y_max: i16,
     /// see somewhere else
-    mac_style: u16,
+    mac_style: MacStyle,
     /// Smallest readable size in pixels.
     lowest_rec_ppem: u16,
     /// Deprecated (Set to 2).

--- a/resources/codegen_inputs/os2.rs
+++ b/resources/codegen_inputs/os2.rs
@@ -1,5 +1,34 @@
 #![parse_module(read_fonts::tables::os2)]
 
+/// OS/2 [selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection)
+flags u16 SelectionFlags {
+    /// Bit 0: Font contains italic or oblique glyphs, otherwise they are
+    /// upright. 
+    ITALIC = 0x0001,
+    /// Bit 1: Glyphs are underscored.
+    UNDERSCORE = 0x0002,
+    /// Bit 2: Glyphs have their foreground and background reversed.
+    NEGATIVE = 0x0004,
+    /// Bit 3: Outline (hollow) glyphs, otherwise they are solid.
+    OUTLINED = 0x0008,
+    /// Bit 4: Glyphs are overstruck.
+    STRIKEOUT = 0x0010,
+    /// Bit 5: Glyphs are emboldened.
+    BOLD = 0x0020,
+    /// Bit 6: Glyphs are in the standard weight/style for the font.
+    REGULAR = 0x0040,
+    /// Bit 7: If set, it is strongly recommended that applications use
+    /// OS/2.sTypoAscender - OS/2.sTypoDescender + OS/2.sTypoLineGap as
+    /// the default line spacing for this font.
+    USE_TYPO_METRICS = 0x0080,
+    /// Bit 8: The font has 'name' table strings consistent with a
+    /// weight/width/slope family without requiring use of name IDs 21 and 22.
+    WWS = 0x0100,
+    /// Bit 9: Font contains oblique glyphs.
+    OBLIQUE = 0x0200,
+    // Bits 10-15 are reserved. Set to 0.
+}
+
 /// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
 #[tag = "OS/2"]
 #[skip_constructor]
@@ -85,7 +114,7 @@ table Os2 {
     /// [Font selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection).
     ///
     /// Contains information concerning the nature of the font patterns.
-    fs_selection: u16,
+    fs_selection: SelectionFlags,
     /// The minimum Unicode index (character code) in this font.
     us_first_char_index: u16,
     /// The maximum Unicode index (character code) in this font.

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -23,7 +23,7 @@
 //!
 
 use read_fonts::{
-    tables::{glyf::Glyf, hmtx::LongMetric, hvar::Hvar, loca::Loca},
+    tables::{glyf::Glyf, hmtx::LongMetric, hvar::Hvar, loca::Loca, os2::SelectionFlags},
     types::{BigEndian, GlyphId},
     TableProvider,
 };
@@ -148,8 +148,10 @@ impl Metrics {
         let os2 = font.os2().ok();
         let mut used_typo_metrics = false;
         if let Some(os2) = &os2 {
-            const USE_TYPO_METRICS: u16 = 1 << 7;
-            if os2.fs_selection() & USE_TYPO_METRICS != 0 {
+            if os2
+                .fs_selection()
+                .contains(SelectionFlags::USE_TYPO_METRICS)
+            {
                 metrics.ascent = os2.s_typo_ascender() as f32 * scale;
                 metrics.descent = os2.s_typo_descender() as f32 * scale;
                 metrics.leading = os2.s_typo_line_gap() as f32 * scale;

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -5,7 +5,16 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-/// <https://docs.microsoft.com/en-us/typography/opentype/spec/head>
+pub use read_fonts::tables::head::MacStyle;
+
+impl FontWrite for MacStyle {
+    fn write_into(&self, writer: &mut TableWriter) {
+        writer.write_slice(&self.bits().to_be_bytes())
+    }
+}
+
+/// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
+/// (font header) table.
 #[derive(Clone, Debug)]
 pub struct Head {
     /// Set by font manufacturer.
@@ -40,7 +49,7 @@ pub struct Head {
     /// Maximum y coordinate across all glyph bounding boxes.
     pub y_max: i16,
     /// see somewhere else
-    pub mac_style: u16,
+    pub mac_style: MacStyle,
     /// Smallest readable size in pixels.
     pub lowest_rec_ppem: u16,
     /// Deprecated (Set to 2).
@@ -85,7 +94,7 @@ impl Head {
         y_min: i16,
         x_max: i16,
         y_max: i16,
-        mac_style: u16,
+        mac_style: MacStyle,
         lowest_rec_ppem: u16,
         index_to_loc_format: i16,
     ) -> Self {

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -5,6 +5,14 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+pub use read_fonts::tables::os2::SelectionFlags;
+
+impl FontWrite for SelectionFlags {
+    fn write_into(&self, writer: &mut TableWriter) {
+        writer.write_slice(&self.bits().to_be_bytes())
+    }
+}
+
 /// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
 #[derive(Clone, Debug)]
 pub struct Os2 {
@@ -81,7 +89,7 @@ pub struct Os2 {
     /// [Font selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection).
     ///
     /// Contains information concerning the nature of the font patterns.
-    pub fs_selection: u16,
+    pub fs_selection: SelectionFlags,
     /// The minimum Unicode index (character code) in this font.
     pub us_first_char_index: u16,
     /// The maximum Unicode index (character code) in this font.


### PR DESCRIPTION
Adds flags types for `OS/2.fsSelection` and `head.macStyle`. Update uses to match. I didn't do `OS/2.fsType` because it has a weird mask component where bits don't precisely match intended usage.

Looks like this won't break fontmake-rs because it doesn't touch these fields yet.

Addresses half of #360.

JMM