### PR TITLE
Add types to represent typed arrays of offsets

### DIFF
--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -651,12 +651,11 @@ impl<'a> BaseValues<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`base_coord_offsets`][Self::base_coord_offsets].
-    pub fn base_coords(&self) -> impl Iterator<Item = Result<BaseCoord<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`base_coord_offsets`][Self::base_coord_offsets].
+    pub fn base_coords(&self) -> ArrayOfOffsets<'a, BaseCoord, Offset16> {
         let data = self.data;
-        self.base_coord_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.base_coord_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -558,12 +558,11 @@ impl<'a> LayerList<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`paint_offsets`][Self::paint_offsets].
-    pub fn paints(&self) -> impl Iterator<Item = Result<Paint<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`paint_offsets`][Self::paint_offsets].
+    pub fn paints(&self) -> ArrayOfOffsets<'a, Paint, Offset32> {
         let data = self.data;
-        self.paint_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.paint_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -331,12 +331,11 @@ impl<'a> AttachList<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`attach_point_offsets`][Self::attach_point_offsets].
-    pub fn attach_points(&self) -> impl Iterator<Item = Result<AttachPoint<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`attach_point_offsets`][Self::attach_point_offsets].
+    pub fn attach_points(&self) -> ArrayOfOffsets<'a, AttachPoint, Offset16> {
         let data = self.data;
-        self.attach_point_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.attach_point_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -510,12 +509,11 @@ impl<'a> LigCaretList<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`lig_glyph_offsets`][Self::lig_glyph_offsets].
-    pub fn lig_glyphs(&self) -> impl Iterator<Item = Result<LigGlyph<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`lig_glyph_offsets`][Self::lig_glyph_offsets].
+    pub fn lig_glyphs(&self) -> ArrayOfOffsets<'a, LigGlyph, Offset16> {
         let data = self.data;
-        self.lig_glyph_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.lig_glyph_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -604,12 +602,11 @@ impl<'a> LigGlyph<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`caret_value_offsets`][Self::caret_value_offsets].
-    pub fn caret_values(&self) -> impl Iterator<Item = Result<CaretValue<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`caret_value_offsets`][Self::caret_value_offsets].
+    pub fn caret_values(&self) -> ArrayOfOffsets<'a, CaretValue, Offset16> {
         let data = self.data;
-        self.caret_value_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.caret_value_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -983,12 +980,11 @@ impl<'a> MarkGlyphSets<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverages(&self) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
+    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset32> {
         let data = self.data;
-        self.coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1458,13 +1458,12 @@ impl<'a> PairPosFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`pair_set_offsets`][Self::pair_set_offsets].
-    pub fn pair_sets(&self) -> impl Iterator<Item = Result<PairSet<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`pair_set_offsets`][Self::pair_set_offsets].
+    pub fn pair_sets(&self) -> ArrayOfOffsets<'a, PairSet, Offset16> {
         let data = self.data;
+        let offsets = self.pair_set_offsets();
         let args = (self.value_format1(), self.value_format2());
-        self.pair_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve_with_args(data, &args))
+        ArrayOfOffsets::new(offsets, data, args)
     }
 }
 
@@ -2540,14 +2539,13 @@ impl<'a> BaseRecord<'a> {
         self.base_anchor_offsets
     }
 
-    /// Attempt to resolve [`base_anchor_offsets`][Self::base_anchor_offsets].
+    /// A dynamically resolving wrapper for [`base_anchor_offsets`][Self::base_anchor_offsets].
     pub fn base_anchors(
         &self,
         data: FontData<'a>,
-    ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
-        self.base_anchor_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+    ) -> ArrayOfNullableOffsets<'a, AnchorTable, Offset16> {
+        let offsets = self.base_anchor_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -2831,15 +2829,12 @@ impl<'a> LigatureArray<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`ligature_attach_offsets`][Self::ligature_attach_offsets].
-    pub fn ligature_attaches(
-        &self,
-    ) -> impl Iterator<Item = Result<LigatureAttach<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`ligature_attach_offsets`][Self::ligature_attach_offsets].
+    pub fn ligature_attaches(&self) -> ArrayOfOffsets<'a, LigatureAttach, Offset16> {
         let data = self.data;
+        let offsets = self.ligature_attach_offsets();
         let args = self.mark_class_count();
-        self.ligature_attach_offsets()
-            .iter()
-            .map(move |off| off.get().resolve_with_args(data, &args))
+        ArrayOfOffsets::new(offsets, data, args)
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
@@ -2999,14 +2994,13 @@ impl<'a> ComponentRecord<'a> {
         self.ligature_anchor_offsets
     }
 
-    /// Attempt to resolve [`ligature_anchor_offsets`][Self::ligature_anchor_offsets].
+    /// A dynamically resolving wrapper for [`ligature_anchor_offsets`][Self::ligature_anchor_offsets].
     pub fn ligature_anchors(
         &self,
         data: FontData<'a>,
-    ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
-        self.ligature_anchor_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+    ) -> ArrayOfNullableOffsets<'a, AnchorTable, Offset16> {
+        let offsets = self.ligature_anchor_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -3341,14 +3335,13 @@ impl<'a> Mark2Record<'a> {
         self.mark2_anchor_offsets
     }
 
-    /// Attempt to resolve [`mark2_anchor_offsets`][Self::mark2_anchor_offsets].
+    /// A dynamically resolving wrapper for [`mark2_anchor_offsets`][Self::mark2_anchor_offsets].
     pub fn mark2_anchors(
         &self,
         data: FontData<'a>,
-    ) -> impl Iterator<Item = Option<Result<AnchorTable<'a>, ReadError>>> + 'a {
-        self.mark2_anchor_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+    ) -> ArrayOfNullableOffsets<'a, AnchorTable, Offset16> {
+        let offsets = self.mark2_anchor_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -537,12 +537,11 @@ impl<'a> MultipleSubstFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`sequence_offsets`][Self::sequence_offsets].
-    pub fn sequences(&self) -> impl Iterator<Item = Result<Sequence<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`sequence_offsets`][Self::sequence_offsets].
+    pub fn sequences(&self) -> ArrayOfOffsets<'a, Sequence, Offset16> {
         let data = self.data;
-        self.sequence_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.sequence_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -737,12 +736,11 @@ impl<'a> AlternateSubstFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`alternate_set_offsets`][Self::alternate_set_offsets].
-    pub fn alternate_sets(&self) -> impl Iterator<Item = Result<AlternateSet<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`alternate_set_offsets`][Self::alternate_set_offsets].
+    pub fn alternate_sets(&self) -> ArrayOfOffsets<'a, AlternateSet, Offset16> {
         let data = self.data;
-        self.alternate_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.alternate_set_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -939,12 +937,11 @@ impl<'a> LigatureSubstFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`ligature_set_offsets`][Self::ligature_set_offsets].
-    pub fn ligature_sets(&self) -> impl Iterator<Item = Result<LigatureSet<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`ligature_set_offsets`][Self::ligature_set_offsets].
+    pub fn ligature_sets(&self) -> ArrayOfOffsets<'a, LigatureSet, Offset16> {
         let data = self.data;
-        self.ligature_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.ligature_set_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -1034,12 +1031,11 @@ impl<'a> LigatureSet<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`ligature_offsets`][Self::ligature_offsets].
-    pub fn ligatures(&self) -> impl Iterator<Item = Result<Ligature<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`ligature_offsets`][Self::ligature_offsets].
+    pub fn ligatures(&self) -> ArrayOfOffsets<'a, Ligature, Offset16> {
         let data = self.data;
-        self.ligature_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.ligature_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -1446,14 +1442,11 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverages(
-        &self,
-    ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
+    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
         let data = self.data;
-        self.backtrack_coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.backtrack_coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyphs in lookahead sequence.
@@ -1469,14 +1462,11 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverages(
-        &self,
-    ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
+    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
         let data = self.data;
-        self.lookahead_coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.lookahead_coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyph IDs in the substituteGlyphIDs array.

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -687,15 +687,14 @@ impl<'a, T> LookupList<'a, T> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`lookup_offsets`][Self::lookup_offsets].
-    pub fn lookups(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a
+    /// A dynamically resolving wrapper for [`lookup_offsets`][Self::lookup_offsets].
+    pub fn lookups(&self) -> ArrayOfOffsets<'a, T, Offset16>
     where
         T: FontRead<'a>,
     {
         let data = self.data;
-        self.lookup_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.lookup_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -834,15 +833,14 @@ impl<'a, T> Lookup<'a, T> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`subtable_offsets`][Self::subtable_offsets].
-    pub fn subtables(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a
+    /// A dynamically resolving wrapper for [`subtable_offsets`][Self::subtable_offsets].
+    pub fn subtables(&self) -> ArrayOfOffsets<'a, T, Offset16>
     where
         T: FontRead<'a>,
     {
         let data = self.data;
-        self.subtable_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.subtable_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Index (base 0) into GDEF mark glyph sets structure. This field
@@ -1567,14 +1565,11 @@ impl<'a> SequenceContextFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
-    pub fn seq_rule_sets(
-        &self,
-    ) -> impl Iterator<Item = Option<Result<SequenceRuleSet<'a>, ReadError>>> + 'a {
+    /// A dynamically resolving wrapper for [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
+    pub fn seq_rule_sets(&self) -> ArrayOfNullableOffsets<'a, SequenceRuleSet, Offset16> {
         let data = self.data;
-        self.seq_rule_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.seq_rule_set_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -1664,12 +1659,11 @@ impl<'a> SequenceRuleSet<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`seq_rule_offsets`][Self::seq_rule_offsets].
-    pub fn seq_rules(&self) -> impl Iterator<Item = Result<SequenceRule<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`seq_rule_offsets`][Self::seq_rule_offsets].
+    pub fn seq_rules(&self) -> ArrayOfOffsets<'a, SequenceRule, Offset16> {
         let data = self.data;
-        self.seq_rule_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.seq_rule_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -1910,14 +1904,13 @@ impl<'a> SequenceContextFormat2<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
+    /// A dynamically resolving wrapper for [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
     pub fn class_seq_rule_sets(
         &self,
-    ) -> impl Iterator<Item = Option<Result<ClassSequenceRuleSet<'a>, ReadError>>> + 'a {
+    ) -> ArrayOfNullableOffsets<'a, ClassSequenceRuleSet, Offset16> {
         let data = self.data;
-        self.class_seq_rule_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.class_seq_rule_set_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -2015,14 +2008,11 @@ impl<'a> ClassSequenceRuleSet<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
-    pub fn class_seq_rules(
-        &self,
-    ) -> impl Iterator<Item = Result<ClassSequenceRule<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
+    pub fn class_seq_rules(&self) -> ArrayOfOffsets<'a, ClassSequenceRule, Offset16> {
         let data = self.data;
-        self.class_seq_rule_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.class_seq_rule_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -2250,12 +2240,11 @@ impl<'a> SequenceContextFormat3<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverages(&self) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
+    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
         let data = self.data;
-        self.coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Array of SequenceLookupRecords
@@ -2436,14 +2425,13 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
+    /// A dynamically resolving wrapper for [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
     pub fn chained_seq_rule_sets(
         &self,
-    ) -> impl Iterator<Item = Option<Result<ChainedSequenceRuleSet<'a>, ReadError>>> + 'a {
+    ) -> ArrayOfNullableOffsets<'a, ChainedSequenceRuleSet, Offset16> {
         let data = self.data;
-        self.chained_seq_rule_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.chained_seq_rule_set_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -2537,14 +2525,11 @@ impl<'a> ChainedSequenceRuleSet<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
-    pub fn chained_seq_rules(
-        &self,
-    ) -> impl Iterator<Item = Result<ChainedSequenceRule<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
+    pub fn chained_seq_rules(&self) -> ArrayOfOffsets<'a, ChainedSequenceRule, Offset16> {
         let data = self.data;
-        self.chained_seq_rule_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.chained_seq_rule_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -2884,14 +2869,13 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
+    /// A dynamically resolving wrapper for [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
     pub fn chained_class_seq_rule_sets(
         &self,
-    ) -> impl Iterator<Item = Option<Result<ChainedClassSequenceRuleSet<'a>, ReadError>>> + 'a {
+    ) -> ArrayOfNullableOffsets<'a, ChainedClassSequenceRuleSet, Offset16> {
         let data = self.data;
-        self.chained_class_seq_rule_set_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.chained_class_seq_rule_set_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -3003,14 +2987,13 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
+    /// A dynamically resolving wrapper for [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
     pub fn chained_class_seq_rules(
         &self,
-    ) -> impl Iterator<Item = Result<ChainedClassSequenceRule<'a>, ReadError>> + 'a {
+    ) -> ArrayOfOffsets<'a, ChainedClassSequenceRule, Offset16> {
         let data = self.data;
-        self.chained_class_seq_rule_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.chained_class_seq_rule_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 
@@ -3319,14 +3302,11 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverages(
-        &self,
-    ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
+    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
         let data = self.data;
-        self.backtrack_coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.backtrack_coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyphs in the input sequence
@@ -3341,14 +3321,11 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`input_coverage_offsets`][Self::input_coverage_offsets].
-    pub fn input_coverages(
-        &self,
-    ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`input_coverage_offsets`][Self::input_coverage_offsets].
+    pub fn input_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
         let data = self.data;
-        self.input_coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.input_coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyphs in the lookahead sequence
@@ -3363,14 +3340,11 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverages(
-        &self,
-    ) -> impl Iterator<Item = Result<CoverageTable<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
+    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
         let data = self.data;
-        self.lookahead_coverage_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.lookahead_coverage_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of SequenceLookupRecords
@@ -3944,12 +3918,11 @@ impl<'a> ConditionSet<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`condition_offsets`][Self::condition_offsets].
-    pub fn conditions(&self) -> impl Iterator<Item = Result<ConditionFormat1<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
+    pub fn conditions(&self) -> ArrayOfOffsets<'a, ConditionFormat1, Offset32> {
         let data = self.data;
-        self.condition_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.condition_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -295,12 +295,11 @@ impl<'a> AxisValueArray<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`axis_value_offsets`][Self::axis_value_offsets].
-    pub fn axis_values(&self) -> impl Iterator<Item = Result<AxisValue<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`axis_value_offsets`][Self::axis_value_offsets].
+    pub fn axis_values(&self) -> ArrayOfOffsets<'a, AxisValue, Offset16> {
         let data = self.data;
-        self.axis_value_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.axis_value_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -361,12 +361,11 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`nonnullable_offsets`][Self::nonnullable_offsets].
-    pub fn nonnullables(&self) -> impl Iterator<Item = Result<Dummy<'a>, ReadError>> + 'a {
+    /// A dynamically resolving wrapper for [`nonnullable_offsets`][Self::nonnullable_offsets].
+    pub fn nonnullables(&self) -> ArrayOfOffsets<'a, Dummy, Offset16> {
         let data = self.data;
-        self.nonnullable_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.nonnullable_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
     }
 
     /// An offset that is nullable, but always present
@@ -375,12 +374,11 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`nullable_offsets`][Self::nullable_offsets].
-    pub fn nullables(&self) -> impl Iterator<Item = Option<Result<Dummy<'a>, ReadError>>> + 'a {
+    /// A dynamically resolving wrapper for [`nullable_offsets`][Self::nullable_offsets].
+    pub fn nullables(&self) -> ArrayOfNullableOffsets<'a, Dummy, Offset16> {
         let data = self.data;
-        self.nullable_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.nullable_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 
     /// A normal offset that is versioned
@@ -389,13 +387,11 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
         Some(self.data.read_array(range).unwrap())
     }
 
-    /// Attempt to resolve [`versioned_nonnullable_offsets`][Self::versioned_nonnullable_offsets].
-    pub fn versioned_nonnullables(
-        &self,
-    ) -> Option<impl Iterator<Item = Result<Dummy<'a>, ReadError>> + 'a> {
+    /// A dynamically resolving wrapper for [`versioned_nonnullable_offsets`][Self::versioned_nonnullable_offsets].
+    pub fn versioned_nonnullables(&self) -> Option<ArrayOfOffsets<'a, Dummy, Offset16>> {
         let data = self.data;
-        self.versioned_nonnullable_offsets()
-            .map(|x| x.iter().map(move |off| off.get().resolve(data)))
+        let offsets = self.versioned_nonnullable_offsets();
+        offsets.map(|offsets| ArrayOfOffsets::new(offsets, data, ()))
     }
 
     /// An offset that is nullable and versioned
@@ -404,13 +400,11 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
         Some(self.data.read_array(range).unwrap())
     }
 
-    /// Attempt to resolve [`versioned_nullable_offsets`][Self::versioned_nullable_offsets].
-    pub fn versioned_nullables(
-        &self,
-    ) -> Option<impl Iterator<Item = Option<Result<Dummy<'a>, ReadError>>> + 'a> {
+    /// A dynamically resolving wrapper for [`versioned_nullable_offsets`][Self::versioned_nullable_offsets].
+    pub fn versioned_nullables(&self) -> Option<ArrayOfNullableOffsets<'a, Dummy, Offset16>> {
         let data = self.data;
-        self.versioned_nullable_offsets()
-            .map(|x| x.iter().map(move |off| off.get().resolve(data)))
+        let offsets = self.versioned_nullable_offsets();
+        offsets.map(|offsets| ArrayOfNullableOffsets::new(offsets, data, ()))
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -1018,14 +1018,11 @@ impl<'a> ItemVariationStore<'a> {
         self.data.read_array(range).unwrap()
     }
 
-    /// Attempt to resolve [`item_variation_data_offsets`][Self::item_variation_data_offsets].
-    pub fn item_variation_datas(
-        &self,
-    ) -> impl Iterator<Item = Option<Result<ItemVariationData<'a>, ReadError>>> + 'a {
+    /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
+    pub fn item_variation_datas(&self) -> ArrayOfNullableOffsets<'a, ItemVariationData, Offset32> {
         let data = self.data;
-        self.item_variation_data_offsets()
-            .iter()
-            .map(move |off| off.get().resolve(data))
+        let offsets = self.item_variation_data_offsets();
+        ArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -14,6 +14,7 @@ extern crate core as std;
 pub mod array;
 mod font_data;
 mod offset;
+mod offset_array;
 mod read;
 mod table_provider;
 mod table_ref;
@@ -30,6 +31,7 @@ mod test_helpers;
 
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
+pub use offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
 pub use read::{ComputeSize, FontRead, FontReadWithArgs, ReadArgs, ReadError, VarSize};
 pub use table_provider::{TableProvider, TopLevelTable};
 pub use table_ref::TableRef;
@@ -43,6 +45,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::array::{ComputedArray, VarLenArray};
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
+    pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
     pub use crate::read::{
         ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
     };

--- a/read-fonts/src/offset_array.rs
+++ b/read-fonts/src/offset_array.rs
@@ -1,0 +1,148 @@
+//! Arrays of offsets with dynamic resolution
+//!
+//! This module provides a number of types that wrap arrays of offsets, dynamically
+//! resolving individual offsets as they are accessed.
+
+use crate::offset::ResolveNullableOffset;
+use font_types::{BigEndian, Nullable, Offset16, Scalar};
+
+use crate::{FontData, FontReadWithArgs, Offset, ReadArgs, ReadError, ResolveOffset};
+
+/// An array of offsets that can be resolved on access.
+///
+/// This bundles up the raw offsets with the data used to resolve them, along
+/// with any arguments needed to resolve those offsets; it provides a simple
+/// ergonomic interface that unburdens the user from needing to manually
+/// determine the appropriate input data and arguments for a raw offset.
+#[derive(Clone)]
+pub struct ArrayOfOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
+    offsets: &'a [BigEndian<O>],
+    data: FontData<'a>,
+    args: T::Args,
+}
+
+/// An array of nullable offsets that can be resolved on access.
+///
+/// This is identical to [`ArrayOfOffsets`], except that each offset is
+/// allowed to be null.
+#[derive(Clone)]
+pub struct ArrayOfNullableOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
+    offsets: &'a [BigEndian<Nullable<O>>],
+    data: FontData<'a>,
+    args: T::Args,
+}
+
+impl<'a, T, O> ArrayOfOffsets<'a, T, O>
+where
+    O: Scalar,
+    T: ReadArgs,
+{
+    pub(crate) fn new(offsets: &'a [BigEndian<O>], data: FontData<'a>, args: T::Args) -> Self {
+        Self {
+            offsets,
+            data,
+            args,
+        }
+    }
+}
+
+impl<'a, T, O> ArrayOfOffsets<'a, T, O>
+where
+    O: Scalar + Offset,
+    T: ReadArgs + FontReadWithArgs<'a>,
+    T::Args: Copy + 'static,
+{
+    /// The number of offsets in the array
+    pub fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// `true` if the array is empty
+    pub fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+
+    /// Resolve the offset at the provided index.
+    ///
+    /// Note: if the index is invalid this will return the `InvalidCollectionIndex`
+    /// error variant instead of `None`.
+    pub fn get(&self, idx: usize) -> Result<T, ReadError> {
+        self.offsets
+            .get(idx)
+            .ok_or(ReadError::InvalidCollectionIndex(idx as _))
+            .and_then(|o| o.get().resolve_with_args(self.data, &self.args))
+    }
+
+    /// Iterate over all of the offset targets.
+    ///
+    /// Each offset will be resolved as it is encountered.
+    pub fn iter(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a {
+        let mut iter = self.offsets.iter();
+        let args = self.args;
+        let data = self.data;
+        std::iter::from_fn(move || {
+            iter.next()
+                .map(|off| off.get().resolve_with_args(data, &args))
+        })
+    }
+}
+
+impl<'a, T, O> ArrayOfNullableOffsets<'a, T, O>
+where
+    O: Scalar + Offset,
+    T: ReadArgs,
+{
+    pub(crate) fn new(
+        offsets: &'a [BigEndian<Nullable<O>>],
+        data: FontData<'a>,
+        args: T::Args,
+    ) -> Self {
+        Self {
+            offsets,
+            data,
+            args,
+        }
+    }
+}
+
+impl<'a, T, O> ArrayOfNullableOffsets<'a, T, O>
+where
+    O: Scalar + Offset,
+    T: ReadArgs + FontReadWithArgs<'a>,
+    T::Args: Copy + 'static,
+{
+    /// The number of offsets in the array
+    pub fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// `true` if the array is empty
+    pub fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+
+    /// Resolve the offset at the provided index.
+    ///
+    /// This will return `None` only if the offset *exists*, but is null. if the
+    /// provided index does not exist, this will return the `InvalidCollectionIndex`
+    /// error variant.
+    pub fn get(&self, idx: usize) -> Option<Result<T, ReadError>> {
+        let Some(offset) = self.offsets.get(idx) else {
+            return Some(Err(ReadError::InvalidCollectionIndex(idx as _)))
+        };
+        offset.get().resolve_with_args(self.data, &self.args)
+    }
+
+    /// Iterate over all of the offset targets.
+    ///
+    /// Each offset will be resolved as it is encountered.
+    pub fn iter(&self) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
+        let mut iter = self.offsets.iter();
+        let args = self.args;
+        let data = self.data;
+        std::iter::from_fn(move || {
+            iter.next()
+                .map(|off| off.get().resolve_with_args(data, &args))
+        })
+    }
+}

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -45,6 +45,20 @@ pub trait FontReadWithArgs<'a>: Sized + ReadArgs {
     fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError>;
 }
 
+// a blanket impl of ReadArgs/FontReadWithArgs for general FontRead types.
+//
+// This is used by ArrayOfOffsets/ArrayOfNullableOffsets to provide a common
+// interface for regardless of whether a type has args.
+impl<'a, T: FontRead<'a>> ReadArgs for T {
+    type Args = ();
+}
+
+impl<'a, T: FontRead<'a>> FontReadWithArgs<'a> for T {
+    fn read_with_args(data: FontData<'a>, _: &Self::Args) -> Result<Self, ReadError> {
+        Self::read(data)
+    }
+}
+
 /// A trait for tables that have multiple possible formats.
 pub trait Format<T> {
     /// The format value for this table.

--- a/read-fonts/src/tables/stat.rs
+++ b/read-fonts/src/tables/stat.rs
@@ -22,6 +22,7 @@ mod tests {
         let axis_values = table.offset_to_axis_values().unwrap();
         let axis_values = axis_values
             .axis_values()
+            .iter()
             .map(|x| x.unwrap())
             .collect::<Vec<_>>();
 

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -546,11 +546,7 @@ impl<'a> ItemVariationStore<'a> {
         index: DeltaSetIndex,
         coords: &[F2Dot14],
     ) -> Result<i32, ReadError> {
-        let data = match self
-            .item_variation_datas()
-            .nth(index.outer as usize)
-            .flatten()
-        {
+        let data = match self.item_variation_datas().get(index.outer as usize) {
             Some(data) => data?,
             None => return Ok(0),
         };

--- a/read-fonts/src/tests/gpos.rs
+++ b/read-fonts/src/tests/gpos.rs
@@ -43,8 +43,8 @@ fn pairposformat1() {
     assert_eq!(table.value_format2(), ValueFormat::X_PLACEMENT);
     assert_eq!(table.pair_set_count(), 2);
 
-    let set1 = table.pair_sets().next().unwrap().unwrap();
-    let set2 = table.pair_sets().nth(1).unwrap().unwrap();
+    let set1 = table.pair_sets().get(0).unwrap();
+    let set2 = table.pair_sets().get(1).unwrap();
     assert_eq!(set1.pair_value_records().iter().count(), 1);
     assert_eq!(set2.pair_value_records().iter().count(), 1);
 
@@ -124,7 +124,7 @@ fn markligposformat1() {
     let table = MarkLigPosFormat1::read(test_data::MARKLIGPOSFORMAT1.into()).unwrap();
     let lig_array = table.ligature_array().unwrap();
     assert_eq!(lig_array.ligature_count(), 1);
-    let lig_attach = lig_array.ligature_attaches().next().unwrap().unwrap();
+    let lig_attach = lig_array.ligature_attaches().get(0).unwrap();
     assert_eq!(lig_attach.component_count(), 3);
     let comp_record = lig_attach
         .component_records()

--- a/read-fonts/src/tests/test_gdef.rs
+++ b/read-fonts/src/tests/test_gdef.rs
@@ -25,7 +25,7 @@ fn attach_list_table() {
     let table = AttachList::read(test_data::ATTACHLIST_TABLE.into()).unwrap();
     assert_eq!(table.glyph_count(), 2);
     assert_eq!(table.attach_point_offsets().len(), 2);
-    let attach_point = table.attach_points().nth(1).unwrap().unwrap();
+    let attach_point = table.attach_points().get(1).unwrap();
     assert_eq!(attach_point.point_indices()[0].get(), 14);
     assert_eq!(attach_point.point_indices()[1].get(), 23);
 }
@@ -33,8 +33,8 @@ fn attach_list_table() {
 #[test]
 fn lig_caret_list() {
     let table = LigCaretList::read(test_data::LIGCARETLIST_TABLE.into()).unwrap();
-    let glyph1 = table.lig_glyphs().next().unwrap().unwrap();
-    let glyph2 = table.lig_glyphs().nth(1).unwrap().unwrap();
+    let glyph1 = table.lig_glyphs().get(0).unwrap();
+    let glyph2 = table.lig_glyphs().get(1).unwrap();
     assert_eq!(glyph1.caret_value_offsets().len(), 1);
     assert_eq!(glyph2.caret_value_offsets().len(), 2);
     let g1c0: CaretValueFormat1 = glyph1.caret_value_offsets()[0]

--- a/read-fonts/src/tests/test_gsub.rs
+++ b/read-fonts/src/tests/test_gsub.rs
@@ -27,8 +27,8 @@ fn singlesubstformat2() {
 fn multiplesubstformat1() {
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#example-4-multiplesubstformat1-subtable
     let table = MultipleSubstFormat1::read(test_data::MULTIPLESUBSTFORMAT1_TABLE.into()).unwrap();
-    assert_eq!(table.sequences().count(), 1);
-    let seq0 = table.sequences().next().unwrap().unwrap();
+    assert_eq!(table.sequences().len(), 1);
+    let seq0 = table.sequences().get(0).unwrap();
     assert_eq!(
         seq0.substitute_glyph_ids(),
         &[GlyphId::new(26), GlyphId::new(26), GlyphId::new(29)]
@@ -39,8 +39,8 @@ fn multiplesubstformat1() {
 fn alternatesubstformat1() {
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#example-5-alternatesubstformat-1-subtable
     let table = AlternateSubstFormat1::read(test_data::ALTERNATESUBSTFORMAT1_TABLE.into()).unwrap();
-    assert_eq!(table.alternate_sets().count(), 1);
-    let altset0 = table.alternate_sets().next().unwrap().unwrap();
+    assert_eq!(table.alternate_sets().len(), 1);
+    let altset0 = table.alternate_sets().get(0).unwrap();
     assert_eq!(
         altset0.alternate_glyph_ids(),
         &[GlyphId::new(0xc9), GlyphId::new(0xca)]
@@ -51,19 +51,19 @@ fn alternatesubstformat1() {
 fn ligaturesubstformat1() {
     // https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#example-6-ligaturesubstformat1-subtable
     let table = LigatureSubstFormat1::read(test_data::LIGATURESUBSTFORMAT1_TABLE.into()).unwrap();
-    assert_eq!(table.ligature_sets().count(), 2);
-    let ligset0 = table.ligature_sets().next().unwrap().unwrap();
+    assert_eq!(table.ligature_sets().len(), 2);
+    let ligset0 = table.ligature_sets().get(0).unwrap();
 
-    assert_eq!(ligset0.ligatures().count(), 1);
-    let lig0 = ligset0.ligatures().next().unwrap().unwrap();
+    assert_eq!(ligset0.ligatures().len(), 1);
+    let lig0 = ligset0.ligatures().get(0).unwrap();
     assert_eq!(lig0.ligature_glyph(), GlyphId::new(347));
     assert_eq!(
         lig0.component_glyph_ids(),
         &[GlyphId::new(0x28), GlyphId::new(0x17)]
     );
 
-    let ligset1 = table.ligature_sets().nth(1).unwrap().unwrap();
-    let lig0 = ligset1.ligatures().next().unwrap().unwrap();
+    let ligset1 = table.ligature_sets().get(1).unwrap();
+    let lig0 = ligset1.ligatures().get(0).unwrap();
     assert_eq!(lig0.ligature_glyph(), GlyphId::new(0xf1));
     assert_eq!(
         lig0.component_glyph_ids(),

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -489,7 +489,7 @@ impl<'a> FromObjRef<read_fonts::tables::base::BaseValues<'a>> for BaseValues {
     fn from_obj_ref(obj: &read_fonts::tables::base::BaseValues<'a>, _: FontData) -> Self {
         BaseValues {
             default_baseline_index: obj.default_baseline_index(),
-            base_coords: obj.base_coords().map(|x| x.to_owned_table()).collect(),
+            base_coords: obj.base_coords().to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -178,7 +178,7 @@ impl<'a> FromObjRef<read_fonts::tables::gdef::AttachList<'a>> for AttachList {
     fn from_obj_ref(obj: &read_fonts::tables::gdef::AttachList<'a>, _: FontData) -> Self {
         AttachList {
             coverage: obj.coverage().to_owned_table(),
-            attach_points: obj.attach_points().map(|x| x.to_owned_table()).collect(),
+            attach_points: obj.attach_points().to_owned_table(),
         }
     }
 }
@@ -299,7 +299,7 @@ impl<'a> FromObjRef<read_fonts::tables::gdef::LigCaretList<'a>> for LigCaretList
     fn from_obj_ref(obj: &read_fonts::tables::gdef::LigCaretList<'a>, _: FontData) -> Self {
         LigCaretList {
             coverage: obj.coverage().to_owned_table(),
-            lig_glyphs: obj.lig_glyphs().map(|x| x.to_owned_table()).collect(),
+            lig_glyphs: obj.lig_glyphs().to_owned_table(),
         }
     }
 }
@@ -356,7 +356,7 @@ impl Validate for LigGlyph {
 impl<'a> FromObjRef<read_fonts::tables::gdef::LigGlyph<'a>> for LigGlyph {
     fn from_obj_ref(obj: &read_fonts::tables::gdef::LigGlyph<'a>, _: FontData) -> Self {
         LigGlyph {
-            caret_values: obj.caret_values().map(|x| x.to_owned_table()).collect(),
+            caret_values: obj.caret_values().to_owned_table(),
         }
     }
 }
@@ -646,7 +646,7 @@ impl Validate for MarkGlyphSets {
 impl<'a> FromObjRef<read_fonts::tables::gdef::MarkGlyphSets<'a>> for MarkGlyphSets {
     fn from_obj_ref(obj: &read_fonts::tables::gdef::MarkGlyphSets<'a>, _: FontData) -> Self {
         MarkGlyphSets {
-            coverages: obj.coverages().map(|x| x.to_owned_table()).collect(),
+            coverages: obj.coverages().to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -921,7 +921,7 @@ impl<'a> FromObjRef<read_fonts::tables::gpos::PairPosFormat1<'a>> for PairPosFor
     fn from_obj_ref(obj: &read_fonts::tables::gpos::PairPosFormat1<'a>, _: FontData) -> Self {
         PairPosFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            pair_sets: obj.pair_sets().map(|x| x.to_owned_table()).collect(),
+            pair_sets: obj.pair_sets().to_owned_table(),
         }
     }
 }
@@ -1538,10 +1538,7 @@ impl Validate for BaseRecord {
 impl FromObjRef<read_fonts::tables::gpos::BaseRecord<'_>> for BaseRecord {
     fn from_obj_ref(obj: &read_fonts::tables::gpos::BaseRecord, offset_data: FontData) -> Self {
         BaseRecord {
-            base_anchors: obj
-                .base_anchors(offset_data)
-                .map(|x| x.to_owned_table())
-                .collect(),
+            base_anchors: obj.base_anchors(offset_data).to_owned_table(),
         }
     }
 }
@@ -1679,10 +1676,7 @@ impl Validate for LigatureArray {
 impl<'a> FromObjRef<read_fonts::tables::gpos::LigatureArray<'a>> for LigatureArray {
     fn from_obj_ref(obj: &read_fonts::tables::gpos::LigatureArray<'a>, _: FontData) -> Self {
         LigatureArray {
-            ligature_attaches: obj
-                .ligature_attaches()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            ligature_attaches: obj.ligature_attaches().to_owned_table(),
         }
     }
 }
@@ -1788,10 +1782,7 @@ impl FromObjRef<read_fonts::tables::gpos::ComponentRecord<'_>> for ComponentReco
         offset_data: FontData,
     ) -> Self {
         ComponentRecord {
-            ligature_anchors: obj
-                .ligature_anchors(offset_data)
-                .map(|x| x.to_owned_table())
-                .collect(),
+            ligature_anchors: obj.ligature_anchors(offset_data).to_owned_table(),
         }
     }
 }
@@ -1980,10 +1971,7 @@ impl Validate for Mark2Record {
 impl FromObjRef<read_fonts::tables::gpos::Mark2Record<'_>> for Mark2Record {
     fn from_obj_ref(obj: &read_fonts::tables::gpos::Mark2Record, offset_data: FontData) -> Self {
         Mark2Record {
-            mark2_anchors: obj
-                .mark2_anchors(offset_data)
-                .map(|x| x.to_owned_table())
-                .collect(),
+            mark2_anchors: obj.mark2_anchors(offset_data).to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -439,7 +439,7 @@ impl<'a> FromObjRef<read_fonts::tables::gsub::MultipleSubstFormat1<'a>> for Mult
     fn from_obj_ref(obj: &read_fonts::tables::gsub::MultipleSubstFormat1<'a>, _: FontData) -> Self {
         MultipleSubstFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            sequences: obj.sequences().map(|x| x.to_owned_table()).collect(),
+            sequences: obj.sequences().to_owned_table(),
         }
     }
 }
@@ -566,7 +566,7 @@ impl<'a> FromObjRef<read_fonts::tables::gsub::AlternateSubstFormat1<'a>> for Alt
     ) -> Self {
         AlternateSubstFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            alternate_sets: obj.alternate_sets().map(|x| x.to_owned_table()).collect(),
+            alternate_sets: obj.alternate_sets().to_owned_table(),
         }
     }
 }
@@ -693,7 +693,7 @@ impl<'a> FromObjRef<read_fonts::tables::gsub::LigatureSubstFormat1<'a>> for Liga
     fn from_obj_ref(obj: &read_fonts::tables::gsub::LigatureSubstFormat1<'a>, _: FontData) -> Self {
         LigatureSubstFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            ligature_sets: obj.ligature_sets().map(|x| x.to_owned_table()).collect(),
+            ligature_sets: obj.ligature_sets().to_owned_table(),
         }
     }
 }
@@ -751,7 +751,7 @@ impl Validate for LigatureSet {
 impl<'a> FromObjRef<read_fonts::tables::gsub::LigatureSet<'a>> for LigatureSet {
     fn from_obj_ref(obj: &read_fonts::tables::gsub::LigatureSet<'a>, _: FontData) -> Self {
         LigatureSet {
-            ligatures: obj.ligatures().map(|x| x.to_owned_table()).collect(),
+            ligatures: obj.ligatures().to_owned_table(),
         }
     }
 }
@@ -1052,14 +1052,8 @@ impl<'a> FromObjRef<read_fonts::tables::gsub::ReverseChainSingleSubstFormat1<'a>
         let offset_data = obj.offset_data();
         ReverseChainSingleSubstFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            backtrack_coverages: obj
-                .backtrack_coverages()
-                .map(|x| x.to_owned_table())
-                .collect(),
-            lookahead_coverages: obj
-                .lookahead_coverages()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            backtrack_coverages: obj.backtrack_coverages().to_owned_table(),
+            lookahead_coverages: obj.lookahead_coverages().to_owned_table(),
             substitute_glyph_ids: obj.substitute_glyph_ids().to_owned_obj(offset_data),
         }
     }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -517,7 +517,7 @@ where
 {
     fn from_obj_ref(obj: &read_fonts::tables::layout::LookupList<'a, U>, _: FontData) -> Self {
         LookupList {
-            lookups: obj.lookups().map(|x| x.to_owned_table()).collect(),
+            lookups: obj.lookups().to_owned_table(),
         }
     }
 }
@@ -575,7 +575,7 @@ where
     fn from_obj_ref(obj: &read_fonts::tables::layout::Lookup<'a, U>, _: FontData) -> Self {
         Lookup {
             lookup_flag: obj.lookup_flag(),
-            subtables: obj.subtables().map(|x| x.to_owned_table()).collect(),
+            subtables: obj.subtables().to_owned_table(),
             mark_filtering_set: obj.mark_filtering_set(),
         }
     }
@@ -1163,7 +1163,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::SequenceContextFormat1<'a>>
     ) -> Self {
         SequenceContextFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            seq_rule_sets: obj.seq_rule_sets().map(|x| x.to_owned_table()).collect(),
+            seq_rule_sets: obj.seq_rule_sets().to_owned_table(),
         }
     }
 }
@@ -1224,7 +1224,7 @@ impl Validate for SequenceRuleSet {
 impl<'a> FromObjRef<read_fonts::tables::layout::SequenceRuleSet<'a>> for SequenceRuleSet {
     fn from_obj_ref(obj: &read_fonts::tables::layout::SequenceRuleSet<'a>, _: FontData) -> Self {
         SequenceRuleSet {
-            seq_rules: obj.seq_rules().map(|x| x.to_owned_table()).collect(),
+            seq_rules: obj.seq_rules().to_owned_table(),
         }
     }
 }
@@ -1377,10 +1377,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::SequenceContextFormat2<'a>>
         SequenceContextFormat2 {
             coverage: obj.coverage().to_owned_table(),
             class_def: obj.class_def().to_owned_table(),
-            class_seq_rule_sets: obj
-                .class_seq_rule_sets()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            class_seq_rule_sets: obj.class_seq_rule_sets().to_owned_table(),
         }
     }
 }
@@ -1444,7 +1441,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::ClassSequenceRuleSet<'a>> for Cl
         _: FontData,
     ) -> Self {
         ClassSequenceRuleSet {
-            class_seq_rules: obj.class_seq_rules().map(|x| x.to_owned_table()).collect(),
+            class_seq_rules: obj.class_seq_rules().to_owned_table(),
         }
     }
 }
@@ -1591,7 +1588,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::SequenceContextFormat3<'a>>
     ) -> Self {
         let offset_data = obj.offset_data();
         SequenceContextFormat3 {
-            coverages: obj.coverages().map(|x| x.to_owned_table()).collect(),
+            coverages: obj.coverages().to_owned_table(),
             seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
@@ -1759,10 +1756,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::ChainedSequenceContextFormat1<'a
     ) -> Self {
         ChainedSequenceContextFormat1 {
             coverage: obj.coverage().to_owned_table(),
-            chained_seq_rule_sets: obj
-                .chained_seq_rule_sets()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            chained_seq_rule_sets: obj.chained_seq_rule_sets().to_owned_table(),
         }
     }
 }
@@ -1828,10 +1822,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::ChainedSequenceRuleSet<'a>>
         _: FontData,
     ) -> Self {
         ChainedSequenceRuleSet {
-            chained_seq_rules: obj
-                .chained_seq_rules()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            chained_seq_rules: obj.chained_seq_rules().to_owned_table(),
         }
     }
 }
@@ -2037,10 +2028,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::ChainedSequenceContextFormat2<'a
             backtrack_class_def: obj.backtrack_class_def().to_owned_table(),
             input_class_def: obj.input_class_def().to_owned_table(),
             lookahead_class_def: obj.lookahead_class_def().to_owned_table(),
-            chained_class_seq_rule_sets: obj
-                .chained_class_seq_rule_sets()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            chained_class_seq_rule_sets: obj.chained_class_seq_rule_sets().to_owned_table(),
         }
     }
 }
@@ -2109,10 +2097,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::ChainedClassSequenceRuleSet<'a>>
         _: FontData,
     ) -> Self {
         ChainedClassSequenceRuleSet {
-            chained_class_seq_rules: obj
-                .chained_class_seq_rules()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            chained_class_seq_rules: obj.chained_class_seq_rules().to_owned_table(),
         }
     }
 }
@@ -2317,15 +2302,9 @@ impl<'a> FromObjRef<read_fonts::tables::layout::ChainedSequenceContextFormat3<'a
     ) -> Self {
         let offset_data = obj.offset_data();
         ChainedSequenceContextFormat3 {
-            backtrack_coverages: obj
-                .backtrack_coverages()
-                .map(|x| x.to_owned_table())
-                .collect(),
-            input_coverages: obj.input_coverages().map(|x| x.to_owned_table()).collect(),
-            lookahead_coverages: obj
-                .lookahead_coverages()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            backtrack_coverages: obj.backtrack_coverages().to_owned_table(),
+            input_coverages: obj.input_coverages().to_owned_table(),
+            lookahead_coverages: obj.lookahead_coverages().to_owned_table(),
             seq_lookup_records: obj.seq_lookup_records().to_owned_obj(offset_data),
         }
     }
@@ -2732,7 +2711,7 @@ impl Validate for ConditionSet {
 impl<'a> FromObjRef<read_fonts::tables::layout::ConditionSet<'a>> for ConditionSet {
     fn from_obj_ref(obj: &read_fonts::tables::layout::ConditionSet<'a>, _: FontData) -> Self {
         ConditionSet {
-            conditions: obj.conditions().map(|x| x.to_owned_table()).collect(),
+            conditions: obj.conditions().to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -182,7 +182,7 @@ impl Validate for AxisValueArray {
 impl<'a> FromObjRef<read_fonts::tables::stat::AxisValueArray<'a>> for AxisValueArray {
     fn from_obj_ref(obj: &read_fonts::tables::stat::AxisValueArray<'a>, _: FontData) -> Self {
         AxisValueArray {
-            axis_values: obj.axis_values().map(|x| x.to_owned_table()).collect(),
+            axis_values: obj.axis_values().to_owned_table(),
         }
     }
 }

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -220,14 +220,10 @@ impl<'a> FromObjRef<read_fonts::codegen_test::offsets_arrays::KindsOfArraysOfOff
         _: FontData,
     ) -> Self {
         KindsOfArraysOfOffsets {
-            nonnullables: obj.nonnullables().map(|x| x.to_owned_table()).collect(),
-            nullables: obj.nullables().map(|x| x.to_owned_table()).collect(),
-            versioned_nonnullables: obj
-                .versioned_nonnullables()
-                .map(|obj| obj.map(|x| x.to_owned_table()).collect()),
-            versioned_nullables: obj
-                .versioned_nullables()
-                .map(|obj| obj.map(|x| x.to_owned_table()).collect()),
+            nonnullables: obj.nonnullables().to_owned_table(),
+            nullables: obj.nullables().to_owned_table(),
+            versioned_nonnullables: obj.versioned_nonnullables().map(|obj| obj.to_owned_table()),
+            versioned_nullables: obj.versioned_nullables().map(|obj| obj.to_owned_table()),
         }
     }
 }

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -572,10 +572,7 @@ impl<'a> FromObjRef<read_fonts::tables::variations::ItemVariationStore<'a>> for 
         ItemVariationStore {
             format: obj.format(),
             variation_region_list: obj.variation_region_list().to_owned_table(),
-            item_variation_datas: obj
-                .item_variation_datas()
-                .map(|x| x.to_owned_table())
-                .collect(),
+            item_variation_datas: obj.item_variation_datas().to_owned_table(),
         }
     }
 }

--- a/write-fonts/src/from_obj.rs
+++ b/write-fonts/src/from_obj.rs
@@ -2,7 +2,9 @@
 
 use std::collections::BTreeSet;
 
-use read::{FontData, ReadError};
+use read::{
+    ArrayOfNullableOffsets, ArrayOfOffsets, FontData, FontReadWithArgs, Offset, ReadArgs, ReadError,
+};
 use types::{BigEndian, Scalar};
 
 use crate::{NullableOffsetMarker, OffsetMarker};
@@ -163,4 +165,53 @@ impl<T: FromTableRef<U>, U, const N: usize> FromTableRef<Option<Result<U, ReadEr
             _ => NullableOffsetMarker::new(None),
         }
     }
+}
+
+// impls for converting arrays:
+impl<'a, T, U, O, const N: usize> FromObjRef<ArrayOfOffsets<'a, U, O>> for Vec<OffsetMarker<T, N>>
+where
+    T: FromObjRef<U> + Default,
+    U: ReadArgs + FontReadWithArgs<'a>,
+    U::Args: 'static,
+    O: Scalar + Offset,
+{
+    fn from_obj_ref(from: &ArrayOfOffsets<'a, U, O>, data: FontData) -> Self {
+        from.iter()
+            .map(|x| OffsetMarker::from_obj_ref(&x, data))
+            .collect()
+    }
+}
+
+impl<'a, T, U, O, const N: usize> FromObjRef<ArrayOfNullableOffsets<'a, U, O>>
+    for Vec<NullableOffsetMarker<T, N>>
+where
+    T: FromObjRef<U> + Default,
+    U: ReadArgs + FontReadWithArgs<'a>,
+    U::Args: 'static,
+    O: Scalar + Offset,
+{
+    fn from_obj_ref(from: &ArrayOfNullableOffsets<'a, U, O>, data: FontData) -> Self {
+        from.iter()
+            .map(|x| NullableOffsetMarker::from_obj_ref(&x, data))
+            .collect()
+    }
+}
+
+impl<'a, T, U, O, const N: usize> FromTableRef<ArrayOfOffsets<'a, U, O>> for Vec<OffsetMarker<T, N>>
+where
+    T: FromTableRef<U> + Default,
+    U: ReadArgs + FontReadWithArgs<'a>,
+    U::Args: 'static,
+    O: Scalar + Offset,
+{
+}
+
+impl<'a, T, U, O, const N: usize> FromTableRef<ArrayOfNullableOffsets<'a, U, O>>
+    for Vec<NullableOffsetMarker<T, N>>
+where
+    T: FromObjRef<U> + Default,
+    U: ReadArgs + FontReadWithArgs<'a>,
+    U::Args: 'static,
+    O: Scalar + Offset,
+{
 }

--- a/write-fonts/src/tables/gpos.rs
+++ b/write-fonts/src/tables/gpos.rs
@@ -193,10 +193,10 @@ mod tests {
 
         assert_eq!(table.lookup_flag(), LookupFlag::empty());
         assert_eq!(table.sub_table_count(), 2);
-        let read_gpos::SinglePos::Format1(sub1) = table.subtables().next().unwrap().unwrap() else {
+        let read_gpos::SinglePos::Format1(sub1) = table.subtables().get(0).unwrap() else {
             panic!("wrong table type");
         };
-        let read_gpos::SinglePos::Format1(sub2) = table.subtables().nth(1).unwrap().unwrap() else {
+        let read_gpos::SinglePos::Format1(sub2) = table.subtables().get(1).unwrap() else {
             panic!("wrong table type");
         };
 

--- a/write-fonts/src/tables/stat.rs
+++ b/write-fonts/src/tables/stat.rs
@@ -26,13 +26,8 @@ fn convert_axis_value_offsets(
     from: Result<read_fonts::tables::stat::AxisValueArray, ReadError>,
 ) -> OffsetMarker<Vec<OffsetMarker<AxisValue>>, WIDTH_32> {
     from.ok()
-        .map(|array| {
-            array
-                .axis_values()
-                .map(|val| val.to_owned_obj(array.offset_data()))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
+        .map(|array| array.axis_values().to_owned_obj(array.offset_data()))
+        .unwrap_or_else(Vec::new)
         .into()
 }
 
@@ -71,7 +66,7 @@ mod tests {
         assert_eq!(read.axis_value_count(), 2);
         let axis_values = read.offset_to_axis_values().unwrap();
         assert_eq!(axis_values.axis_value_offsets().len(), 2);
-        let value2 = axis_values.axis_values().nth(1).unwrap().unwrap();
+        let value2 = axis_values.axis_values().get(1).unwrap();
         let read_stat::AxisValue::Format1(value2) = value2 else { panic!("wrong format"); };
         assert_eq!(value2.value_name_id(), NameId::new(261));
     }


### PR DESCRIPTION
This was a long-standing papercut: in codegen we generate typed getters for offsets, but for arrays of offsets this was limited to generating an iterator.

This was a slightly annoying API, since an iterator cannot be retained, and does not provide random access.

This patch addresses this by adding a pair of concrete types that can wrap arrays of offsets and nullable offsets, and can dynamically resolve those offsets as they are accessed.

I've had this branch written for months and sitting around, so we might as well get it in now.

This is a breaking change.