### PR TITLE
Add graphviz support for debugging

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -230,6 +230,10 @@ pub(crate) fn generate_compile_impl(
                 fn write_into(&self, writer: &mut TableWriter) {
                     #( #write_stmts; )*
                 }
+
+                fn name(&self) -> &'static str {
+                    #name_string
+                }
             }
         }
     });

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -388,9 +388,11 @@ pub(crate) fn generate_group_compile(
     let mut write_match_arms = Vec::new();
     let mut validate_match_arms = Vec::new();
     let mut from_obj_match_arms = Vec::new();
+    let mut name_arms = Vec::new();
     let from_type = quote!(#parse_module :: #name);
     for var in &item.variants {
         let var_name = &var.name;
+        let var_name_string = format!("{name}.{var_name}");
         let typ = &var.typ;
 
         variant_decls.push(quote! { #var_name ( #inner <#typ> ) });
@@ -399,6 +401,7 @@ pub(crate) fn generate_group_compile(
         from_obj_match_arms.push(
             quote! { #from_type :: #var_name(table) => Self :: #var_name(table.to_owned_obj(data)) },
         );
+        name_arms.push(quote! { Self:: #var_name(_) => #var_name_string  });
     }
     let first_var_name = &item.variants.first().unwrap().name;
 
@@ -419,6 +422,12 @@ pub(crate) fn generate_group_compile(
             fn write_into(&self, writer: &mut TableWriter) {
                 match self {
                     #( #write_match_arms, )*
+                }
+            }
+
+            fn name(&self) -> &'static str {
+                match self {
+                    #( #name_arms, )*
                 }
             }
         }
@@ -469,6 +478,12 @@ pub(crate) fn generate_format_compile(
         quote!( Self::#var_name(item) => item.validate_impl(ctx), )
     });
 
+    let name_arms = item.variants.iter().map(|variant| {
+        let var_name = &variant.name;
+        let var_name_str = format!("{name}.{var_name}");
+        quote!( Self::#var_name(_) => #var_name_str, )
+    });
+
     let from_obj_impl = item
         .attrs
         .skip_from_obj
@@ -496,6 +511,12 @@ pub(crate) fn generate_format_compile(
             fn write_into(&self, writer: &mut TableWriter) {
                 match self {
                     #( #write_arms )*
+                }
+            }
+
+            fn name(&self) -> &'static str {
+                match self {
+                    #( #name_arms )*
                 }
             }
         }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 
 [features]
+default = ["dot2"]
 
 [dependencies]
 font-types = { version = "0.1.5", path = "../font-types" }
@@ -16,6 +17,7 @@ read-fonts = { version = "0.2.0", path = "../read-fonts" }
 log = "0.4"
 bitflags = "1.3"
 kurbo = "0.9.4"
+dot2 = { version = "1.0", optional = true }
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -33,6 +33,9 @@ impl FontWrite for Avar {
         (array_len(&self.axis_segment_maps).unwrap() as u16).write_into(writer);
         self.axis_segment_maps.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Avar"
+    }
 }
 
 impl Validate for Avar {
@@ -93,6 +96,9 @@ impl FontWrite for SegmentMaps {
         (array_len(&self.axis_value_maps).unwrap() as u16).write_into(writer);
         self.axis_value_maps.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SegmentMaps"
+    }
 }
 
 impl Validate for SegmentMaps {
@@ -139,6 +145,9 @@ impl FontWrite for AxisValueMap {
     fn write_into(&self, writer: &mut TableWriter) {
         self.from_coordinate.write_into(writer);
         self.to_coordinate.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AxisValueMap"
     }
 }
 

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -38,6 +38,9 @@ impl FontWrite for Base {
             .compatible((1, 1))
             .then(|| self.item_var_store.write_into(writer));
     }
+    fn name(&self) -> &'static str {
+        "Base"
+    }
 }
 
 impl Validate for Base {
@@ -103,6 +106,9 @@ impl FontWrite for Axis {
         self.base_tag_list.write_into(writer);
         self.base_script_list.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Axis"
+    }
 }
 
 impl Validate for Axis {
@@ -158,6 +164,9 @@ impl FontWrite for BaseTagList {
         (array_len(&self.baseline_tags).unwrap() as u16).write_into(writer);
         self.baseline_tags.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "BaseTagList"
+    }
 }
 
 impl Validate for BaseTagList {
@@ -211,6 +220,9 @@ impl FontWrite for BaseScriptList {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.base_script_records).unwrap() as u16).write_into(writer);
         self.base_script_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseScriptList"
     }
 }
 
@@ -268,6 +280,9 @@ impl FontWrite for BaseScriptRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.base_script_tag.write_into(writer);
         self.base_script.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseScriptRecord"
     }
 }
 
@@ -327,6 +342,9 @@ impl FontWrite for BaseScript {
         self.default_min_max.write_into(writer);
         (array_len(&self.base_lang_sys_records).unwrap() as u16).write_into(writer);
         self.base_lang_sys_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseScript"
     }
 }
 
@@ -392,6 +410,9 @@ impl FontWrite for BaseLangSysRecord {
         self.base_lang_sys_tag.write_into(writer);
         self.min_max.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "BaseLangSysRecord"
+    }
 }
 
 impl Validate for BaseLangSysRecord {
@@ -445,6 +466,9 @@ impl FontWrite for BaseValues {
         self.default_baseline_index.write_into(writer);
         (array_len(&self.base_coords).unwrap() as u16).write_into(writer);
         self.base_coords.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseValues"
     }
 }
 
@@ -514,6 +538,9 @@ impl FontWrite for MinMax {
         self.max_coord.write_into(writer);
         (array_len(&self.feat_min_max_records).unwrap() as u16).write_into(writer);
         self.feat_min_max_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "MinMax"
     }
 }
 
@@ -590,6 +617,9 @@ impl FontWrite for FeatMinMaxRecord {
         self.min_coord.write_into(writer);
         self.max_coord.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "FeatMinMaxRecord"
+    }
 }
 
 impl Validate for FeatMinMaxRecord {
@@ -660,6 +690,13 @@ impl FontWrite for BaseCoord {
             Self::Format3(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "BaseCoord.Format1",
+            Self::Format2(_) => "BaseCoord.Format2",
+            Self::Format3(_) => "BaseCoord.Format3",
+        }
+    }
 }
 
 impl Validate for BaseCoord {
@@ -710,6 +747,9 @@ impl FontWrite for BaseCoordFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coordinate.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseCoordFormat1"
     }
 }
 
@@ -764,6 +804,9 @@ impl FontWrite for BaseCoordFormat2 {
         self.reference_glyph.write_into(writer);
         self.base_coord_point.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "BaseCoordFormat2"
+    }
 }
 
 impl Validate for BaseCoordFormat2 {
@@ -816,6 +859,9 @@ impl FontWrite for BaseCoordFormat3 {
         (3 as u16).write_into(writer);
         self.coordinate.write_into(writer);
         self.device.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseCoordFormat3"
     }
 }
 

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -29,6 +29,9 @@ impl FontWrite for Cmap {
         (array_len(&self.encoding_records).unwrap() as u16).write_into(writer);
         self.encoding_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Cmap"
+    }
 }
 
 impl Validate for Cmap {
@@ -93,6 +96,9 @@ impl FontWrite for EncodingRecord {
         self.platform_id.write_into(writer);
         self.encoding_id.write_into(writer);
         self.subtable.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "EncodingRecord"
     }
 }
 
@@ -273,6 +279,19 @@ impl FontWrite for CmapSubtable {
             Self::Format14(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format0(_) => "CmapSubtable.Format0",
+            Self::Format2(_) => "CmapSubtable.Format2",
+            Self::Format4(_) => "CmapSubtable.Format4",
+            Self::Format6(_) => "CmapSubtable.Format6",
+            Self::Format8(_) => "CmapSubtable.Format8",
+            Self::Format10(_) => "CmapSubtable.Format10",
+            Self::Format12(_) => "CmapSubtable.Format12",
+            Self::Format13(_) => "CmapSubtable.Format13",
+            Self::Format14(_) => "CmapSubtable.Format14",
+        }
+    }
 }
 
 impl Validate for CmapSubtable {
@@ -344,6 +363,9 @@ impl FontWrite for Cmap0 {
         self.language.write_into(writer);
         self.glyph_id_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Cmap0"
+    }
 }
 
 impl Validate for Cmap0 {
@@ -399,6 +421,9 @@ impl FontWrite for Cmap2 {
         self.length.write_into(writer);
         self.language.write_into(writer);
         self.sub_header_keys.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Cmap2"
     }
 }
 
@@ -456,6 +481,9 @@ impl FontWrite for SubHeader {
         self.entry_count.write_into(writer);
         self.id_delta.write_into(writer);
         self.id_range_offset.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SubHeader"
     }
 }
 
@@ -555,6 +583,9 @@ impl FontWrite for Cmap4 {
         self.id_range_offsets.write_into(writer);
         self.glyph_id_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Cmap4"
+    }
 }
 
 impl Validate for Cmap4 {
@@ -632,6 +663,9 @@ impl FontWrite for Cmap6 {
         self.first_code.write_into(writer);
         self.entry_count.write_into(writer);
         self.glyph_id_array.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Cmap6"
     }
 }
 
@@ -716,6 +750,9 @@ impl FontWrite for Cmap8 {
         self.num_groups.write_into(writer);
         self.groups.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Cmap8"
+    }
 }
 
 impl Validate for Cmap8 {
@@ -784,6 +821,9 @@ impl FontWrite for SequentialMapGroup {
         self.end_char_code.write_into(writer);
         self.start_glyph_id.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SequentialMapGroup"
+    }
 }
 
 impl Validate for SequentialMapGroup {
@@ -845,6 +885,9 @@ impl FontWrite for Cmap10 {
         self.start_char_code.write_into(writer);
         self.num_chars.write_into(writer);
         self.glyph_id_array.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Cmap10"
     }
 }
 
@@ -913,6 +956,9 @@ impl FontWrite for Cmap12 {
         self.language.write_into(writer);
         self.num_groups.write_into(writer);
         self.groups.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Cmap12"
     }
 }
 
@@ -985,6 +1031,9 @@ impl FontWrite for Cmap13 {
         self.num_groups.write_into(writer);
         self.groups.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Cmap13"
+    }
 }
 
 impl Validate for Cmap13 {
@@ -1049,6 +1098,9 @@ impl FontWrite for ConstantMapGroup {
         self.end_char_code.write_into(writer);
         self.glyph_id.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ConstantMapGroup"
+    }
 }
 
 impl Validate for ConstantMapGroup {
@@ -1098,6 +1150,9 @@ impl FontWrite for Cmap14 {
         self.length.write_into(writer);
         self.num_var_selector_records.write_into(writer);
         self.var_selector.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Cmap14"
     }
 }
 
@@ -1167,6 +1222,9 @@ impl FontWrite for VariationSelector {
         self.default_uvs.write_into(writer);
         self.non_default_uvs.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "VariationSelector"
+    }
 }
 
 impl Validate for VariationSelector {
@@ -1218,6 +1276,9 @@ impl FontWrite for DefaultUvs {
     fn write_into(&self, writer: &mut TableWriter) {
         self.num_unicode_value_ranges.write_into(writer);
         self.ranges.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "DefaultUvs"
     }
 }
 
@@ -1273,6 +1334,9 @@ impl FontWrite for NonDefaultUvs {
     fn write_into(&self, writer: &mut TableWriter) {
         self.num_uvs_mappings.write_into(writer);
         self.uvs_mapping.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "NonDefaultUvs"
     }
 }
 
@@ -1332,6 +1396,9 @@ impl FontWrite for UvsMapping {
         self.unicode_value.write_into(writer);
         self.glyph_id.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "UvsMapping"
+    }
 }
 
 impl Validate for UvsMapping {
@@ -1370,6 +1437,9 @@ impl FontWrite for UnicodeRange {
     fn write_into(&self, writer: &mut TableWriter) {
         self.start_unicode_value.write_into(writer);
         self.additional_count.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "UnicodeRange"
     }
 }
 

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -86,6 +86,9 @@ impl FontWrite for Cpal {
             .compatible(1)
             .then(|| self.palette_entry_labels_array.write_into(writer));
     }
+    fn name(&self) -> &'static str {
+        "Cpal"
+    }
 }
 
 impl Validate for Cpal {
@@ -162,6 +165,9 @@ impl FontWrite for ColorRecord {
         self.green.write_into(writer);
         self.red.write_into(writer);
         self.alpha.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ColorRecord"
     }
 }
 

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -46,6 +46,9 @@ impl FontWrite for TableDirectory {
         self.range_shift.write_into(writer);
         self.table_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "TableDirectory"
+    }
 }
 
 impl Validate for TableDirectory {
@@ -92,6 +95,9 @@ impl FontWrite for TableRecord {
         self.checksum.write_into(writer);
         self.offset.write_into(writer);
         self.length.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "TableRecord"
     }
 }
 

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -48,6 +48,9 @@ impl FontWrite for Fvar {
         self.instance_count.write_into(writer);
         (self.instance_size() as u16).write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Fvar"
+    }
 }
 
 impl Validate for Fvar {
@@ -107,6 +110,9 @@ impl FontWrite for AxisInstanceArrays {
     fn write_into(&self, writer: &mut TableWriter) {
         self.axes.write_into(writer);
         self.instances.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AxisInstanceArrays"
     }
 }
 
@@ -191,6 +197,9 @@ impl FontWrite for VariationAxisRecord {
         self.max_value.write_into(writer);
         self.flags.write_into(writer);
         self.axis_name_id.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "VariationAxisRecord"
     }
 }
 

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -64,6 +64,9 @@ impl FontWrite for Gdef {
             .compatible((1, 3))
             .then(|| self.item_var_store.write_into(writer));
     }
+    fn name(&self) -> &'static str {
+        "Gdef"
+    }
 }
 
 impl Validate for Gdef {
@@ -150,6 +153,9 @@ impl FontWrite for AttachList {
         (array_len(&self.attach_points).unwrap() as u16).write_into(writer);
         self.attach_points.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AttachList"
+    }
 }
 
 impl Validate for AttachList {
@@ -206,6 +212,9 @@ impl FontWrite for AttachPoint {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.point_indices).unwrap() as u16).write_into(writer);
         self.point_indices.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AttachPoint"
     }
 }
 
@@ -265,6 +274,9 @@ impl FontWrite for LigCaretList {
         (array_len(&self.lig_glyphs).unwrap() as u16).write_into(writer);
         self.lig_glyphs.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "LigCaretList"
+    }
 }
 
 impl Validate for LigCaretList {
@@ -322,6 +334,9 @@ impl FontWrite for LigGlyph {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.caret_values).unwrap() as u16).write_into(writer);
         self.caret_values.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "LigGlyph"
     }
 }
 
@@ -393,6 +408,13 @@ impl FontWrite for CaretValue {
             Self::Format3(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "CaretValue.Format1",
+            Self::Format2(_) => "CaretValue.Format2",
+            Self::Format3(_) => "CaretValue.Format3",
+        }
+    }
 }
 
 impl Validate for CaretValue {
@@ -444,6 +466,9 @@ impl FontWrite for CaretValueFormat1 {
         (1 as u16).write_into(writer);
         self.coordinate.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "CaretValueFormat1"
+    }
 }
 
 impl Validate for CaretValueFormat1 {
@@ -488,6 +513,9 @@ impl FontWrite for CaretValueFormat2 {
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
         self.caret_value_point_index.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "CaretValueFormat2"
     }
 }
 
@@ -539,6 +567,9 @@ impl FontWrite for CaretValueFormat3 {
         (3 as u16).write_into(writer);
         self.coordinate.write_into(writer);
         self.device.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "CaretValueFormat3"
     }
 }
 
@@ -593,6 +624,9 @@ impl FontWrite for MarkGlyphSets {
         (1 as u16).write_into(writer);
         (array_len(&self.coverages).unwrap() as u16).write_into(writer);
         self.coverages.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "MarkGlyphSets"
     }
 }
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -48,6 +48,9 @@ impl FontWrite for Gpos {
             .compatible((1, 1))
             .then(|| self.feature_variations.write_into(writer));
     }
+    fn name(&self) -> &'static str {
+        "Gpos"
+    }
 }
 
 impl Validate for Gpos {
@@ -124,6 +127,19 @@ impl FontWrite for PositionLookup {
             Self::Contextual(table) => table.write_into(writer),
             Self::ChainContextual(table) => table.write_into(writer),
             Self::Extension(table) => table.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Single(_) => "PositionLookup.Single",
+            Self::Pair(_) => "PositionLookup.Pair",
+            Self::Cursive(_) => "PositionLookup.Cursive",
+            Self::MarkToBase(_) => "PositionLookup.MarkToBase",
+            Self::MarkToLig(_) => "PositionLookup.MarkToLig",
+            Self::MarkToMark(_) => "PositionLookup.MarkToMark",
+            Self::Contextual(_) => "PositionLookup.Contextual",
+            Self::ChainContextual(_) => "PositionLookup.ChainContextual",
+            Self::Extension(_) => "PositionLookup.Extension",
         }
     }
 }
@@ -236,6 +252,13 @@ impl FontWrite for AnchorTable {
             Self::Format3(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "AnchorTable.Format1",
+            Self::Format2(_) => "AnchorTable.Format2",
+            Self::Format3(_) => "AnchorTable.Format3",
+        }
+    }
 }
 
 impl Validate for AnchorTable {
@@ -293,6 +316,9 @@ impl FontWrite for AnchorFormat1 {
         self.x_coordinate.write_into(writer);
         self.y_coordinate.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AnchorFormat1"
+    }
 }
 
 impl Validate for AnchorFormat1 {
@@ -346,6 +372,9 @@ impl FontWrite for AnchorFormat2 {
         self.x_coordinate.write_into(writer);
         self.y_coordinate.write_into(writer);
         self.anchor_point.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AnchorFormat2"
     }
 }
 
@@ -415,6 +444,9 @@ impl FontWrite for AnchorFormat3 {
         self.x_device.write_into(writer);
         self.y_device.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AnchorFormat3"
+    }
 }
 
 impl Validate for AnchorFormat3 {
@@ -473,6 +505,9 @@ impl FontWrite for MarkArray {
         (array_len(&self.mark_records).unwrap() as u16).write_into(writer);
         self.mark_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MarkArray"
+    }
 }
 
 impl Validate for MarkArray {
@@ -529,6 +564,9 @@ impl FontWrite for MarkRecord {
         self.mark_class.write_into(writer);
         self.mark_anchor.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MarkRecord"
+    }
 }
 
 impl Validate for MarkRecord {
@@ -580,6 +618,12 @@ impl FontWrite for SinglePos {
         match self {
             Self::Format1(item) => item.write_into(writer),
             Self::Format2(item) => item.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "SinglePos.Format1",
+            Self::Format2(_) => "SinglePos.Format2",
         }
     }
 }
@@ -639,6 +683,9 @@ impl FontWrite for SinglePosFormat1 {
         (self.compute_value_format() as ValueFormat).write_into(writer);
         self.value_record.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SinglePosFormat1"
+    }
 }
 
 impl Validate for SinglePosFormat1 {
@@ -697,6 +744,9 @@ impl FontWrite for SinglePosFormat2 {
         (self.compute_value_format() as ValueFormat).write_into(writer);
         (array_len(&self.value_records).unwrap() as u16).write_into(writer);
         self.value_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SinglePosFormat2"
     }
 }
 
@@ -781,6 +831,12 @@ impl FontWrite for PairPos {
             Self::Format2(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "PairPos.Format1",
+            Self::Format2(_) => "PairPos.Format2",
+        }
+    }
 }
 
 impl Validate for PairPos {
@@ -840,6 +896,9 @@ impl FontWrite for PairPosFormat1 {
         (array_len(&self.pair_sets).unwrap() as u16).write_into(writer);
         self.pair_sets.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "PairPosFormat1"
+    }
 }
 
 impl Validate for PairPosFormat1 {
@@ -896,6 +955,9 @@ impl FontWrite for PairSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.pair_value_records).unwrap() as u16).write_into(writer);
         self.pair_value_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "PairSet"
     }
 }
 
@@ -960,6 +1022,9 @@ impl FontWrite for PairValueRecord {
         self.value_record1.write_into(writer);
         self.value_record2.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "PairValueRecord"
+    }
 }
 
 impl Validate for PairValueRecord {
@@ -1023,6 +1088,9 @@ impl FontWrite for PairPosFormat2 {
         (self.compute_class1_count() as u16).write_into(writer);
         (self.compute_class2_count() as u16).write_into(writer);
         self.class1_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "PairPosFormat2"
     }
 }
 
@@ -1091,6 +1159,9 @@ impl FontWrite for Class1Record {
     fn write_into(&self, writer: &mut TableWriter) {
         self.class2_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Class1Record"
+    }
 }
 
 impl Validate for Class1Record {
@@ -1142,6 +1213,9 @@ impl FontWrite for Class2Record {
         self.value_record1.write_into(writer);
         self.value_record2.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Class2Record"
+    }
 }
 
 impl Validate for Class2Record {
@@ -1183,6 +1257,9 @@ impl FontWrite for CursivePosFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.entry_exit_record).unwrap() as u16).write_into(writer);
         self.entry_exit_record.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "CursivePosFormat1"
     }
 }
 
@@ -1246,6 +1323,9 @@ impl FontWrite for EntryExitRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.entry_anchor.write_into(writer);
         self.exit_anchor.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "EntryExitRecord"
     }
 }
 
@@ -1318,6 +1398,9 @@ impl FontWrite for MarkBasePosFormat1 {
         self.mark_array.write_into(writer);
         self.base_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MarkBasePosFormat1"
+    }
 }
 
 impl Validate for MarkBasePosFormat1 {
@@ -1379,6 +1462,9 @@ impl FontWrite for BaseArray {
         (array_len(&self.base_records).unwrap() as u16).write_into(writer);
         self.base_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "BaseArray"
+    }
 }
 
 impl Validate for BaseArray {
@@ -1430,6 +1516,9 @@ impl BaseRecord {
 impl FontWrite for BaseRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.base_anchors.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "BaseRecord"
     }
 }
 
@@ -1501,6 +1590,9 @@ impl FontWrite for MarkLigPosFormat1 {
         self.mark_array.write_into(writer);
         self.ligature_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MarkLigPosFormat1"
+    }
 }
 
 impl Validate for MarkLigPosFormat1 {
@@ -1566,6 +1658,9 @@ impl FontWrite for LigatureArray {
         (array_len(&self.ligature_attaches).unwrap() as u16).write_into(writer);
         self.ligature_attaches.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "LigatureArray"
+    }
 }
 
 impl Validate for LigatureArray {
@@ -1613,6 +1708,9 @@ impl FontWrite for LigatureAttach {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.component_records).unwrap() as u16).write_into(writer);
         self.component_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "LigatureAttach"
     }
 }
 
@@ -1665,6 +1763,9 @@ impl ComponentRecord {
 impl FontWrite for ComponentRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.ligature_anchors.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ComponentRecord"
     }
 }
 
@@ -1739,6 +1840,9 @@ impl FontWrite for MarkMarkPosFormat1 {
         self.mark1_array.write_into(writer);
         self.mark2_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MarkMarkPosFormat1"
+    }
 }
 
 impl Validate for MarkMarkPosFormat1 {
@@ -1800,6 +1904,9 @@ impl FontWrite for Mark2Array {
         (array_len(&self.mark2_records).unwrap() as u16).write_into(writer);
         self.mark2_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Mark2Array"
+    }
 }
 
 impl Validate for Mark2Array {
@@ -1851,6 +1958,9 @@ impl Mark2Record {
 impl FontWrite for Mark2Record {
     fn write_into(&self, writer: &mut TableWriter) {
         self.mark2_anchors.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Mark2Record"
     }
 }
 
@@ -1965,6 +2075,18 @@ impl FontWrite for ExtensionSubtable {
             Self::MarkToMark(table) => table.write_into(writer),
             Self::Contextual(table) => table.write_into(writer),
             Self::ChainContextual(table) => table.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Single(_) => "ExtensionSubtable.Single",
+            Self::Pair(_) => "ExtensionSubtable.Pair",
+            Self::Cursive(_) => "ExtensionSubtable.Cursive",
+            Self::MarkToBase(_) => "ExtensionSubtable.MarkToBase",
+            Self::MarkToLig(_) => "ExtensionSubtable.MarkToLig",
+            Self::MarkToMark(_) => "ExtensionSubtable.MarkToMark",
+            Self::Contextual(_) => "ExtensionSubtable.Contextual",
+            Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -47,6 +47,9 @@ impl FontWrite for Gsub {
             .compatible((1, 1))
             .then(|| self.feature_variations.write_into(writer));
     }
+    fn name(&self) -> &'static str {
+        "Gsub"
+    }
 }
 
 impl Validate for Gsub {
@@ -121,6 +124,18 @@ impl FontWrite for SubstitutionLookup {
             Self::ChainContextual(table) => table.write_into(writer),
             Self::Extension(table) => table.write_into(writer),
             Self::Reverse(table) => table.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Single(_) => "SubstitutionLookup.Single",
+            Self::Multiple(_) => "SubstitutionLookup.Multiple",
+            Self::Alternate(_) => "SubstitutionLookup.Alternate",
+            Self::Ligature(_) => "SubstitutionLookup.Ligature",
+            Self::Contextual(_) => "SubstitutionLookup.Contextual",
+            Self::ChainContextual(_) => "SubstitutionLookup.ChainContextual",
+            Self::Extension(_) => "SubstitutionLookup.Extension",
+            Self::Reverse(_) => "SubstitutionLookup.Reverse",
         }
     }
 }
@@ -208,6 +223,12 @@ impl FontWrite for SingleSubst {
             Self::Format2(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "SingleSubst.Format1",
+            Self::Format2(_) => "SingleSubst.Format2",
+        }
+    }
 }
 
 impl Validate for SingleSubst {
@@ -263,6 +284,9 @@ impl FontWrite for SingleSubstFormat1 {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
         self.delta_glyph_id.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SingleSubstFormat1"
     }
 }
 
@@ -321,6 +345,9 @@ impl FontWrite for SingleSubstFormat2 {
         self.coverage.write_into(writer);
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SingleSubstFormat2"
     }
 }
 
@@ -387,6 +414,9 @@ impl FontWrite for MultipleSubstFormat1 {
         (array_len(&self.sequences).unwrap() as u16).write_into(writer);
         self.sequences.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MultipleSubstFormat1"
+    }
 }
 
 impl Validate for MultipleSubstFormat1 {
@@ -444,6 +474,9 @@ impl FontWrite for Sequence {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Sequence"
     }
 }
 
@@ -504,6 +537,9 @@ impl FontWrite for AlternateSubstFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.alternate_sets).unwrap() as u16).write_into(writer);
         self.alternate_sets.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AlternateSubstFormat1"
     }
 }
 
@@ -569,6 +605,9 @@ impl FontWrite for AlternateSet {
         (array_len(&self.alternate_glyph_ids).unwrap() as u16).write_into(writer);
         self.alternate_glyph_ids.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AlternateSet"
+    }
 }
 
 impl Validate for AlternateSet {
@@ -629,6 +668,9 @@ impl FontWrite for LigatureSubstFormat1 {
         (array_len(&self.ligature_sets).unwrap() as u16).write_into(writer);
         self.ligature_sets.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "LigatureSubstFormat1"
+    }
 }
 
 impl Validate for LigatureSubstFormat1 {
@@ -688,6 +730,9 @@ impl FontWrite for LigatureSet {
         (array_len(&self.ligatures).unwrap() as u16).write_into(writer);
         self.ligatures.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "LigatureSet"
+    }
 }
 
 impl Validate for LigatureSet {
@@ -745,6 +790,9 @@ impl FontWrite for Ligature {
         self.ligature_glyph.write_into(writer);
         (plus_one(&self.component_glyph_ids.len()).unwrap() as u16).write_into(writer);
         self.component_glyph_ids.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Ligature"
     }
 }
 
@@ -857,6 +905,17 @@ impl FontWrite for ExtensionSubtable {
             Self::Reverse(table) => table.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Single(_) => "ExtensionSubtable.Single",
+            Self::Multiple(_) => "ExtensionSubtable.Multiple",
+            Self::Alternate(_) => "ExtensionSubtable.Alternate",
+            Self::Ligature(_) => "ExtensionSubtable.Ligature",
+            Self::Contextual(_) => "ExtensionSubtable.Contextual",
+            Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
+            Self::Reverse(_) => "ExtensionSubtable.Reverse",
+        }
+    }
 }
 
 impl Validate for ExtensionSubtable {
@@ -950,6 +1009,9 @@ impl FontWrite for ReverseChainSingleSubstFormat1 {
         self.lookahead_coverages.write_into(writer);
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ReverseChainSingleSubstFormat1"
     }
 }
 

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -32,6 +32,9 @@ impl FontWrite for Gvar {
         (self.compute_data_array_offset() as u32).write_into(writer);
         (self.compile_variation_data()).write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Gvar"
+    }
 }
 
 impl Validate for Gvar {
@@ -73,6 +76,9 @@ impl SharedTuples {
 impl FontWrite for SharedTuples {
     fn write_into(&self, writer: &mut TableWriter) {
         self.tuples.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SharedTuples"
     }
 }
 

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -138,6 +138,9 @@ impl FontWrite for Head {
         self.index_to_loc_format.write_into(writer);
         (0 as i16).write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Head"
+    }
 }
 
 impl Validate for Head {

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -91,6 +91,9 @@ impl FontWrite for Hhea {
         (0 as i16).write_into(writer);
         self.number_of_long_metrics.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Hhea"
+    }
 }
 
 impl Validate for Hhea {

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -31,6 +31,9 @@ impl FontWrite for Hmtx {
         self.h_metrics.write_into(writer);
         self.left_side_bearings.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Hmtx"
+    }
 }
 
 impl Validate for Hmtx {
@@ -84,6 +87,9 @@ impl FontWrite for LongMetric {
     fn write_into(&self, writer: &mut TableWriter) {
         self.advance.write_into(writer);
         self.side_bearing.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "LongMetric"
     }
 }
 

--- a/write-fonts/generated/generated_hvar.rs
+++ b/write-fonts/generated/generated_hvar.rs
@@ -48,6 +48,9 @@ impl FontWrite for Hvar {
         self.lsb_mapping.write_into(writer);
         self.rsb_mapping.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Hvar"
+    }
 }
 
 impl Validate for Hvar {

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -29,6 +29,9 @@ impl FontWrite for ScriptList {
         (array_len(&self.script_records).unwrap() as u16).write_into(writer);
         self.script_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ScriptList"
+    }
 }
 
 impl Validate for ScriptList {
@@ -85,6 +88,9 @@ impl FontWrite for ScriptRecord {
         self.script_tag.write_into(writer);
         self.script.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ScriptRecord"
+    }
 }
 
 impl Validate for ScriptRecord {
@@ -132,6 +138,9 @@ impl FontWrite for Script {
         self.default_lang_sys.write_into(writer);
         (array_len(&self.lang_sys_records).unwrap() as u16).write_into(writer);
         self.lang_sys_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Script"
     }
 }
 
@@ -191,6 +200,9 @@ impl FontWrite for LangSysRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.lang_sys_tag.write_into(writer);
         self.lang_sys.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "LangSysRecord"
     }
 }
 
@@ -253,6 +265,9 @@ impl FontWrite for LangSys {
         (array_len(&self.feature_indices).unwrap() as u16).write_into(writer);
         self.feature_indices.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "LangSys"
+    }
 }
 
 impl Validate for LangSys {
@@ -307,6 +322,9 @@ impl FontWrite for FeatureList {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.feature_records).unwrap() as u16).write_into(writer);
         self.feature_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "FeatureList"
     }
 }
 
@@ -365,6 +383,9 @@ impl FontWrite for FeatureRecord {
         self.feature_tag.write_into(writer);
         self.feature.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "FeatureRecord"
+    }
 }
 
 impl Validate for FeatureRecord {
@@ -415,6 +436,9 @@ impl FontWrite for Feature {
         self.feature_params.write_into(writer);
         (array_len(&self.lookup_list_indices).unwrap() as u16).write_into(writer);
         self.lookup_list_indices.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Feature"
     }
 }
 
@@ -467,6 +491,9 @@ impl<T: FontWrite> FontWrite for LookupList<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.lookups).unwrap() as u16).write_into(writer);
         self.lookups.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "LookupList"
     }
 }
 
@@ -584,6 +611,9 @@ impl FontWrite for CoverageFormat1 {
         (array_len(&self.glyph_array).unwrap() as u16).write_into(writer);
         self.glyph_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "CoverageFormat1"
+    }
 }
 
 impl Validate for CoverageFormat1 {
@@ -638,6 +668,9 @@ impl FontWrite for CoverageFormat2 {
         (2 as u16).write_into(writer);
         (array_len(&self.range_records).unwrap() as u16).write_into(writer);
         self.range_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "CoverageFormat2"
     }
 }
 
@@ -700,6 +733,9 @@ impl FontWrite for RangeRecord {
         self.end_glyph_id.write_into(writer);
         self.start_coverage_index.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "RangeRecord"
+    }
 }
 
 impl Validate for RangeRecord {
@@ -746,6 +782,12 @@ impl FontWrite for CoverageTable {
         match self {
             Self::Format1(item) => item.write_into(writer),
             Self::Format2(item) => item.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "CoverageTable.Format1",
+            Self::Format2(_) => "CoverageTable.Format2",
         }
     }
 }
@@ -805,6 +847,9 @@ impl FontWrite for ClassDefFormat1 {
         (array_len(&self.class_value_array).unwrap() as u16).write_into(writer);
         self.class_value_array.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ClassDefFormat1"
+    }
 }
 
 impl Validate for ClassDefFormat1 {
@@ -860,6 +905,9 @@ impl FontWrite for ClassDefFormat2 {
         (2 as u16).write_into(writer);
         (array_len(&self.class_range_records).unwrap() as u16).write_into(writer);
         self.class_range_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ClassDefFormat2"
     }
 }
 
@@ -922,6 +970,9 @@ impl FontWrite for ClassRangeRecord {
         self.end_glyph_id.write_into(writer);
         self.class.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ClassRangeRecord"
+    }
 }
 
 impl Validate for ClassRangeRecord {
@@ -974,6 +1025,12 @@ impl FontWrite for ClassDef {
         match self {
             Self::Format1(item) => item.write_into(writer),
             Self::Format2(item) => item.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "ClassDef.Format1",
+            Self::Format2(_) => "ClassDef.Format2",
         }
     }
 }
@@ -1029,6 +1086,9 @@ impl FontWrite for SequenceLookupRecord {
         self.sequence_index.write_into(writer);
         self.lookup_list_index.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SequenceLookupRecord"
+    }
 }
 
 impl Validate for SequenceLookupRecord {
@@ -1072,6 +1132,9 @@ impl FontWrite for SequenceContextFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.seq_rule_sets).unwrap() as u16).write_into(writer);
         self.seq_rule_sets.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SequenceContextFormat1"
     }
 }
 
@@ -1140,6 +1203,9 @@ impl FontWrite for SequenceRuleSet {
         (array_len(&self.seq_rules).unwrap() as u16).write_into(writer);
         self.seq_rules.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SequenceRuleSet"
+    }
 }
 
 impl Validate for SequenceRuleSet {
@@ -1201,6 +1267,9 @@ impl FontWrite for SequenceRule {
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.input_sequence.write_into(writer);
         self.seq_lookup_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SequenceRule"
     }
 }
 
@@ -1273,6 +1342,9 @@ impl FontWrite for SequenceContextFormat2 {
         self.class_def.write_into(writer);
         (array_len(&self.class_seq_rule_sets).unwrap() as u16).write_into(writer);
         self.class_seq_rule_sets.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SequenceContextFormat2"
     }
 }
 
@@ -1348,6 +1420,9 @@ impl FontWrite for ClassSequenceRuleSet {
         (array_len(&self.class_seq_rules).unwrap() as u16).write_into(writer);
         self.class_seq_rules.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ClassSequenceRuleSet"
+    }
 }
 
 impl Validate for ClassSequenceRuleSet {
@@ -1414,6 +1489,9 @@ impl FontWrite for ClassSequenceRule {
         self.input_sequence.write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ClassSequenceRule"
+    }
 }
 
 impl Validate for ClassSequenceRule {
@@ -1479,6 +1557,9 @@ impl FontWrite for SequenceContextFormat3 {
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.coverages.write_into(writer);
         self.seq_lookup_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "SequenceContextFormat3"
     }
 }
 
@@ -1577,6 +1658,13 @@ impl FontWrite for SequenceContext {
             Self::Format3(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "SequenceContext.Format1",
+            Self::Format2(_) => "SequenceContext.Format2",
+            Self::Format3(_) => "SequenceContext.Format3",
+        }
+    }
 }
 
 impl Validate for SequenceContext {
@@ -1640,6 +1728,9 @@ impl FontWrite for ChainedSequenceContextFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.chained_seq_rule_sets).unwrap() as u16).write_into(writer);
         self.chained_seq_rule_sets.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ChainedSequenceContextFormat1"
     }
 }
 
@@ -1710,6 +1801,9 @@ impl FontWrite for ChainedSequenceRuleSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.chained_seq_rules).unwrap() as u16).write_into(writer);
         self.chained_seq_rules.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ChainedSequenceRuleSet"
     }
 }
 
@@ -1795,6 +1889,9 @@ impl FontWrite for ChainedSequenceRule {
         self.lookahead_sequence.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ChainedSequenceRule"
     }
 }
 
@@ -1898,6 +1995,9 @@ impl FontWrite for ChainedSequenceContextFormat2 {
         (array_len(&self.chained_class_seq_rule_sets).unwrap() as u16).write_into(writer);
         self.chained_class_seq_rule_sets.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ChainedSequenceContextFormat2"
+    }
 }
 
 impl Validate for ChainedSequenceContextFormat2 {
@@ -1982,6 +2082,9 @@ impl FontWrite for ChainedClassSequenceRuleSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.chained_class_seq_rules).unwrap() as u16).write_into(writer);
         self.chained_class_seq_rules.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ChainedClassSequenceRuleSet"
     }
 }
 
@@ -2068,6 +2171,9 @@ impl FontWrite for ChainedClassSequenceRule {
         self.lookahead_sequence.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ChainedClassSequenceRule"
     }
 }
 
@@ -2165,6 +2271,9 @@ impl FontWrite for ChainedSequenceContextFormat3 {
         self.lookahead_coverages.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ChainedSequenceContextFormat3"
     }
 }
 
@@ -2300,6 +2409,13 @@ impl FontWrite for ChainedSequenceContext {
             Self::Format3(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "ChainedSequenceContext.Format1",
+            Self::Format2(_) => "ChainedSequenceContext.Format2",
+            Self::Format3(_) => "ChainedSequenceContext.Format3",
+        }
+    }
 }
 
 impl Validate for ChainedSequenceContext {
@@ -2362,6 +2478,9 @@ impl FontWrite for Device {
         self.delta_format.write_into(writer);
         self.delta_value.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Device"
+    }
 }
 
 impl Validate for Device {
@@ -2418,6 +2537,9 @@ impl FontWrite for VariationIndex {
         self.delta_set_inner_index.write_into(writer);
         self.delta_format.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "VariationIndex"
+    }
 }
 
 impl Validate for VariationIndex {
@@ -2468,6 +2590,9 @@ impl FontWrite for FeatureVariations {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         (array_len(&self.feature_variation_records).unwrap() as u32).write_into(writer);
         self.feature_variation_records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "FeatureVariations"
     }
 }
 
@@ -2531,6 +2656,9 @@ impl FontWrite for FeatureVariationRecord {
         self.condition_set.write_into(writer);
         self.feature_table_substitution.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "FeatureVariationRecord"
+    }
 }
 
 impl Validate for FeatureVariationRecord {
@@ -2582,6 +2710,9 @@ impl FontWrite for ConditionSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.conditions).unwrap() as u16).write_into(writer);
         self.conditions.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ConditionSet"
     }
 }
 
@@ -2652,6 +2783,9 @@ impl FontWrite for ConditionFormat1 {
         self.filter_range_min_value.write_into(writer);
         self.filter_range_max_value.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "ConditionFormat1"
+    }
 }
 
 impl Validate for ConditionFormat1 {
@@ -2699,6 +2833,9 @@ impl FontWrite for FeatureTableSubstitution {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         (array_len(&self.substitutions).unwrap() as u16).write_into(writer);
         self.substitutions.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "FeatureTableSubstitution"
     }
 }
 
@@ -2765,6 +2902,9 @@ impl FontWrite for FeatureTableSubstitutionRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.feature_index.write_into(writer);
         self.alternate_feature.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "FeatureTableSubstitutionRecord"
     }
 }
 
@@ -2853,6 +2993,9 @@ impl FontWrite for SizeParams {
         self.range_start.write_into(writer);
         self.range_end.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SizeParams"
+    }
 }
 
 impl Validate for SizeParams {
@@ -2905,6 +3048,9 @@ impl FontWrite for StylisticSetParams {
     fn write_into(&self, writer: &mut TableWriter) {
         (0 as u16).write_into(writer);
         self.ui_name_id.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "StylisticSetParams"
     }
 }
 
@@ -2986,6 +3132,9 @@ impl FontWrite for CharacterVariantParams {
         self.first_param_ui_label_name_id.write_into(writer);
         (array_len(&self.character).unwrap() as u16).write_into(writer);
         self.character.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "CharacterVariantParams"
     }
 }
 

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -137,6 +137,9 @@ impl FontWrite for Maxp {
                 .write_into(writer)
         });
     }
+    fn name(&self) -> &'static str {
+        "Maxp"
+    }
 }
 
 impl Validate for Maxp {

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -47,6 +47,9 @@ impl FontWrite for Name {
             });
         });
     }
+    fn name(&self) -> &'static str {
+        "Name"
+    }
 }
 
 impl Validate for Name {
@@ -119,6 +122,9 @@ impl FontWrite for LangTagRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         (self.compile_name_string()).write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "LangTagRecord"
+    }
 }
 
 impl Validate for LangTagRecord {
@@ -176,6 +182,9 @@ impl FontWrite for NameRecord {
         self.language_id.write_into(writer);
         self.name_id.write_into(writer);
         (self.compile_name_string()).write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "NameRecord"
     }
 }
 

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -269,6 +269,9 @@ impl FontWrite for Os2 {
                 .write_into(writer)
         });
     }
+    fn name(&self) -> &'static str {
+        "Os2"
+    }
 }
 
 impl Validate for Os2 {

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -128,6 +128,9 @@ impl FontWrite for Post {
                 .write_into(writer)
         });
     }
+    fn name(&self) -> &'static str {
+        "Post"
+    }
 }
 
 impl Validate for Post {

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -43,6 +43,9 @@ impl FontWrite for Stat {
                 .write_into(writer)
         });
     }
+    fn name(&self) -> &'static str {
+        "Stat"
+    }
 }
 
 impl Validate for Stat {
@@ -118,6 +121,9 @@ impl FontWrite for AxisRecord {
         self.axis_name_id.write_into(writer);
         self.axis_ordering.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AxisRecord"
+    }
 }
 
 impl Validate for AxisRecord {
@@ -154,6 +160,9 @@ impl AxisValueArray {
 impl FontWrite for AxisValueArray {
     fn write_into(&self, writer: &mut TableWriter) {
         self.axis_values.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AxisValueArray"
     }
 }
 
@@ -266,6 +275,14 @@ impl FontWrite for AxisValue {
             Self::Format4(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "AxisValue.Format1",
+            Self::Format2(_) => "AxisValue.Format2",
+            Self::Format3(_) => "AxisValue.Format3",
+            Self::Format4(_) => "AxisValue.Format4",
+        }
+    }
 }
 
 impl Validate for AxisValue {
@@ -340,6 +357,9 @@ impl FontWrite for AxisValueFormat1 {
         self.flags.write_into(writer);
         self.value_name_id.write_into(writer);
         self.value.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AxisValueFormat1"
     }
 }
 
@@ -421,6 +441,9 @@ impl FontWrite for AxisValueFormat2 {
         self.range_min_value.write_into(writer);
         self.range_max_value.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AxisValueFormat2"
+    }
 }
 
 impl Validate for AxisValueFormat2 {
@@ -496,6 +519,9 @@ impl FontWrite for AxisValueFormat3 {
         self.value.write_into(writer);
         self.linked_value.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AxisValueFormat3"
+    }
 }
 
 impl Validate for AxisValueFormat3 {
@@ -560,6 +586,9 @@ impl FontWrite for AxisValueFormat4 {
         self.value_name_id.write_into(writer);
         self.axis_values.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "AxisValueFormat4"
+    }
 }
 
 impl Validate for AxisValueFormat4 {
@@ -616,6 +645,9 @@ impl FontWrite for AxisValueRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.axis_index.write_into(writer);
         self.value.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "AxisValueRecord"
     }
 }
 

--- a/write-fonts/generated/generated_test_enum.rs
+++ b/write-fonts/generated/generated_test_enum.rs
@@ -39,6 +39,9 @@ impl FontWrite for MyRecord {
         self.my_enum1.write_into(writer);
         self.my_enum2.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "MyRecord"
+    }
 }
 
 impl Validate for MyRecord {

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -25,6 +25,9 @@ impl FontWrite for Table1 {
         self.heft.write_into(writer);
         self.flex.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Table1"
+    }
 }
 
 impl Validate for Table1 {
@@ -70,6 +73,9 @@ impl FontWrite for Table2 {
         (array_len(&self.values).unwrap() as u16).write_into(writer);
         self.values.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Table2"
+    }
 }
 
 impl Validate for Table2 {
@@ -112,6 +118,9 @@ impl FontWrite for Table3 {
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
         self.something.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Table3"
     }
 }
 
@@ -167,6 +176,13 @@ impl FontWrite for MyTable {
             Self::Format1(item) => item.write_into(writer),
             Self::MyFormat22(item) => item.write_into(writer),
             Self::Format3(item) => item.write_into(writer),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format1(_) => "MyTable.Format1",
+            Self::MyFormat22(_) => "MyTable.MyFormat22",
+            Self::Format3(_) => "MyTable.Format3",
         }
     }
 }

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -63,6 +63,9 @@ impl FontWrite for KindsOfOffsets {
             .compatible((1, 1))
             .then(|| self.versioned_nullable.write_into(writer));
     }
+    fn name(&self) -> &'static str {
+        "KindsOfOffsets"
+    }
 }
 
 impl Validate for KindsOfOffsets {
@@ -161,6 +164,9 @@ impl FontWrite for KindsOfArraysOfOffsets {
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
+    }
+    fn name(&self) -> &'static str {
+        "KindsOfArraysOfOffsets"
     }
 }
 
@@ -284,6 +290,9 @@ impl FontWrite for KindsOfArrays {
                 .write_into(writer)
         });
     }
+    fn name(&self) -> &'static str {
+        "KindsOfArrays"
+    }
 }
 
 impl Validate for KindsOfArrays {
@@ -365,6 +374,9 @@ impl FontWrite for Dummy {
         self.value.write_into(writer);
         (0 as u16).write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Dummy"
+    }
 }
 
 impl Validate for Dummy {
@@ -399,6 +411,9 @@ impl FontWrite for Shmecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.length.write_into(writer);
         self.breadth.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "Shmecord"
     }
 }
 

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -30,6 +30,9 @@ impl FontWrite for BasicTable {
         (array_len(&self.array_records).unwrap() as u32).write_into(writer);
         self.array_records.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "BasicTable"
+    }
 }
 
 impl Validate for BasicTable {
@@ -93,6 +96,9 @@ impl FontWrite for SimpleRecord {
         self.val1.write_into(writer);
         (self.compile_va2()).write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "SimpleRecord"
+    }
 }
 
 impl Validate for SimpleRecord {
@@ -128,6 +134,9 @@ impl FontWrite for ContainsArrays {
     fn write_into(&self, writer: &mut TableWriter) {
         self.scalars.write_into(writer);
         self.records.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ContainsArrays"
     }
 }
 
@@ -183,6 +192,9 @@ impl FontWrite for ContainsOffests {
         (array_len(&self.array).unwrap() as u16).write_into(writer);
         self.array.write_into(writer);
         self.other.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ContainsOffests"
     }
 }
 

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -36,6 +36,9 @@ impl FontWrite for TupleVariationHeader {
         self.intermediate_start_tuple.write_into(writer);
         self.intermediate_end_tuple.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "TupleVariationHeader"
+    }
 }
 
 impl Validate for TupleVariationHeader {
@@ -92,6 +95,9 @@ impl FontWrite for Tuple {
     fn write_into(&self, writer: &mut TableWriter) {
         self.values.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Tuple"
+    }
 }
 
 impl Validate for Tuple {
@@ -144,6 +150,9 @@ impl FontWrite for DeltaSetIndexMapFormat0 {
         self.entry_format.write_into(writer);
         self.map_count.write_into(writer);
         self.map_data.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "DeltaSetIndexMapFormat0"
     }
 }
 
@@ -209,6 +218,9 @@ impl FontWrite for DeltaSetIndexMapFormat1 {
         self.entry_format.write_into(writer);
         self.map_count.write_into(writer);
         self.map_data.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "DeltaSetIndexMapFormat1"
     }
 }
 
@@ -284,6 +296,12 @@ impl FontWrite for DeltaSetIndexMap {
             Self::Format1(item) => item.write_into(writer),
         }
     }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Format0(_) => "DeltaSetIndexMap.Format0",
+            Self::Format1(_) => "DeltaSetIndexMap.Format1",
+        }
+    }
 }
 
 impl Validate for DeltaSetIndexMap {
@@ -340,6 +358,9 @@ impl FontWrite for VariationRegionList {
         (self.compute_axis_count() as u16).write_into(writer);
         (array_len(&self.variation_regions).unwrap() as u16).write_into(writer);
         self.variation_regions.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "VariationRegionList"
     }
 }
 
@@ -407,6 +428,9 @@ impl FontWrite for VariationRegion {
     fn write_into(&self, writer: &mut TableWriter) {
         self.region_axes.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "VariationRegion"
+    }
 }
 
 impl Validate for VariationRegion {
@@ -460,6 +484,9 @@ impl FontWrite for RegionAxisCoordinates {
         self.start_coord.write_into(writer);
         self.peak_coord.write_into(writer);
         self.end_coord.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "RegionAxisCoordinates"
     }
 }
 
@@ -515,6 +542,9 @@ impl FontWrite for ItemVariationStore {
         self.variation_region_list.write_into(writer);
         (array_len(&self.item_variation_datas).unwrap() as u16).write_into(writer);
         self.item_variation_datas.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ItemVariationStore"
     }
 }
 
@@ -601,6 +631,9 @@ impl FontWrite for ItemVariationData {
         (array_len(&self.region_indexes).unwrap() as u16).write_into(writer);
         self.region_indexes.write_into(writer);
         self.delta_sets.write_into(writer);
+    }
+    fn name(&self) -> &'static str {
+        "ItemVariationData"
     }
 }
 

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -90,6 +90,9 @@ impl FontWrite for Vhea {
         (0 as i16).write_into(writer);
         self.number_of_long_ver_metrics.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Vhea"
+    }
 }
 
 impl Validate for Vhea {

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -30,6 +30,9 @@ impl FontWrite for Vmtx {
         self.v_metrics.write_into(writer);
         self.top_side_bearings.write_into(writer);
     }
+    fn name(&self) -> &'static str {
+        "Vmtx"
+    }
 }
 
 impl Validate for Vmtx {

--- a/write-fonts/src/error.rs
+++ b/write-fonts/src/error.rs
@@ -15,6 +15,16 @@ pub enum Error {
     PackingFailed(PackingError),
 }
 
+impl PackingError {
+    /// Write a graphviz file representing the failed packing to the provided path.
+    ///
+    /// Has the same semantics as [`std::fs::write`].
+    #[cfg(feature = "dot2")]
+    pub fn write_graph_viz(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+        self.graph.write_graph_viz(path)
+    }
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -6,10 +6,13 @@ use std::{
     sync::atomic::AtomicUsize,
 };
 
+#[cfg(feature = "dot2")]
+mod graphviz;
+
 static OBJECT_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Hash, PartialEq, Eq)]
-pub(crate) struct ObjectId(usize);
+pub struct ObjectId(usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
@@ -44,7 +47,7 @@ impl std::fmt::Display for OffsetLen {
 /// Nodes are assigned a space, and nodes in lower spaces are always
 /// packed before nodes in higher spaces.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Hash, PartialEq, Eq)]
-struct Space(u32);
+pub struct Space(u32);
 
 impl Space {
     /// A generic space for nodes reachable via 16-bit offsets.
@@ -687,6 +690,11 @@ impl Graph {
             }
         }
         result
+    }
+
+    #[cfg(feature = "dot2")]
+    pub(crate) fn write_graph_viz(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+        graphviz::GraphVizGraph::from_graph(self).write_to_file(path)
     }
 }
 

--- a/write-fonts/src/graph/graphviz.rs
+++ b/write-fonts/src/graph/graphviz.rs
@@ -1,0 +1,133 @@
+//! Support for generating graphviz files from our object graph
+
+use super::{Graph, ObjectId, OffsetLen, Space};
+
+pub struct GraphVizGraph<'a> {
+    graph: &'a Graph,
+    edges: Vec<GraphVizEdge>,
+}
+
+impl<'a> GraphVizGraph<'a> {
+    pub(crate) fn from_graph(graph: &'a Graph) -> Self {
+        let mut edges = Vec::new();
+        for (parent_id, table) in &graph.objects {
+            let parent = &graph.nodes[parent_id];
+            for link in &table.offsets {
+                let child = &graph.nodes[&link.object];
+                let len = child.position - parent.position;
+                edges.push(GraphVizEdge {
+                    source: *parent_id,
+                    target: link.object,
+                    len,
+                    type_: link.len,
+                });
+            }
+        }
+        GraphVizGraph { graph, edges }
+    }
+
+    /// Write out this graph as a graphviz file to the provided path.
+    ///
+    /// Overwrites any existing file at this location.
+    pub fn write_to_file(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+        let mut buf = Vec::new();
+        dot2::render(self, &mut buf).unwrap();
+        std::fs::write(path, &buf)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GraphVizEdge {
+    source: ObjectId,
+    target: ObjectId,
+    len: u32,
+    type_: OffsetLen,
+}
+
+impl<'a> dot2::GraphWalk<'a> for GraphVizGraph<'a> {
+    type Node = ObjectId;
+
+    type Edge = GraphVizEdge;
+
+    type Subgraph = Space;
+
+    fn nodes(&'a self) -> dot2::Nodes<'a, Self::Node> {
+        self.graph.order.as_slice().into()
+    }
+
+    fn edges(&'a self) -> dot2::Edges<'a, Self::Edge> {
+        self.edges.as_slice().into()
+    }
+
+    fn source(&'a self, edge: &Self::Edge) -> Self::Node {
+        edge.source
+    }
+
+    fn target(&'a self, edge: &Self::Edge) -> Self::Node {
+        edge.target
+    }
+
+    fn subgraphs(&'a self) -> dot2::Subgraphs<'a, Self::Subgraph> {
+        let mut spaces: Vec<_> = self.graph.nodes.values().map(|x| x.space).collect();
+        spaces.sort_unstable();
+        spaces.dedup();
+        spaces.into()
+    }
+
+    fn subgraph_nodes(&'a self, s: &Self::Subgraph) -> dot2::Nodes<'a, Self::Node> {
+        self.graph
+            .nodes
+            .iter()
+            .filter_map(|(id, node)| (node.space == *s).then_some(*id))
+            .collect()
+    }
+}
+
+impl<'a> dot2::Labeller<'a> for GraphVizGraph<'a> {
+    type Node = ObjectId;
+
+    type Edge = GraphVizEdge;
+
+    type Subgraph = Space;
+
+    fn graph_id(&'a self) -> dot2::Result<dot2::Id<'a>> {
+        dot2::Id::new("TablePacking")
+    }
+
+    fn node_id(&'a self, n: &Self::Node) -> dot2::Result<dot2::Id<'a>> {
+        dot2::Id::new(format!("N{}", n.0))
+    }
+
+    fn node_label<'b>(&'b self, n: &Self::Node) -> dot2::Result<dot2::label::Text<'b>> {
+        let obj = &self.graph.objects[n];
+        let node = &self.graph.nodes[n];
+
+        let name = if obj.name.is_empty() {
+            // if we have no name (generally because this is a test) then use
+            // the object id instead.
+            format!("{n:?} ({}B, S{})", obj.bytes.len(), node.space.0)
+        } else {
+            format!("{} ({}B, S{})", obj.name, obj.bytes.len(), node.space.0)
+        };
+        Ok(dot2::label::Text::LabelStr(name.into()))
+    }
+
+    fn edge_label(&'a self, e: &Self::Edge) -> dot2::label::Text<'a> {
+        dot2::label::Text::LabelStr(e.len.to_string().into())
+    }
+
+    fn edge_color(&'a self, e: &Self::Edge) -> Option<dot2::label::Text<'a>> {
+        if e.len > e.type_.max_value() {
+            return Some(dot2::label::Text::LabelStr("firebrick".into()));
+        }
+        None
+    }
+
+    fn edge_style(&'a self, e: &Self::Edge) -> dot2::Style {
+        if e.len > e.type_.max_value() {
+            dot2::Style::Bold
+        } else {
+            dot2::Style::Solid
+        }
+    }
+}

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -12,6 +12,9 @@ use types::Uint24;
 pub trait FontWrite {
     /// Write our data and information about offsets into this [TableWriter].
     fn write_into(&self, writer: &mut TableWriter);
+    fn name(&self) -> &'static str {
+        "Unknown"
+    }
 }
 
 /// An object that manages a collection of serialized tables.


### PR DESCRIPTION
This adds the ability to write out a graphviz file of the object graph, so we can visualize what is happening when packing fails (or when we're curious).

To make the graph more useful, I've also added a method to the `FontWrite` trait that lets tables include a name; this way we can display the name in the graph. 