### PR TITLE
bump minor version for read-fonts, write-fonts & skrifa; bump patch for font-types

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.1.4", path = "../font-types" }
+font-types = { version = "0.1.5", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 xflags = "0.2.4"
-read-fonts = { path = "../read-fonts",version = "0.1.4" }
-font-types = { path = "../font-types",version = "0.1.4" }
+read-fonts = { path = "../read-fonts",version = "0.2.0" }
+font-types = { path = "../font-types",version = "0.1.5" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."
@@ -15,7 +15,7 @@ traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { version = "0.1.4", path = "../font-types" }
+font-types = { version = "0.1.5", path = "../font-types" }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
@@ -14,7 +14,7 @@ scale = []
 hinting = []
 
 [dependencies]
-read-fonts = { version = "0.1.4", path = "../read-fonts" }
+read-fonts = { version = "0.2.0", path = "../read-fonts" }
 
 [dev-dependencies]
 font-test-data= { path = "../font-test-data" }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.1.11"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-font-types = { version = "0.1.4", path = "../font-types" }
-read-fonts = { version = "0.1.4", path = "../read-fonts" }
+font-types = { version = "0.1.5", path = "../font-types" }
+read-fonts = { version = "0.2.0", path = "../read-fonts" }
 bitflags = "1.3"
 kurbo = "0.9.4"
 
@@ -20,6 +20,6 @@ kurbo = "0.9.4"
 diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.1.4", path = "../read-fonts", features = [ "codegen_test"] }
+read-fonts = { version = "0.2.0", path = "../read-fonts", features = [ "codegen_test"] }
 log = "0.4"
 env_logger = "0.10.0"


### PR DESCRIPTION
I run

```
$ ./resources/scripts/bump-version font-types patch
```

and then

```
$ ./resources/scripts/bump-version read-fonts write-fonts skrifa minor
```