### PR TITLE
Add lifetime to T for generated ArrayOfOffsets

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -816,12 +816,15 @@ impl Field {
                 quote!(ArrayOfOffsets)
             };
 
+            let target_lifetime = (!target_is_generic).then(|| quote!(<'a>));
+
             let args_token = if self.attrs.read_offset_args.is_some() {
                 quote!(args)
             } else {
                 quote!(())
             };
-            let mut return_type = quote!( #array_type<'a, #target_ident, #offset_type> );
+            let mut return_type =
+                quote!( #array_type<'a, #target_ident #target_lifetime, #offset_type> );
             let mut body = quote!(#array_type::new(offsets, data, #args_token));
             if self.is_version_dependent() {
                 return_type = quote!( Option< #return_type > );

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -652,7 +652,7 @@ impl<'a> BaseValues<'a> {
     }
 
     /// A dynamically resolving wrapper for [`base_coord_offsets`][Self::base_coord_offsets].
-    pub fn base_coords(&self) -> ArrayOfOffsets<'a, BaseCoord, Offset16> {
+    pub fn base_coords(&self) -> ArrayOfOffsets<'a, BaseCoord<'a>, Offset16> {
         let data = self.data;
         let offsets = self.base_coord_offsets();
         ArrayOfOffsets::new(offsets, data, ())

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -559,7 +559,7 @@ impl<'a> LayerList<'a> {
     }
 
     /// A dynamically resolving wrapper for [`paint_offsets`][Self::paint_offsets].
-    pub fn paints(&self) -> ArrayOfOffsets<'a, Paint, Offset32> {
+    pub fn paints(&self) -> ArrayOfOffsets<'a, Paint<'a>, Offset32> {
         let data = self.data;
         let offsets = self.paint_offsets();
         ArrayOfOffsets::new(offsets, data, ())

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -332,7 +332,7 @@ impl<'a> AttachList<'a> {
     }
 
     /// A dynamically resolving wrapper for [`attach_point_offsets`][Self::attach_point_offsets].
-    pub fn attach_points(&self) -> ArrayOfOffsets<'a, AttachPoint, Offset16> {
+    pub fn attach_points(&self) -> ArrayOfOffsets<'a, AttachPoint<'a>, Offset16> {
         let data = self.data;
         let offsets = self.attach_point_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -510,7 +510,7 @@ impl<'a> LigCaretList<'a> {
     }
 
     /// A dynamically resolving wrapper for [`lig_glyph_offsets`][Self::lig_glyph_offsets].
-    pub fn lig_glyphs(&self) -> ArrayOfOffsets<'a, LigGlyph, Offset16> {
+    pub fn lig_glyphs(&self) -> ArrayOfOffsets<'a, LigGlyph<'a>, Offset16> {
         let data = self.data;
         let offsets = self.lig_glyph_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -603,7 +603,7 @@ impl<'a> LigGlyph<'a> {
     }
 
     /// A dynamically resolving wrapper for [`caret_value_offsets`][Self::caret_value_offsets].
-    pub fn caret_values(&self) -> ArrayOfOffsets<'a, CaretValue, Offset16> {
+    pub fn caret_values(&self) -> ArrayOfOffsets<'a, CaretValue<'a>, Offset16> {
         let data = self.data;
         let offsets = self.caret_value_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -981,7 +981,7 @@ impl<'a> MarkGlyphSets<'a> {
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset32> {
+    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset32> {
         let data = self.data;
         let offsets = self.coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1459,7 +1459,7 @@ impl<'a> PairPosFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`pair_set_offsets`][Self::pair_set_offsets].
-    pub fn pair_sets(&self) -> ArrayOfOffsets<'a, PairSet, Offset16> {
+    pub fn pair_sets(&self) -> ArrayOfOffsets<'a, PairSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.pair_set_offsets();
         let args = (self.value_format1(), self.value_format2());
@@ -2543,7 +2543,7 @@ impl<'a> BaseRecord<'a> {
     pub fn base_anchors(
         &self,
         data: FontData<'a>,
-    ) -> ArrayOfNullableOffsets<'a, AnchorTable, Offset16> {
+    ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
         let offsets = self.base_anchor_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
     }
@@ -2830,7 +2830,7 @@ impl<'a> LigatureArray<'a> {
     }
 
     /// A dynamically resolving wrapper for [`ligature_attach_offsets`][Self::ligature_attach_offsets].
-    pub fn ligature_attaches(&self) -> ArrayOfOffsets<'a, LigatureAttach, Offset16> {
+    pub fn ligature_attaches(&self) -> ArrayOfOffsets<'a, LigatureAttach<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_attach_offsets();
         let args = self.mark_class_count();
@@ -2998,7 +2998,7 @@ impl<'a> ComponentRecord<'a> {
     pub fn ligature_anchors(
         &self,
         data: FontData<'a>,
-    ) -> ArrayOfNullableOffsets<'a, AnchorTable, Offset16> {
+    ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
         let offsets = self.ligature_anchor_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
     }
@@ -3339,7 +3339,7 @@ impl<'a> Mark2Record<'a> {
     pub fn mark2_anchors(
         &self,
         data: FontData<'a>,
-    ) -> ArrayOfNullableOffsets<'a, AnchorTable, Offset16> {
+    ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
         let offsets = self.mark2_anchor_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
     }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -538,7 +538,7 @@ impl<'a> MultipleSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`sequence_offsets`][Self::sequence_offsets].
-    pub fn sequences(&self) -> ArrayOfOffsets<'a, Sequence, Offset16> {
+    pub fn sequences(&self) -> ArrayOfOffsets<'a, Sequence<'a>, Offset16> {
         let data = self.data;
         let offsets = self.sequence_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -737,7 +737,7 @@ impl<'a> AlternateSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`alternate_set_offsets`][Self::alternate_set_offsets].
-    pub fn alternate_sets(&self) -> ArrayOfOffsets<'a, AlternateSet, Offset16> {
+    pub fn alternate_sets(&self) -> ArrayOfOffsets<'a, AlternateSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.alternate_set_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -938,7 +938,7 @@ impl<'a> LigatureSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`ligature_set_offsets`][Self::ligature_set_offsets].
-    pub fn ligature_sets(&self) -> ArrayOfOffsets<'a, LigatureSet, Offset16> {
+    pub fn ligature_sets(&self) -> ArrayOfOffsets<'a, LigatureSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_set_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -1032,7 +1032,7 @@ impl<'a> LigatureSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`ligature_offsets`][Self::ligature_offsets].
-    pub fn ligatures(&self) -> ArrayOfOffsets<'a, Ligature, Offset16> {
+    pub fn ligatures(&self) -> ArrayOfOffsets<'a, Ligature<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -1443,7 +1443,7 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
+    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.backtrack_coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -1463,7 +1463,7 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
+    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.lookahead_coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1566,7 +1566,7 @@ impl<'a> SequenceContextFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
-    pub fn seq_rule_sets(&self) -> ArrayOfNullableOffsets<'a, SequenceRuleSet, Offset16> {
+    pub fn seq_rule_sets(&self) -> ArrayOfNullableOffsets<'a, SequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.seq_rule_set_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
@@ -1660,7 +1660,7 @@ impl<'a> SequenceRuleSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_offsets`][Self::seq_rule_offsets].
-    pub fn seq_rules(&self) -> ArrayOfOffsets<'a, SequenceRule, Offset16> {
+    pub fn seq_rules(&self) -> ArrayOfOffsets<'a, SequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.seq_rule_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -1907,7 +1907,7 @@ impl<'a> SequenceContextFormat2<'a> {
     /// A dynamically resolving wrapper for [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
     pub fn class_seq_rule_sets(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ClassSequenceRuleSet, Offset16> {
+    ) -> ArrayOfNullableOffsets<'a, ClassSequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.class_seq_rule_set_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
@@ -2009,7 +2009,7 @@ impl<'a> ClassSequenceRuleSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
-    pub fn class_seq_rules(&self) -> ArrayOfOffsets<'a, ClassSequenceRule, Offset16> {
+    pub fn class_seq_rules(&self) -> ArrayOfOffsets<'a, ClassSequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.class_seq_rule_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -2241,7 +2241,7 @@ impl<'a> SequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
+    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -2428,7 +2428,7 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// A dynamically resolving wrapper for [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
     pub fn chained_seq_rule_sets(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ChainedSequenceRuleSet, Offset16> {
+    ) -> ArrayOfNullableOffsets<'a, ChainedSequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_seq_rule_set_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
@@ -2526,7 +2526,7 @@ impl<'a> ChainedSequenceRuleSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
-    pub fn chained_seq_rules(&self) -> ArrayOfOffsets<'a, ChainedSequenceRule, Offset16> {
+    pub fn chained_seq_rules(&self) -> ArrayOfOffsets<'a, ChainedSequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_seq_rule_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -2872,7 +2872,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
     pub fn chained_class_seq_rule_sets(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ChainedClassSequenceRuleSet, Offset16> {
+    ) -> ArrayOfNullableOffsets<'a, ChainedClassSequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_class_seq_rule_set_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
@@ -2990,7 +2990,7 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
     pub fn chained_class_seq_rules(
         &self,
-    ) -> ArrayOfOffsets<'a, ChainedClassSequenceRule, Offset16> {
+    ) -> ArrayOfOffsets<'a, ChainedClassSequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_class_seq_rule_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -3303,7 +3303,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
+    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.backtrack_coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -3322,7 +3322,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`input_coverage_offsets`][Self::input_coverage_offsets].
-    pub fn input_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
+    pub fn input_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.input_coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -3341,7 +3341,7 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable, Offset16> {
+    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.lookahead_coverage_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -3919,7 +3919,7 @@ impl<'a> ConditionSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
-    pub fn conditions(&self) -> ArrayOfOffsets<'a, ConditionFormat1, Offset32> {
+    pub fn conditions(&self) -> ArrayOfOffsets<'a, ConditionFormat1<'a>, Offset32> {
         let data = self.data;
         let offsets = self.condition_offsets();
         ArrayOfOffsets::new(offsets, data, ())

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -296,7 +296,7 @@ impl<'a> AxisValueArray<'a> {
     }
 
     /// A dynamically resolving wrapper for [`axis_value_offsets`][Self::axis_value_offsets].
-    pub fn axis_values(&self) -> ArrayOfOffsets<'a, AxisValue, Offset16> {
+    pub fn axis_values(&self) -> ArrayOfOffsets<'a, AxisValue<'a>, Offset16> {
         let data = self.data;
         let offsets = self.axis_value_offsets();
         ArrayOfOffsets::new(offsets, data, ())

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -362,7 +362,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// A dynamically resolving wrapper for [`nonnullable_offsets`][Self::nonnullable_offsets].
-    pub fn nonnullables(&self) -> ArrayOfOffsets<'a, Dummy, Offset16> {
+    pub fn nonnullables(&self) -> ArrayOfOffsets<'a, Dummy<'a>, Offset16> {
         let data = self.data;
         let offsets = self.nonnullable_offsets();
         ArrayOfOffsets::new(offsets, data, ())
@@ -375,7 +375,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// A dynamically resolving wrapper for [`nullable_offsets`][Self::nullable_offsets].
-    pub fn nullables(&self) -> ArrayOfNullableOffsets<'a, Dummy, Offset16> {
+    pub fn nullables(&self) -> ArrayOfNullableOffsets<'a, Dummy<'a>, Offset16> {
         let data = self.data;
         let offsets = self.nullable_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
@@ -388,7 +388,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// A dynamically resolving wrapper for [`versioned_nonnullable_offsets`][Self::versioned_nonnullable_offsets].
-    pub fn versioned_nonnullables(&self) -> Option<ArrayOfOffsets<'a, Dummy, Offset16>> {
+    pub fn versioned_nonnullables(&self) -> Option<ArrayOfOffsets<'a, Dummy<'a>, Offset16>> {
         let data = self.data;
         let offsets = self.versioned_nonnullable_offsets();
         offsets.map(|offsets| ArrayOfOffsets::new(offsets, data, ()))
@@ -401,7 +401,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 
     /// A dynamically resolving wrapper for [`versioned_nullable_offsets`][Self::versioned_nullable_offsets].
-    pub fn versioned_nullables(&self) -> Option<ArrayOfNullableOffsets<'a, Dummy, Offset16>> {
+    pub fn versioned_nullables(&self) -> Option<ArrayOfNullableOffsets<'a, Dummy<'a>, Offset16>> {
         let data = self.data;
         let offsets = self.versioned_nullable_offsets();
         offsets.map(|offsets| ArrayOfNullableOffsets::new(offsets, data, ()))

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -1019,7 +1019,9 @@ impl<'a> ItemVariationStore<'a> {
     }
 
     /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
-    pub fn item_variation_datas(&self) -> ArrayOfNullableOffsets<'a, ItemVariationData, Offset32> {
+    pub fn item_variation_datas(
+        &self,
+    ) -> ArrayOfNullableOffsets<'a, ItemVariationData<'a>, Offset32> {
         let data = self.data;
         let offsets = self.item_variation_data_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())


### PR DESCRIPTION
We currently generate return types like:
```rust
ArrayOfNullableOffsets<'a, ItemVariationData, Offset32>
```
where `ItemVariationData`  may need an explicit `'a` lifetime to be useful. This changes codegen to add those lifetimes when the target is not generic. @cmyr  please double check me on this.