### PR TITLE
minor bump write-fonts => 0.3.0

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
https://github.com/googlefonts/fontations/pull/389  broke compatibility. I now can't build fontmake-rs against fontations latest for iup because fea-rs kerplodes. Step 1 toward fixing that. JMM.