### PR TITLE
[ci] test packages individually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,8 +53,17 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: cargo test
-        run: cargo test --all-targets --all-features
+      - name: cargo test font-types
+        run: cargo test -p font-types --all-targest --all-features
+
+      - name: cargo test read-fonts
+        run: cargo test -p read-fonts --all-targest --all-features
+
+      - name: cargo test write-fonts
+        run: cargo test -p write-fonts --all-targest --all-features
+
+      - name: cargo test skrifa
+        run: cargo test -p skrifa --all-targest --all-features
 
   ensure-clean-codegen:
     name: check codegen is up-to-date

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,9 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # test all packages individually to ensure deterministic resolution
+      # of dependencies for each package
+      
       - name: cargo test font-types
         run: cargo test -p font-types --all-targets --all-features
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,16 +54,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: cargo test font-types
-        run: cargo test -p font-types --all-targest --all-features
+        run: cargo test -p font-types --all-targets --all-features
 
       - name: cargo test read-fonts
-        run: cargo test -p read-fonts --all-targest --all-features
+        run: cargo test -p read-fonts --all-targets --all-features
 
       - name: cargo test write-fonts
-        run: cargo test -p write-fonts --all-targest --all-features
+        run: cargo test -p write-fonts --all-targets --all-features
 
       - name: cargo test skrifa
-        run: cargo test -p skrifa --all-targest --all-features
+        run: cargo test -p skrifa --all-targets --all-features
 
   ensure-clean-codegen:
     name: check codegen is up-to-date


### PR DESCRIPTION
Runs `cargo test -p` for each package rather than a single `cargo test` for the whole workspace.

Closes #363 