### PR TITLE
Make FromBytes sealed trait

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -41,6 +41,7 @@ pub(crate) fn generate(item: &Record) -> syn::Result<TokenStream> {
                 const RAW_BYTE_LEN: usize = #( #inner_types::RAW_BYTE_LEN )+*;
             }
 
+            impl sealed::Sealed for #name {}
             /// SAFETY: see the [`FromBytes`] trait documentation.
             unsafe impl FromBytes for #name {
                 fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -167,6 +167,8 @@ impl FixedSize for TableRecord {
         Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for TableRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for TableRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -173,6 +173,8 @@ impl FixedSize for AxisValueMap {
     const RAW_BYTE_LEN: usize = F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for AxisValueMap {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for AxisValueMap {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -399,6 +399,8 @@ impl FixedSize for BaseScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for BaseScriptRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for BaseScriptRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -575,6 +577,8 @@ impl BaseLangSysRecord {
 impl FixedSize for BaseLangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for BaseLangSysRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for BaseLangSysRecord {
@@ -877,6 +881,8 @@ impl FeatMinMaxRecord {
 impl FixedSize for FeatMinMaxRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for FeatMinMaxRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for FeatMinMaxRecord {

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -138,6 +138,8 @@ impl FixedSize for EncodingRecord {
         PlatformId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for EncodingRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for EncodingRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -511,6 +513,8 @@ impl FixedSize for SubHeader {
     const RAW_BYTE_LEN: usize =
         u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for SubHeader {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for SubHeader {
@@ -1049,6 +1053,8 @@ impl FixedSize for SequentialMapGroup {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for SequentialMapGroup {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for SequentialMapGroup {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -1470,6 +1476,8 @@ impl FixedSize for ConstantMapGroup {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for ConstantMapGroup {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ConstantMapGroup {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -1649,6 +1657,8 @@ impl FixedSize for VariationSelector {
     const RAW_BYTE_LEN: usize =
         Uint24::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for VariationSelector {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for VariationSelector {
@@ -1853,6 +1863,8 @@ impl FixedSize for UvsMapping {
     const RAW_BYTE_LEN: usize = Uint24::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for UvsMapping {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for UvsMapping {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -1899,6 +1911,8 @@ impl UnicodeRange {
 impl FixedSize for UnicodeRange {
     const RAW_BYTE_LEN: usize = Uint24::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for UnicodeRange {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for UnicodeRange {

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -328,6 +328,8 @@ impl FixedSize for BaseGlyph {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for BaseGlyph {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for BaseGlyph {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -375,6 +377,8 @@ impl Layer {
 impl FixedSize for Layer {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for Layer {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for Layer {
@@ -504,6 +508,8 @@ impl BaseGlyphPaint {
 impl FixedSize for BaseGlyphPaint {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for BaseGlyphPaint {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for BaseGlyphPaint {
@@ -739,6 +745,8 @@ impl FixedSize for Clip {
     const RAW_BYTE_LEN: usize =
         GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + Offset24::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for Clip {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for Clip {
@@ -1053,6 +1061,8 @@ impl FixedSize for ColorIndex {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for ColorIndex {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ColorIndex {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -1106,6 +1116,8 @@ impl VarColorIndex {
 impl FixedSize for VarColorIndex {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for VarColorIndex {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for VarColorIndex {
@@ -1161,6 +1173,8 @@ impl ColorStop {
 impl FixedSize for ColorStop {
     const RAW_BYTE_LEN: usize = F2Dot14::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for ColorStop {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ColorStop {
@@ -1224,6 +1238,8 @@ impl FixedSize for VarColorStop {
     const RAW_BYTE_LEN: usize =
         F2Dot14::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for VarColorStop {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for VarColorStop {

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -307,6 +307,8 @@ impl FixedSize for ColorRecord {
         u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for ColorRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ColorRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -327,6 +327,8 @@ impl FixedSize for VariationAxisRecord {
         + NameId::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for VariationAxisRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for VariationAxisRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1010,6 +1010,8 @@ impl FixedSize for MarkRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for MarkRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for MarkRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -2249,6 +2251,8 @@ impl EntryExitRecord {
 impl FixedSize for EntryExitRecord {
     const RAW_BYTE_LEN: usize = Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for EntryExitRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for EntryExitRecord {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -137,6 +137,8 @@ impl FixedSize for LongMetric {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for LongMetric {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for LongMetric {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -112,6 +112,8 @@ impl FixedSize for ScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for ScriptRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ScriptRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -263,6 +265,8 @@ impl LangSysRecord {
 impl FixedSize for LangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for LangSysRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for LangSysRecord {
@@ -488,6 +492,8 @@ impl FeatureRecord {
 impl FixedSize for FeatureRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for FeatureRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for FeatureRecord {
@@ -1113,6 +1119,8 @@ impl FixedSize for RangeRecord {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for RangeRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for RangeRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -1403,6 +1411,8 @@ impl FixedSize for ClassRangeRecord {
     const RAW_BYTE_LEN: usize = GlyphId::RAW_BYTE_LEN + GlyphId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for ClassRangeRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ClassRangeRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -1494,6 +1504,8 @@ impl SequenceLookupRecord {
 impl FixedSize for SequenceLookupRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for SequenceLookupRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for SequenceLookupRecord {
@@ -3877,6 +3889,8 @@ impl FixedSize for FeatureVariationRecord {
     const RAW_BYTE_LEN: usize = Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for FeatureVariationRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for FeatureVariationRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -4211,6 +4225,8 @@ impl FeatureTableSubstitutionRecord {
 impl FixedSize for FeatureTableSubstitutionRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for FeatureTableSubstitutionRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for FeatureTableSubstitutionRecord {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -173,6 +173,8 @@ impl FixedSize for ValueRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for ValueRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ValueRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -195,6 +195,8 @@ impl FixedSize for LangTagRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for LangTagRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for LangTagRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -274,6 +276,8 @@ impl FixedSize for NameRecord {
         + u16::RAW_BYTE_LEN
         + Offset16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for NameRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for NameRecord {

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -442,6 +442,8 @@ impl FixedSize for FdSelectRange3 {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for FdSelectRange3 {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for FdSelectRange3 {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -589,6 +591,8 @@ impl FdSelectRange4 {
 impl FixedSize for FdSelectRange4 {
     const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for FdSelectRange4 {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for FdSelectRange4 {

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -227,6 +227,8 @@ impl FixedSize for AxisRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + NameId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for AxisRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for AxisRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -893,6 +895,8 @@ impl AxisValueRecord {
 impl FixedSize for AxisValueRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Fixed::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for AxisValueRecord {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for AxisValueRecord {

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -112,6 +112,8 @@ impl FixedSize for MyRecord {
     const RAW_BYTE_LEN: usize = MyEnum1::RAW_BYTE_LEN + MyEnum2::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for MyRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for MyRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -721,6 +721,8 @@ impl FixedSize for Shmecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for Shmecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for Shmecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -147,6 +147,8 @@ impl FixedSize for SimpleRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for SimpleRecord {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for SimpleRecord {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
@@ -275,6 +277,8 @@ impl ContainsOffests {
 impl FixedSize for ContainsOffests {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
+
+impl sealed::Sealed for ContainsOffests {}
 
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for ContainsOffests {

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -925,6 +925,8 @@ impl FixedSize for RegionAxisCoordinates {
         F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+impl sealed::Sealed for RegionAxisCoordinates {}
+
 /// SAFETY: see the [`FromBytes`] trait documentation.
 unsafe impl FromBytes for RegionAxisCoordinates {
     fn this_trait_should_only_be_implemented_in_generated_code() {}

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
+    pub(crate) use crate::read::sealed;
     pub use crate::read::{
         ComputeSize, FontRead, FontReadWithArgs, Format, FromBytes, ReadArgs, ReadError, VarSize,
     };

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -121,17 +121,24 @@ pub trait VarSize {
 ///
 /// In practice, this trait is only implemented for `u8`, `BigEndian<T>`,
 /// and for structs where all fields are those base types.
-pub unsafe trait FromBytes: FixedSize {
+pub unsafe trait FromBytes: FixedSize + sealed::Sealed {
     /// You should not be implementing this trait!
     #[doc(hidden)]
     fn this_trait_should_only_be_implemented_in_generated_code();
 }
 
+// a sealed trait. see <https://rust-lang.github.io/api-guidelines/future-proofing.html>
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
+impl sealed::Sealed for u8 {}
 // SAFETY: any byte can be interpreted as any other byte
 unsafe impl FromBytes for u8 {
     fn this_trait_should_only_be_implemented_in_generated_code() {}
 }
 
+impl<T: Scalar> sealed::Sealed for BigEndian<T> {}
 // SAFETY: BigEndian<T> is always wrapper around a transparent fixed-size byte array
 unsafe impl<T: Scalar> FromBytes for BigEndian<T> {
     fn this_trait_should_only_be_implemented_in_generated_code() {}


### PR DESCRIPTION
This prevents it from ever being implemented outside of `read-fonts`.

See discussion at https://github.com/googlefonts/fontations/issues/436#issuecomment-1583069720