### PR TITLE
bump patch for font-types and read-fonts

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.1.6", path = "../font-types" }
+font-types = { version = "0.1.7", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 xflags = "0.2.4"
-read-fonts = { path = "../read-fonts",version = "0.2.0" }
-font-types = { path = "../font-types",version = "0.1.6" }
+read-fonts = { path = "../read-fonts",version = "0.2.1" }
+font-types = { path = "../font-types",version = "0.1.7" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."
@@ -15,7 +15,7 @@ traversal = ["std"]
 default = ["traversal"]
 
 [dependencies]
-font-types = { version = "0.1.6", path = "../font-types" }
+font-types = { version = "0.1.7", path = "../font-types" }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -14,7 +14,7 @@ scale = []
 hinting = []
 
 [dependencies]
-read-fonts = { version = "0.2.0", path = "../read-fonts" }
+read-fonts = { version = "0.2.1", path = "../read-fonts" }
 
 [dev-dependencies]
 font-test-data= { path = "../font-test-data" }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["text-processing", "parsing", "graphics"]
 default = ["dot2"]
 
 [dependencies]
-font-types = { version = "0.1.6", path = "../font-types" }
-read-fonts = { version = "0.2.0", path = "../read-fonts" }
+font-types = { version = "0.1.7", path = "../font-types" }
+read-fonts = { version = "0.2.1", path = "../read-fonts" }
 log = "0.4"
 bitflags = "1.3"
 kurbo = "0.9.4"
@@ -23,5 +23,5 @@ dot2 = { version = "1.0", optional = true }
 diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.2.0", path = "../read-fonts", features = [ "codegen_test"] }
+read-fonts = { version = "0.2.1", path = "../read-fonts", features = [ "codegen_test"] }
 env_logger = "0.10.0"


### PR DESCRIPTION
     Changes for font-types from font-types-v0.1.6 to 0.1.7
             45277f2 bump patch for font-types and read-fonts
             ec575c8 Forbid unsafe in font-types
     Changes for read-fonts from read-fonts-v0.2.0 to 0.2.1
             45277f2 bump patch for font-types and read-fonts
             80a7a70 font-types => 0.1.6
             1066567 Support writing sparse tuple stores
             abc5939 Add iterators for cmap