### PR TITLE
Default OS/2 version to 4 not 2

### DIFF
--- a/write-fonts/src/tables/os2.rs
+++ b/write-fonts/src/tables/os2.rs
@@ -14,7 +14,10 @@ impl Os2 {
                 .or(self.us_max_context)
                 .is_some()
         {
-            2
+            // https://learn.microsoft.com/en-us/typography/opentype/spec/os2
+            // "All versions are supported, but use of version 4 or later is strongly recommended"
+            // Fields for v2, v3, and v4 are the same. Choice of 4 matches behavior of python tooling.
+            4
         } else {
             u16::from(
                 self.ul_code_page_range_1


### PR DESCRIPTION
https://learn.microsoft.com/en-us/typography/opentype/spec/os2 states "use of version 4 or later is strongly recommended." Python tooling appears to agree (OS/2 v4 vs v2 shows up diffing fontmake (python) vs fontc). v2, v3, and v4 have the same fields with modified wording for what some mean.

JMM