### PR TITLE
Fix miscalculation of segment map size in avar

### DIFF
--- a/read-fonts/src/tables/avar.rs
+++ b/read-fonts/src/tables/avar.rs
@@ -35,7 +35,10 @@ impl<'a> VarSize for SegmentMaps<'a> {
     type Size = u16;
 
     fn read_len_at(data: FontData, pos: usize) -> Option<usize> {
-        Some(data.read_at::<u16>(pos).ok()? as usize * AxisValueMap::RAW_BYTE_LEN)
+        Some(
+            data.read_at::<u16>(pos).ok()? as usize * AxisValueMap::RAW_BYTE_LEN
+                + u16::RAW_BYTE_LEN,
+        )
     }
 }
 
@@ -53,46 +56,89 @@ impl<'a> FontRead<'a> for SegmentMaps<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{FontRef, TableProvider};
-    use types::{F2Dot14, Fixed};
+
+    use super::*;
+    use crate::{test_helpers, FontRef, TableProvider};
+
+    fn value_map(from: f32, to: f32) -> [F2Dot14; 2] {
+        [F2Dot14::from_f32(from), F2Dot14::from_f32(to)]
+    }
+
+    // for the purpose of testing it is easier for us to use an array
+    // instead of a concrete type, since we can write that into BeBuffer
+    impl PartialEq<[F2Dot14; 2]> for AxisValueMap {
+        fn eq(&self, other: &[F2Dot14; 2]) -> bool {
+            self.from_coordinate == other[0] && self.to_coordinate == other[1]
+        }
+    }
 
     #[test]
     fn segment_maps() {
         let font = FontRef::new(font_test_data::VAZIRMATN_VAR).unwrap();
         let avar = font.avar().unwrap();
         assert_eq!(avar.axis_count(), 1);
-        fn from_to(from: f32, to: f32) -> (F2Dot14, F2Dot14) {
-            (F2Dot14::from_f32(from), F2Dot14::from_f32(to))
-        }
         let expected_segment_maps = &[vec![
-            from_to(-1.0, -1.0),
-            from_to(-0.6667, -0.5),
-            from_to(-0.3333, -0.25),
-            from_to(0.0, 0.0),
-            from_to(0.2, 0.3674),
-            from_to(0.4, 0.52246),
-            from_to(0.6, 0.67755),
-            from_to(0.8, 0.83875),
-            from_to(1.0, 1.0),
+            value_map(-1.0, -1.0),
+            value_map(-0.6667, -0.5),
+            value_map(-0.3333, -0.25),
+            value_map(0.0, 0.0),
+            value_map(0.2, 0.3674),
+            value_map(0.4, 0.52246),
+            value_map(0.6, 0.67755),
+            value_map(0.8, 0.83875),
+            value_map(1.0, 1.0),
         ]];
         let segment_maps = avar
             .axis_segment_maps()
             .iter()
-            .map(|segment_map| {
-                segment_map
-                    .unwrap()
-                    .axis_value_maps()
-                    .iter()
-                    .map(|axis_value_map| {
-                        (
-                            axis_value_map.from_coordinate(),
-                            axis_value_map.to_coordinate(),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            })
+            .map(|segment_map| segment_map.unwrap().axis_value_maps().to_owned())
             .collect::<Vec<_>>();
-        assert_eq!(&segment_maps, expected_segment_maps);
+        assert_eq!(segment_maps, expected_segment_maps);
+    }
+
+    #[test]
+    fn segment_maps_multi_axis() {
+        use test_helpers::BeBuffer;
+
+        let segment_one_maps = [
+            value_map(-1.0, -1.0),
+            value_map(-0.6667, -0.5),
+            value_map(-0.3333, -0.25),
+        ];
+        let segment_two_maps = [value_map(0.8, 0.83875), value_map(1.0, 1.0)];
+
+        let data = BeBuffer::new()
+            .push(MajorMinor::VERSION_1_0)
+            .push(0u16) // reserved
+            .push(2u16) // axis count
+            // segment map one
+            .push(3u16) // position count
+            .extend(segment_one_maps[0])
+            .extend(segment_one_maps[1])
+            .extend(segment_one_maps[2])
+            // segment map two
+            .push(2u16) // position count
+            .extend(segment_two_maps[0])
+            .extend(segment_two_maps[1]);
+
+        let avar = super::Avar::read(data.font_data()).unwrap();
+        assert_eq!(avar.axis_segment_maps().iter().count(), 2);
+        assert_eq!(
+            avar.axis_segment_maps()
+                .get(0)
+                .unwrap()
+                .unwrap()
+                .axis_value_maps,
+            segment_one_maps,
+        );
+        assert_eq!(
+            avar.axis_segment_maps()
+                .get(1)
+                .unwrap()
+                .unwrap()
+                .axis_value_maps,
+            segment_two_maps,
+        );
     }
 
     #[test]


### PR DESCRIPTION
This is a curious case; avar is unique in that it has a hand written impl of the `VarSize` trait, and that impl was not accounting for the length of the count field itself when determining the size. This meant that the size could be zero, which would prevent us from advancing while iterating, leading to a hang.

This works fine when there was only a single segment map, since we do not truncate the data when reading the type; but it would cause us to read incorrect values when tables contained multiple axes.

This fixes the issue, and adds a test case with multiple axes.

The big question I have, though, is: why haven't we hit this before? Or maybe we have hit this before, and I haven't noticed?


cc @dfrg, want to double check that this makes sense?

fixes #367 