### PR TITLE
Replace FontWrite 'name' method with 'table_type' method

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -217,6 +217,14 @@ pub(crate) fn generate_compile_impl(
         }
     };
 
+    let maybe_table_type = attrs.tag.is_some().then(|| {
+        quote! {
+            fn type_(&self) -> TableType {
+                TableType::TopLevel( #name::TAG )
+            }
+        }
+    });
+
     let validation_impl = quote! {
         impl #validate_impl_params Validate for #name <#generic_param> {
             #validation_fn
@@ -234,6 +242,8 @@ pub(crate) fn generate_compile_impl(
                 fn name(&self) -> &'static str {
                     #name_string
                 }
+
+                #maybe_table_type
             }
         }
     });

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -217,13 +217,11 @@ pub(crate) fn generate_compile_impl(
         }
     };
 
-    let maybe_table_type = attrs.tag.is_some().then(|| {
-        quote! {
-            fn type_(&self) -> TableType {
-                TableType::TopLevel( #name::TAG )
-            }
-        }
-    });
+    let table_type = if attrs.tag.is_some() {
+        quote!(TableType::TopLevel( #name::TAG ))
+    } else {
+        quote!( TableType::Named( #name_string ) )
+    };
 
     let validation_impl = quote! {
         impl #validate_impl_params Validate for #name <#generic_param> {
@@ -243,7 +241,9 @@ pub(crate) fn generate_compile_impl(
                     #name_string
                 }
 
-                #maybe_table_type
+                fn table_type(&self) -> TableType {
+                    #table_type
+                }
             }
         }
     });

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -237,10 +237,6 @@ pub(crate) fn generate_compile_impl(
                     #( #write_stmts; )*
                 }
 
-                fn name(&self) -> &'static str {
-                    #name_string
-                }
-
                 fn table_type(&self) -> TableType {
                     #table_type
                 }

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -389,6 +389,7 @@ pub(crate) fn generate_group_compile(
     let mut validate_match_arms = Vec::new();
     let mut from_obj_match_arms = Vec::new();
     let mut name_arms = Vec::new();
+    let mut type_arms = Vec::new();
     let from_type = quote!(#parse_module :: #name);
     for var in &item.variants {
         let var_name = &var.name;
@@ -402,6 +403,7 @@ pub(crate) fn generate_group_compile(
             quote! { #from_type :: #var_name(table) => Self :: #var_name(table.to_owned_obj(data)) },
         );
         name_arms.push(quote! { Self:: #var_name(_) => #var_name_string  });
+        type_arms.push(quote! { Self:: #var_name(table) => table.type_()  });
     }
     let first_var_name = &item.variants.first().unwrap().name;
 
@@ -428,6 +430,12 @@ pub(crate) fn generate_group_compile(
             fn name(&self) -> &'static str {
                 match self {
                     #( #name_arms, )*
+                }
+            }
+
+            fn type_(&self) -> TableType {
+                match self {
+                    #( #type_arms, )*
                 }
             }
         }

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -403,7 +403,7 @@ pub(crate) fn generate_group_compile(
             quote! { #from_type :: #var_name(table) => Self :: #var_name(table.to_owned_obj(data)) },
         );
         name_arms.push(quote! { Self:: #var_name(_) => #var_name_string  });
-        type_arms.push(quote! { Self:: #var_name(table) => table.type_()  });
+        type_arms.push(quote! { Self:: #var_name(table) => table.table_type()  });
     }
     let first_var_name = &item.variants.first().unwrap().name;
 
@@ -433,7 +433,7 @@ pub(crate) fn generate_group_compile(
                 }
             }
 
-            fn type_(&self) -> TableType {
+            fn table_type(&self) -> TableType {
                 match self {
                     #( #type_arms, )*
                 }

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -36,7 +36,7 @@ impl FontWrite for Avar {
     fn name(&self) -> &'static str {
         "Avar"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Avar::TAG)
     }
 }
@@ -102,6 +102,9 @@ impl FontWrite for SegmentMaps {
     fn name(&self) -> &'static str {
         "SegmentMaps"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SegmentMaps")
+    }
 }
 
 impl Validate for SegmentMaps {
@@ -151,6 +154,9 @@ impl FontWrite for AxisValueMap {
     }
     fn name(&self) -> &'static str {
         "AxisValueMap"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueMap")
     }
 }
 

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -33,9 +33,6 @@ impl FontWrite for Avar {
         (array_len(&self.axis_segment_maps).unwrap() as u16).write_into(writer);
         self.axis_segment_maps.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Avar"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Avar::TAG)
     }
@@ -99,9 +96,6 @@ impl FontWrite for SegmentMaps {
         (array_len(&self.axis_value_maps).unwrap() as u16).write_into(writer);
         self.axis_value_maps.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "SegmentMaps"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("SegmentMaps")
     }
@@ -151,9 +145,6 @@ impl FontWrite for AxisValueMap {
     fn write_into(&self, writer: &mut TableWriter) {
         self.from_coordinate.write_into(writer);
         self.to_coordinate.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AxisValueMap"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueMap")

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -36,6 +36,9 @@ impl FontWrite for Avar {
     fn name(&self) -> &'static str {
         "Avar"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Avar::TAG)
+    }
 }
 
 impl Validate for Avar {

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -41,7 +41,7 @@ impl FontWrite for Base {
     fn name(&self) -> &'static str {
         "Base"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Base::TAG)
     }
 }
@@ -112,6 +112,9 @@ impl FontWrite for Axis {
     fn name(&self) -> &'static str {
         "Axis"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Axis")
+    }
 }
 
 impl Validate for Axis {
@@ -170,6 +173,9 @@ impl FontWrite for BaseTagList {
     fn name(&self) -> &'static str {
         "BaseTagList"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseTagList")
+    }
 }
 
 impl Validate for BaseTagList {
@@ -226,6 +232,9 @@ impl FontWrite for BaseScriptList {
     }
     fn name(&self) -> &'static str {
         "BaseScriptList"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseScriptList")
     }
 }
 
@@ -286,6 +295,9 @@ impl FontWrite for BaseScriptRecord {
     }
     fn name(&self) -> &'static str {
         "BaseScriptRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseScriptRecord")
     }
 }
 
@@ -348,6 +360,9 @@ impl FontWrite for BaseScript {
     }
     fn name(&self) -> &'static str {
         "BaseScript"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseScript")
     }
 }
 
@@ -416,6 +431,9 @@ impl FontWrite for BaseLangSysRecord {
     fn name(&self) -> &'static str {
         "BaseLangSysRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseLangSysRecord")
+    }
 }
 
 impl Validate for BaseLangSysRecord {
@@ -472,6 +490,9 @@ impl FontWrite for BaseValues {
     }
     fn name(&self) -> &'static str {
         "BaseValues"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseValues")
     }
 }
 
@@ -544,6 +565,9 @@ impl FontWrite for MinMax {
     }
     fn name(&self) -> &'static str {
         "MinMax"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MinMax")
     }
 }
 
@@ -622,6 +646,9 @@ impl FontWrite for FeatMinMaxRecord {
     }
     fn name(&self) -> &'static str {
         "FeatMinMaxRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatMinMaxRecord")
     }
 }
 
@@ -754,6 +781,9 @@ impl FontWrite for BaseCoordFormat1 {
     fn name(&self) -> &'static str {
         "BaseCoordFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseCoordFormat1")
+    }
 }
 
 impl Validate for BaseCoordFormat1 {
@@ -810,6 +840,9 @@ impl FontWrite for BaseCoordFormat2 {
     fn name(&self) -> &'static str {
         "BaseCoordFormat2"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseCoordFormat2")
+    }
 }
 
 impl Validate for BaseCoordFormat2 {
@@ -865,6 +898,9 @@ impl FontWrite for BaseCoordFormat3 {
     }
     fn name(&self) -> &'static str {
         "BaseCoordFormat3"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseCoordFormat3")
     }
 }
 

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -41,6 +41,9 @@ impl FontWrite for Base {
     fn name(&self) -> &'static str {
         "Base"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Base::TAG)
+    }
 }
 
 impl Validate for Base {

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -38,9 +38,6 @@ impl FontWrite for Base {
             .compatible((1, 1))
             .then(|| self.item_var_store.write_into(writer));
     }
-    fn name(&self) -> &'static str {
-        "Base"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Base::TAG)
     }
@@ -109,9 +106,6 @@ impl FontWrite for Axis {
         self.base_tag_list.write_into(writer);
         self.base_script_list.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Axis"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Axis")
     }
@@ -170,9 +164,6 @@ impl FontWrite for BaseTagList {
         (array_len(&self.baseline_tags).unwrap() as u16).write_into(writer);
         self.baseline_tags.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "BaseTagList"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseTagList")
     }
@@ -229,9 +220,6 @@ impl FontWrite for BaseScriptList {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.base_script_records).unwrap() as u16).write_into(writer);
         self.base_script_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseScriptList"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseScriptList")
@@ -292,9 +280,6 @@ impl FontWrite for BaseScriptRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.base_script_tag.write_into(writer);
         self.base_script.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseScriptRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseScriptRecord")
@@ -357,9 +342,6 @@ impl FontWrite for BaseScript {
         self.default_min_max.write_into(writer);
         (array_len(&self.base_lang_sys_records).unwrap() as u16).write_into(writer);
         self.base_lang_sys_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseScript"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseScript")
@@ -428,9 +410,6 @@ impl FontWrite for BaseLangSysRecord {
         self.base_lang_sys_tag.write_into(writer);
         self.min_max.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "BaseLangSysRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseLangSysRecord")
     }
@@ -487,9 +466,6 @@ impl FontWrite for BaseValues {
         self.default_baseline_index.write_into(writer);
         (array_len(&self.base_coords).unwrap() as u16).write_into(writer);
         self.base_coords.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseValues"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseValues")
@@ -562,9 +538,6 @@ impl FontWrite for MinMax {
         self.max_coord.write_into(writer);
         (array_len(&self.feat_min_max_records).unwrap() as u16).write_into(writer);
         self.feat_min_max_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "MinMax"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("MinMax")
@@ -644,9 +617,6 @@ impl FontWrite for FeatMinMaxRecord {
         self.min_coord.write_into(writer);
         self.max_coord.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "FeatMinMaxRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatMinMaxRecord")
     }
@@ -720,11 +690,11 @@ impl FontWrite for BaseCoord {
             Self::Format3(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "BaseCoord.Format1",
-            Self::Format2(_) => "BaseCoord.Format2",
-            Self::Format3(_) => "BaseCoord.Format3",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
         }
     }
 }
@@ -777,9 +747,6 @@ impl FontWrite for BaseCoordFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coordinate.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseCoordFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseCoordFormat1")
@@ -837,9 +804,6 @@ impl FontWrite for BaseCoordFormat2 {
         self.reference_glyph.write_into(writer);
         self.base_coord_point.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "BaseCoordFormat2"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseCoordFormat2")
     }
@@ -895,9 +859,6 @@ impl FontWrite for BaseCoordFormat3 {
         (3 as u16).write_into(writer);
         self.coordinate.write_into(writer);
         self.device.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseCoordFormat3"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseCoordFormat3")

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -29,9 +29,6 @@ impl FontWrite for Cmap {
         (array_len(&self.encoding_records).unwrap() as u16).write_into(writer);
         self.encoding_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Cmap"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Cmap::TAG)
     }
@@ -99,9 +96,6 @@ impl FontWrite for EncodingRecord {
         self.platform_id.write_into(writer);
         self.encoding_id.write_into(writer);
         self.subtable.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "EncodingRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("EncodingRecord")
@@ -285,17 +279,17 @@ impl FontWrite for CmapSubtable {
             Self::Format14(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format0(_) => "CmapSubtable.Format0",
-            Self::Format2(_) => "CmapSubtable.Format2",
-            Self::Format4(_) => "CmapSubtable.Format4",
-            Self::Format6(_) => "CmapSubtable.Format6",
-            Self::Format8(_) => "CmapSubtable.Format8",
-            Self::Format10(_) => "CmapSubtable.Format10",
-            Self::Format12(_) => "CmapSubtable.Format12",
-            Self::Format13(_) => "CmapSubtable.Format13",
-            Self::Format14(_) => "CmapSubtable.Format14",
+            Self::Format0(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format4(item) => item.table_type(),
+            Self::Format6(item) => item.table_type(),
+            Self::Format8(item) => item.table_type(),
+            Self::Format10(item) => item.table_type(),
+            Self::Format12(item) => item.table_type(),
+            Self::Format13(item) => item.table_type(),
+            Self::Format14(item) => item.table_type(),
         }
     }
 }
@@ -369,9 +363,6 @@ impl FontWrite for Cmap0 {
         self.language.write_into(writer);
         self.glyph_id_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Cmap0"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap0")
     }
@@ -430,9 +421,6 @@ impl FontWrite for Cmap2 {
         self.length.write_into(writer);
         self.language.write_into(writer);
         self.sub_header_keys.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Cmap2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap2")
@@ -493,9 +481,6 @@ impl FontWrite for SubHeader {
         self.entry_count.write_into(writer);
         self.id_delta.write_into(writer);
         self.id_range_offset.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SubHeader"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SubHeader")
@@ -598,9 +583,6 @@ impl FontWrite for Cmap4 {
         self.id_range_offsets.write_into(writer);
         self.glyph_id_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Cmap4"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap4")
     }
@@ -681,9 +663,6 @@ impl FontWrite for Cmap6 {
         self.first_code.write_into(writer);
         self.entry_count.write_into(writer);
         self.glyph_id_array.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Cmap6"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap6")
@@ -771,9 +750,6 @@ impl FontWrite for Cmap8 {
         self.num_groups.write_into(writer);
         self.groups.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Cmap8"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap8")
     }
@@ -845,9 +821,6 @@ impl FontWrite for SequentialMapGroup {
         self.end_char_code.write_into(writer);
         self.start_glyph_id.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "SequentialMapGroup"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("SequentialMapGroup")
     }
@@ -912,9 +885,6 @@ impl FontWrite for Cmap10 {
         self.start_char_code.write_into(writer);
         self.num_chars.write_into(writer);
         self.glyph_id_array.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Cmap10"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap10")
@@ -986,9 +956,6 @@ impl FontWrite for Cmap12 {
         self.language.write_into(writer);
         self.num_groups.write_into(writer);
         self.groups.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Cmap12"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap12")
@@ -1064,9 +1031,6 @@ impl FontWrite for Cmap13 {
         self.num_groups.write_into(writer);
         self.groups.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Cmap13"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap13")
     }
@@ -1134,9 +1098,6 @@ impl FontWrite for ConstantMapGroup {
         self.end_char_code.write_into(writer);
         self.glyph_id.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ConstantMapGroup"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ConstantMapGroup")
     }
@@ -1189,9 +1150,6 @@ impl FontWrite for Cmap14 {
         self.length.write_into(writer);
         self.num_var_selector_records.write_into(writer);
         self.var_selector.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Cmap14"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Cmap14")
@@ -1264,9 +1222,6 @@ impl FontWrite for VariationSelector {
         self.default_uvs.write_into(writer);
         self.non_default_uvs.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "VariationSelector"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("VariationSelector")
     }
@@ -1321,9 +1276,6 @@ impl FontWrite for DefaultUvs {
     fn write_into(&self, writer: &mut TableWriter) {
         self.num_unicode_value_ranges.write_into(writer);
         self.ranges.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "DefaultUvs"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("DefaultUvs")
@@ -1382,9 +1334,6 @@ impl FontWrite for NonDefaultUvs {
     fn write_into(&self, writer: &mut TableWriter) {
         self.num_uvs_mappings.write_into(writer);
         self.uvs_mapping.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "NonDefaultUvs"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("NonDefaultUvs")
@@ -1447,9 +1396,6 @@ impl FontWrite for UvsMapping {
         self.unicode_value.write_into(writer);
         self.glyph_id.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "UvsMapping"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("UvsMapping")
     }
@@ -1491,9 +1437,6 @@ impl FontWrite for UnicodeRange {
     fn write_into(&self, writer: &mut TableWriter) {
         self.start_unicode_value.write_into(writer);
         self.additional_count.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "UnicodeRange"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("UnicodeRange")

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -32,6 +32,9 @@ impl FontWrite for Cmap {
     fn name(&self) -> &'static str {
         "Cmap"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Cmap::TAG)
+    }
 }
 
 impl Validate for Cmap {

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -32,7 +32,7 @@ impl FontWrite for Cmap {
     fn name(&self) -> &'static str {
         "Cmap"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Cmap::TAG)
     }
 }
@@ -102,6 +102,9 @@ impl FontWrite for EncodingRecord {
     }
     fn name(&self) -> &'static str {
         "EncodingRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("EncodingRecord")
     }
 }
 
@@ -369,6 +372,9 @@ impl FontWrite for Cmap0 {
     fn name(&self) -> &'static str {
         "Cmap0"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap0")
+    }
 }
 
 impl Validate for Cmap0 {
@@ -427,6 +433,9 @@ impl FontWrite for Cmap2 {
     }
     fn name(&self) -> &'static str {
         "Cmap2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap2")
     }
 }
 
@@ -487,6 +496,9 @@ impl FontWrite for SubHeader {
     }
     fn name(&self) -> &'static str {
         "SubHeader"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SubHeader")
     }
 }
 
@@ -589,6 +601,9 @@ impl FontWrite for Cmap4 {
     fn name(&self) -> &'static str {
         "Cmap4"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap4")
+    }
 }
 
 impl Validate for Cmap4 {
@@ -669,6 +684,9 @@ impl FontWrite for Cmap6 {
     }
     fn name(&self) -> &'static str {
         "Cmap6"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap6")
     }
 }
 
@@ -756,6 +774,9 @@ impl FontWrite for Cmap8 {
     fn name(&self) -> &'static str {
         "Cmap8"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap8")
+    }
 }
 
 impl Validate for Cmap8 {
@@ -827,6 +848,9 @@ impl FontWrite for SequentialMapGroup {
     fn name(&self) -> &'static str {
         "SequentialMapGroup"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequentialMapGroup")
+    }
 }
 
 impl Validate for SequentialMapGroup {
@@ -891,6 +915,9 @@ impl FontWrite for Cmap10 {
     }
     fn name(&self) -> &'static str {
         "Cmap10"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap10")
     }
 }
 
@@ -962,6 +989,9 @@ impl FontWrite for Cmap12 {
     }
     fn name(&self) -> &'static str {
         "Cmap12"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap12")
     }
 }
 
@@ -1037,6 +1067,9 @@ impl FontWrite for Cmap13 {
     fn name(&self) -> &'static str {
         "Cmap13"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap13")
+    }
 }
 
 impl Validate for Cmap13 {
@@ -1104,6 +1137,9 @@ impl FontWrite for ConstantMapGroup {
     fn name(&self) -> &'static str {
         "ConstantMapGroup"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ConstantMapGroup")
+    }
 }
 
 impl Validate for ConstantMapGroup {
@@ -1156,6 +1192,9 @@ impl FontWrite for Cmap14 {
     }
     fn name(&self) -> &'static str {
         "Cmap14"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Cmap14")
     }
 }
 
@@ -1228,6 +1267,9 @@ impl FontWrite for VariationSelector {
     fn name(&self) -> &'static str {
         "VariationSelector"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("VariationSelector")
+    }
 }
 
 impl Validate for VariationSelector {
@@ -1282,6 +1324,9 @@ impl FontWrite for DefaultUvs {
     }
     fn name(&self) -> &'static str {
         "DefaultUvs"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("DefaultUvs")
     }
 }
 
@@ -1340,6 +1385,9 @@ impl FontWrite for NonDefaultUvs {
     }
     fn name(&self) -> &'static str {
         "NonDefaultUvs"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("NonDefaultUvs")
     }
 }
 
@@ -1402,6 +1450,9 @@ impl FontWrite for UvsMapping {
     fn name(&self) -> &'static str {
         "UvsMapping"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("UvsMapping")
+    }
 }
 
 impl Validate for UvsMapping {
@@ -1443,6 +1494,9 @@ impl FontWrite for UnicodeRange {
     }
     fn name(&self) -> &'static str {
         "UnicodeRange"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("UnicodeRange")
     }
 }
 

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -86,9 +86,6 @@ impl FontWrite for Cpal {
             .compatible(1)
             .then(|| self.palette_entry_labels_array.write_into(writer));
     }
-    fn name(&self) -> &'static str {
-        "Cpal"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Cpal::TAG)
     }
@@ -168,9 +165,6 @@ impl FontWrite for ColorRecord {
         self.green.write_into(writer);
         self.red.write_into(writer);
         self.alpha.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ColorRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ColorRecord")

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -89,6 +89,9 @@ impl FontWrite for Cpal {
     fn name(&self) -> &'static str {
         "Cpal"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Cpal::TAG)
+    }
 }
 
 impl Validate for Cpal {

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -89,7 +89,7 @@ impl FontWrite for Cpal {
     fn name(&self) -> &'static str {
         "Cpal"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Cpal::TAG)
     }
 }
@@ -171,6 +171,9 @@ impl FontWrite for ColorRecord {
     }
     fn name(&self) -> &'static str {
         "ColorRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ColorRecord")
     }
 }
 

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -46,9 +46,6 @@ impl FontWrite for TableDirectory {
         self.range_shift.write_into(writer);
         self.table_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "TableDirectory"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("TableDirectory")
     }
@@ -98,9 +95,6 @@ impl FontWrite for TableRecord {
         self.checksum.write_into(writer);
         self.offset.write_into(writer);
         self.length.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "TableRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("TableRecord")

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -49,6 +49,9 @@ impl FontWrite for TableDirectory {
     fn name(&self) -> &'static str {
         "TableDirectory"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("TableDirectory")
+    }
 }
 
 impl Validate for TableDirectory {
@@ -98,6 +101,9 @@ impl FontWrite for TableRecord {
     }
     fn name(&self) -> &'static str {
         "TableRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("TableRecord")
     }
 }
 

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -48,9 +48,6 @@ impl FontWrite for Fvar {
         self.instance_count.write_into(writer);
         (self.instance_size() as u16).write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Fvar"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Fvar::TAG)
     }
@@ -113,9 +110,6 @@ impl FontWrite for AxisInstanceArrays {
     fn write_into(&self, writer: &mut TableWriter) {
         self.axes.write_into(writer);
         self.instances.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AxisInstanceArrays"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisInstanceArrays")
@@ -203,9 +197,6 @@ impl FontWrite for VariationAxisRecord {
         self.max_value.write_into(writer);
         self.flags.write_into(writer);
         self.axis_name_id.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "VariationAxisRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("VariationAxisRecord")

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -51,7 +51,7 @@ impl FontWrite for Fvar {
     fn name(&self) -> &'static str {
         "Fvar"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Fvar::TAG)
     }
 }
@@ -116,6 +116,9 @@ impl FontWrite for AxisInstanceArrays {
     }
     fn name(&self) -> &'static str {
         "AxisInstanceArrays"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisInstanceArrays")
     }
 }
 
@@ -203,6 +206,9 @@ impl FontWrite for VariationAxisRecord {
     }
     fn name(&self) -> &'static str {
         "VariationAxisRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("VariationAxisRecord")
     }
 }
 

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -51,6 +51,9 @@ impl FontWrite for Fvar {
     fn name(&self) -> &'static str {
         "Fvar"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Fvar::TAG)
+    }
 }
 
 impl Validate for Fvar {

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -67,6 +67,9 @@ impl FontWrite for Gdef {
     fn name(&self) -> &'static str {
         "Gdef"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Gdef::TAG)
+    }
 }
 
 impl Validate for Gdef {

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -64,9 +64,6 @@ impl FontWrite for Gdef {
             .compatible((1, 3))
             .then(|| self.item_var_store.write_into(writer));
     }
-    fn name(&self) -> &'static str {
-        "Gdef"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Gdef::TAG)
     }
@@ -156,9 +153,6 @@ impl FontWrite for AttachList {
         (array_len(&self.attach_points).unwrap() as u16).write_into(writer);
         self.attach_points.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AttachList"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AttachList")
     }
@@ -218,9 +212,6 @@ impl FontWrite for AttachPoint {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.point_indices).unwrap() as u16).write_into(writer);
         self.point_indices.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AttachPoint"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AttachPoint")
@@ -283,9 +274,6 @@ impl FontWrite for LigCaretList {
         (array_len(&self.lig_glyphs).unwrap() as u16).write_into(writer);
         self.lig_glyphs.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "LigCaretList"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("LigCaretList")
     }
@@ -346,9 +334,6 @@ impl FontWrite for LigGlyph {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.caret_values).unwrap() as u16).write_into(writer);
         self.caret_values.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "LigGlyph"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("LigGlyph")
@@ -423,11 +408,11 @@ impl FontWrite for CaretValue {
             Self::Format3(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "CaretValue.Format1",
-            Self::Format2(_) => "CaretValue.Format2",
-            Self::Format3(_) => "CaretValue.Format3",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
         }
     }
 }
@@ -481,9 +466,6 @@ impl FontWrite for CaretValueFormat1 {
         (1 as u16).write_into(writer);
         self.coordinate.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "CaretValueFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("CaretValueFormat1")
     }
@@ -531,9 +513,6 @@ impl FontWrite for CaretValueFormat2 {
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
         self.caret_value_point_index.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "CaretValueFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("CaretValueFormat2")
@@ -588,9 +567,6 @@ impl FontWrite for CaretValueFormat3 {
         (3 as u16).write_into(writer);
         self.coordinate.write_into(writer);
         self.device.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "CaretValueFormat3"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("CaretValueFormat3")
@@ -648,9 +624,6 @@ impl FontWrite for MarkGlyphSets {
         (1 as u16).write_into(writer);
         (array_len(&self.coverages).unwrap() as u16).write_into(writer);
         self.coverages.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "MarkGlyphSets"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("MarkGlyphSets")

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -67,7 +67,7 @@ impl FontWrite for Gdef {
     fn name(&self) -> &'static str {
         "Gdef"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Gdef::TAG)
     }
 }
@@ -159,6 +159,9 @@ impl FontWrite for AttachList {
     fn name(&self) -> &'static str {
         "AttachList"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AttachList")
+    }
 }
 
 impl Validate for AttachList {
@@ -218,6 +221,9 @@ impl FontWrite for AttachPoint {
     }
     fn name(&self) -> &'static str {
         "AttachPoint"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AttachPoint")
     }
 }
 
@@ -280,6 +286,9 @@ impl FontWrite for LigCaretList {
     fn name(&self) -> &'static str {
         "LigCaretList"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LigCaretList")
+    }
 }
 
 impl Validate for LigCaretList {
@@ -340,6 +349,9 @@ impl FontWrite for LigGlyph {
     }
     fn name(&self) -> &'static str {
         "LigGlyph"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LigGlyph")
     }
 }
 
@@ -472,6 +484,9 @@ impl FontWrite for CaretValueFormat1 {
     fn name(&self) -> &'static str {
         "CaretValueFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CaretValueFormat1")
+    }
 }
 
 impl Validate for CaretValueFormat1 {
@@ -519,6 +534,9 @@ impl FontWrite for CaretValueFormat2 {
     }
     fn name(&self) -> &'static str {
         "CaretValueFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CaretValueFormat2")
     }
 }
 
@@ -573,6 +591,9 @@ impl FontWrite for CaretValueFormat3 {
     }
     fn name(&self) -> &'static str {
         "CaretValueFormat3"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CaretValueFormat3")
     }
 }
 
@@ -630,6 +651,9 @@ impl FontWrite for MarkGlyphSets {
     }
     fn name(&self) -> &'static str {
         "MarkGlyphSets"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MarkGlyphSets")
     }
 }
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -48,9 +48,6 @@ impl FontWrite for Gpos {
             .compatible((1, 1))
             .then(|| self.feature_variations.write_into(writer));
     }
-    fn name(&self) -> &'static str {
-        "Gpos"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Gpos::TAG)
     }
@@ -130,19 +127,6 @@ impl FontWrite for PositionLookup {
             Self::Contextual(table) => table.write_into(writer),
             Self::ChainContextual(table) => table.write_into(writer),
             Self::Extension(table) => table.write_into(writer),
-        }
-    }
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Single(_) => "PositionLookup.Single",
-            Self::Pair(_) => "PositionLookup.Pair",
-            Self::Cursive(_) => "PositionLookup.Cursive",
-            Self::MarkToBase(_) => "PositionLookup.MarkToBase",
-            Self::MarkToLig(_) => "PositionLookup.MarkToLig",
-            Self::MarkToMark(_) => "PositionLookup.MarkToMark",
-            Self::Contextual(_) => "PositionLookup.Contextual",
-            Self::ChainContextual(_) => "PositionLookup.ChainContextual",
-            Self::Extension(_) => "PositionLookup.Extension",
         }
     }
     fn table_type(&self) -> TableType {
@@ -268,11 +252,11 @@ impl FontWrite for AnchorTable {
             Self::Format3(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "AnchorTable.Format1",
-            Self::Format2(_) => "AnchorTable.Format2",
-            Self::Format3(_) => "AnchorTable.Format3",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
         }
     }
 }
@@ -332,9 +316,6 @@ impl FontWrite for AnchorFormat1 {
         self.x_coordinate.write_into(writer);
         self.y_coordinate.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AnchorFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AnchorFormat1")
     }
@@ -391,9 +372,6 @@ impl FontWrite for AnchorFormat2 {
         self.x_coordinate.write_into(writer);
         self.y_coordinate.write_into(writer);
         self.anchor_point.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AnchorFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AnchorFormat2")
@@ -466,9 +444,6 @@ impl FontWrite for AnchorFormat3 {
         self.x_device.write_into(writer);
         self.y_device.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AnchorFormat3"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AnchorFormat3")
     }
@@ -530,9 +505,6 @@ impl FontWrite for MarkArray {
         (array_len(&self.mark_records).unwrap() as u16).write_into(writer);
         self.mark_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MarkArray"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MarkArray")
     }
@@ -592,9 +564,6 @@ impl FontWrite for MarkRecord {
         self.mark_class.write_into(writer);
         self.mark_anchor.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MarkRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MarkRecord")
     }
@@ -651,10 +620,10 @@ impl FontWrite for SinglePos {
             Self::Format2(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "SinglePos.Format1",
-            Self::Format2(_) => "SinglePos.Format2",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
         }
     }
 }
@@ -713,9 +682,6 @@ impl FontWrite for SinglePosFormat1 {
         self.coverage.write_into(writer);
         (self.compute_value_format() as ValueFormat).write_into(writer);
         self.value_record.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SinglePosFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SinglePosFormat1")
@@ -778,9 +744,6 @@ impl FontWrite for SinglePosFormat2 {
         (self.compute_value_format() as ValueFormat).write_into(writer);
         (array_len(&self.value_records).unwrap() as u16).write_into(writer);
         self.value_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SinglePosFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SinglePosFormat2")
@@ -868,10 +831,10 @@ impl FontWrite for PairPos {
             Self::Format2(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "PairPos.Format1",
-            Self::Format2(_) => "PairPos.Format2",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
         }
     }
 }
@@ -933,9 +896,6 @@ impl FontWrite for PairPosFormat1 {
         (array_len(&self.pair_sets).unwrap() as u16).write_into(writer);
         self.pair_sets.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "PairPosFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("PairPosFormat1")
     }
@@ -995,9 +955,6 @@ impl FontWrite for PairSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.pair_value_records).unwrap() as u16).write_into(writer);
         self.pair_value_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "PairSet"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("PairSet")
@@ -1065,9 +1022,6 @@ impl FontWrite for PairValueRecord {
         self.value_record1.write_into(writer);
         self.value_record2.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "PairValueRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("PairValueRecord")
     }
@@ -1134,9 +1088,6 @@ impl FontWrite for PairPosFormat2 {
         (self.compute_class1_count() as u16).write_into(writer);
         (self.compute_class2_count() as u16).write_into(writer);
         self.class1_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "PairPosFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("PairPosFormat2")
@@ -1208,9 +1159,6 @@ impl FontWrite for Class1Record {
     fn write_into(&self, writer: &mut TableWriter) {
         self.class2_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Class1Record"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Class1Record")
     }
@@ -1265,9 +1213,6 @@ impl FontWrite for Class2Record {
         self.value_record1.write_into(writer);
         self.value_record2.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Class2Record"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Class2Record")
     }
@@ -1312,9 +1257,6 @@ impl FontWrite for CursivePosFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.entry_exit_record).unwrap() as u16).write_into(writer);
         self.entry_exit_record.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "CursivePosFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("CursivePosFormat1")
@@ -1381,9 +1323,6 @@ impl FontWrite for EntryExitRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.entry_anchor.write_into(writer);
         self.exit_anchor.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "EntryExitRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("EntryExitRecord")
@@ -1459,9 +1398,6 @@ impl FontWrite for MarkBasePosFormat1 {
         self.mark_array.write_into(writer);
         self.base_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MarkBasePosFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MarkBasePosFormat1")
     }
@@ -1526,9 +1462,6 @@ impl FontWrite for BaseArray {
         (array_len(&self.base_records).unwrap() as u16).write_into(writer);
         self.base_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "BaseArray"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseArray")
     }
@@ -1583,9 +1516,6 @@ impl BaseRecord {
 impl FontWrite for BaseRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.base_anchors.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "BaseRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("BaseRecord")
@@ -1660,9 +1590,6 @@ impl FontWrite for MarkLigPosFormat1 {
         self.mark_array.write_into(writer);
         self.ligature_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MarkLigPosFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MarkLigPosFormat1")
     }
@@ -1731,9 +1658,6 @@ impl FontWrite for LigatureArray {
         (array_len(&self.ligature_attaches).unwrap() as u16).write_into(writer);
         self.ligature_attaches.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "LigatureArray"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("LigatureArray")
     }
@@ -1784,9 +1708,6 @@ impl FontWrite for LigatureAttach {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.component_records).unwrap() as u16).write_into(writer);
         self.component_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "LigatureAttach"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("LigatureAttach")
@@ -1842,9 +1763,6 @@ impl ComponentRecord {
 impl FontWrite for ComponentRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.ligature_anchors.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ComponentRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ComponentRecord")
@@ -1922,9 +1840,6 @@ impl FontWrite for MarkMarkPosFormat1 {
         self.mark1_array.write_into(writer);
         self.mark2_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MarkMarkPosFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MarkMarkPosFormat1")
     }
@@ -1989,9 +1904,6 @@ impl FontWrite for Mark2Array {
         (array_len(&self.mark2_records).unwrap() as u16).write_into(writer);
         self.mark2_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Mark2Array"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Mark2Array")
     }
@@ -2046,9 +1958,6 @@ impl Mark2Record {
 impl FontWrite for Mark2Record {
     fn write_into(&self, writer: &mut TableWriter) {
         self.mark2_anchors.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Mark2Record"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Mark2Record")
@@ -2166,18 +2075,6 @@ impl FontWrite for ExtensionSubtable {
             Self::MarkToMark(table) => table.write_into(writer),
             Self::Contextual(table) => table.write_into(writer),
             Self::ChainContextual(table) => table.write_into(writer),
-        }
-    }
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Single(_) => "ExtensionSubtable.Single",
-            Self::Pair(_) => "ExtensionSubtable.Pair",
-            Self::Cursive(_) => "ExtensionSubtable.Cursive",
-            Self::MarkToBase(_) => "ExtensionSubtable.MarkToBase",
-            Self::MarkToLig(_) => "ExtensionSubtable.MarkToLig",
-            Self::MarkToMark(_) => "ExtensionSubtable.MarkToMark",
-            Self::Contextual(_) => "ExtensionSubtable.Contextual",
-            Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
         }
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -51,7 +51,7 @@ impl FontWrite for Gpos {
     fn name(&self) -> &'static str {
         "Gpos"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Gpos::TAG)
     }
 }
@@ -145,17 +145,17 @@ impl FontWrite for PositionLookup {
             Self::Extension(_) => "PositionLookup.Extension",
         }
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Single(table) => table.type_(),
-            Self::Pair(table) => table.type_(),
-            Self::Cursive(table) => table.type_(),
-            Self::MarkToBase(table) => table.type_(),
-            Self::MarkToLig(table) => table.type_(),
-            Self::MarkToMark(table) => table.type_(),
-            Self::Contextual(table) => table.type_(),
-            Self::ChainContextual(table) => table.type_(),
-            Self::Extension(table) => table.type_(),
+            Self::Single(table) => table.table_type(),
+            Self::Pair(table) => table.table_type(),
+            Self::Cursive(table) => table.table_type(),
+            Self::MarkToBase(table) => table.table_type(),
+            Self::MarkToLig(table) => table.table_type(),
+            Self::MarkToMark(table) => table.table_type(),
+            Self::Contextual(table) => table.table_type(),
+            Self::ChainContextual(table) => table.table_type(),
+            Self::Extension(table) => table.table_type(),
         }
     }
 }
@@ -335,6 +335,9 @@ impl FontWrite for AnchorFormat1 {
     fn name(&self) -> &'static str {
         "AnchorFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AnchorFormat1")
+    }
 }
 
 impl Validate for AnchorFormat1 {
@@ -391,6 +394,9 @@ impl FontWrite for AnchorFormat2 {
     }
     fn name(&self) -> &'static str {
         "AnchorFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AnchorFormat2")
     }
 }
 
@@ -463,6 +469,9 @@ impl FontWrite for AnchorFormat3 {
     fn name(&self) -> &'static str {
         "AnchorFormat3"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AnchorFormat3")
+    }
 }
 
 impl Validate for AnchorFormat3 {
@@ -524,6 +533,9 @@ impl FontWrite for MarkArray {
     fn name(&self) -> &'static str {
         "MarkArray"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MarkArray")
+    }
 }
 
 impl Validate for MarkArray {
@@ -582,6 +594,9 @@ impl FontWrite for MarkRecord {
     }
     fn name(&self) -> &'static str {
         "MarkRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MarkRecord")
     }
 }
 
@@ -702,6 +717,9 @@ impl FontWrite for SinglePosFormat1 {
     fn name(&self) -> &'static str {
         "SinglePosFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SinglePosFormat1")
+    }
 }
 
 impl Validate for SinglePosFormat1 {
@@ -763,6 +781,9 @@ impl FontWrite for SinglePosFormat2 {
     }
     fn name(&self) -> &'static str {
         "SinglePosFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SinglePosFormat2")
     }
 }
 
@@ -915,6 +936,9 @@ impl FontWrite for PairPosFormat1 {
     fn name(&self) -> &'static str {
         "PairPosFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("PairPosFormat1")
+    }
 }
 
 impl Validate for PairPosFormat1 {
@@ -974,6 +998,9 @@ impl FontWrite for PairSet {
     }
     fn name(&self) -> &'static str {
         "PairSet"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("PairSet")
     }
 }
 
@@ -1041,6 +1068,9 @@ impl FontWrite for PairValueRecord {
     fn name(&self) -> &'static str {
         "PairValueRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("PairValueRecord")
+    }
 }
 
 impl Validate for PairValueRecord {
@@ -1107,6 +1137,9 @@ impl FontWrite for PairPosFormat2 {
     }
     fn name(&self) -> &'static str {
         "PairPosFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("PairPosFormat2")
     }
 }
 
@@ -1178,6 +1211,9 @@ impl FontWrite for Class1Record {
     fn name(&self) -> &'static str {
         "Class1Record"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Class1Record")
+    }
 }
 
 impl Validate for Class1Record {
@@ -1232,6 +1268,9 @@ impl FontWrite for Class2Record {
     fn name(&self) -> &'static str {
         "Class2Record"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Class2Record")
+    }
 }
 
 impl Validate for Class2Record {
@@ -1276,6 +1315,9 @@ impl FontWrite for CursivePosFormat1 {
     }
     fn name(&self) -> &'static str {
         "CursivePosFormat1"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CursivePosFormat1")
     }
 }
 
@@ -1342,6 +1384,9 @@ impl FontWrite for EntryExitRecord {
     }
     fn name(&self) -> &'static str {
         "EntryExitRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("EntryExitRecord")
     }
 }
 
@@ -1417,6 +1462,9 @@ impl FontWrite for MarkBasePosFormat1 {
     fn name(&self) -> &'static str {
         "MarkBasePosFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MarkBasePosFormat1")
+    }
 }
 
 impl Validate for MarkBasePosFormat1 {
@@ -1481,6 +1529,9 @@ impl FontWrite for BaseArray {
     fn name(&self) -> &'static str {
         "BaseArray"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseArray")
+    }
 }
 
 impl Validate for BaseArray {
@@ -1535,6 +1586,9 @@ impl FontWrite for BaseRecord {
     }
     fn name(&self) -> &'static str {
         "BaseRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BaseRecord")
     }
 }
 
@@ -1609,6 +1663,9 @@ impl FontWrite for MarkLigPosFormat1 {
     fn name(&self) -> &'static str {
         "MarkLigPosFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MarkLigPosFormat1")
+    }
 }
 
 impl Validate for MarkLigPosFormat1 {
@@ -1677,6 +1734,9 @@ impl FontWrite for LigatureArray {
     fn name(&self) -> &'static str {
         "LigatureArray"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LigatureArray")
+    }
 }
 
 impl Validate for LigatureArray {
@@ -1727,6 +1787,9 @@ impl FontWrite for LigatureAttach {
     }
     fn name(&self) -> &'static str {
         "LigatureAttach"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LigatureAttach")
     }
 }
 
@@ -1782,6 +1845,9 @@ impl FontWrite for ComponentRecord {
     }
     fn name(&self) -> &'static str {
         "ComponentRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ComponentRecord")
     }
 }
 
@@ -1859,6 +1925,9 @@ impl FontWrite for MarkMarkPosFormat1 {
     fn name(&self) -> &'static str {
         "MarkMarkPosFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MarkMarkPosFormat1")
+    }
 }
 
 impl Validate for MarkMarkPosFormat1 {
@@ -1923,6 +1992,9 @@ impl FontWrite for Mark2Array {
     fn name(&self) -> &'static str {
         "Mark2Array"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Mark2Array")
+    }
 }
 
 impl Validate for Mark2Array {
@@ -1977,6 +2049,9 @@ impl FontWrite for Mark2Record {
     }
     fn name(&self) -> &'static str {
         "Mark2Record"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Mark2Record")
     }
 }
 
@@ -2105,16 +2180,16 @@ impl FontWrite for ExtensionSubtable {
             Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
         }
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Single(table) => table.type_(),
-            Self::Pair(table) => table.type_(),
-            Self::Cursive(table) => table.type_(),
-            Self::MarkToBase(table) => table.type_(),
-            Self::MarkToLig(table) => table.type_(),
-            Self::MarkToMark(table) => table.type_(),
-            Self::Contextual(table) => table.type_(),
-            Self::ChainContextual(table) => table.type_(),
+            Self::Single(table) => table.table_type(),
+            Self::Pair(table) => table.table_type(),
+            Self::Cursive(table) => table.table_type(),
+            Self::MarkToBase(table) => table.table_type(),
+            Self::MarkToLig(table) => table.table_type(),
+            Self::MarkToMark(table) => table.table_type(),
+            Self::Contextual(table) => table.table_type(),
+            Self::ChainContextual(table) => table.table_type(),
         }
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -51,6 +51,9 @@ impl FontWrite for Gpos {
     fn name(&self) -> &'static str {
         "Gpos"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Gpos::TAG)
+    }
 }
 
 impl Validate for Gpos {
@@ -140,6 +143,19 @@ impl FontWrite for PositionLookup {
             Self::Contextual(_) => "PositionLookup.Contextual",
             Self::ChainContextual(_) => "PositionLookup.ChainContextual",
             Self::Extension(_) => "PositionLookup.Extension",
+        }
+    }
+    fn type_(&self) -> TableType {
+        match self {
+            Self::Single(table) => table.type_(),
+            Self::Pair(table) => table.type_(),
+            Self::Cursive(table) => table.type_(),
+            Self::MarkToBase(table) => table.type_(),
+            Self::MarkToLig(table) => table.type_(),
+            Self::MarkToMark(table) => table.type_(),
+            Self::Contextual(table) => table.type_(),
+            Self::ChainContextual(table) => table.type_(),
+            Self::Extension(table) => table.type_(),
         }
     }
 }
@@ -2087,6 +2103,18 @@ impl FontWrite for ExtensionSubtable {
             Self::MarkToMark(_) => "ExtensionSubtable.MarkToMark",
             Self::Contextual(_) => "ExtensionSubtable.Contextual",
             Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
+        }
+    }
+    fn type_(&self) -> TableType {
+        match self {
+            Self::Single(table) => table.type_(),
+            Self::Pair(table) => table.type_(),
+            Self::Cursive(table) => table.type_(),
+            Self::MarkToBase(table) => table.type_(),
+            Self::MarkToLig(table) => table.type_(),
+            Self::MarkToMark(table) => table.type_(),
+            Self::Contextual(table) => table.type_(),
+            Self::ChainContextual(table) => table.type_(),
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -47,9 +47,6 @@ impl FontWrite for Gsub {
             .compatible((1, 1))
             .then(|| self.feature_variations.write_into(writer));
     }
-    fn name(&self) -> &'static str {
-        "Gsub"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Gsub::TAG)
     }
@@ -127,18 +124,6 @@ impl FontWrite for SubstitutionLookup {
             Self::ChainContextual(table) => table.write_into(writer),
             Self::Extension(table) => table.write_into(writer),
             Self::Reverse(table) => table.write_into(writer),
-        }
-    }
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Single(_) => "SubstitutionLookup.Single",
-            Self::Multiple(_) => "SubstitutionLookup.Multiple",
-            Self::Alternate(_) => "SubstitutionLookup.Alternate",
-            Self::Ligature(_) => "SubstitutionLookup.Ligature",
-            Self::Contextual(_) => "SubstitutionLookup.Contextual",
-            Self::ChainContextual(_) => "SubstitutionLookup.ChainContextual",
-            Self::Extension(_) => "SubstitutionLookup.Extension",
-            Self::Reverse(_) => "SubstitutionLookup.Reverse",
         }
     }
     fn table_type(&self) -> TableType {
@@ -238,10 +223,10 @@ impl FontWrite for SingleSubst {
             Self::Format2(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "SingleSubst.Format1",
-            Self::Format2(_) => "SingleSubst.Format2",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
         }
     }
 }
@@ -299,9 +284,6 @@ impl FontWrite for SingleSubstFormat1 {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
         self.delta_glyph_id.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SingleSubstFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SingleSubstFormat1")
@@ -363,9 +345,6 @@ impl FontWrite for SingleSubstFormat2 {
         self.coverage.write_into(writer);
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SingleSubstFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SingleSubstFormat2")
@@ -435,9 +414,6 @@ impl FontWrite for MultipleSubstFormat1 {
         (array_len(&self.sequences).unwrap() as u16).write_into(writer);
         self.sequences.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MultipleSubstFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MultipleSubstFormat1")
     }
@@ -498,9 +474,6 @@ impl FontWrite for Sequence {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Sequence"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Sequence")
@@ -564,9 +537,6 @@ impl FontWrite for AlternateSubstFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.alternate_sets).unwrap() as u16).write_into(writer);
         self.alternate_sets.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AlternateSubstFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AlternateSubstFormat1")
@@ -635,9 +605,6 @@ impl FontWrite for AlternateSet {
         (array_len(&self.alternate_glyph_ids).unwrap() as u16).write_into(writer);
         self.alternate_glyph_ids.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AlternateSet"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AlternateSet")
     }
@@ -701,9 +668,6 @@ impl FontWrite for LigatureSubstFormat1 {
         (array_len(&self.ligature_sets).unwrap() as u16).write_into(writer);
         self.ligature_sets.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "LigatureSubstFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("LigatureSubstFormat1")
     }
@@ -766,9 +730,6 @@ impl FontWrite for LigatureSet {
         (array_len(&self.ligatures).unwrap() as u16).write_into(writer);
         self.ligatures.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "LigatureSet"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("LigatureSet")
     }
@@ -829,9 +790,6 @@ impl FontWrite for Ligature {
         self.ligature_glyph.write_into(writer);
         (plus_one(&self.component_glyph_ids.len()).unwrap() as u16).write_into(writer);
         self.component_glyph_ids.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Ligature"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Ligature")
@@ -947,17 +905,6 @@ impl FontWrite for ExtensionSubtable {
             Self::Reverse(table) => table.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Single(_) => "ExtensionSubtable.Single",
-            Self::Multiple(_) => "ExtensionSubtable.Multiple",
-            Self::Alternate(_) => "ExtensionSubtable.Alternate",
-            Self::Ligature(_) => "ExtensionSubtable.Ligature",
-            Self::Contextual(_) => "ExtensionSubtable.Contextual",
-            Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
-            Self::Reverse(_) => "ExtensionSubtable.Reverse",
-        }
-    }
     fn table_type(&self) -> TableType {
         match self {
             Self::Single(table) => table.table_type(),
@@ -1062,9 +1009,6 @@ impl FontWrite for ReverseChainSingleSubstFormat1 {
         self.lookahead_coverages.write_into(writer);
         (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ReverseChainSingleSubstFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ReverseChainSingleSubstFormat1")

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -50,7 +50,7 @@ impl FontWrite for Gsub {
     fn name(&self) -> &'static str {
         "Gsub"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Gsub::TAG)
     }
 }
@@ -141,16 +141,16 @@ impl FontWrite for SubstitutionLookup {
             Self::Reverse(_) => "SubstitutionLookup.Reverse",
         }
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Single(table) => table.type_(),
-            Self::Multiple(table) => table.type_(),
-            Self::Alternate(table) => table.type_(),
-            Self::Ligature(table) => table.type_(),
-            Self::Contextual(table) => table.type_(),
-            Self::ChainContextual(table) => table.type_(),
-            Self::Extension(table) => table.type_(),
-            Self::Reverse(table) => table.type_(),
+            Self::Single(table) => table.table_type(),
+            Self::Multiple(table) => table.table_type(),
+            Self::Alternate(table) => table.table_type(),
+            Self::Ligature(table) => table.table_type(),
+            Self::Contextual(table) => table.table_type(),
+            Self::ChainContextual(table) => table.table_type(),
+            Self::Extension(table) => table.table_type(),
+            Self::Reverse(table) => table.table_type(),
         }
     }
 }
@@ -303,6 +303,9 @@ impl FontWrite for SingleSubstFormat1 {
     fn name(&self) -> &'static str {
         "SingleSubstFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SingleSubstFormat1")
+    }
 }
 
 impl Validate for SingleSubstFormat1 {
@@ -363,6 +366,9 @@ impl FontWrite for SingleSubstFormat2 {
     }
     fn name(&self) -> &'static str {
         "SingleSubstFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SingleSubstFormat2")
     }
 }
 
@@ -432,6 +438,9 @@ impl FontWrite for MultipleSubstFormat1 {
     fn name(&self) -> &'static str {
         "MultipleSubstFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MultipleSubstFormat1")
+    }
 }
 
 impl Validate for MultipleSubstFormat1 {
@@ -492,6 +501,9 @@ impl FontWrite for Sequence {
     }
     fn name(&self) -> &'static str {
         "Sequence"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Sequence")
     }
 }
 
@@ -555,6 +567,9 @@ impl FontWrite for AlternateSubstFormat1 {
     }
     fn name(&self) -> &'static str {
         "AlternateSubstFormat1"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AlternateSubstFormat1")
     }
 }
 
@@ -623,6 +638,9 @@ impl FontWrite for AlternateSet {
     fn name(&self) -> &'static str {
         "AlternateSet"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AlternateSet")
+    }
 }
 
 impl Validate for AlternateSet {
@@ -686,6 +704,9 @@ impl FontWrite for LigatureSubstFormat1 {
     fn name(&self) -> &'static str {
         "LigatureSubstFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LigatureSubstFormat1")
+    }
 }
 
 impl Validate for LigatureSubstFormat1 {
@@ -748,6 +769,9 @@ impl FontWrite for LigatureSet {
     fn name(&self) -> &'static str {
         "LigatureSet"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LigatureSet")
+    }
 }
 
 impl Validate for LigatureSet {
@@ -808,6 +832,9 @@ impl FontWrite for Ligature {
     }
     fn name(&self) -> &'static str {
         "Ligature"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Ligature")
     }
 }
 
@@ -931,15 +958,15 @@ impl FontWrite for ExtensionSubtable {
             Self::Reverse(_) => "ExtensionSubtable.Reverse",
         }
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Single(table) => table.type_(),
-            Self::Multiple(table) => table.type_(),
-            Self::Alternate(table) => table.type_(),
-            Self::Ligature(table) => table.type_(),
-            Self::Contextual(table) => table.type_(),
-            Self::ChainContextual(table) => table.type_(),
-            Self::Reverse(table) => table.type_(),
+            Self::Single(table) => table.table_type(),
+            Self::Multiple(table) => table.table_type(),
+            Self::Alternate(table) => table.table_type(),
+            Self::Ligature(table) => table.table_type(),
+            Self::Contextual(table) => table.table_type(),
+            Self::ChainContextual(table) => table.table_type(),
+            Self::Reverse(table) => table.table_type(),
         }
     }
 }
@@ -1038,6 +1065,9 @@ impl FontWrite for ReverseChainSingleSubstFormat1 {
     }
     fn name(&self) -> &'static str {
         "ReverseChainSingleSubstFormat1"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ReverseChainSingleSubstFormat1")
     }
 }
 

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -50,6 +50,9 @@ impl FontWrite for Gsub {
     fn name(&self) -> &'static str {
         "Gsub"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Gsub::TAG)
+    }
 }
 
 impl Validate for Gsub {
@@ -136,6 +139,18 @@ impl FontWrite for SubstitutionLookup {
             Self::ChainContextual(_) => "SubstitutionLookup.ChainContextual",
             Self::Extension(_) => "SubstitutionLookup.Extension",
             Self::Reverse(_) => "SubstitutionLookup.Reverse",
+        }
+    }
+    fn type_(&self) -> TableType {
+        match self {
+            Self::Single(table) => table.type_(),
+            Self::Multiple(table) => table.type_(),
+            Self::Alternate(table) => table.type_(),
+            Self::Ligature(table) => table.type_(),
+            Self::Contextual(table) => table.type_(),
+            Self::ChainContextual(table) => table.type_(),
+            Self::Extension(table) => table.type_(),
+            Self::Reverse(table) => table.type_(),
         }
     }
 }
@@ -914,6 +929,17 @@ impl FontWrite for ExtensionSubtable {
             Self::Contextual(_) => "ExtensionSubtable.Contextual",
             Self::ChainContextual(_) => "ExtensionSubtable.ChainContextual",
             Self::Reverse(_) => "ExtensionSubtable.Reverse",
+        }
+    }
+    fn type_(&self) -> TableType {
+        match self {
+            Self::Single(table) => table.type_(),
+            Self::Multiple(table) => table.type_(),
+            Self::Alternate(table) => table.type_(),
+            Self::Ligature(table) => table.type_(),
+            Self::Contextual(table) => table.type_(),
+            Self::ChainContextual(table) => table.type_(),
+            Self::Reverse(table) => table.type_(),
         }
     }
 }

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -35,6 +35,9 @@ impl FontWrite for Gvar {
     fn name(&self) -> &'static str {
         "Gvar"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Gvar::TAG)
+    }
 }
 
 impl Validate for Gvar {

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -35,7 +35,7 @@ impl FontWrite for Gvar {
     fn name(&self) -> &'static str {
         "Gvar"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Gvar::TAG)
     }
 }
@@ -82,6 +82,9 @@ impl FontWrite for SharedTuples {
     }
     fn name(&self) -> &'static str {
         "SharedTuples"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SharedTuples")
     }
 }
 

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -32,9 +32,6 @@ impl FontWrite for Gvar {
         (self.compute_data_array_offset() as u32).write_into(writer);
         (self.compile_variation_data()).write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Gvar"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Gvar::TAG)
     }
@@ -79,9 +76,6 @@ impl SharedTuples {
 impl FontWrite for SharedTuples {
     fn write_into(&self, writer: &mut TableWriter) {
         self.tuples.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SharedTuples"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SharedTuples")

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -141,6 +141,9 @@ impl FontWrite for Head {
     fn name(&self) -> &'static str {
         "Head"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Head::TAG)
+    }
 }
 
 impl Validate for Head {

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -141,7 +141,7 @@ impl FontWrite for Head {
     fn name(&self) -> &'static str {
         "Head"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Head::TAG)
     }
 }

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -138,9 +138,6 @@ impl FontWrite for Head {
         self.index_to_loc_format.write_into(writer);
         (0 as i16).write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Head"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Head::TAG)
     }

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -94,6 +94,9 @@ impl FontWrite for Hhea {
     fn name(&self) -> &'static str {
         "Hhea"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Hhea::TAG)
+    }
 }
 
 impl Validate for Hhea {

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -91,9 +91,6 @@ impl FontWrite for Hhea {
         (0 as i16).write_into(writer);
         self.number_of_long_metrics.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Hhea"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Hhea::TAG)
     }

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -94,7 +94,7 @@ impl FontWrite for Hhea {
     fn name(&self) -> &'static str {
         "Hhea"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Hhea::TAG)
     }
 }

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -31,9 +31,6 @@ impl FontWrite for Hmtx {
         self.h_metrics.write_into(writer);
         self.left_side_bearings.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Hmtx"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Hmtx::TAG)
     }
@@ -90,9 +87,6 @@ impl FontWrite for LongMetric {
     fn write_into(&self, writer: &mut TableWriter) {
         self.advance.write_into(writer);
         self.side_bearing.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "LongMetric"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("LongMetric")

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -34,6 +34,9 @@ impl FontWrite for Hmtx {
     fn name(&self) -> &'static str {
         "Hmtx"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Hmtx::TAG)
+    }
 }
 
 impl Validate for Hmtx {

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -34,7 +34,7 @@ impl FontWrite for Hmtx {
     fn name(&self) -> &'static str {
         "Hmtx"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Hmtx::TAG)
     }
 }
@@ -93,6 +93,9 @@ impl FontWrite for LongMetric {
     }
     fn name(&self) -> &'static str {
         "LongMetric"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LongMetric")
     }
 }
 

--- a/write-fonts/generated/generated_hvar.rs
+++ b/write-fonts/generated/generated_hvar.rs
@@ -51,7 +51,7 @@ impl FontWrite for Hvar {
     fn name(&self) -> &'static str {
         "Hvar"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Hvar::TAG)
     }
 }

--- a/write-fonts/generated/generated_hvar.rs
+++ b/write-fonts/generated/generated_hvar.rs
@@ -51,6 +51,9 @@ impl FontWrite for Hvar {
     fn name(&self) -> &'static str {
         "Hvar"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Hvar::TAG)
+    }
 }
 
 impl Validate for Hvar {

--- a/write-fonts/generated/generated_hvar.rs
+++ b/write-fonts/generated/generated_hvar.rs
@@ -48,9 +48,6 @@ impl FontWrite for Hvar {
         self.lsb_mapping.write_into(writer);
         self.rsb_mapping.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Hvar"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Hvar::TAG)
     }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -32,6 +32,9 @@ impl FontWrite for ScriptList {
     fn name(&self) -> &'static str {
         "ScriptList"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ScriptList")
+    }
 }
 
 impl Validate for ScriptList {
@@ -91,6 +94,9 @@ impl FontWrite for ScriptRecord {
     fn name(&self) -> &'static str {
         "ScriptRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ScriptRecord")
+    }
 }
 
 impl Validate for ScriptRecord {
@@ -141,6 +147,9 @@ impl FontWrite for Script {
     }
     fn name(&self) -> &'static str {
         "Script"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Script")
     }
 }
 
@@ -203,6 +212,9 @@ impl FontWrite for LangSysRecord {
     }
     fn name(&self) -> &'static str {
         "LangSysRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LangSysRecord")
     }
 }
 
@@ -268,6 +280,9 @@ impl FontWrite for LangSys {
     fn name(&self) -> &'static str {
         "LangSys"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LangSys")
+    }
 }
 
 impl Validate for LangSys {
@@ -325,6 +340,9 @@ impl FontWrite for FeatureList {
     }
     fn name(&self) -> &'static str {
         "FeatureList"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatureList")
     }
 }
 
@@ -386,6 +404,9 @@ impl FontWrite for FeatureRecord {
     fn name(&self) -> &'static str {
         "FeatureRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatureRecord")
+    }
 }
 
 impl Validate for FeatureRecord {
@@ -439,6 +460,9 @@ impl FontWrite for Feature {
     }
     fn name(&self) -> &'static str {
         "Feature"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Feature")
     }
 }
 
@@ -494,6 +518,9 @@ impl<T: FontWrite> FontWrite for LookupList<T> {
     }
     fn name(&self) -> &'static str {
         "LookupList"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LookupList")
     }
 }
 
@@ -614,6 +641,9 @@ impl FontWrite for CoverageFormat1 {
     fn name(&self) -> &'static str {
         "CoverageFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CoverageFormat1")
+    }
 }
 
 impl Validate for CoverageFormat1 {
@@ -671,6 +701,9 @@ impl FontWrite for CoverageFormat2 {
     }
     fn name(&self) -> &'static str {
         "CoverageFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CoverageFormat2")
     }
 }
 
@@ -735,6 +768,9 @@ impl FontWrite for RangeRecord {
     }
     fn name(&self) -> &'static str {
         "RangeRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("RangeRecord")
     }
 }
 
@@ -850,6 +886,9 @@ impl FontWrite for ClassDefFormat1 {
     fn name(&self) -> &'static str {
         "ClassDefFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassDefFormat1")
+    }
 }
 
 impl Validate for ClassDefFormat1 {
@@ -908,6 +947,9 @@ impl FontWrite for ClassDefFormat2 {
     }
     fn name(&self) -> &'static str {
         "ClassDefFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassDefFormat2")
     }
 }
 
@@ -972,6 +1014,9 @@ impl FontWrite for ClassRangeRecord {
     }
     fn name(&self) -> &'static str {
         "ClassRangeRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassRangeRecord")
     }
 }
 
@@ -1089,6 +1134,9 @@ impl FontWrite for SequenceLookupRecord {
     fn name(&self) -> &'static str {
         "SequenceLookupRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequenceLookupRecord")
+    }
 }
 
 impl Validate for SequenceLookupRecord {
@@ -1135,6 +1183,9 @@ impl FontWrite for SequenceContextFormat1 {
     }
     fn name(&self) -> &'static str {
         "SequenceContextFormat1"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequenceContextFormat1")
     }
 }
 
@@ -1206,6 +1257,9 @@ impl FontWrite for SequenceRuleSet {
     fn name(&self) -> &'static str {
         "SequenceRuleSet"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequenceRuleSet")
+    }
 }
 
 impl Validate for SequenceRuleSet {
@@ -1270,6 +1324,9 @@ impl FontWrite for SequenceRule {
     }
     fn name(&self) -> &'static str {
         "SequenceRule"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequenceRule")
     }
 }
 
@@ -1345,6 +1402,9 @@ impl FontWrite for SequenceContextFormat2 {
     }
     fn name(&self) -> &'static str {
         "SequenceContextFormat2"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequenceContextFormat2")
     }
 }
 
@@ -1423,6 +1483,9 @@ impl FontWrite for ClassSequenceRuleSet {
     fn name(&self) -> &'static str {
         "ClassSequenceRuleSet"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassSequenceRuleSet")
+    }
 }
 
 impl Validate for ClassSequenceRuleSet {
@@ -1492,6 +1555,9 @@ impl FontWrite for ClassSequenceRule {
     fn name(&self) -> &'static str {
         "ClassSequenceRule"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassSequenceRule")
+    }
 }
 
 impl Validate for ClassSequenceRule {
@@ -1560,6 +1626,9 @@ impl FontWrite for SequenceContextFormat3 {
     }
     fn name(&self) -> &'static str {
         "SequenceContextFormat3"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SequenceContextFormat3")
     }
 }
 
@@ -1732,6 +1801,9 @@ impl FontWrite for ChainedSequenceContextFormat1 {
     fn name(&self) -> &'static str {
         "ChainedSequenceContextFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedSequenceContextFormat1")
+    }
 }
 
 impl Validate for ChainedSequenceContextFormat1 {
@@ -1804,6 +1876,9 @@ impl FontWrite for ChainedSequenceRuleSet {
     }
     fn name(&self) -> &'static str {
         "ChainedSequenceRuleSet"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedSequenceRuleSet")
     }
 }
 
@@ -1892,6 +1967,9 @@ impl FontWrite for ChainedSequenceRule {
     }
     fn name(&self) -> &'static str {
         "ChainedSequenceRule"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedSequenceRule")
     }
 }
 
@@ -1998,6 +2076,9 @@ impl FontWrite for ChainedSequenceContextFormat2 {
     fn name(&self) -> &'static str {
         "ChainedSequenceContextFormat2"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedSequenceContextFormat2")
+    }
 }
 
 impl Validate for ChainedSequenceContextFormat2 {
@@ -2085,6 +2166,9 @@ impl FontWrite for ChainedClassSequenceRuleSet {
     }
     fn name(&self) -> &'static str {
         "ChainedClassSequenceRuleSet"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedClassSequenceRuleSet")
     }
 }
 
@@ -2174,6 +2258,9 @@ impl FontWrite for ChainedClassSequenceRule {
     }
     fn name(&self) -> &'static str {
         "ChainedClassSequenceRule"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedClassSequenceRule")
     }
 }
 
@@ -2274,6 +2361,9 @@ impl FontWrite for ChainedSequenceContextFormat3 {
     }
     fn name(&self) -> &'static str {
         "ChainedSequenceContextFormat3"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ChainedSequenceContextFormat3")
     }
 }
 
@@ -2481,6 +2571,9 @@ impl FontWrite for Device {
     fn name(&self) -> &'static str {
         "Device"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Device")
+    }
 }
 
 impl Validate for Device {
@@ -2540,6 +2633,9 @@ impl FontWrite for VariationIndex {
     fn name(&self) -> &'static str {
         "VariationIndex"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("VariationIndex")
+    }
 }
 
 impl Validate for VariationIndex {
@@ -2593,6 +2689,9 @@ impl FontWrite for FeatureVariations {
     }
     fn name(&self) -> &'static str {
         "FeatureVariations"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatureVariations")
     }
 }
 
@@ -2659,6 +2758,9 @@ impl FontWrite for FeatureVariationRecord {
     fn name(&self) -> &'static str {
         "FeatureVariationRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatureVariationRecord")
+    }
 }
 
 impl Validate for FeatureVariationRecord {
@@ -2713,6 +2815,9 @@ impl FontWrite for ConditionSet {
     }
     fn name(&self) -> &'static str {
         "ConditionSet"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ConditionSet")
     }
 }
 
@@ -2786,6 +2891,9 @@ impl FontWrite for ConditionFormat1 {
     fn name(&self) -> &'static str {
         "ConditionFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ConditionFormat1")
+    }
 }
 
 impl Validate for ConditionFormat1 {
@@ -2836,6 +2944,9 @@ impl FontWrite for FeatureTableSubstitution {
     }
     fn name(&self) -> &'static str {
         "FeatureTableSubstitution"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatureTableSubstitution")
     }
 }
 
@@ -2905,6 +3016,9 @@ impl FontWrite for FeatureTableSubstitutionRecord {
     }
     fn name(&self) -> &'static str {
         "FeatureTableSubstitutionRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FeatureTableSubstitutionRecord")
     }
 }
 
@@ -2996,6 +3110,9 @@ impl FontWrite for SizeParams {
     fn name(&self) -> &'static str {
         "SizeParams"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SizeParams")
+    }
 }
 
 impl Validate for SizeParams {
@@ -3051,6 +3168,9 @@ impl FontWrite for StylisticSetParams {
     }
     fn name(&self) -> &'static str {
         "StylisticSetParams"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("StylisticSetParams")
     }
 }
 
@@ -3135,6 +3255,9 @@ impl FontWrite for CharacterVariantParams {
     }
     fn name(&self) -> &'static str {
         "CharacterVariantParams"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CharacterVariantParams")
     }
 }
 

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -29,9 +29,6 @@ impl FontWrite for ScriptList {
         (array_len(&self.script_records).unwrap() as u16).write_into(writer);
         self.script_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ScriptList"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ScriptList")
     }
@@ -91,9 +88,6 @@ impl FontWrite for ScriptRecord {
         self.script_tag.write_into(writer);
         self.script.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ScriptRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ScriptRecord")
     }
@@ -144,9 +138,6 @@ impl FontWrite for Script {
         self.default_lang_sys.write_into(writer);
         (array_len(&self.lang_sys_records).unwrap() as u16).write_into(writer);
         self.lang_sys_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Script"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Script")
@@ -209,9 +200,6 @@ impl FontWrite for LangSysRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.lang_sys_tag.write_into(writer);
         self.lang_sys.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "LangSysRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("LangSysRecord")
@@ -277,9 +265,6 @@ impl FontWrite for LangSys {
         (array_len(&self.feature_indices).unwrap() as u16).write_into(writer);
         self.feature_indices.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "LangSys"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("LangSys")
     }
@@ -337,9 +322,6 @@ impl FontWrite for FeatureList {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.feature_records).unwrap() as u16).write_into(writer);
         self.feature_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "FeatureList"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatureList")
@@ -401,9 +383,6 @@ impl FontWrite for FeatureRecord {
         self.feature_tag.write_into(writer);
         self.feature.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "FeatureRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatureRecord")
     }
@@ -457,9 +436,6 @@ impl FontWrite for Feature {
         self.feature_params.write_into(writer);
         (array_len(&self.lookup_list_indices).unwrap() as u16).write_into(writer);
         self.lookup_list_indices.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Feature"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Feature")
@@ -515,9 +491,6 @@ impl<T: FontWrite> FontWrite for LookupList<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.lookups).unwrap() as u16).write_into(writer);
         self.lookups.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "LookupList"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("LookupList")
@@ -638,9 +611,6 @@ impl FontWrite for CoverageFormat1 {
         (array_len(&self.glyph_array).unwrap() as u16).write_into(writer);
         self.glyph_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "CoverageFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("CoverageFormat1")
     }
@@ -698,9 +668,6 @@ impl FontWrite for CoverageFormat2 {
         (2 as u16).write_into(writer);
         (array_len(&self.range_records).unwrap() as u16).write_into(writer);
         self.range_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "CoverageFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("CoverageFormat2")
@@ -766,9 +733,6 @@ impl FontWrite for RangeRecord {
         self.end_glyph_id.write_into(writer);
         self.start_coverage_index.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "RangeRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("RangeRecord")
     }
@@ -820,10 +784,10 @@ impl FontWrite for CoverageTable {
             Self::Format2(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "CoverageTable.Format1",
-            Self::Format2(_) => "CoverageTable.Format2",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
         }
     }
 }
@@ -883,9 +847,6 @@ impl FontWrite for ClassDefFormat1 {
         (array_len(&self.class_value_array).unwrap() as u16).write_into(writer);
         self.class_value_array.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ClassDefFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ClassDefFormat1")
     }
@@ -944,9 +905,6 @@ impl FontWrite for ClassDefFormat2 {
         (2 as u16).write_into(writer);
         (array_len(&self.class_range_records).unwrap() as u16).write_into(writer);
         self.class_range_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ClassDefFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ClassDefFormat2")
@@ -1012,9 +970,6 @@ impl FontWrite for ClassRangeRecord {
         self.end_glyph_id.write_into(writer);
         self.class.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ClassRangeRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ClassRangeRecord")
     }
@@ -1072,10 +1027,10 @@ impl FontWrite for ClassDef {
             Self::Format2(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "ClassDef.Format1",
-            Self::Format2(_) => "ClassDef.Format2",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
         }
     }
 }
@@ -1131,9 +1086,6 @@ impl FontWrite for SequenceLookupRecord {
         self.sequence_index.write_into(writer);
         self.lookup_list_index.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "SequenceLookupRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("SequenceLookupRecord")
     }
@@ -1180,9 +1132,6 @@ impl FontWrite for SequenceContextFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.seq_rule_sets).unwrap() as u16).write_into(writer);
         self.seq_rule_sets.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SequenceContextFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SequenceContextFormat1")
@@ -1254,9 +1203,6 @@ impl FontWrite for SequenceRuleSet {
         (array_len(&self.seq_rules).unwrap() as u16).write_into(writer);
         self.seq_rules.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "SequenceRuleSet"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("SequenceRuleSet")
     }
@@ -1321,9 +1267,6 @@ impl FontWrite for SequenceRule {
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.input_sequence.write_into(writer);
         self.seq_lookup_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SequenceRule"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SequenceRule")
@@ -1399,9 +1342,6 @@ impl FontWrite for SequenceContextFormat2 {
         self.class_def.write_into(writer);
         (array_len(&self.class_seq_rule_sets).unwrap() as u16).write_into(writer);
         self.class_seq_rule_sets.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SequenceContextFormat2"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SequenceContextFormat2")
@@ -1480,9 +1420,6 @@ impl FontWrite for ClassSequenceRuleSet {
         (array_len(&self.class_seq_rules).unwrap() as u16).write_into(writer);
         self.class_seq_rules.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ClassSequenceRuleSet"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ClassSequenceRuleSet")
     }
@@ -1552,9 +1489,6 @@ impl FontWrite for ClassSequenceRule {
         self.input_sequence.write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ClassSequenceRule"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ClassSequenceRule")
     }
@@ -1623,9 +1557,6 @@ impl FontWrite for SequenceContextFormat3 {
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.coverages.write_into(writer);
         self.seq_lookup_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "SequenceContextFormat3"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("SequenceContextFormat3")
@@ -1727,11 +1658,11 @@ impl FontWrite for SequenceContext {
             Self::Format3(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "SequenceContext.Format1",
-            Self::Format2(_) => "SequenceContext.Format2",
-            Self::Format3(_) => "SequenceContext.Format3",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
         }
     }
 }
@@ -1797,9 +1728,6 @@ impl FontWrite for ChainedSequenceContextFormat1 {
         self.coverage.write_into(writer);
         (array_len(&self.chained_seq_rule_sets).unwrap() as u16).write_into(writer);
         self.chained_seq_rule_sets.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ChainedSequenceContextFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedSequenceContextFormat1")
@@ -1873,9 +1801,6 @@ impl FontWrite for ChainedSequenceRuleSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.chained_seq_rules).unwrap() as u16).write_into(writer);
         self.chained_seq_rules.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ChainedSequenceRuleSet"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedSequenceRuleSet")
@@ -1964,9 +1889,6 @@ impl FontWrite for ChainedSequenceRule {
         self.lookahead_sequence.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ChainedSequenceRule"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedSequenceRule")
@@ -2073,9 +1995,6 @@ impl FontWrite for ChainedSequenceContextFormat2 {
         (array_len(&self.chained_class_seq_rule_sets).unwrap() as u16).write_into(writer);
         self.chained_class_seq_rule_sets.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ChainedSequenceContextFormat2"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedSequenceContextFormat2")
     }
@@ -2163,9 +2082,6 @@ impl FontWrite for ChainedClassSequenceRuleSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.chained_class_seq_rules).unwrap() as u16).write_into(writer);
         self.chained_class_seq_rules.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ChainedClassSequenceRuleSet"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedClassSequenceRuleSet")
@@ -2255,9 +2171,6 @@ impl FontWrite for ChainedClassSequenceRule {
         self.lookahead_sequence.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ChainedClassSequenceRule"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedClassSequenceRule")
@@ -2358,9 +2271,6 @@ impl FontWrite for ChainedSequenceContextFormat3 {
         self.lookahead_coverages.write_into(writer);
         (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
         self.seq_lookup_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ChainedSequenceContextFormat3"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ChainedSequenceContextFormat3")
@@ -2499,11 +2409,11 @@ impl FontWrite for ChainedSequenceContext {
             Self::Format3(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "ChainedSequenceContext.Format1",
-            Self::Format2(_) => "ChainedSequenceContext.Format2",
-            Self::Format3(_) => "ChainedSequenceContext.Format3",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
         }
     }
 }
@@ -2568,9 +2478,6 @@ impl FontWrite for Device {
         self.delta_format.write_into(writer);
         self.delta_value.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Device"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Device")
     }
@@ -2630,9 +2537,6 @@ impl FontWrite for VariationIndex {
         self.delta_set_inner_index.write_into(writer);
         self.delta_format.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "VariationIndex"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("VariationIndex")
     }
@@ -2686,9 +2590,6 @@ impl FontWrite for FeatureVariations {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         (array_len(&self.feature_variation_records).unwrap() as u32).write_into(writer);
         self.feature_variation_records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "FeatureVariations"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatureVariations")
@@ -2755,9 +2656,6 @@ impl FontWrite for FeatureVariationRecord {
         self.condition_set.write_into(writer);
         self.feature_table_substitution.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "FeatureVariationRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatureVariationRecord")
     }
@@ -2812,9 +2710,6 @@ impl FontWrite for ConditionSet {
     fn write_into(&self, writer: &mut TableWriter) {
         (array_len(&self.conditions).unwrap() as u16).write_into(writer);
         self.conditions.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ConditionSet"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ConditionSet")
@@ -2888,9 +2783,6 @@ impl FontWrite for ConditionFormat1 {
         self.filter_range_min_value.write_into(writer);
         self.filter_range_max_value.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "ConditionFormat1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("ConditionFormat1")
     }
@@ -2941,9 +2833,6 @@ impl FontWrite for FeatureTableSubstitution {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         (array_len(&self.substitutions).unwrap() as u16).write_into(writer);
         self.substitutions.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "FeatureTableSubstitution"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatureTableSubstitution")
@@ -3013,9 +2902,6 @@ impl FontWrite for FeatureTableSubstitutionRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.feature_index.write_into(writer);
         self.alternate_feature.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "FeatureTableSubstitutionRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("FeatureTableSubstitutionRecord")
@@ -3107,9 +2993,6 @@ impl FontWrite for SizeParams {
         self.range_start.write_into(writer);
         self.range_end.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "SizeParams"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("SizeParams")
     }
@@ -3165,9 +3048,6 @@ impl FontWrite for StylisticSetParams {
     fn write_into(&self, writer: &mut TableWriter) {
         (0 as u16).write_into(writer);
         self.ui_name_id.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "StylisticSetParams"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("StylisticSetParams")
@@ -3252,9 +3132,6 @@ impl FontWrite for CharacterVariantParams {
         self.first_param_ui_label_name_id.write_into(writer);
         (array_len(&self.character).unwrap() as u16).write_into(writer);
         self.character.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "CharacterVariantParams"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("CharacterVariantParams")

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -140,7 +140,7 @@ impl FontWrite for Maxp {
     fn name(&self) -> &'static str {
         "Maxp"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Maxp::TAG)
     }
 }

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -140,6 +140,9 @@ impl FontWrite for Maxp {
     fn name(&self) -> &'static str {
         "Maxp"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Maxp::TAG)
+    }
 }
 
 impl Validate for Maxp {

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -137,9 +137,6 @@ impl FontWrite for Maxp {
                 .write_into(writer)
         });
     }
-    fn name(&self) -> &'static str {
-        "Maxp"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Maxp::TAG)
     }

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -47,9 +47,6 @@ impl FontWrite for Name {
             });
         });
     }
-    fn name(&self) -> &'static str {
-        "Name"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Name::TAG)
     }
@@ -125,9 +122,6 @@ impl FontWrite for LangTagRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         (self.compile_name_string()).write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "LangTagRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("LangTagRecord")
     }
@@ -188,9 +182,6 @@ impl FontWrite for NameRecord {
         self.language_id.write_into(writer);
         self.name_id.write_into(writer);
         (self.compile_name_string()).write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "NameRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("NameRecord")

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -50,7 +50,7 @@ impl FontWrite for Name {
     fn name(&self) -> &'static str {
         "Name"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Name::TAG)
     }
 }
@@ -128,6 +128,9 @@ impl FontWrite for LangTagRecord {
     fn name(&self) -> &'static str {
         "LangTagRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("LangTagRecord")
+    }
 }
 
 impl Validate for LangTagRecord {
@@ -188,6 +191,9 @@ impl FontWrite for NameRecord {
     }
     fn name(&self) -> &'static str {
         "NameRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("NameRecord")
     }
 }
 

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -50,6 +50,9 @@ impl FontWrite for Name {
     fn name(&self) -> &'static str {
         "Name"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Name::TAG)
+    }
 }
 
 impl Validate for Name {

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -272,7 +272,7 @@ impl FontWrite for Os2 {
     fn name(&self) -> &'static str {
         "Os2"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Os2::TAG)
     }
 }

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -272,6 +272,9 @@ impl FontWrite for Os2 {
     fn name(&self) -> &'static str {
         "Os2"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Os2::TAG)
+    }
 }
 
 impl Validate for Os2 {

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -269,9 +269,6 @@ impl FontWrite for Os2 {
                 .write_into(writer)
         });
     }
-    fn name(&self) -> &'static str {
-        "Os2"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Os2::TAG)
     }

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -128,9 +128,6 @@ impl FontWrite for Post {
                 .write_into(writer)
         });
     }
-    fn name(&self) -> &'static str {
-        "Post"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Post::TAG)
     }

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -131,7 +131,7 @@ impl FontWrite for Post {
     fn name(&self) -> &'static str {
         "Post"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Post::TAG)
     }
 }

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -131,6 +131,9 @@ impl FontWrite for Post {
     fn name(&self) -> &'static str {
         "Post"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Post::TAG)
+    }
 }
 
 impl Validate for Post {

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -46,6 +46,9 @@ impl FontWrite for Stat {
     fn name(&self) -> &'static str {
         "Stat"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Stat::TAG)
+    }
 }
 
 impl Validate for Stat {

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -46,7 +46,7 @@ impl FontWrite for Stat {
     fn name(&self) -> &'static str {
         "Stat"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Stat::TAG)
     }
 }
@@ -127,6 +127,9 @@ impl FontWrite for AxisRecord {
     fn name(&self) -> &'static str {
         "AxisRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisRecord")
+    }
 }
 
 impl Validate for AxisRecord {
@@ -166,6 +169,9 @@ impl FontWrite for AxisValueArray {
     }
     fn name(&self) -> &'static str {
         "AxisValueArray"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueArray")
     }
 }
 
@@ -364,6 +370,9 @@ impl FontWrite for AxisValueFormat1 {
     fn name(&self) -> &'static str {
         "AxisValueFormat1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueFormat1")
+    }
 }
 
 impl Validate for AxisValueFormat1 {
@@ -447,6 +456,9 @@ impl FontWrite for AxisValueFormat2 {
     fn name(&self) -> &'static str {
         "AxisValueFormat2"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueFormat2")
+    }
 }
 
 impl Validate for AxisValueFormat2 {
@@ -525,6 +537,9 @@ impl FontWrite for AxisValueFormat3 {
     fn name(&self) -> &'static str {
         "AxisValueFormat3"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueFormat3")
+    }
 }
 
 impl Validate for AxisValueFormat3 {
@@ -592,6 +607,9 @@ impl FontWrite for AxisValueFormat4 {
     fn name(&self) -> &'static str {
         "AxisValueFormat4"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueFormat4")
+    }
 }
 
 impl Validate for AxisValueFormat4 {
@@ -651,6 +669,9 @@ impl FontWrite for AxisValueRecord {
     }
     fn name(&self) -> &'static str {
         "AxisValueRecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("AxisValueRecord")
     }
 }
 

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -43,9 +43,6 @@ impl FontWrite for Stat {
                 .write_into(writer)
         });
     }
-    fn name(&self) -> &'static str {
-        "Stat"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Stat::TAG)
     }
@@ -124,9 +121,6 @@ impl FontWrite for AxisRecord {
         self.axis_name_id.write_into(writer);
         self.axis_ordering.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AxisRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisRecord")
     }
@@ -166,9 +160,6 @@ impl AxisValueArray {
 impl FontWrite for AxisValueArray {
     fn write_into(&self, writer: &mut TableWriter) {
         self.axis_values.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AxisValueArray"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueArray")
@@ -284,12 +275,12 @@ impl FontWrite for AxisValue {
             Self::Format4(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "AxisValue.Format1",
-            Self::Format2(_) => "AxisValue.Format2",
-            Self::Format3(_) => "AxisValue.Format3",
-            Self::Format4(_) => "AxisValue.Format4",
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
+            Self::Format4(item) => item.table_type(),
         }
     }
 }
@@ -366,9 +357,6 @@ impl FontWrite for AxisValueFormat1 {
         self.flags.write_into(writer);
         self.value_name_id.write_into(writer);
         self.value.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AxisValueFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueFormat1")
@@ -453,9 +441,6 @@ impl FontWrite for AxisValueFormat2 {
         self.range_min_value.write_into(writer);
         self.range_max_value.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AxisValueFormat2"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueFormat2")
     }
@@ -534,9 +519,6 @@ impl FontWrite for AxisValueFormat3 {
         self.value.write_into(writer);
         self.linked_value.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AxisValueFormat3"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueFormat3")
     }
@@ -604,9 +586,6 @@ impl FontWrite for AxisValueFormat4 {
         self.value_name_id.write_into(writer);
         self.axis_values.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "AxisValueFormat4"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueFormat4")
     }
@@ -666,9 +645,6 @@ impl FontWrite for AxisValueRecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.axis_index.write_into(writer);
         self.value.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "AxisValueRecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("AxisValueRecord")

--- a/write-fonts/generated/generated_test_enum.rs
+++ b/write-fonts/generated/generated_test_enum.rs
@@ -39,9 +39,6 @@ impl FontWrite for MyRecord {
         self.my_enum1.write_into(writer);
         self.my_enum2.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "MyRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("MyRecord")
     }

--- a/write-fonts/generated/generated_test_enum.rs
+++ b/write-fonts/generated/generated_test_enum.rs
@@ -42,6 +42,9 @@ impl FontWrite for MyRecord {
     fn name(&self) -> &'static str {
         "MyRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("MyRecord")
+    }
 }
 
 impl Validate for MyRecord {

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -25,9 +25,6 @@ impl FontWrite for Table1 {
         self.heft.write_into(writer);
         self.flex.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Table1"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Table1")
     }
@@ -76,9 +73,6 @@ impl FontWrite for Table2 {
         (array_len(&self.values).unwrap() as u16).write_into(writer);
         self.values.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Table2"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Table2")
     }
@@ -124,9 +118,6 @@ impl FontWrite for Table3 {
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
         self.something.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Table3"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Table3")
@@ -187,11 +178,11 @@ impl FontWrite for MyTable {
             Self::Format3(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format1(_) => "MyTable.Format1",
-            Self::MyFormat22(_) => "MyTable.MyFormat22",
-            Self::Format3(_) => "MyTable.Format3",
+            Self::Format1(item) => item.table_type(),
+            Self::MyFormat22(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
         }
     }
 }

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -28,6 +28,9 @@ impl FontWrite for Table1 {
     fn name(&self) -> &'static str {
         "Table1"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Table1")
+    }
 }
 
 impl Validate for Table1 {
@@ -76,6 +79,9 @@ impl FontWrite for Table2 {
     fn name(&self) -> &'static str {
         "Table2"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Table2")
+    }
 }
 
 impl Validate for Table2 {
@@ -121,6 +127,9 @@ impl FontWrite for Table3 {
     }
     fn name(&self) -> &'static str {
         "Table3"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Table3")
     }
 }
 

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -63,9 +63,6 @@ impl FontWrite for KindsOfOffsets {
             .compatible((1, 1))
             .then(|| self.versioned_nullable.write_into(writer));
     }
-    fn name(&self) -> &'static str {
-        "KindsOfOffsets"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("KindsOfOffsets")
     }
@@ -167,9 +164,6 @@ impl FontWrite for KindsOfArraysOfOffsets {
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-    }
-    fn name(&self) -> &'static str {
-        "KindsOfArraysOfOffsets"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("KindsOfArraysOfOffsets")
@@ -296,9 +290,6 @@ impl FontWrite for KindsOfArrays {
                 .write_into(writer)
         });
     }
-    fn name(&self) -> &'static str {
-        "KindsOfArrays"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("KindsOfArrays")
     }
@@ -383,9 +374,6 @@ impl FontWrite for Dummy {
         self.value.write_into(writer);
         (0 as u16).write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Dummy"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Dummy")
     }
@@ -423,9 +411,6 @@ impl FontWrite for Shmecord {
     fn write_into(&self, writer: &mut TableWriter) {
         self.length.write_into(writer);
         self.breadth.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "Shmecord"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("Shmecord")

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -66,6 +66,9 @@ impl FontWrite for KindsOfOffsets {
     fn name(&self) -> &'static str {
         "KindsOfOffsets"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("KindsOfOffsets")
+    }
 }
 
 impl Validate for KindsOfOffsets {
@@ -167,6 +170,9 @@ impl FontWrite for KindsOfArraysOfOffsets {
     }
     fn name(&self) -> &'static str {
         "KindsOfArraysOfOffsets"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("KindsOfArraysOfOffsets")
     }
 }
 
@@ -293,6 +299,9 @@ impl FontWrite for KindsOfArrays {
     fn name(&self) -> &'static str {
         "KindsOfArrays"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("KindsOfArrays")
+    }
 }
 
 impl Validate for KindsOfArrays {
@@ -377,6 +386,9 @@ impl FontWrite for Dummy {
     fn name(&self) -> &'static str {
         "Dummy"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Dummy")
+    }
 }
 
 impl Validate for Dummy {
@@ -414,6 +426,9 @@ impl FontWrite for Shmecord {
     }
     fn name(&self) -> &'static str {
         "Shmecord"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Shmecord")
     }
 }
 

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -33,6 +33,9 @@ impl FontWrite for BasicTable {
     fn name(&self) -> &'static str {
         "BasicTable"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("BasicTable")
+    }
 }
 
 impl Validate for BasicTable {
@@ -99,6 +102,9 @@ impl FontWrite for SimpleRecord {
     fn name(&self) -> &'static str {
         "SimpleRecord"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("SimpleRecord")
+    }
 }
 
 impl Validate for SimpleRecord {
@@ -137,6 +143,9 @@ impl FontWrite for ContainsArrays {
     }
     fn name(&self) -> &'static str {
         "ContainsArrays"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ContainsArrays")
     }
 }
 
@@ -195,6 +204,9 @@ impl FontWrite for ContainsOffests {
     }
     fn name(&self) -> &'static str {
         "ContainsOffests"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ContainsOffests")
     }
 }
 

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -30,9 +30,6 @@ impl FontWrite for BasicTable {
         (array_len(&self.array_records).unwrap() as u32).write_into(writer);
         self.array_records.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "BasicTable"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("BasicTable")
     }
@@ -99,9 +96,6 @@ impl FontWrite for SimpleRecord {
         self.val1.write_into(writer);
         (self.compile_va2()).write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "SimpleRecord"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("SimpleRecord")
     }
@@ -140,9 +134,6 @@ impl FontWrite for ContainsArrays {
     fn write_into(&self, writer: &mut TableWriter) {
         self.scalars.write_into(writer);
         self.records.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ContainsArrays"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ContainsArrays")
@@ -201,9 +192,6 @@ impl FontWrite for ContainsOffests {
         (array_len(&self.array).unwrap() as u16).write_into(writer);
         self.array.write_into(writer);
         self.other.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ContainsOffests"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ContainsOffests")

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -39,6 +39,9 @@ impl FontWrite for TupleVariationHeader {
     fn name(&self) -> &'static str {
         "TupleVariationHeader"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("TupleVariationHeader")
+    }
 }
 
 impl Validate for TupleVariationHeader {
@@ -98,6 +101,9 @@ impl FontWrite for Tuple {
     fn name(&self) -> &'static str {
         "Tuple"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("Tuple")
+    }
 }
 
 impl Validate for Tuple {
@@ -153,6 +159,9 @@ impl FontWrite for DeltaSetIndexMapFormat0 {
     }
     fn name(&self) -> &'static str {
         "DeltaSetIndexMapFormat0"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("DeltaSetIndexMapFormat0")
     }
 }
 
@@ -221,6 +230,9 @@ impl FontWrite for DeltaSetIndexMapFormat1 {
     }
     fn name(&self) -> &'static str {
         "DeltaSetIndexMapFormat1"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("DeltaSetIndexMapFormat1")
     }
 }
 
@@ -362,6 +374,9 @@ impl FontWrite for VariationRegionList {
     fn name(&self) -> &'static str {
         "VariationRegionList"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("VariationRegionList")
+    }
 }
 
 impl Validate for VariationRegionList {
@@ -431,6 +446,9 @@ impl FontWrite for VariationRegion {
     fn name(&self) -> &'static str {
         "VariationRegion"
     }
+    fn table_type(&self) -> TableType {
+        TableType::Named("VariationRegion")
+    }
 }
 
 impl Validate for VariationRegion {
@@ -487,6 +505,9 @@ impl FontWrite for RegionAxisCoordinates {
     }
     fn name(&self) -> &'static str {
         "RegionAxisCoordinates"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("RegionAxisCoordinates")
     }
 }
 
@@ -545,6 +566,9 @@ impl FontWrite for ItemVariationStore {
     }
     fn name(&self) -> &'static str {
         "ItemVariationStore"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ItemVariationStore")
     }
 }
 
@@ -634,6 +658,9 @@ impl FontWrite for ItemVariationData {
     }
     fn name(&self) -> &'static str {
         "ItemVariationData"
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ItemVariationData")
     }
 }
 

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -36,9 +36,6 @@ impl FontWrite for TupleVariationHeader {
         self.intermediate_start_tuple.write_into(writer);
         self.intermediate_end_tuple.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "TupleVariationHeader"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("TupleVariationHeader")
     }
@@ -98,9 +95,6 @@ impl FontWrite for Tuple {
     fn write_into(&self, writer: &mut TableWriter) {
         self.values.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Tuple"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("Tuple")
     }
@@ -156,9 +150,6 @@ impl FontWrite for DeltaSetIndexMapFormat0 {
         self.entry_format.write_into(writer);
         self.map_count.write_into(writer);
         self.map_data.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "DeltaSetIndexMapFormat0"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("DeltaSetIndexMapFormat0")
@@ -227,9 +218,6 @@ impl FontWrite for DeltaSetIndexMapFormat1 {
         self.entry_format.write_into(writer);
         self.map_count.write_into(writer);
         self.map_data.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "DeltaSetIndexMapFormat1"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("DeltaSetIndexMapFormat1")
@@ -308,10 +296,10 @@ impl FontWrite for DeltaSetIndexMap {
             Self::Format1(item) => item.write_into(writer),
         }
     }
-    fn name(&self) -> &'static str {
+    fn table_type(&self) -> TableType {
         match self {
-            Self::Format0(_) => "DeltaSetIndexMap.Format0",
-            Self::Format1(_) => "DeltaSetIndexMap.Format1",
+            Self::Format0(item) => item.table_type(),
+            Self::Format1(item) => item.table_type(),
         }
     }
 }
@@ -370,9 +358,6 @@ impl FontWrite for VariationRegionList {
         (self.compute_axis_count() as u16).write_into(writer);
         (array_len(&self.variation_regions).unwrap() as u16).write_into(writer);
         self.variation_regions.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "VariationRegionList"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("VariationRegionList")
@@ -443,9 +428,6 @@ impl FontWrite for VariationRegion {
     fn write_into(&self, writer: &mut TableWriter) {
         self.region_axes.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "VariationRegion"
-    }
     fn table_type(&self) -> TableType {
         TableType::Named("VariationRegion")
     }
@@ -502,9 +484,6 @@ impl FontWrite for RegionAxisCoordinates {
         self.start_coord.write_into(writer);
         self.peak_coord.write_into(writer);
         self.end_coord.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "RegionAxisCoordinates"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("RegionAxisCoordinates")
@@ -563,9 +542,6 @@ impl FontWrite for ItemVariationStore {
         self.variation_region_list.write_into(writer);
         (array_len(&self.item_variation_datas).unwrap() as u16).write_into(writer);
         self.item_variation_datas.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ItemVariationStore"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ItemVariationStore")
@@ -655,9 +631,6 @@ impl FontWrite for ItemVariationData {
         (array_len(&self.region_indexes).unwrap() as u16).write_into(writer);
         self.region_indexes.write_into(writer);
         self.delta_sets.write_into(writer);
-    }
-    fn name(&self) -> &'static str {
-        "ItemVariationData"
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ItemVariationData")

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -93,6 +93,9 @@ impl FontWrite for Vhea {
     fn name(&self) -> &'static str {
         "Vhea"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Vhea::TAG)
+    }
 }
 
 impl Validate for Vhea {

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -90,9 +90,6 @@ impl FontWrite for Vhea {
         (0 as i16).write_into(writer);
         self.number_of_long_ver_metrics.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Vhea"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Vhea::TAG)
     }

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -93,7 +93,7 @@ impl FontWrite for Vhea {
     fn name(&self) -> &'static str {
         "Vhea"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Vhea::TAG)
     }
 }

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -33,7 +33,7 @@ impl FontWrite for Vmtx {
     fn name(&self) -> &'static str {
         "Vmtx"
     }
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::TopLevel(Vmtx::TAG)
     }
 }

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -30,9 +30,6 @@ impl FontWrite for Vmtx {
         self.v_metrics.write_into(writer);
         self.top_side_bearings.write_into(writer);
     }
-    fn name(&self) -> &'static str {
-        "Vmtx"
-    }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Vmtx::TAG)
     }

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -33,6 +33,9 @@ impl FontWrite for Vmtx {
     fn name(&self) -> &'static str {
         "Vmtx"
     }
+    fn type_(&self) -> TableType {
+        TableType::TopLevel(Vmtx::TAG)
+    }
 }
 
 impl Validate for Vmtx {

--- a/write-fonts/src/graph/graphviz.rs
+++ b/write-fonts/src/graph/graphviz.rs
@@ -102,12 +102,12 @@ impl<'a> dot2::Labeller<'a> for GraphVizGraph<'a> {
         let obj = &self.graph.objects[n];
         let node = &self.graph.nodes[n];
 
-        let name = if obj.name.is_empty() {
+        let name = if obj.type_.is_mock() {
             // if we have no name (generally because this is a test) then use
             // the object id instead.
             format!("{n:?} ({}B, S{})", obj.bytes.len(), node.space.0)
         } else {
-            format!("{} ({}B, S{})", obj.name, obj.bytes.len(), node.space.0)
+            format!("{} ({}B, S{})", obj.type_, obj.bytes.len(), node.space.0)
         };
         Ok(dot2::label::Text::LabelStr(name.into()))
     }

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -8,6 +8,7 @@ mod graph;
 mod offsets;
 pub mod pens;
 mod round;
+mod table_type;
 pub mod tables;
 pub mod util;
 pub mod validate;
@@ -34,6 +35,7 @@ pub(crate) mod codegen_prelude {
 
     pub use super::from_obj::{FromObjRef, FromTableRef, ToOwnedObj, ToOwnedTable};
     pub use super::offsets::{NullableOffsetMarker, OffsetMarker, WIDTH_16, WIDTH_24, WIDTH_32};
+    pub use super::table_type::TableType;
     pub use super::validate::{Validate, ValidationCtx};
     pub use super::write::{FontWrite, TableWriter};
     pub use std::collections::BTreeSet;

--- a/write-fonts/src/table_type.rs
+++ b/write-fonts/src/table_type.rs
@@ -1,0 +1,62 @@
+//! Identifiers for specific tables
+//!
+//! These are used to record the type of certain serialized tables & subtables
+//! that may require special attention while compiling the object graph.
+
+use font_types::Tag;
+use read::TopLevelTable;
+
+use crate::tables::layout::LookupType;
+
+/// A marker for identifying the original source of various compiled tables.
+///
+/// In the general case, once a table has been compiled we do not need to know
+/// what the bytes represent; however in certain special cases we do need this
+/// information, in order to try alternate compilation strategies.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TableType {
+    // a lookup with no special behaviour
+    #[default]
+    Unknown,
+    /// A top-level table
+    TopLevel(Tag),
+    GposLookup(u16),
+    GsubLookup(u16),
+}
+
+impl TableType {
+    pub(crate) const GSUB: TableType = TableType::TopLevel(crate::tables::gsub::Gsub::TAG);
+    pub(crate) const GPOS: TableType = TableType::TopLevel(crate::tables::gpos::Gpos::TAG);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tables::{gpos, gsub};
+    use crate::FontWrite;
+
+    use super::*;
+
+    #[test]
+    fn tagged_table_type() {
+        assert_eq!(gsub::Gsub::default().type_(), TableType::GSUB);
+        assert_eq!(gpos::Gpos::default().type_(), TableType::GPOS);
+
+        assert_eq!(
+            crate::tables::name::Name::default().type_(),
+            TableType::TopLevel(Tag::new(b"name"))
+        );
+    }
+
+    #[test]
+    fn promotable() {
+        assert_eq!(
+            gsub::SubstitutionLookup::Single(Default::default()).type_(),
+            TableType::GsubLookup(1)
+        );
+        assert_eq!(
+            gsub::SubstitutionLookup::Extension(Default::default()).type_(),
+            TableType::GsubLookup(7)
+        );
+    }
+}

--- a/write-fonts/src/tables/gpos.rs
+++ b/write-fonts/src/tables/gpos.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 //use super::layout::value_record::ValueRecord;
 use super::layout::{
     ChainedSequenceContext, ClassDef, CoverageTable, Device, FeatureList, FeatureVariations,
-    Lookup, LookupList, LookupType, ScriptList, SequenceContext,
+    Lookup, LookupList, LookupSubtable, LookupType, ScriptList, SequenceContext,
 };
 
 #[cfg(test)]
@@ -45,17 +45,17 @@ impl Gpos {
     }
 }
 
-super::layout::lookup_type!(SinglePos, 1);
-super::layout::lookup_type!(PairPos, 2);
-super::layout::lookup_type!(CursivePosFormat1, 3);
-super::layout::lookup_type!(MarkBasePosFormat1, 4);
-super::layout::lookup_type!(MarkLigPosFormat1, 5);
-super::layout::lookup_type!(MarkMarkPosFormat1, 6);
-super::layout::lookup_type!(PositionSequenceContext, 7);
-super::layout::lookup_type!(PositionChainContext, 8);
-super::layout::lookup_type!(ExtensionSubtable, 9);
+super::layout::lookup_type!(gpos, SinglePos, 1);
+super::layout::lookup_type!(gpos, PairPos, 2);
+super::layout::lookup_type!(gpos, CursivePosFormat1, 3);
+super::layout::lookup_type!(gpos, MarkBasePosFormat1, 4);
+super::layout::lookup_type!(gpos, MarkLigPosFormat1, 5);
+super::layout::lookup_type!(gpos, MarkMarkPosFormat1, 6);
+super::layout::lookup_type!(gpos, PositionSequenceContext, 7);
+super::layout::lookup_type!(gpos, PositionChainContext, 8);
+super::layout::lookup_type!(gpos, ExtensionSubtable, 9);
 
-impl<T: LookupType + FontWrite> FontWrite for ExtensionPosFormat1<T> {
+impl<T: LookupSubtable + FontWrite> FontWrite for ExtensionPosFormat1<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         1u16.write_into(writer);
         T::TYPE.write_into(writer);

--- a/write-fonts/src/tables/gsub.rs
+++ b/write-fonts/src/tables/gsub.rs
@@ -6,7 +6,7 @@ include!("../../generated/generated_gsub.rs");
 
 use super::layout::{
     ChainedSequenceContext, CoverageTable, FeatureList, FeatureVariations, Lookup, LookupList,
-    LookupType, ScriptList, SequenceContext,
+    LookupSubtable, LookupType, ScriptList, SequenceContext,
 };
 
 #[cfg(test)]
@@ -38,16 +38,16 @@ impl Gsub {
     }
 }
 
-super::layout::lookup_type!(SingleSubst, 1);
-super::layout::lookup_type!(MultipleSubstFormat1, 2);
-super::layout::lookup_type!(AlternateSubstFormat1, 3);
-super::layout::lookup_type!(LigatureSubstFormat1, 4);
-super::layout::lookup_type!(SubstitutionSequenceContext, 5);
-super::layout::lookup_type!(SubstitutionChainContext, 6);
-super::layout::lookup_type!(ExtensionSubtable, 7);
-super::layout::lookup_type!(ReverseChainSingleSubstFormat1, 8);
+super::layout::lookup_type!(gsub, SingleSubst, 1);
+super::layout::lookup_type!(gsub, MultipleSubstFormat1, 2);
+super::layout::lookup_type!(gsub, AlternateSubstFormat1, 3);
+super::layout::lookup_type!(gsub, LigatureSubstFormat1, 4);
+super::layout::lookup_type!(gsub, SubstitutionSequenceContext, 5);
+super::layout::lookup_type!(gsub, SubstitutionChainContext, 6);
+super::layout::lookup_type!(gsub, ExtensionSubtable, 7);
+super::layout::lookup_type!(gsub, ReverseChainSingleSubstFormat1, 8);
 
-impl<T: LookupType + FontWrite> FontWrite for ExtensionSubstFormat1<T> {
+impl<T: LookupSubtable + FontWrite> FontWrite for ExtensionSubstFormat1<T> {
     fn write_into(&self, writer: &mut TableWriter) {
         1u16.write_into(writer);
         T::TYPE.write_into(writer);

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -57,8 +57,8 @@ macro_rules! table_newtype {
                 self.0.write_into(writer)
             }
 
-            fn type_(&self) -> crate::table_type::TableType {
-                self.0.type_()
+            fn table_type(&self) -> crate::table_type::TableType {
+                self.0.table_type()
             }
         }
 
@@ -104,7 +104,7 @@ impl<T: LookupSubtable + FontWrite> FontWrite for Lookup<T> {
         self.mark_filtering_set.write_into(writer);
     }
 
-    fn type_(&self) -> crate::table_type::TableType {
+    fn table_type(&self) -> crate::table_type::TableType {
         T::TYPE.into()
     }
 }

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -166,20 +166,10 @@ pub enum LookupType {
 }
 
 impl LookupType {
-    pub(crate) const GSUB_EXT_TYPE: u16 = 7;
-    pub(crate) const GPOS_EXT_TYPE: u16 = 9;
-
     pub(crate) fn to_raw(self) -> u16 {
         match self {
             LookupType::Gpos(val) => val,
             LookupType::Gsub(val) => val,
-        }
-    }
-
-    pub(crate) fn promote(self) -> Self {
-        match self {
-            LookupType::Gpos(_) => LookupType::Gpos(Self::GPOS_EXT_TYPE),
-            LookupType::Gsub(_) => LookupType::Gsub(Self::GSUB_EXT_TYPE),
         }
     }
 }

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -23,7 +23,7 @@ pub trait FontWrite {
     ///
     /// This only matters in cases where a table may require additional processing
     /// after initial compilation, such as with GPOS/GSUB lookups.
-    fn type_(&self) -> TableType {
+    fn table_type(&self) -> TableType {
         TableType::Unknown
     }
 }
@@ -77,7 +77,7 @@ impl TableWriter {
         self.stack.push(TableData::default());
         table.write_into(self);
         let mut table_data = self.stack.pop().unwrap();
-        table_data.type_ = table.type_();
+        table_data.type_ = table.table_type();
         table_data.name = table.name();
         self.tables.add(table_data)
     }

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -14,11 +14,6 @@ pub trait FontWrite {
     /// Write our data and information about offsets into this [TableWriter].
     fn write_into(&self, writer: &mut TableWriter);
 
-    /// The name of this table or record; used for debugging
-    fn name(&self) -> &'static str {
-        "Unknown"
-    }
-
     /// The type of this table.
     ///
     /// This only matters in cases where a table may require additional processing
@@ -78,7 +73,6 @@ impl TableWriter {
         table.write_into(self);
         let mut table_data = self.stack.pop().unwrap();
         table_data.type_ = table.table_type();
-        table_data.name = table.name();
         self.tables.add(table_data)
     }
 
@@ -145,7 +139,6 @@ impl Default for TableWriter {
 /// The encoded data for a given table, along with info on included offsets
 #[derive(Debug, Default, Clone)] // DO NOT DERIVE MORE TRAITS! we want to ignore name field
 pub(crate) struct TableData {
-    pub(crate) name: &'static str,
     pub(crate) type_: TableType,
     pub(crate) bytes: Vec<u8>,
     pub(crate) offsets: Vec<OffsetRecord>,
@@ -213,7 +206,6 @@ impl TableData {
     #[cfg(test)]
     pub fn make_mock(size: usize) -> Self {
         TableData {
-            name: "",
             bytes: vec![0xca; size], // has no special meaning
             offsets: Vec::new(),
             type_: TableType::Unknown,


### PR DESCRIPTION
*this was originally part of #400, but I'm splitting it out here*

So as part of the table splitting and promotion work I needed some way to track the original source type of compiled bytes in order to possibly modify them afterwards. This ended up overlapping significantly with the `name` method on `FontWrite`, and I think it makes sense to combine them; in the general case tables can store their name directly in the result as a `&'static str` (like in the name method) and in the special cases we can manually provide a reasonable name.

So this does that; it replaces the `name` method with a `table_type` method, and then adds the basics of this new `TableType` enum; this will be used to handle promotion in #400.