### PR TITLE
Use #[capabilites] on Tuple type

### DIFF
--- a/font-types/src/raw.rs
+++ b/font-types/src/raw.rs
@@ -47,7 +47,7 @@ pub trait ReadScalar: FixedSize {
 }
 
 /// A wrapper around raw big-endian bytes for some type.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct BigEndian<T: Scalar>(pub(crate) T::Raw);
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -123,7 +123,7 @@ impl<'a> std::fmt::Debug for TupleVariationHeader<'a> {
 /// The tuple variation store formats reference regions within the font’s
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Tuple<'a> {
     /// Coordinate array specifying a position within the font’s variation space.
     ///

--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -37,6 +37,7 @@ table TupleVariationHeader {
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
 #[read_args(axis_count: u16)]
+#[capabilites(hash, equality, order)]
 record Tuple<'a> {
     /// Coordinate array specifying a position within the font’s variation space.
     ///

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -70,7 +70,7 @@ impl<'a> FromTableRef<read_fonts::tables::variations::TupleVariationHeader<'a>>
 /// The tuple variation store formats reference regions within the font’s
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Tuple {
     /// Coordinate array specifying a position within the font’s variation space.
     ///

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -366,21 +366,6 @@ impl Tuple {
     }
 }
 
-//FIXME: get that "derive extra traits" stuff merged.
-impl std::hash::Hash for Tuple {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.values.hash(state);
-    }
-}
-
-impl std::cmp::PartialEq for Tuple {
-    fn eq(&self, other: &Self) -> bool {
-        self.values == other.values
-    }
-}
-
-impl std::cmp::Eq for Tuple {}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This also adds a missing impl of Hash for BigEndian<T>

~based on #215 which should be merged first.~