### PR TITLE
Add SAFETY comment and remove an unsafe

### DIFF
--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -27,7 +27,7 @@ impl<'a> std::io::Write for PrettyPrinter<'a> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let len = self.writer.write(buf)?;
         let wrote_buf = &buf[..len];
-        let wrote_str = std::String::from_utf8_lossy(wrote_buf);
+        let wrote_str = String::from_utf8_lossy(wrote_buf);
         self.line_pos = match wrote_buf.iter().rev().position(|b| *b == b'\n') {
             Some(pos) => {
                 assert_eq!(pos, 0);

--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -27,7 +27,7 @@ impl<'a> std::io::Write for PrettyPrinter<'a> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let len = self.writer.write(buf)?;
         let wrote_buf = &buf[..len];
-        let wrote_str = unsafe { std::str::from_utf8_unchecked(wrote_buf) };
+        let wrote_str = std::str::from_utf8(wrote_buf);
         self.line_pos = match wrote_buf.iter().rev().position(|b| *b == b'\n') {
             Some(pos) => {
                 assert_eq!(pos, 0);

--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -27,7 +27,7 @@ impl<'a> std::io::Write for PrettyPrinter<'a> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let len = self.writer.write(buf)?;
         let wrote_buf = &buf[..len];
-        let wrote_str = std::str::from_utf8_lossy(wrote_buf);
+        let wrote_str = std::String::from_utf8_lossy(wrote_buf);
         self.line_pos = match wrote_buf.iter().rev().position(|b| *b == b'\n') {
             Some(pos) => {
                 assert_eq!(pos, 0);

--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -27,7 +27,7 @@ impl<'a> std::io::Write for PrettyPrinter<'a> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let len = self.writer.write(buf)?;
         let wrote_buf = &buf[..len];
-        let wrote_str = std::str::from_utf8(wrote_buf);
+        let wrote_str = std::str::from_utf8_lossy(wrote_buf);
         self.line_pos = match wrote_buf.iter().rev().position(|b| *b == b'\n') {
             Some(pos) => {
                 assert_eq!(pos, 0);

--- a/read-fonts/src/tables/post.rs
+++ b/read-fonts/src/tables/post.rs
@@ -73,6 +73,8 @@ impl<'a> FontRead<'a> for PString<'a> {
             .get(1..len as usize + 1)
             .ok_or(ReadError::OutOfBounds)?;
         if pstring.is_ascii() {
+            // SAFETY: `pstring` must be valid UTF-8, which is known to be the
+            // case since ASCII is a subset of UTF-8 and `is_ascii()` is true.
             Ok(PString(unsafe { std::str::from_utf8_unchecked(pstring) }))
         } else {
             //FIXME not really sure how we want to handle this?


### PR DESCRIPTION
This adds a SAFETY comment on one use of unsafe, and in the other case a comment could not be written to explain how it is guaranteed to be safe, so remove the use of the unsafe method and use the safe from_utf8() instead.

Some followup work to address https://github.com/googlefonts/fontations/issues/435