### PR TITLE
bump write-fonts to 0.6.1

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
```
$ cargo release changes
     Changes for write-fonts from write-fonts-v0.6.0 to 0.6.1
             6e1dfa7 get rid of the const/static because rustc is smarter than I thought
             25dc979 make a simple isclose function that uses a static default FloatComparator
             7a943a5 add a few tests for is_mid_point
             8c75944 check if oncurves can be implied both before and after rounding
             1bb5a33 implement OtRound for kurbo::Vec2
             b7994cc port python's math.isclose so we can match 100% fonttools
             59075aa write midpoint computation more tersely
             89803d0 check that p0,p1,p2 are collinear as well as equidistant before dropping p1
             60cb4f7 add (failing) repro for equidistant-not-collinear on-curve
             38ddfbb Stop spamming writing table
```
