### PR TITLE
Add log support to table packing

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 font-types = { version = "0.1.5", path = "../font-types" }
 read-fonts = { version = "0.2.0", path = "../read-fonts" }
+log = "0.4"
 bitflags = "1.3"
 kurbo = "0.9.4"
 
@@ -21,5 +22,4 @@ diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
 read-fonts = { version = "0.2.0", path = "../read-fonts", features = [ "codegen_test"] }
-log = "0.4"
 env_logger = "0.10.0"

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -205,6 +205,8 @@ impl Graph {
 
     /// returns `true` if a solution is found, `false` otherwise
     pub(crate) fn topological_sort(&mut self) -> bool {
+        log::info!("attempting to pack {} objects", self.objects.len());
+
         self.sort_kahn();
         if !self.find_overflows().is_empty() {
             self.sort_shortest_distance();
@@ -213,7 +215,12 @@ impl Graph {
             self.assign_32bit_spaces();
             self.sort_shortest_distance();
         }
-        self.find_overflows().is_empty()
+
+        let n_overflows = self.find_overflows().len();
+        if n_overflows > 0 {
+            log::info!("packing failed with {n_overflows} overflows");
+        }
+        n_overflows == 0
     }
 
     fn find_overflows(&self) -> Vec<(ObjectId, ObjectId)> {


### PR DESCRIPTION
Logging will be important for things like table splitting and promotion, so this makes the log crate a non-dev dependency in `write-fonts`.