### PR TITLE
[skrifa] clean up warnings

### DIFF
--- a/skrifa/src/attribute.rs
+++ b/skrifa/src/attribute.rs
@@ -6,7 +6,6 @@ use read_fonts::{
         os2::{Os2, SelectionFlags},
         post::Post,
     },
-    types::Tag,
     TableProvider,
 };
 

--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn map_variants() {
-        use super::{CmapSubtable, MapVariant::*};
+        use super::MapVariant::*;
         let font = FontRef::new(font_test_data::CMAP14_FONT1).unwrap();
         let charmap = font.charmap();
         let selector = '\u{e0100}';

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -12,8 +12,6 @@
 //! for additional details.
 
 #![forbid(unsafe_code)]
-// TODO: this is temporary-- remove when hinting is added.
-#![allow(dead_code, unused_imports, unused_variables)]
 
 /// Expose our "raw" underlying parser crate.
 pub extern crate read_fonts as raw;

--- a/skrifa/src/provider.rs
+++ b/skrifa/src/provider.rs
@@ -1,7 +1,7 @@
 use super::{
     attribute::Attributes,
     charmap::Charmap,
-    instance::{LocationRef, NormalizedCoord, Size},
+    instance::{LocationRef, Size},
     metrics::{GlyphMetrics, Metrics},
     string::{LocalizedStrings, StringId},
     variation::{AxisCollection, NamedInstanceCollection},

--- a/skrifa/src/scale/glyf/deltas.rs
+++ b/skrifa/src/scale/glyf/deltas.rs
@@ -2,8 +2,8 @@ use core::ops::RangeInclusive;
 
 use read_fonts::{
     tables::glyf::{PointFlags, PointMarker},
-    tables::gvar::{GlyphDelta, Gvar, TupleVariation},
-    types::{F26Dot6, F2Dot14, Fixed, GlyphId, Point},
+    tables::gvar::{Gvar, TupleVariation},
+    types::{F2Dot14, Fixed, GlyphId, Point},
     ReadError,
 };
 
@@ -54,7 +54,7 @@ pub fn simple_glyph(
     for delta in deltas.iter_mut() {
         *delta = Default::default();
     }
-    let Ok(var_data) = gvar.glyph_variation_data(glyph_id) else {
+    if gvar.glyph_variation_data(glyph_id).is_err() {
         // Empty variation data for a glyph is not an error.
         return Ok(());
     };

--- a/skrifa/src/scale/glyf/hint/mod.rs
+++ b/skrifa/src/scale/glyf/hint/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::scaler::ScalerFont;
 use crate::scale::Hinting;
 
@@ -67,7 +69,7 @@ pub struct HintContext {
 }
 
 impl HintContext {
-    pub fn hint(&mut self, glyph: HintGlyph) -> bool {
+    pub fn hint(&mut self, _glyph: HintGlyph) -> bool {
         true
     }
 }

--- a/skrifa/src/scale/glyf/scaler.rs
+++ b/skrifa/src/scale/glyf/scaler.rs
@@ -140,6 +140,7 @@ impl<'a> Scaler<'a> {
             &mut self.context.unscaled[..],
             &mut outline.flags[point_base..],
         )?;
+        #[cfg(feature = "hinting")]
         let ins = simple.instructions();
         for point in &self.phantom {
             self.context
@@ -269,6 +270,7 @@ impl<'a> Scaler<'a> {
     ) -> Result<()> {
         // The base indices of the points and contours for the current glyph.
         let point_base = outline.points.len();
+        #[cfg(feature = "hinting")]
         let contour_base = outline.contours.len();
         let scale = self.font.scale;
         if self.font.is_scaled {
@@ -491,6 +493,7 @@ impl<'a> Scaler<'a> {
         self.phantom[3].y = self.phantom[2].y - F26Dot6::from_bits(vadvance);
     }
 
+    #[cfg(feature = "hinting")]
     fn push_phantom(&mut self, outline: &mut Outline) {
         for i in 0..4 {
             outline.points.push(self.phantom[i]);
@@ -693,6 +696,7 @@ impl<'a> ScalerFont<'a> {
     }
 
     #[cfg(feature = "hinting")]
+    #[allow(dead_code)]
     pub(crate) fn scale_cvt(&self, scale: Option<i32>, scaled_cvt: &mut Vec<i32>) {
         if scaled_cvt.len() < self.cvt.len() {
             scaled_cvt.resize(self.cvt.len(), 0);

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -164,10 +164,7 @@ use super::{
     font::UniqueId,
     instance::{NormalizedCoord, Size},
     setting::VariationSetting,
-    GlyphId, Tag,
 };
-
-use core::str::FromStr;
 
 /// Limit for recursion when loading TrueType composite glyphs.
 const GLYF_COMPOSITE_RECURSION_LIMIT: usize = 32;
@@ -226,7 +223,7 @@ impl Context {
 
 #[cfg(test)]
 mod tests {
-    use super::{test, Context, GlyphId, Pen, Scaler, Size};
+    use super::{test, Context, Size};
     use font_test_data::{VAZIRMATN_VAR, VAZIRMATN_VAR_GLYPHS};
     use read_fonts::FontRef;
 

--- a/skrifa/src/scale/scaler.rs
+++ b/skrifa/src/scale/scaler.rs
@@ -3,9 +3,9 @@ use super::{glyf, Context, Error, NormalizedCoord, Pen, Result, Size, UniqueId, 
 #[cfg(feature = "hinting")]
 use super::Hinting;
 
-use core::{borrow::Borrow, str::FromStr};
+use core::borrow::Borrow;
 use read_fonts::{
-    types::{Fixed, GlyphId, Tag},
+    types::{Fixed, GlyphId},
     TableProvider,
 };
 

--- a/skrifa/src/scale/test.rs
+++ b/skrifa/src/scale/test.rs
@@ -1,11 +1,10 @@
 //! Helpers for unit testing
 
-use super::{Context, GlyphId, Pen, Scaler};
+use super::Pen;
 use core::str::FromStr;
 use read_fonts::{
     tables::glyf::PointFlags,
-    types::{F26Dot6, F2Dot14, Point},
-    FontRef,
+    types::{F26Dot6, F2Dot14, GlyphId, Point},
 };
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -17,8 +16,6 @@ pub enum PathElement {
     QuadTo([f32; 4]),
     CurveTo([f32; 6]),
 }
-
-use PathElement::*;
 
 #[derive(Default)]
 pub struct Path(pub Vec<PathElement>);

--- a/skrifa/src/small_array.rs
+++ b/skrifa/src/small_array.rs
@@ -34,17 +34,6 @@ where
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn len(&self) -> usize {
-        match &self.storage {
-            SmallStorage::Inline(_, len) => *len,
-            SmallStorage::Heap(vec) => vec.len(),
-        }
-    }
-
     pub fn as_slice(&self) -> &[T] {
         match &self.storage {
             SmallStorage::Inline(array, len) => &array[..*len],

--- a/skrifa/src/variation.rs
+++ b/skrifa/src/variation.rs
@@ -253,7 +253,6 @@ impl<'a> AxisCollection<'a> {
             value: f32,
             present: bool,
         }
-        let len = self.len();
         let mut results = SmallArray::<_, 8>::new(Entry::default(), self.len());
         for (axis, result) in self.iter().zip(results.as_mut_slice()) {
             result.tag = axis.tag();
@@ -408,7 +407,7 @@ impl<'a> NamedInstanceCollection<'a> {
 mod tests {
     use super::*;
     use crate::MetadataProvider as _;
-    use font_test_data::{SIMPLE_GLYF, VAZIRMATN_VAR};
+    use font_test_data::VAZIRMATN_VAR;
     use read_fonts::FontRef;
     use std::str::FromStr;
 


### PR DESCRIPTION
We had allows at crate level for unused and dead code to support feature gated hinting stuff but that has _allowed_ these things to proliferate in the codebase. This PR removes those, cleans up the mess and adds more targeted allows where necessary.

No functional changes, so JMM if it looks good.