### PR TITLE
[ci] Remove packaging step from CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,27 +88,6 @@ jobs:
       - name: cargo check read-fonts
         run: cargo check --manifest-path=read-fonts/Cargo.toml --no-default-features
 
-  cargo-package:
-    name: cargo package
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: cargo package font-types
-        run: cargo package --manifest-path=font-types/Cargo.toml
-
-      - name: cargo package read-fonts
-        run: cargo package --manifest-path=read-fonts/Cargo.toml
-
-      - name: cargo package write-fonts
-        run: cargo package --manifest-path=write-fonts/Cargo.toml
-
-      - name: cargo package skrifa
-        run: cargo package --manifest-path=skrifa/Cargo.toml
-
   check-wasm:
     name: cargo check wasm
     runs-on: ubuntu-latest

--- a/read-fonts/build.rs
+++ b/read-fonts/build.rs
@@ -17,9 +17,16 @@ static FILES_TO_MOVE: &[&str] = &[
     "../resources/test_fonts/ttf/simple_glyf.ttf",
     "../resources/test_fonts/ttf/vazirmatn_var_trimmed.ttf",
     "../resources/test_fonts/extracted/vazirmatn_var_trimmed-glyphs.txt",
+    // if you have added a new test file, add it to the list here
 ];
 
 fn main() {
+    println!("cargo:rerun-if-changed=../resources/test_fonts/");
+    //NOTE: IMPORTANT: ATTN: EXTREME DANGER
+    //
+    // Please do not change this code unless you know why it is how it is,
+    // which is explained in more detail here:
+    // <https://github.com/googlefonts/fontations/issues/345#issuecomment-1499624835>
     let out_dir = std::env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir);
     for path in FILES_TO_MOVE.iter().map(Path::new) {


### PR DESCRIPTION
This was well intentioned, but will end up being a false alarm far more often than it catches a real issue. In the unlikely case that we *do* break packaging again, we will at least catch it during our release process.