### PR TITLE
check that p0,p1,p2 are both collinear AND equidistant before making p1 implied

### DIFF
--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -118,8 +118,14 @@ impl ContourPoint {
         Self::new(point, false)
     }
 
-    fn distance(&self, other: &Self) -> f64 {
-        self.point.distance(other.point)
+    /// Return True if p0, p1 (self) and p2 are collinear and p1 is equidistant from p0 and p2
+    fn is_midpoint_between(&self, p0: &Self, p2: &Self) -> bool {
+        let p1 = self;
+        let p1p0 = p1.point - p0.point;
+        let p2p1 = p2.point - p1.point;
+        // should tolerance be a parameter?
+        let eps = f32::EPSILON as f64;
+        (p1p0.x - p2p1.x).abs() < eps && (p1p0.y - p2p1.y).abs() < eps
     }
 }
 
@@ -227,12 +233,8 @@ fn is_implicit_on_curve(points: &[ContourPoint], idx: usize) -> bool {
     if p0.on_curve || p0.on_curve != p2.on_curve {
         return false;
     }
-    // if the distance between p1 and p0 is approximately the same as the distance
-    // between p2 and p1, then we can drop p1
-    let p1p0 = p1.distance(p0);
-    let p2p1 = p2.distance(p1);
-    // should tolerance be a parameter?
-    (p1p0 - p2p1).abs() < f32::EPSILON as f64
+    // drop p1 if exactly between p0 and p2
+    p1.is_midpoint_between(p0, p2)
 }
 
 #[inline]

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -117,16 +117,6 @@ impl ContourPoint {
     fn off_curve(point: kurbo::Point) -> Self {
         Self::new(point, false)
     }
-
-    /// Return True if p0, p1 (self) and p2 are collinear and p1 is equidistant from p0 and p2
-    fn is_midpoint_between(&self, p0: &Self, p2: &Self) -> bool {
-        let p1 = self;
-        let p1p0 = p1.point - p0.point;
-        let p2p1 = p2.point - p1.point;
-        // should tolerance be a parameter?
-        let eps = f32::EPSILON as f64;
-        (p1p0.x - p2p1.x).abs() < eps && (p1p0.y - p2p1.y).abs() < eps
-    }
 }
 
 impl From<ContourPoint> for CurvePoint {
@@ -234,7 +224,9 @@ fn is_implicit_on_curve(points: &[ContourPoint], idx: usize) -> bool {
         return false;
     }
     // drop p1 if exactly between p0 and p2
-    p1.is_midpoint_between(p0, p2)
+    let delta_mid = p0.point.midpoint(p2.point) - p1.point;
+    let eps = f32::EPSILON as f64;
+    delta_mid.x.abs() < eps && delta_mid.y.abs() < eps
 }
 
 #[inline]

--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -1632,6 +1632,31 @@ mod tests {
     }
 
     #[test]
+    fn simple_glyph_from_kurbo_equidistant_but_not_collinear_points() {
+        let mut path = BezPath::new();
+        path.move_to((0.0, 0.0));
+        path.quad_to((2.0, 2.0), (4.0, 3.0));
+        path.quad_to((6.0, 2.0), (8.0, 0.0));
+        path.close_path();
+
+        let glyph = SimpleGlyph::from_kurbo(&path).unwrap();
+
+        assert_contour_points(
+            &glyph,
+            vec![vec![
+                CurvePoint::on_curve(0, 0),
+                CurvePoint::off_curve(2, 2),
+                // the following on-curve point is equidistant from the previous/next
+                // off-curve points but it is not on the same line hence it must NOT
+                // be dropped
+                CurvePoint::on_curve(4, 3),
+                CurvePoint::off_curve(6, 2),
+                CurvePoint::on_curve(8, 0),
+            ]],
+        );
+    }
+
+    #[test]
     fn repeatable_flags_basic() {
         let flags = [
             SimpleGlyphFlags::ON_CURVE_POINT,


### PR DESCRIPTION
Before we were simply testing that the euclidean distance between p1 and p0 was the same as the distance between p2 and p1, without actually enforcing that the three points were on the same line.
Here we check that the two vectors p1p0 and p2p1's x/y components are almost the same.
FontTools also does the same, see:
https://github.com/fonttools/fonttools/blob/66ce7c0e0c0ffdd11b2b5011323305f166ee3b85/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L1599-L1601