### PR TITLE
Add 'serde' feature to read/write-fonts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
 
       # test all packages individually to ensure deterministic resolution
       # of dependencies for each package
-      
+
       - name: cargo test font-types
         run: cargo test -p font-types --all-targets --all-features
 
@@ -64,6 +64,9 @@ jobs:
 
       - name: cargo test write-fonts
         run: cargo test -p write-fonts --all-targets --all-features
+
+      - name: cargo test write-fonts default features
+        run: cargo test -p write-fonts --all-targets
 
       - name: cargo test skrifa
         run: cargo test -p skrifa --all-targets --all-features

--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -25,6 +25,7 @@ pub(crate) fn generate_flags(raw: &BitFlags) -> proc_macro2::TokenStream {
     quote! {
         #( #docs )*
         #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct #name { bits: #typ }
         impl #name {
             #( #variant_decls )*
@@ -339,6 +340,7 @@ pub(crate) fn generate_raw_enum(raw: &RawEnum) -> TokenStream {
     quote! {
         #( #docs )*
         #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[repr(#typ)]
         pub enum #name {
             #( #variants )*

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -323,6 +323,7 @@ pub(crate) fn generate_compile_impl(
     Ok(quote! {
         #( #docs )*
         #[derive(Clone, Debug, #maybe_derive_default PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct #name <#generic_param> {
             #( #field_decls, )*
         }

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -402,6 +402,7 @@ pub(crate) fn generate_group_compile(
     Ok(quote! {
         #( #docs)*
         #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub enum #name {
             #( #variant_decls, )*
         }
@@ -498,6 +499,7 @@ pub(crate) fn generate_format_compile(
     Ok(quote! {
         #( #docs )*
         #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub enum #name {
             #( #variants ),*
         }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -14,9 +14,11 @@ codegen_test = []
 scaler_test = []
 traversal = ["std"]
 default = ["traversal"]
+serde = ["dep:serde", "font-types/serde"]
 
 [dependencies]
 font-types = { version = "0.4.0", path = "../font-types" }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -166,6 +166,7 @@ impl<'a> SomeRecord<'a> for EncodingRecord {
 
 /// <https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#platform-ids>
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u16)]
 pub enum PlatformId {
     #[default]

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -1438,6 +1438,7 @@ impl<'a> std::fmt::Debug for VarColorLine<'a> {
 
 /// [Extend](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) enumeration
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum Extend {
     #[default]
@@ -5510,6 +5511,7 @@ impl<'a> std::fmt::Debug for PaintComposite<'a> {
 
 /// [CompositeMode](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#format-32-paintcomposite) enumeration
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum CompositeMode {
     Clear = 0,

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -223,6 +223,7 @@ impl<'a> std::fmt::Debug for Gdef<'a> {
 
 /// Used in the [Glyph Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table)
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u16)]
 pub enum GlyphClassDef {
     #[default]

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -219,6 +219,7 @@ impl<'a> std::fmt::Debug for SimpleGlyph<'a> {
 
 /// Flags used in [SimpleGlyph]
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimpleGlyphFlags {
     bits: u8,
 }
@@ -726,6 +727,7 @@ impl<'a> std::fmt::Debug for CompositeGlyph<'a> {
 
 /// Flags used in [CompositeGlyph]
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -220,6 +220,7 @@ impl<'a> SomeTable<'a> for PositionLookup<'a> {
 
 /// See [ValueRecord]
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueFormat {
     bits: u16,
 }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -177,6 +177,7 @@ impl<'a> std::fmt::Debug for Gvar<'a> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GvarFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The `macStyle` field for the head table.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MacStyle {
     bits: u16,
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -3525,6 +3525,7 @@ impl<'a> SomeTable<'a> for ChainedSequenceContext<'a> {
 /// [Device](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 /// delta formats
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u16)]
 pub enum DeltaFormat {
     /// Signed 2-bit value, 8 values per uint16

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// OS/2 [selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection)
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// Sbix header flags.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HeaderFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -920,6 +920,7 @@ impl<'a> SomeRecord<'a> for AxisValueRecord {
 
 /// [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags).
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueTableFlags {
     bits: u16,
 }

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -6,6 +6,7 @@
 use crate::codegen_prelude::*;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u16)]
 pub enum MyEnum1 {
     /// doc me baby
@@ -49,6 +50,7 @@ impl<'a> From<MyEnum1> for FieldType<'a> {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u16)]
 pub enum MyEnum2 {
     ItsATwo = 2,

--- a/read-fonts/generated/generated_test_flags.rs
+++ b/read-fonts/generated/generated_test_flags.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// Some flags!
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueFormat {
     bits: u16,
 }

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -424,6 +424,7 @@ impl<'a> SomeTable<'a> for DeltaSetIndexMap<'a> {
 
 /// Entry format for a [DeltaSetIndexMap].
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntryFormat {
     bits: u8,
 }

--- a/read-fonts/src/tables/lookupflag.rs
+++ b/read-fonts/src/tables/lookupflag.rs
@@ -5,6 +5,7 @@
 
 /// The [LookupFlag](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#lookupFlag) bit enumeration.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupFlag(u16);
 
 impl LookupFlag {

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -12,6 +12,7 @@ pub struct DeltaSetIndex {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TupleIndex(u16);
 
 impl TupleIndex {
@@ -97,6 +98,7 @@ impl types::Scalar for TupleIndex {
 ///
 /// [header]: https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuple-variation-store-header
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TupleVariationCount(u16);
 
 impl TupleVariationCount {

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 default = ["dot2"]
 read = []
+serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
 font-types = { version = "0.4.0", path = "../font-types" }
@@ -18,6 +19,7 @@ read-fonts = { version = "0.11.1", path = "../read-fonts" }
 log = "0.4"
 kurbo = "0.9.4"
 dot2 = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 diff = "0.1.12"
@@ -27,3 +29,4 @@ read-fonts = { version = "0.11.1", path = "../read-fonts", features = [ "codegen
 env_logger = "0.10.0"
 rstest = "0.18.0"
 pretty_assertions.workspace = true
+bincode = "1.0"

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [avar (Axis Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/avar) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Avar {
     /// The segment maps array — one segment map for each axis, in the order of axes specified in the 'fvar' table.
     pub axis_segment_maps: Vec<SegmentMaps>,
@@ -69,6 +70,7 @@ impl<'a> FontRead<'a> for Avar {
 
 /// [SegmentMaps](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SegmentMaps {
     /// The array of axis value map records for this axis.
     pub axis_value_maps: Vec<AxisValueMap>,
@@ -117,6 +119,7 @@ impl FromObjRef<read_fonts::tables::avar::SegmentMaps<'_>> for SegmentMaps {
 
 /// [AxisValueMap](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueMap {
     /// A normalized coordinate value obtained using default normalization.
     pub from_coordinate: F2Dot14,

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [BASE](https://learn.microsoft.com/en-us/typography/opentype/spec/base) (Baseline) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Base {
     /// Offset to horizontal Axis table, from beginning of BASE table (may be NULL)
     pub horiz_axis: NullableOffsetMarker<Axis>,
@@ -83,6 +84,7 @@ impl<'a> FontRead<'a> for Base {
 
 /// [Axis Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#axis-tables-horizaxis-and-vertaxis)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Axis {
     /// Offset to BaseTagList table, from beginning of Axis table (may
     /// be NULL)
@@ -143,6 +145,7 @@ impl<'a> FontRead<'a> for Axis {
 
 /// [BaseTagList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basetaglist-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseTagList {
     /// Array of 4-byte baseline identification tags — must be in
     /// alphabetical order
@@ -200,6 +203,7 @@ impl<'a> FontRead<'a> for BaseTagList {
 
 /// [BaseScriptList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptlist-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseScriptList {
     /// Array of BaseScriptRecords, in alphabetical order by
     /// baseScriptTag
@@ -259,6 +263,7 @@ impl<'a> FontRead<'a> for BaseScriptList {
 
 /// [BaseScriptRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptrecord)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseScriptRecord {
     /// 4-byte script identification tag
     pub base_script_tag: Tag,
@@ -310,6 +315,7 @@ impl FromObjRef<read_fonts::tables::base::BaseScriptRecord> for BaseScriptRecord
 
 /// [BaseScript Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescript-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseScript {
     /// Offset to BaseValues table, from beginning of BaseScript table (may be NULL)
     pub base_values: NullableOffsetMarker<BaseValues>,
@@ -388,6 +394,7 @@ impl<'a> FontRead<'a> for BaseScript {
 
 /// [BaseLangSysRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseLangSysRecord {
     /// 4-byte language system identification tag
     pub base_lang_sys_tag: Tag,
@@ -439,6 +446,7 @@ impl FromObjRef<read_fonts::tables::base::BaseLangSysRecord> for BaseLangSysReco
 
 /// [BaseValues](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basevalues-table) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseValues {
     /// Index number of default baseline for this script — equals
     /// index position of baseline tag in baselineTags array of the
@@ -504,6 +512,7 @@ impl<'a> FontRead<'a> for BaseValues {
 
 /// [MinMax](https://learn.microsoft.com/en-us/typography/opentype/spec/base#minmax-table) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MinMax {
     /// Offset to BaseCoord table that defines the minimum extent
     /// value, from the beginning of MinMax table (may be NULL)
@@ -584,6 +593,7 @@ impl<'a> FontRead<'a> for MinMax {
 
 /// [FeatMinMaxRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatMinMaxRecord {
     /// 4-byte feature identification tag — must match feature tag in
     /// FeatureList
@@ -649,6 +659,7 @@ impl FromObjRef<read_fonts::tables::base::FeatMinMaxRecord> for FeatMinMaxRecord
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BaseCoord {
     Format1(BaseCoordFormat1),
     Format2(BaseCoordFormat2),
@@ -748,6 +759,7 @@ impl From<BaseCoordFormat3> for BaseCoord {
 
 /// [BaseCoordFormat1](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseCoordFormat1 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -794,6 +806,7 @@ impl<'a> FontRead<'a> for BaseCoordFormat1 {
 
 /// [BaseCoordFormat2](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-2)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseCoordFormat2 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -852,6 +865,7 @@ impl<'a> FontRead<'a> for BaseCoordFormat2 {
 
 /// [BaseCoordFormat3](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-3)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseCoordFormat3 {
     /// X or Y value, in design units
     pub coordinate: i16,

--- a/write-fonts/generated/generated_cff.rs
+++ b/write-fonts/generated/generated_cff.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CffHeader {
     /// Header size (bytes).
     pub hdr_size: u8,

--- a/write-fonts/generated/generated_cff2.rs
+++ b/write-fonts/generated/generated_cff2.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cff2Header {
     /// Header size (bytes).
     pub header_size: u8,

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -9,6 +9,7 @@ pub use read_fonts::tables::cmap::PlatformId;
 
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap {
     pub encoding_records: Vec<EncodingRecord>,
 }
@@ -70,6 +71,7 @@ impl<'a> FontRead<'a> for Cmap {
 
 /// [Encoding Record](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EncodingRecord {
     /// Platform ID.
     pub platform_id: PlatformId,
@@ -131,6 +133,7 @@ impl FontWrite for PlatformId {
 
 /// The different cmap subtable formats.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CmapSubtable {
     Format0(Cmap0),
     Format2(Cmap2),
@@ -391,6 +394,7 @@ impl From<Cmap14> for CmapSubtable {
 
 /// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap0 {
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
@@ -446,6 +450,7 @@ impl<'a> FontRead<'a> for Cmap0 {
 
 /// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap2 {
     /// This is the length in bytes of the subtable.
     pub length: u16,
@@ -506,6 +511,7 @@ impl<'a> FontRead<'a> for Cmap2 {
 
 /// Part of [Cmap2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubHeader {
     /// First valid low byte for this SubHeader.
     pub first_code: u16,
@@ -558,6 +564,7 @@ impl FromObjRef<read_fonts::tables::cmap::SubHeader> for SubHeader {
 
 /// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap4 {
     /// This is the length in bytes of the subtable.
     pub length: u16,
@@ -675,6 +682,7 @@ impl<'a> FontRead<'a> for Cmap4 {
 
 /// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap6 {
     /// This is the length in bytes of the subtable.
     pub length: u16,
@@ -758,6 +766,7 @@ impl<'a> FontRead<'a> for Cmap6 {
 
 /// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap8 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -845,6 +854,7 @@ impl<'a> FontRead<'a> for Cmap8 {
 
 /// Used in [Cmap8] and [Cmap12]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequentialMapGroup {
     /// First character code in this group; note that if this group is
     /// for one or more 16-bit character codes (which is determined
@@ -896,6 +906,7 @@ impl FromObjRef<read_fonts::tables::cmap::SequentialMapGroup> for SequentialMapG
 
 /// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap10 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -972,6 +983,7 @@ impl<'a> FontRead<'a> for Cmap10 {
 
 /// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap12 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -1051,6 +1063,7 @@ impl<'a> FontRead<'a> for Cmap12 {
 
 /// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap13 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -1125,6 +1138,7 @@ impl<'a> FontRead<'a> for Cmap13 {
 
 /// Part of [Cmap13]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConstantMapGroup {
     /// First character code in this group
     pub start_char_code: u32,
@@ -1173,6 +1187,7 @@ impl FromObjRef<read_fonts::tables::cmap::ConstantMapGroup> for ConstantMapGroup
 
 /// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cmap14 {
     /// Byte length of this subtable (including this header)
     pub length: u32,
@@ -1244,6 +1259,7 @@ impl<'a> FontRead<'a> for Cmap14 {
 
 /// Part of [Cmap14]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariationSelector {
     /// Variation selector
     pub var_selector: Uint24,
@@ -1309,6 +1325,7 @@ impl FromObjRef<read_fonts::tables::cmap::VariationSelector> for VariationSelect
 
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DefaultUvs {
     /// Number of Unicode character ranges.
     pub num_unicode_value_ranges: u32,
@@ -1369,6 +1386,7 @@ impl<'a> FontRead<'a> for DefaultUvs {
 
 /// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NonDefaultUvs {
     pub num_uvs_mappings: u32,
     pub uvs_mapping: Vec<UvsMapping>,
@@ -1428,6 +1446,7 @@ impl<'a> FontRead<'a> for NonDefaultUvs {
 
 /// Part of [Cmap14]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UvsMapping {
     /// Base Unicode value of the UVS
     pub unicode_value: Uint24,
@@ -1470,6 +1489,7 @@ impl FromObjRef<read_fonts::tables::cmap::UvsMapping> for UvsMapping {
 
 /// Part of [Cmap14]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnicodeRange {
     /// First value in this range
     pub start_unicode_value: Uint24,

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [CPAL (Color Palette Table)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-table-header) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cpal {
     /// Number of palette entries in each palette.
     pub num_palette_entries: u16,
@@ -136,6 +137,7 @@ impl<'a> FontRead<'a> for Cpal {
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColorRecord {
     /// Blue value (B0).
     pub blue: u8,

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableDirectory {
     /// 0x00010000 or 0x4F54544F
     pub sfnt_version: u32,
@@ -66,6 +67,7 @@ impl Validate for TableDirectory {
 
 /// Record for a table in a font.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TableRecord {
     /// Table identifier.
     pub tag: Tag,
@@ -107,6 +109,7 @@ impl Validate for TableRecord {
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TTCHeader {
     /// Font Collection ID string: \"ttcf\"
     pub ttc_tag: Tag,

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [fvar (Font Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/fvar) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fvar {
     /// Offset in bytes from the beginning of the table to the start of the VariationAxisRecord array. The
     /// InstanceRecord array directly follows.
@@ -71,6 +72,7 @@ impl<'a> FontRead<'a> for Fvar {
 
 /// Shim table to handle combined axis and instance arrays.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisInstanceArrays {
     /// Variation axis record array.
     pub axes: Vec<VariationAxisRecord>,
@@ -135,6 +137,7 @@ impl<'a> FromTableRef<read_fonts::tables::fvar::AxisInstanceArrays<'a>> for Axis
 
 /// The [VariationAxisRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariationAxisRecord {
     /// Tag identifying the design variation for the axis.
     pub axis_tag: Tag,

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -9,6 +9,7 @@ pub use read_fonts::tables::gdef::GlyphClassDef;
 
 /// [GDEF](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#gdef-header) 1.0
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gdef {
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
@@ -128,6 +129,7 @@ impl FontWrite for GlyphClassDef {
 
 /// [Attachment Point List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#attachment-point-list-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachList {
     /// Offset to Coverage table - from beginning of AttachList table
     pub coverage: OffsetMarker<CoverageTable>,
@@ -193,6 +195,7 @@ impl<'a> FontRead<'a> for AttachList {
 
 /// Part of [AttachList]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachPoint {
     /// Array of contour point indices -in increasing numerical order
     pub point_indices: Vec<u16>,
@@ -249,6 +252,7 @@ impl<'a> FontRead<'a> for AttachPoint {
 
 /// [Ligature Caret List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LigCaretList {
     /// Offset to Coverage table - from beginning of LigCaretList table
     pub coverage: OffsetMarker<CoverageTable>,
@@ -314,6 +318,7 @@ impl<'a> FontRead<'a> for LigCaretList {
 
 /// [Ligature Glyph Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-glyph-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LigGlyph {
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
@@ -371,6 +376,7 @@ impl<'a> FontRead<'a> for LigGlyph {
 
 /// [Caret Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caret-value-tables)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CaretValue {
     Format1(CaretValueFormat1),
     Format2(CaretValueFormat2),
@@ -466,6 +472,7 @@ impl From<CaretValueFormat3> for CaretValue {
 
 /// [CaretValue Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CaretValueFormat1 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -512,6 +519,7 @@ impl<'a> FontRead<'a> for CaretValueFormat1 {
 
 /// [CaretValue Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-2)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CaretValueFormat2 {
     /// Contour point index on glyph
     pub caret_value_point_index: u16,
@@ -560,6 +568,7 @@ impl<'a> FontRead<'a> for CaretValueFormat2 {
 
 /// [CaretValue Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-3)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CaretValueFormat3 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -621,6 +630,7 @@ impl<'a> FontRead<'a> for CaretValueFormat3 {
 
 /// [Mark Glyph Sets Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#mark-glyph-sets-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkGlyphSets {
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -10,6 +10,7 @@ pub use read_fonts::tables::gpos::ValueFormat;
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gpos {
     /// Offset to ScriptList table, from beginning of GPOS table
     pub script_list: OffsetMarker<ScriptList>,
@@ -97,6 +98,7 @@ impl<'a> FontRead<'a> for Gpos {
 
 /// A [GPOS Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#gsubLookupTypeEnum) subtable.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PositionLookup {
     Single(Lookup<SinglePos>),
     Pair(Lookup<PairPos>),
@@ -205,6 +207,7 @@ impl FontWrite for ValueFormat {
 /// [Anchor Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-tables)
 /// position one glyph with respect to another.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AnchorTable {
     Format1(AnchorFormat1),
     Format2(AnchorFormat2),
@@ -310,6 +313,7 @@ impl From<AnchorFormat3> for AnchorTable {
 
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnchorFormat1 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -363,6 +367,7 @@ impl<'a> FontRead<'a> for AnchorFormat1 {
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnchorFormat2 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -421,6 +426,7 @@ impl<'a> FontRead<'a> for AnchorFormat2 {
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnchorFormat3 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -502,6 +508,7 @@ impl<'a> FontRead<'a> for AnchorFormat3 {
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkArray {
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
@@ -560,6 +567,7 @@ impl<'a> FontRead<'a> for MarkArray {
 
 /// Part of [MarkArray]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkRecord {
     /// Class defined for the associated mark.
     pub mark_class: u16,
@@ -608,6 +616,7 @@ impl FromObjRef<read_fonts::tables::gpos::MarkRecord> for MarkRecord {
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SinglePos {
     Format1(SinglePosFormat1),
     Format2(SinglePosFormat2),
@@ -687,6 +696,7 @@ impl From<SinglePosFormat2> for SinglePos {
 
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SinglePosFormat1 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -749,6 +759,7 @@ impl<'a> FontRead<'a> for SinglePosFormat1 {
 
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SinglePosFormat2 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -821,6 +832,7 @@ impl<'a> FontRead<'a> for SinglePosFormat2 {
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PairPos {
     Format1(PairPosFormat1),
     Format2(PairPosFormat2),
@@ -910,6 +922,7 @@ impl From<PairPosFormat2> for PairPos {
 
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PairPosFormat1 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -979,6 +992,7 @@ impl<'a> FontRead<'a> for PairPosFormat1 {
 
 /// Part of [PairPosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PairSet {
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
@@ -1033,6 +1047,7 @@ impl<'a> FromTableRef<read_fonts::tables::gpos::PairSet<'a>> for PairSet {}
 
 /// Part of [PairSet]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PairValueRecord {
     /// Glyph ID of second glyph in the pair (first glyph is listed in
     /// the Coverage table).
@@ -1088,6 +1103,7 @@ impl FromObjRef<read_fonts::tables::gpos::PairValueRecord> for PairValueRecord {
 
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PairPosFormat2 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -1186,6 +1202,7 @@ impl<'a> FontRead<'a> for PairPosFormat2 {
 
 /// Part of [PairPosFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Class1Record {
     /// Array of Class2 records, ordered by classes in classDef2.
     pub class2_records: Vec<Class2Record>,
@@ -1234,6 +1251,7 @@ impl FromObjRef<read_fonts::tables::gpos::Class1Record<'_>> for Class1Record {
 
 /// Part of [PairPosFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Class2Record {
     /// Positioning for first glyph — empty if valueFormat1 = 0.
     pub value_record1: ValueRecord,
@@ -1276,6 +1294,7 @@ impl FromObjRef<read_fonts::tables::gpos::Class2Record> for Class2Record {
 
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursivePosFormat1 {
     /// Offset to Coverage table, from beginning of CursivePos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -1343,6 +1362,7 @@ impl<'a> FontRead<'a> for CursivePosFormat1 {
 
 /// Part of [CursivePosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
@@ -1399,6 +1419,7 @@ impl FromObjRef<read_fonts::tables::gpos::EntryExitRecord> for EntryExitRecord {
 
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkBasePosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
@@ -1487,6 +1508,7 @@ impl<'a> FontRead<'a> for MarkBasePosFormat1 {
 
 /// Part of [MarkBasePosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseArray {
     /// Array of BaseRecords, in order of baseCoverage Index.
     pub base_records: Vec<BaseRecord>,
@@ -1540,6 +1562,7 @@ impl<'a> FromTableRef<read_fonts::tables::gpos::BaseArray<'a>> for BaseArray {}
 
 /// Part of [BaseArray]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BaseRecord {
     /// Array of offsets (one per mark class) to Anchor tables. Offsets
     /// are from beginning of BaseArray table, ordered by class
@@ -1588,6 +1611,7 @@ impl FromObjRef<read_fonts::tables::gpos::BaseRecord<'_>> for BaseRecord {
 
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkLigPosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
@@ -1676,6 +1700,7 @@ impl<'a> FontRead<'a> for MarkLigPosFormat1 {
 
 /// Part of [MarkLigPosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LigatureArray {
     /// Array of offsets to LigatureAttach tables. Offsets are from
     /// beginning of LigatureArray table, ordered by ligatureCoverage
@@ -1728,6 +1753,7 @@ impl<'a> FromTableRef<read_fonts::tables::gpos::LigatureArray<'a>> for LigatureA
 
 /// Part of [MarkLigPosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LigatureAttach {
     /// Array of Component records, ordered in writing direction.
     pub component_records: Vec<ComponentRecord>,
@@ -1781,6 +1807,7 @@ impl<'a> FromTableRef<read_fonts::tables::gpos::LigatureAttach<'a>> for Ligature
 
 /// Part of [MarkLigPosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ComponentRecord {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of LigatureAttach table, ordered by class
@@ -1832,6 +1859,7 @@ impl FromObjRef<read_fonts::tables::gpos::ComponentRecord<'_>> for ComponentReco
 
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkMarkPosFormat1 {
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
@@ -1920,6 +1948,7 @@ impl<'a> FontRead<'a> for MarkMarkPosFormat1 {
 
 /// Part of [MarkMarkPosFormat1]Class2Record
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mark2Array {
     /// Array of Mark2Records, in Coverage order.
     pub mark2_records: Vec<Mark2Record>,
@@ -1973,6 +2002,7 @@ impl<'a> FromTableRef<read_fonts::tables::gpos::Mark2Array<'a>> for Mark2Array {
 
 /// Part of [MarkMarkPosFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mark2Record {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of Mark2Array table, in class order (offsets may
@@ -2021,6 +2051,7 @@ impl FromObjRef<read_fonts::tables::gpos::Mark2Record<'_>> for Mark2Record {
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtensionPosFormat1<T> {
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
@@ -2078,6 +2109,7 @@ where
 
 /// A [GPOS Extension Positioning](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning) subtable
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtensionSubtable {
     Single(ExtensionPosFormat1<SinglePos>),
     Pair(ExtensionPosFormat1<PairPos>),

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gsub {
     /// Offset to ScriptList table, from beginning of GSUB table
     pub script_list: OffsetMarker<ScriptList>,
@@ -96,6 +97,7 @@ impl<'a> FontRead<'a> for Gsub {
 
 /// A [GSUB Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsubLookupTypeEnum) subtable.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SubstitutionLookup {
     Single(Lookup<SingleSubst>),
     Multiple(Lookup<MultipleSubstFormat1>),
@@ -193,6 +195,7 @@ impl FromTableRef<read_fonts::tables::gsub::SubstitutionLookup<'_>> for Substitu
 
 /// LookupType 1: [Single Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-1-single-substitution-subtable) Subtable
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SingleSubst {
     Format1(SingleSubstFormat1),
     Format2(SingleSubstFormat2),
@@ -272,6 +275,7 @@ impl From<SingleSubstFormat2> for SingleSubst {
 
 /// [Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -332,6 +336,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat1 {
 
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SingleSubstFormat2 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -399,6 +404,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat2 {
 
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MultipleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -467,6 +473,7 @@ impl<'a> FontRead<'a> for MultipleSubstFormat1 {
 
 /// Part of [MultipleSubstFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Sequence {
     /// String of glyph IDs to substitute
     pub substitute_glyph_ids: Vec<GlyphId>,
@@ -523,6 +530,7 @@ impl<'a> FontRead<'a> for Sequence {
 
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlternateSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -597,6 +605,7 @@ impl<'a> FontRead<'a> for AlternateSubstFormat1 {
 
 /// Part of [AlternateSubstFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlternateSet {
     /// Array of alternate glyph IDs, in arbitrary order
     pub alternate_glyph_ids: Vec<GlyphId>,
@@ -653,6 +662,7 @@ impl<'a> FontRead<'a> for AlternateSet {
 
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LigatureSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -721,6 +731,7 @@ impl<'a> FontRead<'a> for LigatureSubstFormat1 {
 
 /// Part of [LigatureSubstFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LigatureSet {
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
@@ -778,6 +789,7 @@ impl<'a> FontRead<'a> for LigatureSet {
 
 /// Part of [LigatureSubstFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ligature {
     /// glyph ID of ligature to substitute
     pub ligature_glyph: GlyphId,
@@ -832,6 +844,7 @@ impl<'a> FontRead<'a> for Ligature {
 
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtensionSubstFormat1<T> {
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
@@ -889,6 +902,7 @@ where
 
 /// A [GSUB Extension Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#ES) subtable
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtensionSubtable {
     Single(ExtensionSubstFormat1<SingleSubst>),
     Multiple(ExtensionSubstFormat1<MultipleSubstFormat1>),
@@ -979,6 +993,7 @@ impl FromTableRef<read_fonts::tables::gsub::ExtensionSubtable<'_>> for Extension
 
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReverseChainSingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -9,6 +9,7 @@ pub use read_fonts::tables::gvar::GvarFlags;
 
 /// The ['gvar' header](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#gvar-header)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gvar {
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
@@ -62,6 +63,7 @@ impl FontWrite for GvarFlags {
 
 /// Array of tuple records shared across all glyph variation data tables.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SharedTuples {
     pub tuples: Vec<Tuple>,
 }
@@ -112,6 +114,7 @@ impl<'a> FromTableRef<read_fonts::tables::gvar::SharedTuples<'a>> for SharedTupl
 
 /// The [GlyphVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#the-glyphvariationdata-table-array) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GlyphVariationDataHeader {
     /// A packed field. The high 4 bits are flags, and the low 12 bits
     /// are the number of tuple variation tables for this glyph. The

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -16,6 +16,7 @@ impl FontWrite for MacStyle {
 /// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
 /// (font header) table.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Head {
     /// Set by font manufacturer.
     pub font_revision: Fixed,

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hhea {
     /// Typographic ascent.
     pub ascender: FWord,

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hmtx {
     /// Paired advance width/height and left/top side bearing values for each
     /// glyph. Records are indexed by glyph ID.
@@ -66,6 +67,7 @@ impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
 impl<'a> FromTableRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LongMetric {
     /// Advance width/height, in font design units.
     pub advance: u16,

--- a/write-fonts/generated/generated_hvar.rs
+++ b/write-fonts/generated/generated_hvar.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [HVAR (Horizontal Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/hvar) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hvar {
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -9,6 +9,7 @@ pub use read_fonts::tables::layout::DeltaFormat;
 
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScriptList {
     /// Array of ScriptRecords, listed alphabetically by script tag
     pub script_records: Vec<ScriptRecord>,
@@ -66,6 +67,7 @@ impl<'a> FontRead<'a> for ScriptList {
 
 /// [Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScriptRecord {
     /// 4-byte script tag identifier
     pub script_tag: Tag,
@@ -114,6 +116,7 @@ impl FromObjRef<read_fonts::tables::layout::ScriptRecord> for ScriptRecord {
 
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Script {
     /// Offset to default LangSys table, from beginning of Script table
     /// — may be NULL
@@ -179,6 +182,7 @@ impl<'a> FontRead<'a> for Script {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LangSysRecord {
     /// 4-byte LangSysTag identifier
     pub lang_sys_tag: Tag,
@@ -230,6 +234,7 @@ impl FromObjRef<read_fonts::tables::layout::LangSysRecord> for LangSysRecord {
 
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LangSys {
     /// Index of a feature required for this language system; if no
     /// required features = 0xFFFF
@@ -302,6 +307,7 @@ impl<'a> FontRead<'a> for LangSys {
 
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureList {
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
@@ -361,6 +367,7 @@ impl<'a> FontRead<'a> for FeatureList {
 
 /// Part of [FeatureList]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureRecord {
     /// 4-byte feature identification tag
     pub feature_tag: Tag,
@@ -412,6 +419,7 @@ impl FromObjRef<read_fonts::tables::layout::FeatureRecord> for FeatureRecord {
 
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Feature {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     pub feature_params: NullableOffsetMarker<FeatureParams>,
@@ -471,6 +479,7 @@ impl<'a> FromTableRef<read_fonts::tables::layout::Feature<'a>> for Feature {}
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupList<T> {
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
@@ -531,6 +540,7 @@ where
 
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Lookup<T> {
     /// Lookup qualifiers
     pub lookup_flag: LookupFlag,
@@ -590,6 +600,7 @@ where
 
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CoverageFormat1 {
     /// Array of glyph IDs — in numerical order
     pub glyph_array: Vec<GlyphId>,
@@ -648,6 +659,7 @@ impl<'a> FontRead<'a> for CoverageFormat1 {
 
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CoverageFormat2 {
     /// Array of glyph ranges — ordered by startGlyphID.
     pub range_records: Vec<RangeRecord>,
@@ -707,6 +719,7 @@ impl<'a> FontRead<'a> for CoverageFormat2 {
 
 /// Used in [CoverageFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RangeRecord {
     /// First glyph ID in the range
     pub start_glyph_id: GlyphId,
@@ -754,6 +767,7 @@ impl FromObjRef<read_fonts::tables::layout::RangeRecord> for RangeRecord {
 
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CoverageTable {
     Format1(CoverageFormat1),
     Format2(CoverageFormat2),
@@ -834,6 +848,7 @@ impl From<CoverageFormat2> for CoverageTable {
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassDefFormat1 {
     /// First glyph ID of the classValueArray
     pub start_glyph_id: GlyphId,
@@ -897,6 +912,7 @@ impl<'a> FontRead<'a> for ClassDefFormat1 {
 
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassDefFormat2 {
     /// Array of ClassRangeRecords — ordered by startGlyphID
     pub class_range_records: Vec<ClassRangeRecord>,
@@ -956,6 +972,7 @@ impl<'a> FontRead<'a> for ClassDefFormat2 {
 
 /// Used in [ClassDefFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassRangeRecord {
     /// First glyph ID in the range
     pub start_glyph_id: GlyphId,
@@ -1009,6 +1026,7 @@ impl FromObjRef<read_fonts::tables::layout::ClassRangeRecord> for ClassRangeReco
 
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClassDef {
     Format1(ClassDefFormat1),
     Format2(ClassDefFormat2),
@@ -1088,6 +1106,7 @@ impl From<ClassDefFormat2> for ClassDef {
 
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceLookupRecord {
     /// Index (zero-based) into the input glyph sequence
     pub sequence_index: u16,
@@ -1130,6 +1149,7 @@ impl FromObjRef<read_fonts::tables::layout::SequenceLookupRecord> for SequenceLo
 
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
@@ -1206,6 +1226,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat1 {
 
 /// Part of [SequenceContextFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceRuleSet {
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
@@ -1264,6 +1285,7 @@ impl<'a> FontRead<'a> for SequenceRuleSet {
 
 /// Part of [SequenceContextFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceRule {
     /// Array of input glyph IDs—starting with the second glyph
     pub input_sequence: Vec<GlyphId>,
@@ -1331,6 +1353,7 @@ impl<'a> FontRead<'a> for SequenceRule {
 
 /// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
@@ -1420,6 +1443,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat2 {
 
 /// Part of [SequenceContextFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassSequenceRuleSet {
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
@@ -1484,6 +1508,7 @@ impl<'a> FontRead<'a> for ClassSequenceRuleSet {
 
 /// Part of [SequenceContextFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassSequenceRule {
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
@@ -1549,6 +1574,7 @@ impl<'a> FontRead<'a> for ClassSequenceRule {
 
 /// [Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SequenceContextFormat3 {
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
@@ -1631,6 +1657,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat3 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SequenceContext {
     Format1(SequenceContextFormat1),
     Format2(SequenceContextFormat2),
@@ -1738,6 +1765,7 @@ impl From<SequenceContextFormat3> for SequenceContext {
 
 /// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedSequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
@@ -1817,6 +1845,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat1 {
 
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedSequenceRuleSet {
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
@@ -1883,6 +1912,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRuleSet {
 
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedSequenceRule {
     /// Array of backtrack glyph IDs
     pub backtrack_sequence: Vec<GlyphId>,
@@ -1977,6 +2007,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRule {
 
 /// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedSequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
@@ -2089,6 +2120,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat2 {
 
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedClassSequenceRuleSet {
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
@@ -2158,6 +2190,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet {
 
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedClassSequenceRule {
     /// Array of backtrack-sequence classes
     pub backtrack_sequence: Vec<u16>,
@@ -2258,6 +2291,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule {
 
 /// [Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainedSequenceContextFormat3 {
     /// Array of offsets to coverage tables for the backtrack sequence
     pub backtrack_coverages: Vec<OffsetMarker<CoverageTable>>,
@@ -2365,6 +2399,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat3 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChainedSequenceContext {
     Format1(ChainedSequenceContextFormat1),
     Format2(ChainedSequenceContextFormat2),
@@ -2499,6 +2534,7 @@ impl FontWrite for DeltaFormat {
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Device {
     /// Smallest size to correct, in ppem
     pub start_size: u16,
@@ -2548,6 +2584,7 @@ impl<'a> FontRead<'a> for Device {
 
 /// Variation index table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariationIndex {
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
@@ -2612,6 +2649,7 @@ impl<'a> FontRead<'a> for VariationIndex {
 /// ensuring that all VariationIndex tables have been correctly mapped before
 /// the font is compiled.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PendingVariationIndex {
     /// A unique identifier for a given set of deltas.
     pub delta_set_id: u32,
@@ -2630,6 +2668,7 @@ impl Validate for PendingVariationIndex {
 
 /// Either a [Device] table (in a non-variable font) or a [VariationIndex] table (in a variable font)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceOrVariationIndex {
     Device(Device),
     VariationIndex(VariationIndex),
@@ -2728,6 +2767,7 @@ impl From<PendingVariationIndex> for DeviceOrVariationIndex {
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureVariations {
     /// Array of feature variation records.
     pub feature_variation_records: Vec<FeatureVariationRecord>,
@@ -2790,6 +2830,7 @@ impl<'a> FontRead<'a> for FeatureVariations {
 
 /// Part of [FeatureVariations]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureVariationRecord {
     /// Offset to a condition set table, from beginning of
     /// FeatureVariations table.
@@ -2851,6 +2892,7 @@ impl FromObjRef<read_fonts::tables::layout::FeatureVariationRecord> for FeatureV
 
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConditionSet {
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
@@ -2909,6 +2951,7 @@ impl<'a> FontRead<'a> for ConditionSet {
 
 /// [Condition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range): Font Variation Axis Range
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConditionFormat1 {
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
@@ -2974,6 +3017,7 @@ impl<'a> FontRead<'a> for ConditionFormat1 {
 
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureTableSubstitution {
     /// Array of feature table substitution records.
     pub substitutions: Vec<FeatureTableSubstitutionRecord>,
@@ -3041,6 +3085,7 @@ impl<'a> FontRead<'a> for FeatureTableSubstitution {
 
 /// Used in [FeatureTableSubstitution]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureTableSubstitutionRecord {
     /// The feature table index to match.
     pub feature_index: u16,
@@ -3094,6 +3139,7 @@ impl FromObjRef<read_fonts::tables::layout::FeatureTableSubstitutionRecord>
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SizeParams {
     /// The first value represents the design size in 720/inch units (decipoints).
     ///
@@ -3184,6 +3230,7 @@ impl<'a> FontRead<'a> for SizeParams {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StylisticSetParams {
     /// The 'name' table name ID that specifies a string (or strings, for
     /// multiple languages) for a user-interface label for this feature.
@@ -3238,6 +3285,7 @@ impl<'a> FontRead<'a> for StylisticSetParams {
 
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CharacterVariantParams {
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) for a user-interface label for this

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [`maxp`](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Maxp {
     /// The number of glyphs in the font.
     pub num_glyphs: u16,

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [Naming table version 1](https://docs.microsoft.com/en-us/typography/opentype/spec/name#naming-table-version-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Name {
     /// The name records where count is the number of records.
     pub name_record: BTreeSet<NameRecord>,
@@ -101,6 +102,7 @@ impl<'a> FontRead<'a> for Name {
 
 /// Part of [Name]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LangTagRecord {
     /// Language-tag string offset from start of storage area (in
     /// bytes).
@@ -141,6 +143,7 @@ impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NameRecord {
     /// Platform ID.
     pub platform_id: u16,

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -15,6 +15,7 @@ impl FontWrite for SelectionFlags {
 
 /// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Os2 {
     /// [Average weighted escapement](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#xavgcharwidth).
     ///

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// [post (PostScript)](https://docs.microsoft.com/en-us/typography/opentype/spec/post#header) table
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Post {
     /// 0x00010000 for version 1.0 0x00020000 for version 2.0
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version

--- a/write-fonts/generated/generated_postscript.rs
+++ b/write-fonts/generated/generated_postscript.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// An array of variable-sized objects in a `CFF` table.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Index1 {
     /// Number of objects stored in INDEX.
     pub count: u16,
@@ -68,6 +69,7 @@ impl<'a> FontRead<'a> for Index1 {
 
 /// An array of variable-sized objects in a `CFF2` table.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Index2 {
     /// Number of objects stored in INDEX.
     pub count: u32,
@@ -129,6 +131,7 @@ impl<'a> FontRead<'a> for Index2 {
 
 /// Associates a glyph identifier with a Font DICT.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FdSelect {
     Format0(FdSelectFormat0),
     Format3(FdSelectFormat3),
@@ -225,6 +228,7 @@ impl From<FdSelectFormat4> for FdSelect {
 
 /// FdSelect format 0.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FdSelectFormat0 {
     /// FD selector array (one entry for each glyph).
     pub fds: Vec<u8>,
@@ -277,6 +281,7 @@ impl<'a> FontRead<'a> for FdSelectFormat0 {
 
 /// FdSelect format 3.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FdSelectFormat3 {
     /// Range3 array.
     pub ranges: Vec<FdSelectRange3>,
@@ -344,6 +349,7 @@ impl<'a> FontRead<'a> for FdSelectFormat3 {
 
 /// Range struct for FdSelect format 3.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FdSelectRange3 {
     /// First glyph index in range.
     pub first: u16,
@@ -383,6 +389,7 @@ impl FromObjRef<read_fonts::tables::postscript::FdSelectRange3> for FdSelectRang
 
 /// FdSelect format 4.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FdSelectFormat4 {
     /// Range4 array.
     pub ranges: Vec<FdSelectRange4>,
@@ -450,6 +457,7 @@ impl<'a> FontRead<'a> for FdSelectFormat4 {
 
 /// Range struct for FdSelect format 4.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FdSelectRange4 {
     /// First glyph index in range.
     pub first: u32,

--- a/write-fonts/generated/generated_sbix.rs
+++ b/write-fonts/generated/generated_sbix.rs
@@ -15,6 +15,7 @@ impl FontWrite for HeaderFlags {
 
 /// The [sbix (Standard Bitmap Graphics)](https://docs.microsoft.com/en-us/typography/opentype/spec/sbix) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Sbix {
     /// Bit 0: Set to 1.
     /// Bit 1: Draw outlines.
@@ -77,6 +78,7 @@ impl<'a> FromTableRef<read_fonts::tables::sbix::Sbix<'a>> for Sbix {}
 
 /// [Strike](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#strikes) header table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Strike {
     /// The PPEM size for which this strike was designed.
     pub ppem: u16,
@@ -127,6 +129,7 @@ impl<'a> FromTableRef<read_fonts::tables::sbix::Strike<'a>> for Strike {}
 
 /// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GlyphData {
     /// The horizontal (x-axis) position of the left edge of the bitmap graphic in relation to the glyph design space origin.
     pub origin_offset_x: i16,

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -9,6 +9,7 @@ pub use read_fonts::tables::stat::AxisValueTableFlags;
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Stat {
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes array. If designAxisCount is zero, set
@@ -92,6 +93,7 @@ impl<'a> FontRead<'a> for Stat {
 
 /// [Axis Records](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisRecord {
     /// A tag identifying the axis of design variation.
     pub axis_tag: Tag,
@@ -142,6 +144,7 @@ impl FromObjRef<read_fonts::tables::stat::AxisRecord> for AxisRecord {
 
 /// An array of [AxisValue] tables.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueArray {
     /// Array of offsets to axis value tables, in bytes from the start
     /// of the axis value offsets array.
@@ -191,6 +194,7 @@ impl<'a> FromTableRef<read_fonts::tables::stat::AxisValueArray<'a>> for AxisValu
 
 /// [Axis Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AxisValue {
     Format1(AxisValueFormat1),
     Format2(AxisValueFormat2),
@@ -342,6 +346,7 @@ impl From<AxisValueFormat4> for AxisValue {
 
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueFormat1 {
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
@@ -413,6 +418,7 @@ impl<'a> FontRead<'a> for AxisValueFormat1 {
 
 /// [Axis value table format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueFormat2 {
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
@@ -498,6 +504,7 @@ impl<'a> FontRead<'a> for AxisValueFormat2 {
 
 /// [Axis value table format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueFormat3 {
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
@@ -575,6 +582,7 @@ impl<'a> FontRead<'a> for AxisValueFormat3 {
 
 /// [Axis value table format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueFormat4 {
     /// Flags — see below for details.
     pub flags: AxisValueTableFlags,
@@ -650,6 +658,7 @@ impl<'a> FontRead<'a> for AxisValueFormat4 {
 
 /// Part of [AxisValueFormat4]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisValueRecord {
     /// Zero-base index into the axis record array identifying the axis
     /// to which this value applies. Must be less than designAxisCount.

--- a/write-fonts/generated/generated_test_enum.rs
+++ b/write-fonts/generated/generated_test_enum.rs
@@ -22,6 +22,7 @@ impl FontWrite for MyEnum2 {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MyRecord {
     pub my_enum1: MyEnum1,
     pub my_enum2: MyEnum2,

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -6,6 +6,7 @@
 use crate::codegen_prelude::*;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Table1 {
     pub heft: u32,
     pub flex: u16,
@@ -53,6 +54,7 @@ impl<'a> FontRead<'a> for Table1 {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Table2 {
     pub values: Vec<u16>,
 }
@@ -109,6 +111,7 @@ impl<'a> FontRead<'a> for Table2 {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Table3 {
     pub something: u16,
 }
@@ -146,6 +149,7 @@ impl<'a> FontRead<'a> for Table3 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MyTable {
     Format1(Table1),
     MyFormat22(Table2),

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -6,6 +6,7 @@
 use crate::codegen_prelude::*;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KindsOfOffsets {
     /// The major/minor version of the GDEF table
     pub version: MajorMinor,
@@ -133,6 +134,7 @@ impl<'a> FontRead<'a> for KindsOfOffsets {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KindsOfArraysOfOffsets {
     /// A normal array offset
     pub nonnullables: Vec<OffsetMarker<Dummy>>,
@@ -241,6 +243,7 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KindsOfArrays {
     pub version: u16,
     /// an array of scalars
@@ -360,6 +363,7 @@ impl<'a> FontRead<'a> for KindsOfArrays {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dummy {
     pub value: u16,
 }
@@ -398,6 +402,7 @@ impl<'a> FontRead<'a> for Dummy {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Shmecord {
     pub length: u16,
     pub breadth: u32,

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -6,6 +6,7 @@
 use crate::codegen_prelude::*;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BasicTable {
     pub simple_records: Vec<SimpleRecord>,
     pub array_records: Vec<ContainsArrays>,
@@ -79,6 +80,7 @@ impl<'a> FontRead<'a> for BasicTable {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimpleRecord {
     pub val1: u16,
     pub va2: u32,
@@ -115,6 +117,7 @@ impl FromObjRef<read_fonts::codegen_test::records::SimpleRecord> for SimpleRecor
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContainsArrays {
     pub scalars: Vec<u16>,
     pub records: Vec<SimpleRecord>,
@@ -171,6 +174,7 @@ impl FromObjRef<read_fonts::codegen_test::records::ContainsArrays<'_>> for Conta
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContainsOffests {
     pub array: OffsetMarker<Vec<SimpleRecord>>,
     pub other: OffsetMarker<BasicTable, WIDTH_32>,

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -9,6 +9,7 @@ pub use read_fonts::tables::variations::EntryFormat;
 
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TupleVariationHeader {
     /// The size in bytes of the serialized data for this tuple
     /// variation table.
@@ -74,6 +75,7 @@ impl<'a> FromTableRef<read_fonts::tables::variations::TupleVariationHeader<'a>>
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tuple {
     /// Coordinate array specifying a position within the font’s variation space.
     ///
@@ -122,6 +124,7 @@ impl FromObjRef<read_fonts::tables::variations::Tuple<'_>> for Tuple {
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeltaSetIndexMapFormat0 {
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
@@ -190,6 +193,7 @@ impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0 {
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeltaSetIndexMapFormat1 {
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
@@ -258,6 +262,7 @@ impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1 {
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeltaSetIndexMap {
     Format0(DeltaSetIndexMapFormat0),
     Format1(DeltaSetIndexMapFormat1),
@@ -352,6 +357,7 @@ impl FontWrite for EntryFormat {
 
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariationRegionList {
     /// Array of variation regions.
     pub variation_regions: Vec<VariationRegion>,
@@ -421,6 +427,7 @@ impl<'a> FontRead<'a> for VariationRegionList {
 
 /// The [VariationRegion](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariationRegion {
     /// Array of region axis coordinates records, in the order of axes
     /// given in the 'fvar' table.
@@ -471,6 +478,7 @@ impl FromObjRef<read_fonts::tables::variations::VariationRegion<'_>> for Variati
 
 /// The [RegionAxisCoordinates](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegionAxisCoordinates {
     /// The region start coordinate value for the current axis.
     pub start_coord: F2Dot14,
@@ -521,6 +529,7 @@ impl FromObjRef<read_fonts::tables::variations::RegionAxisCoordinates> for Regio
 
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ItemVariationStore {
     /// Offset in bytes from the start of the item variation store to
     /// the variation region list.
@@ -598,6 +607,7 @@ impl<'a> FontRead<'a> for ItemVariationStore {
 
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ItemVariationData {
     /// The number of delta sets for distinct items.
     pub item_count: u16,

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vhea {
     /// Typographic ascent.
     pub ascender: FWord,

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -7,6 +7,7 @@ use crate::codegen_prelude::*;
 
 /// The [vmtx (Vertical Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/vmtx) table
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vmtx {
     /// Paired advance height and top side bearing values for each
     /// glyph. Records are indexed by glyph ID.

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -3,6 +3,8 @@
 use super::write::{FontWrite, TableWriter};
 
 /// The width in bytes of an Offset16
+#[allow(dead_code)] // currently unused because of a serde bug?
+                    // https://github.com/serde-rs/serde/issues/2449
 pub const WIDTH_16: usize = 2;
 /// The width in bytes of an Offset24
 #[allow(dead_code)] // will be used one day :')
@@ -14,16 +16,17 @@ pub const WIDTH_32: usize = 4;
 ///
 /// The generic const `N` is the width of the offset, in bytes.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct OffsetMarker<T, const N: usize = WIDTH_16> {
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OffsetMarker<T, const N: usize = 2> {
     obj: T,
-    //error: Option<Box<ReadError>>,
 }
 
 /// An offset subtable which may be null.
 ///
 /// The generic const `N` is the width of the offset, in bytes.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NullableOffsetMarker<T, const N: usize = WIDTH_16> {
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NullableOffsetMarker<T, const N: usize = 2> {
     obj: Option<T>,
 }
 

--- a/write-fonts/src/tables.rs
+++ b/write-fonts/src/tables.rs
@@ -1,5 +1,8 @@
 //! A directory of all the font tables.
 
+// NOTE: if you add a new table, also add it to the test below to make sure
+// that serde works!
+
 pub mod avar;
 pub mod base;
 pub mod cmap;
@@ -24,3 +27,37 @@ pub mod stat;
 pub mod variations;
 pub mod vhea;
 pub mod vmtx;
+
+// ensure that all of our types implement the serde traits
+#[cfg(feature = "serde")]
+#[test]
+fn do_we_even_serde() {
+    #[derive(Default, serde::Deserialize, serde::Serialize)]
+    struct AllTables {
+        avar: avar::Avar,
+        base: base::Base,
+        cmap: cmap::Cmap,
+        fvar: fvar::Fvar,
+        gdef: gdef::Gdef,
+        glyf: glyf::Glyf,
+        gpos: gpos::Gpos,
+        gsub: gsub::Gsub,
+        gvar: gvar::Gvar,
+        head: head::Head,
+        hhea: hhea::Hhea,
+        hmtx: hmtx::Hmtx,
+        hvar: hvar::Hvar,
+        loca: loca::Loca,
+        maxp: maxp::Maxp,
+        name: name::Name,
+        os2: os2::Os2,
+        post: post::Post,
+        sbix: sbix::Sbix,
+        stat: stat::Stat,
+        vhea: vhea::Vhea,
+        vmtx: vmtx::Vmtx,
+    }
+    let tables = AllTables::default();
+    let dumped = bincode::serialize(&tables).unwrap();
+    let _loaded: AllTables = bincode::deserialize(&dumped).unwrap();
+}

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -24,6 +24,8 @@ pub use simple::{Contour, MalformedPath, SimpleGlyph};
 /// the positions of each individual glyph stored in the ['loca' table][super::loca].
 /// As such, these two tables must be constructed together. The [`GlyfLocaBuilder`]
 /// type is provided to simplify this.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Glyf(Vec<u8>);
 
 impl TopLevelTable for Glyf {

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -277,6 +277,7 @@ impl GlyphDeltas {
 
 /// The serializable representation of a glyph's variation data
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GlyphVariationData {
     tuple_variation_headers: Vec<TupleVariationHeader>,
     // optional; present if multiple variations have the same point numbers
@@ -286,6 +287,7 @@ pub struct GlyphVariationData {
 
 /// The serializable representation of a single glyph tuple variation data
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct GlyphTupleVariationData {
     // this is possibly shared, if multiple are identical for a given glyph
     private_point_numbers: Option<PackedPointNumbers>,

--- a/write-fonts/src/tables/instance_record.rs
+++ b/write-fonts/src/tables/instance_record.rs
@@ -5,6 +5,7 @@ use crate::codegen_prelude::*;
 
 /// The [InstanceRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#instancerecord)
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InstanceRecord {
     /// The name ID for entries in the 'name' table that provide subfamily names for this instance.
     pub subfamily_name_id: NameId,

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -43,6 +43,7 @@ macro_rules! table_newtype {
         ///
         /// You can access the inner type via `Deref` or the `as_inner` method.
         #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct $name($inner);
 
         impl $name {
@@ -206,6 +207,7 @@ impl FontWrite for LookupType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FeatureParams {
     StylisticSet(StylisticSetParams),
     Size(SizeParams),

--- a/write-fonts/src/tables/loca.rs
+++ b/write-fonts/src/tables/loca.rs
@@ -13,6 +13,8 @@ use crate::{
 /// The [loca] table.
 ///
 /// [loca]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Loca {
     // we just store u32, and then convert to u16 if needed in the `FontWrite` impl
     pub(crate) offsets: Vec<u32>,
@@ -27,8 +29,10 @@ pub struct Loca {
 /// [locformat]: super::head::Head::index_to_loc_format
 /// [spec]: https://learn.microsoft.com/en-us/typography/opentype/spec/loca
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LocaFormat {
+    #[default]
     Short = 0,
     Long = 1,
 }

--- a/write-fonts/src/tables/post.rs
+++ b/write-fonts/src/tables/post.rs
@@ -8,6 +8,7 @@ include!("../../generated/generated_post.rs");
 
 /// A string in the post table.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PString(String);
 
 impl Post {

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -23,6 +23,7 @@ use crate::{
 /// VariationIndex table for each of the specified values.
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValueRecord {
     // Okay so... this demands some explanation.
     //

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -68,6 +68,7 @@ impl VariationRegionList {
 
 /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#packed-point-numbers>
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PackedPointNumbers {
     /// Contains deltas for all point numbers
     #[default]
@@ -78,6 +79,7 @@ pub enum PackedPointNumbers {
 
 /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#packed-deltas>
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PackedDeltas {
     deltas: Vec<i16>,
 }


### PR DESCRIPTION
This is intended to be used to serialize test cases in write-fonts; it is also added in read-fonts since write-fonts reuses flags and enums declared in read-fonts.

One funny thing: (I think) this hit a serde bug around using non-literals to provide default values for const generics, which we do in the OffsetMarker types in write-fonts; I've opened an issue upstream at https://github.com/serde-rs/serde/issues/2449