### PR TITLE
Cleanup cmap test assertions

### DIFF
--- a/font-types/src/raw.rs
+++ b/font-types/src/raw.rs
@@ -86,6 +86,8 @@ impl<T: Scalar + Default> Default for BigEndian<T> {
     }
 }
 
+//NOTE: do to the orphan rules, we cannot impl the inverse of this, e.g.
+// impl<T> PartialEq<BigEndian<T>> for T (<https://doc.rust-lang.org/error_codes/E0210.html>)
 impl<T: Scalar + Copy + PartialEq> PartialEq<T> for BigEndian<T> {
     fn eq(&self, other: &T) -> bool {
         self.get() == *other

--- a/write-fonts/src/tables/cmap.rs
+++ b/write-fonts/src/tables/cmap.rs
@@ -131,7 +131,7 @@ impl Cmap {
 
 #[cfg(test)]
 mod tests {
-    use font_types::{BigEndian, GlyphId, Scalar};
+    use font_types::GlyphId;
     use read::{
         tables::cmap::{Cmap, CmapSubtable, PlatformId},
         FontData, FontRead,
@@ -141,10 +141,6 @@ mod tests {
         dump_table,
         tables::cmap::{self as write, UNICODE_BMP_ENCODING, WINDOWS_BMP_ENCODING},
     };
-
-    fn to_vec<T: Scalar>(bees: &[BigEndian<T>]) -> Vec<T> {
-        bees.iter().map(|be| be.get()).collect()
-    }
 
     fn assert_generates_simple_cmap(mappings: Vec<(char, GlyphId)>) {
         let cmap = write::Cmap::from_mappings(mappings);
@@ -181,20 +177,11 @@ mod tests {
                     cmap4.range_shift()
                 )
             );
-            assert_eq!(
-                vec![10u16, 30u16, 153u16, 0xffffu16],
-                to_vec(cmap4.start_code())
-            );
-            assert_eq!(
-                vec![20u16, 90u16, 480u16, 0xffffu16],
-                to_vec(cmap4.end_code())
-            );
+            assert_eq!(cmap4.start_code(), &[10u16, 30u16, 153u16, 0xffffu16]);
+            assert_eq!(cmap4.end_code(), &[20u16, 90u16, 480u16, 0xffffu16]);
             // The example starts at gid 1, we're starting at 0
-            assert_eq!(vec![-10i16, -19i16, -81i16, 1i16], to_vec(cmap4.id_delta()));
-            assert_eq!(
-                vec![0u16, 0u16, 0u16, 0u16],
-                to_vec(cmap4.id_range_offsets())
-            );
+            assert_eq!(cmap4.id_delta(), &[-10i16, -19i16, -81i16, 1i16]);
+            assert_eq!(cmap4.id_range_offsets(), &[0u16, 0u16, 0u16, 0u16]);
         }
     }
 


### PR DESCRIPTION
I'm sorry Rod, but this patch is going to make you mad.

Noticed this when reviewing old PRs; I thought it shouldn't be necessary to make everything a vec, since there should be PartialEq impls for comparing BigEndian types to their native values, and that should mean you can then compare slices directly, since that's provided by std.

And this works! With one small, infuriating caveat:

*We can impl PartialEq<T> for BigEndian<T>, but not the other way around*.

What this means is that you can write, `be_val == ne_val` but not `ne_val == be_val`. This is related to the orphan rules (https://doc.rust-lang.org/error_codes/E0210.html) and the tl;dr there is that we can't impl a foreign trait (PartialEq) on a foreign type (T). So we are stuck with this weird asymetry.

That said, I thought it would be useful to PR this patch so that other folks are aware of this fact, and can avoid confusion in the future.