### PR TITLE
Tighten up safety guarantees

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -40,6 +40,10 @@ pub(crate) fn generate(item: &Record) -> syn::Result<TokenStream> {
             impl FixedSize for #name {
                 const RAW_BYTE_LEN: usize = #( #inner_types::RAW_BYTE_LEN )+*;
             }
+
+            unsafe impl JustBytes for #name {
+                fn this_trait_should_only_be_implemented_in_generated_code() {}
+            }
         }
     });
     let maybe_impl_read_with_args = (has_read_args).then(|| generate_read_with_args(item));

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -41,7 +41,8 @@ pub(crate) fn generate(item: &Record) -> syn::Result<TokenStream> {
                 const RAW_BYTE_LEN: usize = #( #inner_types::RAW_BYTE_LEN )+*;
             }
 
-            unsafe impl JustBytes for #name {
+            /// SAFETY: see the [`FromBytes`] trait documentation.
+            unsafe impl FromBytes for #name {
                 fn this_trait_should_only_be_implemented_in_generated_code() {}
             }
         }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -167,6 +167,10 @@ impl FixedSize for TableRecord {
         Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for TableRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for TableRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -167,7 +167,8 @@ impl FixedSize for TableRecord {
         Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for TableRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for TableRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -173,6 +173,10 @@ impl FixedSize for AxisValueMap {
     const RAW_BYTE_LEN: usize = F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for AxisValueMap {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for AxisValueMap {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -173,7 +173,8 @@ impl FixedSize for AxisValueMap {
     const RAW_BYTE_LEN: usize = F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for AxisValueMap {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for AxisValueMap {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -399,6 +399,10 @@ impl FixedSize for BaseScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for BaseScriptRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for BaseScriptRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -569,6 +573,10 @@ impl BaseLangSysRecord {
 
 impl FixedSize for BaseLangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for BaseLangSysRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -866,6 +874,10 @@ impl FeatMinMaxRecord {
 
 impl FixedSize for FeatMinMaxRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for FeatMinMaxRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -399,7 +399,8 @@ impl FixedSize for BaseScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for BaseScriptRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for BaseScriptRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -575,7 +576,8 @@ impl FixedSize for BaseLangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for BaseLangSysRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for BaseLangSysRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -876,7 +878,8 @@ impl FixedSize for FeatMinMaxRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for FeatMinMaxRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for FeatMinMaxRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -138,6 +138,10 @@ impl FixedSize for EncodingRecord {
         PlatformId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for EncodingRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for EncodingRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -505,6 +509,10 @@ impl SubHeader {
 impl FixedSize for SubHeader {
     const RAW_BYTE_LEN: usize =
         u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for SubHeader {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -1039,6 +1047,10 @@ impl FixedSize for SequentialMapGroup {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for SequentialMapGroup {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for SequentialMapGroup {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1455,6 +1467,10 @@ impl FixedSize for ConstantMapGroup {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for ConstantMapGroup {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ConstantMapGroup {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1628,6 +1644,10 @@ impl VariationSelector {
 impl FixedSize for VariationSelector {
     const RAW_BYTE_LEN: usize =
         Uint24::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for VariationSelector {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -1828,6 +1848,10 @@ impl FixedSize for UvsMapping {
     const RAW_BYTE_LEN: usize = Uint24::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for UvsMapping {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for UvsMapping {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1868,6 +1892,10 @@ impl UnicodeRange {
 
 impl FixedSize for UnicodeRange {
     const RAW_BYTE_LEN: usize = Uint24::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for UnicodeRange {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -138,7 +138,8 @@ impl FixedSize for EncodingRecord {
         PlatformId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for EncodingRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for EncodingRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -511,7 +512,8 @@ impl FixedSize for SubHeader {
         u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for SubHeader {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for SubHeader {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1047,7 +1049,8 @@ impl FixedSize for SequentialMapGroup {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for SequentialMapGroup {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for SequentialMapGroup {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1467,7 +1470,8 @@ impl FixedSize for ConstantMapGroup {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ConstantMapGroup {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ConstantMapGroup {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1646,7 +1650,8 @@ impl FixedSize for VariationSelector {
         Uint24::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for VariationSelector {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for VariationSelector {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1848,7 +1853,8 @@ impl FixedSize for UvsMapping {
     const RAW_BYTE_LEN: usize = Uint24::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for UvsMapping {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for UvsMapping {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1894,7 +1900,8 @@ impl FixedSize for UnicodeRange {
     const RAW_BYTE_LEN: usize = Uint24::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for UnicodeRange {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for UnicodeRange {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -328,6 +328,10 @@ impl FixedSize for BaseGlyph {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for BaseGlyph {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for BaseGlyph {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -369,6 +373,10 @@ impl Layer {
 
 impl FixedSize for Layer {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for Layer {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -493,6 +501,10 @@ impl BaseGlyphPaint {
 
 impl FixedSize for BaseGlyphPaint {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for BaseGlyphPaint {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -723,6 +735,10 @@ impl Clip {
 impl FixedSize for Clip {
     const RAW_BYTE_LEN: usize =
         GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + Offset24::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for Clip {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -1033,6 +1049,10 @@ impl FixedSize for ColorIndex {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for ColorIndex {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ColorIndex {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1080,6 +1100,10 @@ impl VarColorIndex {
 
 impl FixedSize for VarColorIndex {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for VarColorIndex {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -1130,6 +1154,10 @@ impl ColorStop {
 
 impl FixedSize for ColorStop {
     const RAW_BYTE_LEN: usize = F2Dot14::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for ColorStop {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -1188,6 +1216,10 @@ impl VarColorStop {
 impl FixedSize for VarColorStop {
     const RAW_BYTE_LEN: usize =
         F2Dot14::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for VarColorStop {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -328,7 +328,8 @@ impl FixedSize for BaseGlyph {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for BaseGlyph {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for BaseGlyph {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -375,7 +376,8 @@ impl FixedSize for Layer {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for Layer {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for Layer {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -503,7 +505,8 @@ impl FixedSize for BaseGlyphPaint {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for BaseGlyphPaint {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for BaseGlyphPaint {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -737,7 +740,8 @@ impl FixedSize for Clip {
         GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + Offset24::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for Clip {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for Clip {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1049,7 +1053,8 @@ impl FixedSize for ColorIndex {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ColorIndex {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ColorIndex {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1102,7 +1107,8 @@ impl FixedSize for VarColorIndex {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for VarColorIndex {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for VarColorIndex {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1156,7 +1162,8 @@ impl FixedSize for ColorStop {
     const RAW_BYTE_LEN: usize = F2Dot14::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ColorStop {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ColorStop {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1218,7 +1225,8 @@ impl FixedSize for VarColorStop {
         F2Dot14::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for VarColorStop {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for VarColorStop {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -307,6 +307,10 @@ impl FixedSize for ColorRecord {
         u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for ColorRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ColorRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -307,7 +307,8 @@ impl FixedSize for ColorRecord {
         u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ColorRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ColorRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -327,6 +327,10 @@ impl FixedSize for VariationAxisRecord {
         + NameId::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for VariationAxisRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for VariationAxisRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -327,7 +327,8 @@ impl FixedSize for VariationAxisRecord {
         + NameId::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for VariationAxisRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for VariationAxisRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1010,6 +1010,10 @@ impl FixedSize for MarkRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for MarkRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for MarkRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -2243,6 +2247,10 @@ impl EntryExitRecord {
 
 impl FixedSize for EntryExitRecord {
     const RAW_BYTE_LEN: usize = Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for EntryExitRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1010,7 +1010,8 @@ impl FixedSize for MarkRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for MarkRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for MarkRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -2249,7 +2250,8 @@ impl FixedSize for EntryExitRecord {
     const RAW_BYTE_LEN: usize = Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for EntryExitRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for EntryExitRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -137,6 +137,10 @@ impl FixedSize for LongMetric {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for LongMetric {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for LongMetric {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -137,7 +137,8 @@ impl FixedSize for LongMetric {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for LongMetric {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for LongMetric {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -112,6 +112,10 @@ impl FixedSize for ScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for ScriptRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ScriptRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -257,6 +261,10 @@ impl LangSysRecord {
 
 impl FixedSize for LangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for LangSysRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -477,6 +485,10 @@ impl FeatureRecord {
 
 impl FixedSize for FeatureRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for FeatureRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -1098,6 +1110,10 @@ impl FixedSize for RangeRecord {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for RangeRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for RangeRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1383,6 +1399,10 @@ impl FixedSize for ClassRangeRecord {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for ClassRangeRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ClassRangeRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1468,6 +1488,10 @@ impl SequenceLookupRecord {
 
 impl FixedSize for SequenceLookupRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for SequenceLookupRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]
@@ -3847,6 +3871,10 @@ impl FixedSize for FeatureVariationRecord {
     const RAW_BYTE_LEN: usize = Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for FeatureVariationRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for FeatureVariationRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -4175,6 +4203,10 @@ impl FeatureTableSubstitutionRecord {
 
 impl FixedSize for FeatureTableSubstitutionRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for FeatureTableSubstitutionRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -112,7 +112,8 @@ impl FixedSize for ScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ScriptRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ScriptRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -263,7 +264,8 @@ impl FixedSize for LangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for LangSysRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for LangSysRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -487,7 +489,8 @@ impl FixedSize for FeatureRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for FeatureRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for FeatureRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1110,7 +1113,8 @@ impl FixedSize for RangeRecord {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for RangeRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for RangeRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1399,7 +1403,8 @@ impl FixedSize for ClassRangeRecord {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ClassRangeRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ClassRangeRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -1490,7 +1495,8 @@ impl FixedSize for SequenceLookupRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for SequenceLookupRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for SequenceLookupRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -3871,7 +3877,8 @@ impl FixedSize for FeatureVariationRecord {
     const RAW_BYTE_LEN: usize = Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for FeatureVariationRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for FeatureVariationRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -4205,7 +4212,8 @@ impl FixedSize for FeatureTableSubstitutionRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for FeatureTableSubstitutionRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for FeatureTableSubstitutionRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -173,6 +173,10 @@ impl FixedSize for ValueRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for ValueRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for ValueRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -173,7 +173,8 @@ impl FixedSize for ValueRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ValueRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ValueRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -195,6 +195,10 @@ impl FixedSize for LangTagRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for LangTagRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for LangTagRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -268,6 +272,10 @@ impl FixedSize for NameRecord {
         + NameId::RAW_BYTE_LEN
         + u16::RAW_BYTE_LEN
         + Offset16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for NameRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -195,7 +195,8 @@ impl FixedSize for LangTagRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for LangTagRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for LangTagRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -274,7 +275,8 @@ impl FixedSize for NameRecord {
         + Offset16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for NameRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for NameRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -442,7 +442,8 @@ impl FixedSize for FdSelectRange3 {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for FdSelectRange3 {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for FdSelectRange3 {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -589,7 +590,8 @@ impl FixedSize for FdSelectRange4 {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for FdSelectRange4 {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for FdSelectRange4 {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -442,6 +442,10 @@ impl FixedSize for FdSelectRange3 {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for FdSelectRange3 {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for FdSelectRange3 {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -583,6 +587,10 @@ impl FdSelectRange4 {
 
 impl FixedSize for FdSelectRange4 {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for FdSelectRange4 {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -227,7 +227,8 @@ impl FixedSize for AxisRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + NameId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for AxisRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for AxisRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -893,7 +894,8 @@ impl FixedSize for AxisValueRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Fixed::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for AxisValueRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for AxisValueRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -227,6 +227,10 @@ impl FixedSize for AxisRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + NameId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for AxisRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for AxisRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -887,6 +891,10 @@ impl AxisValueRecord {
 
 impl FixedSize for AxisValueRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Fixed::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for AxisValueRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -112,6 +112,10 @@ impl FixedSize for MyRecord {
     const RAW_BYTE_LEN: usize = MyEnum1::RAW_BYTE_LEN + MyEnum2::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for MyRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for MyRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -112,7 +112,8 @@ impl FixedSize for MyRecord {
     const RAW_BYTE_LEN: usize = MyEnum1::RAW_BYTE_LEN + MyEnum2::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for MyRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for MyRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -721,6 +721,10 @@ impl FixedSize for Shmecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for Shmecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for Shmecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -721,7 +721,8 @@ impl FixedSize for Shmecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for Shmecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for Shmecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -147,7 +147,8 @@ impl FixedSize for SimpleRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for SimpleRecord {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for SimpleRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
@@ -275,7 +276,8 @@ impl FixedSize for ContainsOffests {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for ContainsOffests {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for ContainsOffests {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -147,6 +147,10 @@ impl FixedSize for SimpleRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for SimpleRecord {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for SimpleRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -269,6 +273,10 @@ impl ContainsOffests {
 
 impl FixedSize for ContainsOffests {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
+}
+
+unsafe impl JustBytes for ContainsOffests {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 #[cfg(feature = "traversal")]

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -925,7 +925,8 @@ impl FixedSize for RegionAxisCoordinates {
         F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
-unsafe impl JustBytes for RegionAxisCoordinates {
+/// SAFETY: see the [`FromBytes`] trait documentation.
+unsafe impl FromBytes for RegionAxisCoordinates {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -925,6 +925,10 @@ impl FixedSize for RegionAxisCoordinates {
         F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+unsafe impl JustBytes for RegionAxisCoordinates {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SomeRecord<'a> for RegionAxisCoordinates {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {

--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -1,7 +1,6 @@
 //! Custom array types
 
-use types::FixedSize;
-
+use crate::codegen_prelude::JustBytes;
 use crate::read::{ComputeSize, FontReadWithArgs, ReadArgs, VarSize};
 use crate::{FontData, FontRead, ReadError};
 
@@ -144,11 +143,11 @@ impl<'a, T> FontRead<'a> for VarLenArray<'a, T> {
     }
 }
 
-impl<'a, T: FixedSize> ReadArgs for &'a [T] {
+impl<'a, T: JustBytes> ReadArgs for &'a [T] {
     type Args = u16;
 }
 
-impl<'a, T: FixedSize> FontReadWithArgs<'a> for &'a [T] {
+impl<'a, T: JustBytes> FontReadWithArgs<'a> for &'a [T] {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let len = *args as usize * T::RAW_BYTE_LEN;
         data.read_array(0..len)

--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -1,6 +1,6 @@
 //! Custom array types
 
-use crate::codegen_prelude::JustBytes;
+use crate::codegen_prelude::FromBytes;
 use crate::read::{ComputeSize, FontReadWithArgs, ReadArgs, VarSize};
 use crate::{FontData, FontRead, ReadError};
 
@@ -143,11 +143,11 @@ impl<'a, T> FontRead<'a> for VarLenArray<'a, T> {
     }
 }
 
-impl<'a, T: JustBytes> ReadArgs for &'a [T] {
+impl<'a, T: FromBytes> ReadArgs for &'a [T] {
     type Args = u16;
 }
 
-impl<'a, T: JustBytes> FontReadWithArgs<'a> for &'a [T] {
+impl<'a, T: FromBytes> FontReadWithArgs<'a> for &'a [T] {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let len = *args as usize * T::RAW_BYTE_LEN;
         data.read_array(0..len)

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -47,7 +47,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
     pub use crate::read::{
-        ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
+        ComputeSize, FontRead, FontReadWithArgs, Format, JustBytes, ReadArgs, ReadError, VarSize,
     };
     pub use crate::table_provider::TopLevelTable;
     pub use crate::table_ref::TableRef;

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -32,7 +32,7 @@ mod test_helpers;
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
 pub use offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
-pub use read::{ComputeSize, FontRead, FontReadWithArgs, ReadArgs, ReadError, VarSize};
+pub use read::{ComputeSize, FontRead, FontReadWithArgs, FromBytes, ReadArgs, ReadError, VarSize};
 pub use table_provider::{TableProvider, TopLevelTable};
 pub use table_ref::TableRef;
 
@@ -47,7 +47,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
     pub use crate::read::{
-        ComputeSize, FontRead, FontReadWithArgs, Format, JustBytes, ReadArgs, ReadError, VarSize,
+        ComputeSize, FontRead, FontReadWithArgs, Format, FromBytes, ReadArgs, ReadError, VarSize,
     };
     pub use crate::table_provider::TopLevelTable;
     pub use crate::table_ref::TableRef;

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -1,6 +1,6 @@
 //! Traits for interpreting font data
 
-use types::{FixedSize, Scalar, Tag};
+use types::{BigEndian, FixedSize, Scalar, Tag};
 
 use crate::font_data::FontData;
 
@@ -96,27 +96,44 @@ pub trait VarSize {
 
 /// A marker trait for types that can read from a big-endian buffer without copying.
 ///
-/// This trait should only be implemented by generated code, and only under the
-/// following conditions:
+/// This is used as a trait bound on certain methods on [`FontData`] (such as
+/// [`FontData::read_ref_at`] and [`FontData::read_array`]) in order to ensure
+/// that those methods are only used with types that uphold certain safety
+/// guarantees.
 ///
-/// - the type contains only fields that are also `JustBytes`
-/// - the type is marked #[repr(C)] and #[repr(packed)]
-pub unsafe trait JustBytes: FixedSize {
+/// WARNING: Do not implement this trait manually. Implementations are created
+/// where appropriate during code generation, and there should be no conditions
+/// under which this trait could be implemented, but cannot be implemented by
+/// codegen.
+///
+/// # Safety
+///
+/// If a type `T` implements `FromBytes` then unsafe code may assume that it is
+/// safe to interpret any sequence of bytes with length equal to
+/// `std::mem::size_of::<T>()` as `T`.
+///
+/// we additionally ensure the following conditions:
+///
+/// - the type must have no internal padding
+/// - `std::mem::align_of::<T>() == 1`
+/// - for structs, the type is `repr(packed)` and `repr(C)`, and all fields are
+///   also `FromBytes`
+///
+/// In practice, this trait is only implemented for `u8`, `BigEndian<T>`,
+/// and for structs where all fields are those base types.
+pub unsafe trait FromBytes: FixedSize {
     /// You should not be implementing this trait!
     #[doc(hidden)]
     fn this_trait_should_only_be_implemented_in_generated_code();
 }
 
-unsafe impl JustBytes for u8 {
+// SAFETY: any byte can be interpreted as any other byte
+unsafe impl FromBytes for u8 {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
-unsafe impl<const N: usize> JustBytes for [u8; N] {
-    fn this_trait_should_only_be_implemented_in_generated_code() {}
-}
-unsafe impl<T: Scalar> JustBytes for BigEndian<T>
-where
-    T::Raw: FixedSize,
-{
+
+// SAFETY: BigEndian<T> is always wrapper around a transparent fixed-size byte array
+unsafe impl<T: Scalar> FromBytes for BigEndian<T> {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -1,6 +1,6 @@
 //! Traits for interpreting font data
 
-use font_types::{FixedSize, Scalar, Tag};
+use types::{FixedSize, Scalar, Tag};
 
 use crate::font_data::FontData;
 
@@ -92,6 +92,32 @@ pub trait VarSize {
         let asu32 = data.read_at::<Self::Size>(pos).ok()?.into();
         Some(asu32 as usize + Self::Size::RAW_BYTE_LEN)
     }
+}
+
+/// A marker trait for types that can read from a big-endian buffer without copying.
+///
+/// This trait should only be implemented by generated code, and only under the
+/// following conditions:
+///
+/// - the type contains only fields that are also `JustBytes`
+/// - the type is marked #[repr(C)] and #[repr(packed)]
+pub unsafe trait JustBytes: FixedSize {
+    /// You should not be implementing this trait!
+    #[doc(hidden)]
+    fn this_trait_should_only_be_implemented_in_generated_code();
+}
+
+unsafe impl JustBytes for u8 {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+unsafe impl<const N: usize> JustBytes for [u8; N] {
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
+}
+unsafe impl<T: Scalar> JustBytes for BigEndian<T>
+where
+    T::Raw: FixedSize,
+{
+    fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
 /// An error that occurs when reading font data


### PR DESCRIPTION
This is based on top of #462, but can be reviewed separately.

This addresses the remaining concerns around our use of unsafe.

- It introduces a new trait, `JustBytes`, which is our equivalent of `FromBytes` in zerocopy. This trait is marked unsafe, and is intended to only be implemented during codegen, as well as for `BigEndian<T>` and `u8`.
- It adds `# Safety` and `// SAFETY` documentation blocks and comments where required.

In practice, the most important part of this PR is that we no longer use the general-purpose `FixedSize` trait as the trait bound on methods that involve reinterpreting bytes; this fixes the unsoundness where someone could call one of those methods with a type that implemented that trait, but violated the safety invariants.

- closes #228 
- closes #435 
- references #434,  #436
