### PR TITLE
Make write-fonts Error Send

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."

--- a/write-fonts/src/error.rs
+++ b/write-fonts/src/error.rs
@@ -1,11 +1,13 @@
 //! Errors that occur during writing
 
+use std::sync::Arc;
+
 use crate::{graph::Graph, validate::ValidationReport};
 
 /// A packing could not be found that satisfied all offsets
 #[derive(Clone, Debug)]
 pub struct PackingError {
-    pub(crate) graph: std::rc::Rc<Graph>,
+    pub(crate) graph: Arc<Graph>,
 }
 
 /// An error occured while writing this table
@@ -46,3 +48,15 @@ impl std::fmt::Display for PackingError {
 
 impl std::error::Error for PackingError {}
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Some users, notably fontmake-rs, like Send errors.
+    #[test]
+    fn assert_compiler_error_is_send() {
+        fn send_me_baby<T: Send>() {}
+        send_me_baby::<Error>();
+    }
+}


### PR DESCRIPTION
fea-rs and fontmake-rs both expect this.

While we're at it, rig to release write-fonts.

Will need to update https://github.com/cmyr/fea-rs/pull/135 once published.