### PR TITLE
fix clippy 'hexadecimal literal not in groups of equal size'

### DIFF
--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -91,7 +91,7 @@ fn get_offset_width(font: &FontRef) -> usize {
 fn hex_width(val: u32) -> usize {
     match val {
         0..=0xffff => 4usize,
-        0x10000..=0xffff_ff => 6,
+        0x10000..=0xffffff => 6,
         0x1000000.. => 8,
     }
 }


### PR DESCRIPTION
this started failing recently like so, see:

https://github.com/googlefonts/fontations/actions/runs/4767847180/jobs/8476519981?pr=368#step:4:184

I simply removed the underscore. I can also add it back but then need to padd with 0 to align by 4 bytes I think, e.g. `0x00ff_ffff`