### PR TITLE
Stop spamming writing table to log

### DIFF
--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -49,7 +49,7 @@ pub struct TableWriter {
 /// Returns an error if the table is malformed or cannot otherwise be serialized,
 /// otherwise it will return the bytes encoding the table.
 pub fn dump_table<T: FontWrite + Validate>(table: &T) -> Result<Vec<u8>, Error> {
-    log::info!("writing table '{}'", table.table_type());
+    log::trace!("writing table '{}'", table.table_type());
     table.validate().map_err(Error::ValidationFailed)?;
     let mut graph = TableWriter::make_graph(table);
 


### PR DESCRIPTION
It's annoying to flip on info logging and get streams of writing table. Aside: many of them report unknown, e.g.:

```shell
...
2023-06-06T22:03:59.294694Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294714Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294738Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294763Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294792Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294812Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294832Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294862Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294888Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294907Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294936Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.294971Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295004Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295037Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295063Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295087Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295116Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295148Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295168Z: ThreadId(2): INFO: writing table 'Unknown'
2023-06-06T22:03:59.295704Z: ThreadId(2): INFO: writing table 'head'
2023-06-06T22:03:59.309398Z: ThreadId(4): INFO: writing table 'hhea'
2023-06-06T22:03:59.309787Z: ThreadId(4): INFO: writing table 'hmtx'
2023-06-06T22:03:59.311888Z: ThreadId(4): INFO: writing table 'maxp'
2023-06-06T22:03:59.312092Z: ThreadId(4): INFO: writing table 'head'
...
```

JMM