### PR TITLE
[font-types] Rework raw traits

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1051,7 +1051,7 @@ impl Field {
                 .map(FieldReadArgs::to_tokens_for_validation)
             {
                 Some(args) => quote!(cursor.read_with_args(&#args)?),
-                None => quote!(cursor.read()?),
+                None => quote!(cursor.read_be()?),
             },
         };
         quote!( #name : #rhs )

--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -40,7 +40,7 @@ pub use name_id::NameId;
 pub use offset::{Nullable, Offset16, Offset24, Offset32};
 pub use pen::{Pen, PenCommand};
 pub use point::Point;
-pub use raw::{BigEndian, FixedSize, ReadScalar, Scalar};
+pub use raw::{BigEndian, FixedSize, Scalar};
 pub use tag::{InvalidTag, Tag};
 pub use uint24::Uint24;
 pub use version::{Compatible, MajorMinor, Version16Dot16};

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1674,7 +1674,7 @@ impl<'a> FontReadWithArgs<'a> for PairValueRecord {
         let mut cursor = data.cursor();
         let (value_format1, value_format2) = *args;
         Ok(Self {
-            second_glyph: cursor.read()?,
+            second_glyph: cursor.read_be()?,
             value_record1: cursor.read_with_args(&value_format1)?,
             value_record2: cursor.read_with_args(&value_format2)?,
         })

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -1,6 +1,6 @@
 //! Traits for interpreting font data
 
-use types::{FixedSize, ReadScalar, Tag};
+use font_types::{FixedSize, Scalar, Tag};
 
 use crate::font_data::FontData;
 
@@ -85,7 +85,7 @@ pub trait VarSize {
     ///
     /// When reading this type, we will read this value first, and use it to
     /// determine the total length.
-    type Size: ReadScalar + FixedSize + Into<u32>;
+    type Size: Scalar + Into<u32>;
 
     #[doc(hidden)]
     fn read_len_at(data: FontData, pos: usize) -> Option<usize> {

--- a/read-fonts/src/tables/avar.rs
+++ b/read-fonts/src/tables/avar.rs
@@ -45,7 +45,7 @@ impl<'a> VarSize for SegmentMaps<'a> {
 impl<'a> FontRead<'a> for SegmentMaps<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let position_map_count: BigEndian<u16> = cursor.read()?;
+        let position_map_count: BigEndian<u16> = cursor.read_be()?;
         let axis_value_maps = cursor.read_array(position_map_count.get() as _)?;
         Ok(SegmentMaps {
             position_map_count,

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -45,28 +45,28 @@ impl ValueRecord {
         let mut cursor = data.cursor();
 
         if format.contains(ValueFormat::X_PLACEMENT) {
-            this.x_placement = Some(cursor.read()?);
+            this.x_placement = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::Y_PLACEMENT) {
-            this.y_placement = Some(cursor.read()?);
+            this.y_placement = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::X_ADVANCE) {
-            this.x_advance = Some(cursor.read()?);
+            this.x_advance = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::Y_ADVANCE) {
-            this.y_advance = Some(cursor.read()?);
+            this.y_advance = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::X_PLACEMENT_DEVICE) {
-            this.x_placement_device = Some(cursor.read()?);
+            this.x_placement_device = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::Y_PLACEMENT_DEVICE) {
-            this.y_placement_device = Some(cursor.read()?);
+            this.y_placement_device = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::X_ADVANCE_DEVICE) {
-            this.x_advance_device = Some(cursor.read()?);
+            this.x_advance_device = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::Y_ADVANCE_DEVICE) {
-            this.y_advance_device = Some(cursor.read()?);
+            this.y_advance_device = Some(cursor.read_be()?);
         }
         Ok(this)
     }


### PR DESCRIPTION
As part of the safety work, I wanted to simplify our font-types traits where possible.

In particular, this removes the `ReadScalar` trait, which was intended to provide a unified way to read both `Scalar` types as well as their `BigEndian` wrappers; but the former case is not common, and the extra trait was confusing, so I have separated this functionality.

This means that we will need separate methods for when we want to actually read a BigEndian value, but this doesn't seem too bad.

In addition this adds a new trait to more narrowly encode the condition that the Raw associated type on the Scalar trait should only ever be a fixed-size byte array.