### PR TITLE
Implement GPOS/GSUB extension promotion

### DIFF
--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -1,5 +1,6 @@
 //! A graph for resolving table offsets
 
+use crate::{table_type::TableType, tables::layout::LookupType};
 use font_types::Uint24;
 
 use super::write::TableData;
@@ -286,6 +287,10 @@ impl Graph {
         out
     }
 
+    fn can_potentially_promote_subtables(&self) -> bool {
+        [TableType::GSUB, TableType::GPOS].contains(&self.objects[&self.root].type_)
+    }
+
     /// Attempt to pack the graph.
     ///
     /// This involves finding an order for objects such that all offsets are
@@ -306,6 +311,11 @@ impl Graph {
             return true;
         }
 
+        if self.can_potentially_promote_subtables() {
+            self.try_promoting_subtables();
+        }
+
+        log::info!("assigning spaces");
         self.assign_spaces_hb();
         self.sort_shortest_distance();
 
@@ -808,6 +818,208 @@ impl Graph {
     fn next_space(&mut self) -> Space {
         self.next_space = Space(self.next_space.0 + 1);
         self.next_space
+    }
+
+    fn try_promoting_subtables(&mut self) {
+        let Some((can_promote, parent_id)) = self.get_promotable_subtables() else { return };
+        let to_promote = self.select_promotions_hb(&can_promote, parent_id);
+        log::info!(
+            "promoting {} of {} eligible subtables",
+            to_promote.len(),
+            can_promote.len()
+        );
+        self.actually_promote_subtables(&to_promote);
+    }
+
+    fn actually_promote_subtables(&mut self, to_promote: &[ObjectId]) {
+        fn make_extension(type_: LookupType, subtable_id: ObjectId) -> (ObjectId, TableData) {
+            const EXT_FORMAT: u16 = 1;
+            let mut data = TableData {
+                type_: type_.promote().into(),
+                ..Default::default()
+            };
+            data.write(EXT_FORMAT);
+            data.write(type_.to_raw());
+            data.add_offset(subtable_id, 4, 0);
+            (ObjectId::next(), data)
+        }
+
+        for id in to_promote {
+            // 'id' is a lookup table.
+            // we need to:
+            // - change the subtable type
+            // - create a new extension table for each subtable
+            // - update the object ids
+
+            let mut lookup = self.objects.remove(id).unwrap();
+            let lookup_type = lookup.type_.to_lookup_type().expect("validated before now");
+            for subtable_ref in &mut lookup.offsets {
+                let (ext_id, ext_table) = make_extension(lookup_type, subtable_ref.object);
+                self.nodes
+                    .insert(ext_id, Node::new(ext_table.bytes.len() as _));
+                self.objects.insert(ext_id, ext_table);
+                subtable_ref.object = ext_id;
+            }
+            lookup.write_over(lookup_type.promote().to_raw(), 0);
+            lookup.type_ = lookup_type.promote().into();
+            self.objects.insert(*id, lookup);
+        }
+        self.parents_invalid = true;
+        self.positions_invalid = true;
+    }
+
+    // get the list of tables that can be promoted, as well as the id of their parent table
+    fn get_promotable_subtables(&self) -> Option<(Vec<ObjectId>, ObjectId)> {
+        let can_promote = self
+            .objects
+            .iter()
+            .filter_map(|(id, obj)| (obj.type_.is_promotable()).then_some(*id))
+            .collect::<Vec<_>>();
+
+        if can_promote.is_empty() {
+            return None;
+        }
+
+        // sanity check: ensure that all promotable tables have a common root.
+        let parents = can_promote
+            .iter()
+            .flat_map(|id| {
+                self.nodes
+                    .get(id)
+                    .expect("all nodes exist")
+                    .parents
+                    .iter()
+                    .map(|x| x.0)
+            })
+            .collect::<HashSet<_>>();
+
+        // the only promotable subtables should be lookups, and there should
+        // be a single LookupList that is their parent; if there is more than
+        // one parent then something weird is going on.
+        if parents.len() > 1 {
+            if cfg!(debug_assertions) {
+                panic!("Promotable subtables exist with multiple parents");
+            } else {
+                log::warn!("Promotable subtables exist with multiple parents");
+                return None;
+            }
+        }
+
+        let parent_id = *parents.iter().next().unwrap();
+        Some((can_promote, parent_id))
+    }
+
+    /// select the tables to promote to extension, harfbuzz algorithm
+    ///
+    /// Based on the logic in HarfBuzz's [`_promote_exetnsions_if_needed`][hb-promote] function.
+    ///
+    /// [hb-promote]: https://github.com/harfbuzz/harfbuzz/blob/5d543d64222c6ce45332d0c188790f90691ef112/src/hb-repacker.hh#L97
+    fn select_promotions_hb(&self, candidates: &[ObjectId], parent_id: ObjectId) -> Vec<ObjectId> {
+        struct LookupSize {
+            id: ObjectId,
+            subgraph_size: usize,
+            subtable_count: usize,
+        }
+
+        impl LookupSize {
+            // I could impl Ord but then I need to impl PartialEq and it ends
+            // up being way more code
+            fn sort_key(&self) -> impl Ord {
+                let bytes_per_subtable = self.subtable_count as f64 / self.subgraph_size as f64;
+                // f64 isn't ord, so we turn it into an integer,
+                // then reverse, because we want bigger things first
+                std::cmp::Reverse((bytes_per_subtable * 1e9) as u64)
+            }
+        }
+
+        let mut lookup_sizes = Vec::with_capacity(candidates.len());
+        let mut reusable_buffer = HashSet::new();
+        let mut queue = VecDeque::new();
+        for id in candidates {
+            // get the subgraph size
+            queue.clear();
+            queue.push_back(*id);
+            let subgraph_size = self.find_subgraph_size(&mut queue, &mut reusable_buffer);
+            let subtable_count = self.objects.get(id).unwrap().offsets.len();
+            lookup_sizes.push(LookupSize {
+                id: *id,
+                subgraph_size,
+                subtable_count,
+            });
+        }
+
+        lookup_sizes.sort_by_key(LookupSize::sort_key);
+        const EXTENSION_SIZE: usize = 8; // number of bytes added by an extension subtable
+        const MAX_LAYER_SIZE: usize = u16::MAX as usize;
+
+        let lookup_list_size = self.objects.get(&parent_id).unwrap().bytes.len();
+        let mut l2_l3_size = lookup_list_size; // size of LookupList + lookups
+        let mut l3_l4_size = 0; // Lookups + lookup subtables
+        let mut l4_plus_size = 0; // subtables and anything below that
+
+        // start by assuming all lookups are extensions; we will adjust this later
+        // if we do not promote.
+        for lookup in &lookup_sizes {
+            let subtables_size = lookup.subtable_count * EXTENSION_SIZE;
+            l3_l4_size += subtables_size;
+            l4_plus_size += subtables_size;
+        }
+
+        let mut layers_full = false;
+        let mut to_promote = Vec::new();
+        for lookup in &lookup_sizes {
+            if !layers_full {
+                let lookup_size = self.objects.get(&lookup.id).unwrap().bytes.len();
+                let subtables_size = self.find_children_size(lookup.id);
+                let remaining_size = lookup.subgraph_size - lookup_size - subtables_size;
+                l2_l3_size += lookup_size;
+                l3_l4_size += lookup_size + subtables_size;
+                // adjust down, because we are demoting out of extension space
+                l3_l4_size -= lookup.subtable_count * EXTENSION_SIZE;
+                l4_plus_size += subtables_size + remaining_size;
+
+                if l2_l3_size < MAX_LAYER_SIZE
+                    && l3_l4_size < MAX_LAYER_SIZE
+                    && l4_plus_size < MAX_LAYER_SIZE
+                {
+                    // this lookup fits in the 16-bit space, great
+                    continue;
+                }
+                layers_full = true;
+            }
+            to_promote.push(lookup.id);
+        }
+        to_promote
+    }
+
+    /// the size only of children of this object, not the whole subgraph
+    fn find_children_size(&self, id: ObjectId) -> usize {
+        self.objects[&id]
+            .offsets
+            .iter()
+            .map(|off| self.objects.get(&off.object).unwrap().bytes.len())
+            .sum()
+    }
+
+    fn find_subgraph_size(
+        &self,
+        queue: &mut VecDeque<ObjectId>,
+        visited: &mut HashSet<ObjectId>,
+    ) -> usize {
+        let mut size = 0;
+        visited.clear();
+        while !queue.is_empty() {
+            let next = queue.pop_front().unwrap();
+            visited.insert(next);
+            let obj = self.objects.get(&next).unwrap();
+            size += obj.bytes.len();
+            queue.extend(
+                obj.offsets
+                    .iter()
+                    .filter_map(|obj| (!visited.contains(&obj.object)).then_some(obj.object)),
+            );
+        }
+        size
     }
 
     fn duplicate_subgraph(

--- a/write-fonts/src/table_type.rs
+++ b/write-fonts/src/table_type.rs
@@ -6,7 +6,6 @@
 use std::fmt::Display;
 
 use font_types::Tag;
-#[cfg(test)] // just until we merge promotion
 use read::TopLevelTable;
 
 use crate::tables::layout::LookupType;
@@ -33,14 +32,28 @@ pub enum TableType {
 }
 
 impl TableType {
-    #[cfg(test)]
     pub(crate) const GSUB: TableType = TableType::TopLevel(crate::tables::gsub::Gsub::TAG);
-    #[cfg(test)]
     pub(crate) const GPOS: TableType = TableType::TopLevel(crate::tables::gpos::Gpos::TAG);
 
     #[cfg(feature = "dot2")]
     pub(crate) fn is_mock(&self) -> bool {
         *self == TableType::MockTable
+    }
+
+    pub(crate) fn is_promotable(self) -> bool {
+        match self {
+            TableType::GposLookup(type_) => type_ != LookupType::GPOS_EXT_TYPE,
+            TableType::GsubLookup(type_) => type_ != LookupType::GSUB_EXT_TYPE,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn to_lookup_type(self) -> Option<LookupType> {
+        match self {
+            TableType::GposLookup(type_) => Some(LookupType::Gpos(type_)),
+            TableType::GsubLookup(type_) => Some(LookupType::Gsub(type_)),
+            _ => None,
+        }
     }
 }
 

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -384,6 +384,13 @@ impl FromIterator<GlyphId> for CoverageTableBuilder {
     }
 }
 
+impl FromIterator<GlyphId> for CoverageTable {
+    fn from_iter<T: IntoIterator<Item = GlyphId>>(iter: T) -> Self {
+        let glyphs = iter.into_iter().collect::<Vec<_>>();
+        CoverageTableBuilder::from_glyphs(glyphs).build()
+    }
+}
+
 impl CoverageTableBuilder {
     /// Create a new builder from a vec of `GlyphId`.
     pub fn from_glyphs(mut glyphs: Vec<GlyphId>) -> Self {

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -166,10 +166,20 @@ pub enum LookupType {
 }
 
 impl LookupType {
+    pub(crate) const GSUB_EXT_TYPE: u16 = 7;
+    pub(crate) const GPOS_EXT_TYPE: u16 = 9;
+
     pub(crate) fn to_raw(self) -> u16 {
         match self {
             LookupType::Gpos(val) => val,
             LookupType::Gsub(val) => val,
+        }
+    }
+
+    pub(crate) fn promote(self) -> Self {
+        match self {
+            LookupType::Gpos(_) => LookupType::Gpos(Self::GPOS_EXT_TYPE),
+            LookupType::Gsub(_) => LookupType::Gsub(Self::GSUB_EXT_TYPE),
         }
     }
 }

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -63,7 +63,7 @@ pub fn dump_table<T: FontWrite + Validate>(table: &T) -> Result<Vec<u8>, Error> 
 
 impl TableWriter {
     /// A convenience method for generating a graph with the provided root object.
-    fn make_graph(root: &impl FontWrite) -> Graph {
+    pub(crate) fn make_graph(root: &impl FontWrite) -> Graph {
         let mut writer = TableWriter::default();
         let root_id = writer.add_table(root);
         Graph::from_obj_store(writer.tables, root_id)


### PR DESCRIPTION
The implementation here does not involve `write` types; instead we manually modify the graph in place. The implementation closely follows HarfBuzz.

This adds a `TableType` enum so that we can retain some type information after initial compilation; this somewhat overlaps with the `FontWrite::name` method added in #387, and maybe these could be combined?

This should get additional tests, and I'm working on porting some of the tests from the hb-repacker test suite.

closes #303.