### PR TITLE
Filter implied on curves for interpolatable glyphs

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["text-processing", "parsing", "graphics"]
 font-types = { version = "0.1.4", path = "../font-types" }
 read-fonts = { version = "0.1.4", path = "../read-fonts" }
 bitflags = "1.3"
-kurbo = "0.9.1"
+kurbo = "0.9.4"
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -8,6 +8,7 @@ mod offsets;
 pub mod pens;
 mod round;
 pub mod tables;
+pub mod util;
 pub mod validate;
 mod write;
 

--- a/write-fonts/src/round.rs
+++ b/write-fonts/src/round.rs
@@ -39,3 +39,10 @@ impl OtRound<u16> for f32 {
         (self + 0.5).floor() as u16
     }
 }
+
+impl OtRound<(i16, i16)> for kurbo::Point {
+    #[inline]
+    fn ot_round(self) -> (i16, i16) {
+        (self.x.ot_round(), self.y.ot_round())
+    }
+}

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -1175,6 +1175,26 @@ mod tests {
         simple_glyphs_from_kurbo(&[path1, path2]).unwrap();
     }
 
+    /// Create a number of interpolatable BezPaths with the given element types.
+    /// The paths will be identical except for the point coordinates of the elements,
+    /// which will be (0.0, 0.0), (1.0, 1.0), (2.0, 2.0), etc. for each subsequent
+    /// element. If `last_pt_equal_move` is true, the last point of each sub-path
+    /// will be equal to the first (M) point of that sub-path.
+    /// E.g.:
+    /// ```
+    /// let paths = make_interpolatable_paths(2, "MLLZ", false);
+    /// println!("{:?}", paths[0].to_svg());
+    /// // "M0,0 L1,1 L2,2 Z"
+    /// println!("{:?}", paths[1].to_svg());
+    /// // "M3,3 L4,4 L5,5 Z"
+    /// let paths = make_interpolatable_paths(3, "MLLLZMQQZ", true);
+    /// println!("{:?}", paths[0].to_svg());
+    /// // "M0,0 L1,1 L2,2 L0,0 Z M3,3 Q4,4 5,5 Q6,6 3,3 Z"
+    /// println!("{:?}", paths[1].to_svg());
+    /// // "M7,7 L8,8 L9,9 L7,7 Z M10,10 Q11,11 12,12 Q13,13 10,10 Z"
+    /// println!("{:?}", paths[2].to_svg());
+    /// // "M14,14 L15,15 L16,16 L14,14 Z M17,17 Q18,18 19,19 Q20,20 17,17 Z"
+    /// ```
     fn make_interpolatable_paths(
         num_paths: usize,
         el_types: &str,

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -141,7 +141,7 @@ impl InterpolatableContourBuilder {
         }
     }
 
-    /// The total number of points in the set of interpolatable contours
+    /// The total number of points in each interpolatable contour
     fn num_points(&self) -> usize {
         let n = self.0[0].len();
         assert!(self.0.iter().all(|c| c.len() == n));
@@ -165,10 +165,11 @@ impl InterpolatableContourBuilder {
         });
     }
 
+    /// Build the contours, dropping any on-curve points that can be implied in all contours
     fn build(self) -> Vec<Contour> {
         // compute the intersection of all implied on-curve point indices
         let mut drop = HashSet::new();
-        let epsilon = 0.01; // should we make it a parameter?
+        let epsilon = f32::EPSILON as f64; // should we make it a parameter?
         for points in &self.0 {
             let implied = implied_oncurve_points(points, epsilon);
             if drop.is_empty() {

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -379,12 +379,6 @@ pub fn simple_glyphs_from_kurbo(paths: &[BezPath]) -> Result<Vec<SimpleGlyph>, B
 }
 
 impl Contour {
-    /// Create a new contour begining at the provided point
-    pub fn new(pt: impl OtRound<(i16, i16)>) -> Self {
-        let (x, y) = pt.ot_round();
-        Self(vec![CurvePoint::on_curve(x, y)])
-    }
-
     /// The total number of points in this contour
     pub fn len(&self) -> usize {
         self.0.len()
@@ -395,34 +389,8 @@ impl Contour {
         self.0.is_empty()
     }
 
-    /// Add a line segment
-    pub fn line_to(&mut self, pt: impl OtRound<(i16, i16)>) {
-        let (x, y) = pt.ot_round();
-        self.0.push(CurvePoint::on_curve(x, y));
-    }
-
-    /// Add a quadratic curve segment
-    pub fn quad_to(&mut self, p0: impl OtRound<(i16, i16)>, p1: impl OtRound<(i16, i16)>) {
-        let (x0, y0) = p0.ot_round();
-        let (x1, y1) = p1.ot_round();
-        self.0.push(CurvePoint::off_curve(x0, y0));
-        self.0.push(CurvePoint::on_curve(x1, y1));
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = &CurvePoint> {
         self.0.iter()
-    }
-
-    pub fn first(&self) -> Option<&CurvePoint> {
-        self.0.first()
-    }
-
-    pub fn last(&self) -> Option<&CurvePoint> {
-        self.0.last()
-    }
-
-    pub fn pop(&mut self) -> Option<CurvePoint> {
-        self.0.pop()
     }
 }
 

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -92,23 +92,6 @@ pub enum BadKurbo {
     InconsistentPathElements(usize, Vec<&'static str>),
 }
 
-/// A helper trait for converting other point types to open-type compatible reprs
-pub trait OtPoint {
-    fn get(self) -> (i16, i16);
-}
-
-impl OtPoint for kurbo::Point {
-    fn get(self) -> (i16, i16) {
-        (self.x.ot_round(), self.y.ot_round())
-    }
-}
-
-impl OtPoint for (i16, i16) {
-    fn get(self) -> (i16, i16) {
-        self
-    }
-}
-
 /// Point with an associated on-curve flag.
 ///
 /// Similar to read_fonts::tables::glyf::CurvePoint, but uses kurbo::Point directly
@@ -139,7 +122,7 @@ impl ContourPoint {
 
 impl From<ContourPoint> for CurvePoint {
     fn from(pt: ContourPoint) -> Self {
-        let (x, y) = pt.point.get();
+        let (x, y) = pt.point.ot_round();
         CurvePoint::new(x, y, pt.on_curve)
     }
 }
@@ -388,8 +371,8 @@ pub fn simple_glyphs_from_kurbo(paths: &[BezPath]) -> Result<Vec<SimpleGlyph>, B
 
 impl Contour {
     /// Create a new contour begining at the provided point
-    pub fn new(pt: impl OtPoint) -> Self {
-        let (x, y) = pt.get();
+    pub fn new(pt: impl OtRound<(i16, i16)>) -> Self {
+        let (x, y) = pt.ot_round();
         Self(vec![CurvePoint::on_curve(x, y)])
     }
 
@@ -404,15 +387,15 @@ impl Contour {
     }
 
     /// Add a line segment
-    pub fn line_to(&mut self, pt: impl OtPoint) {
-        let (x, y) = pt.get();
+    pub fn line_to(&mut self, pt: impl OtRound<(i16, i16)>) {
+        let (x, y) = pt.ot_round();
         self.0.push(CurvePoint::on_curve(x, y));
     }
 
     /// Add a quadratic curve segment
-    pub fn quad_to(&mut self, p0: impl OtPoint, p1: impl OtPoint) {
-        let (x0, y0) = p0.get();
-        let (x1, y1) = p1.get();
+    pub fn quad_to(&mut self, p0: impl OtRound<(i16, i16)>, p1: impl OtRound<(i16, i16)>) {
+        let (x0, y0) = p0.ot_round();
+        let (x1, y1) = p1.ot_round();
         self.0.push(CurvePoint::off_curve(x0, y0));
         self.0.push(CurvePoint::on_curve(x1, y1));
     }

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -147,6 +147,7 @@ impl From<ContourPoint> for CurvePoint {
 /// A helper struct for building interpolatable contours
 ///
 /// Holds a vec of contour, one contour per glyph.
+#[derive(Clone, Debug, PartialEq)]
 struct InterpolatableContourBuilder(Vec<Vec<ContourPoint>>);
 
 impl InterpolatableContourBuilder {

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -204,8 +204,8 @@ impl InterpolatableContourBuilder {
         contours.iter_mut().for_each(|c| c.0.reserve(num_points));
         for point_idx in (0..num_points).filter(|point_idx| !self.is_implicit_on_curve(*point_idx))
         {
-            for contour_idx in 0..num_contours {
-                contours[contour_idx]
+            for (contour_idx, contour) in contours.iter_mut().enumerate() {
+                contour
                     .0
                     .push(CurvePoint::from(self.0[contour_idx][point_idx]));
             }

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -10,6 +10,7 @@ use read_fonts::{
 
 use crate::{
     from_obj::{FromObjRef, FromTableRef},
+    util::MultiZip,
     FontWrite,
 };
 
@@ -250,19 +251,6 @@ fn is_implicit_on_curve(points: &[ContourPoint], idx: usize) -> bool {
     (p1p0 - p2p1).abs() < f32::EPSILON as f64
 }
 
-// The MultiZip is adapted from https://stackoverflow.com/a/55292215
-
-/// Iterator that iterates over a vector of iterators simultaneously
-struct MultiZip<I: Iterator>(Vec<I>);
-
-impl<I: Iterator> Iterator for MultiZip<I> {
-    type Item = Vec<I::Item>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.iter_mut().map(Iterator::next).collect()
-    }
-}
-
 #[inline]
 fn el_types(elements: &[kurbo::PathEl]) -> Vec<&'static str> {
     elements
@@ -283,7 +271,7 @@ pub fn simple_glyphs_from_kurbo(paths: &[BezPath]) -> Result<Vec<SimpleGlyph>, B
     if num_elements.iter().any(|n| *n != num_elements[0]) {
         return Err(BadKurbo::UnequalNumberOfElements(num_elements));
     }
-    let path_iters = MultiZip(paths.iter().map(|path| path.iter()).collect());
+    let path_iters = MultiZip::new(paths.iter().map(|path| path.iter()).collect());
     let mut contours: Vec<InterpolatableContourBuilder> = Vec::new();
     let mut current: Option<InterpolatableContourBuilder> = None;
     let num_glyphs = paths.len();

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -227,13 +227,10 @@ fn implied_oncurve_points(points: &[(kurbo::Point, bool)], epsilon: f64) -> Hash
 // The MultiZip is adapted from https://stackoverflow.com/a/55292215
 
 /// Iterator that iterates over a vector of iterators simultaneously
-struct MultiZip<T>(Vec<T>);
+struct MultiZip<I: Iterator>(Vec<I>);
 
-impl<T> Iterator for MultiZip<T>
-where
-    T: Iterator,
-{
-    type Item = Vec<T::Item>;
+impl<I: Iterator> Iterator for MultiZip<I> {
+    type Item = Vec<I::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.iter_mut().map(Iterator::next).collect()

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -287,7 +287,7 @@ impl<I: Iterator> Iterator for MultiZip<I> {
     }
 }
 
-pub fn simple_glyphs_from_kurbo(paths: &[&BezPath]) -> Result<Vec<SimpleGlyph>, BadKurbo> {
+pub fn simple_glyphs_from_kurbo(paths: &[BezPath]) -> Result<Vec<SimpleGlyph>, BadKurbo> {
     // check that all paths have the same number of elements so we can zip them together
     let num_elements: Vec<usize> = paths.iter().map(|path| path.elements().len()).collect();
     if num_elements.iter().any(|n| *n != num_elements[0]) {
@@ -455,7 +455,9 @@ impl SimpleGlyph {
     ///
     /// Context courtesy of @anthrotype.
     pub fn from_kurbo(path: &BezPath) -> Result<Self, BadKurbo> {
-        Ok(simple_glyphs_from_kurbo(&[path])?.pop().unwrap())
+        Ok(simple_glyphs_from_kurbo(std::slice::from_ref(path))?
+            .pop()
+            .unwrap())
     }
 
     /// Compute the flags and deltas for this glyph's points.

--- a/write-fonts/src/util.rs
+++ b/write-fonts/src/util.rs
@@ -1,0 +1,21 @@
+//! Misc utility functions
+
+/// Iterator that iterates over a vector of iterators simultaneously.
+///
+/// Adapted from <https://stackoverflow.com/a/55292215>
+pub struct MultiZip<I: Iterator>(Vec<I>);
+
+impl<I: Iterator> MultiZip<I> {
+    /// Create a new MultiZip from a vector of iterators
+    pub fn new(vec_of_iters: Vec<I>) -> Self {
+        Self(vec_of_iters)
+    }
+}
+
+impl<I: Iterator> Iterator for MultiZip<I> {
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.iter_mut().map(Iterator::next).collect()
+    }
+}


### PR DESCRIPTION
~~this is still quite messy and has no unit tests, but seems to work when I use this to build Oswald~~

EDIT: I've updated the PR adding tests, so this is now ready to review.

The PR adds a new public function to write_fonts::tables::glyf module called `simple_glyphs_from_kurbo`, which takes a slice of BezPaths and returns a vector of SimpleGlyphs (or an error if the input paths are not interpolation compatible).

Oncurve points that are impliable (i.e. at equal distance from preceding and following off-curve points) in _all_ the interpolatable paths are dropped from the SimpleGlyph contours.

The same function is also used in the existing SimpleGlyph::from_kurbo constructor to create one SimpleGlyph only instead of a Vec of them.

Linked draft PR in fontmake-rs to make use of this: https://github.com/googlefonts/fontmake-rs/pull/277