### PR TITLE
write-fonts 0.3.2 => 0.3.3

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
Intended to be used to release #411 for fontmake-rs