### PR TITLE
[font-types] Add some pen adapters

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -38,7 +38,7 @@ pub use glyph_id::GlyphId;
 pub use longdatetime::LongDateTime;
 pub use name_id::NameId;
 pub use offset::{Nullable, Offset16, Offset24, Offset32};
-pub use pen::{Pen, PenCommand};
+pub use pen::{BufferPen, Pen, PenCommand, SvgPen};
 pub use point::Point;
 pub use raw::{BigEndian, FixedSize, Scalar};
 pub use tag::{InvalidTag, Tag};

--- a/font-types/src/pen.rs
+++ b/font-types/src/pen.rs
@@ -1,11 +1,17 @@
+//! Types for working with sequences of path commands.
+
+use core::{
+    fmt,
+    iter::{self, Extend},
+};
+
 /// Interface for accepting a sequence of path commands.
 ///
 /// This is a general abstraction to unify ouput for processes that decode and/or
 /// transform outlines.
 ///
-/// /// AbstractPen in Python terms.
-/// <https://github.com/fonttools/fonttools/blob/78e10d8b42095b709cd4125e592d914d3ed1558e/Lib/fontTools/pens/basePen.py#L54>.
-/// Implementations
+/// Roughly equivalent to [AbstractPen](https://github.com/fonttools/fonttools/blob/78e10d8b42095b709cd4125e592d914d3ed1558e/Lib/fontTools/pens/basePen.py#L54)
+/// in FontTools.
 pub trait Pen {
     /// Emit a command to begin a new subpath at (x, y).
     fn move_to(&mut self, x: f32, y: f32);
@@ -83,5 +89,148 @@ impl PenCommand {
             | PenCommand::CurveTo { x, y, .. } => Some((x, y)),
             PenCommand::Close => None,
         }
+    }
+}
+
+/// Pen adapter that outputs commands to SVG path data.
+///
+/// The target may be any type that implements `fmt::Write` such as
+/// `String`.
+pub struct SvgPen<T> {
+    target: T,
+    space: &'static str,
+}
+
+impl<T> SvgPen<T> {
+    pub fn new(target: T) -> Self {
+        Self { target, space: "" }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.target
+    }
+}
+
+impl<T: fmt::Write> Pen for SvgPen<T> {
+    fn move_to(&mut self, x: f32, y: f32) {
+        let _ = write!(self.target, "{}M{},{}", self.space, x, y);
+        self.space = " ";
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        let _ = write!(self.target, "{}L{},{}", self.space, x, y);
+        self.space = " ";
+    }
+
+    fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+        let _ = write!(self.target, "{}Q{},{} {},{}", self.space, cx0, cy0, x, y);
+        self.space = " ";
+    }
+
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        let _ = write!(
+            self.target,
+            "{}C{},{} {},{} {},{}",
+            self.space, cx0, cy0, cx1, cy1, x, y
+        );
+        self.space = " ";
+    }
+
+    fn close(&mut self) {
+        let _ = write!(self.target, "{}Z", self.space);
+        self.space = " ";
+    }
+}
+
+/// Pen adapter that collects commands into a target buffer.
+///
+/// The target may be any type that implements `Extend<PenCommand>` such as
+/// `Vec<PenCommand>`.
+pub struct BufferPen<T> {
+    target: T,
+}
+
+impl<T> BufferPen<T> {
+    pub fn new(target: T) -> Self {
+        Self { target }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.target
+    }
+}
+
+impl<T: Extend<PenCommand>> Pen for BufferPen<T> {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.target.extend(iter::once(PenCommand::MoveTo { x, y }));
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.target.extend(iter::once(PenCommand::LineTo { x, y }));
+    }
+
+    fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+        self.target
+            .extend(iter::once(PenCommand::QuadTo { cx0, cy0, x, y }));
+    }
+
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        self.target.extend(iter::once(PenCommand::CurveTo {
+            cx0,
+            cy0,
+            cx1,
+            cy1,
+            x,
+            y,
+        }));
+    }
+
+    fn close(&mut self) {
+        self.target.extend(iter::once(PenCommand::Close));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BufferPen, PenCommand, SvgPen};
+
+    const TEST_COMMANDS: &[PenCommand] = &[
+        PenCommand::MoveTo { x: 1.0, y: 2.5 },
+        PenCommand::LineTo { x: 42.0, y: 20.0 },
+        PenCommand::QuadTo {
+            cx0: 0.5,
+            cy0: 0.5,
+            x: 1.0,
+            y: 2.0,
+        },
+        PenCommand::CurveTo {
+            cx0: 1.2,
+            cy0: 2.3,
+            cx1: 3.4,
+            cy1: 4.5,
+            x: 5.6,
+            y: 6.7,
+        },
+        PenCommand::Close,
+    ];
+
+    #[test]
+    fn pen_to_svg() {
+        let mut pen = SvgPen::new(String::default());
+        for command in TEST_COMMANDS {
+            command.apply_to(&mut pen);
+        }
+        let buf = pen.into_inner();
+        assert_eq!(buf, "M1,2.5 L42,20 Q0.5,0.5 1,2 C1.2,2.3 3.4,4.5 5.6,6.7 Z");
+    }
+
+    #[test]
+    fn pen_to_buffer() {
+        let mut pen = BufferPen::new(vec![]);
+        for command in TEST_COMMANDS {
+            command.apply_to(&mut pen);
+        }
+        let commands = pen.into_inner();
+        assert_eq!(&commands, TEST_COMMANDS);
     }
 }


### PR DESCRIPTION
Adds new `SvgPen` and `BufferPen` types that impl `Pen` and support output to SVG path data and buffers (containing `PenCommand`s), respectively.

These are implemented in terms of core traits so don't require std.
