### PR TITLE
Bump write-fonts patch, now 0.3.5

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
Intended to be used to release #417