### PR TITLE
Make error types visible and bump-version minor on write-fonts

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -1,7 +1,7 @@
 //! Raw types for compiling opentype tables
 
 mod collections;
-mod error;
+pub mod error;
 mod font_builder;
 pub mod from_obj;
 mod graph;


### PR DESCRIPTION
Nameless errors are more intimidating than intended. Follow-on from #403.