### PR TITLE
Expose outline format in TableProvider

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -51,4 +51,4 @@ pub const TTC_HEADER_TAG: Tag = Tag::new(b"ttcf");
 /// The SFNT version for fonts containing TrueType outlines.
 pub const TT_SFNT_VERSION: u32 = 0x00010000;
 /// The SFNT version for fonts containing CFF outlines.
-pub const CFF_SFTN_VERSION: u32 = 0x4F54544F;
+pub const CFF_SFNT_VERSION: u32 = 0x4F54544F;

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -242,7 +242,7 @@ impl<'a> FontRef<'a> {
         data: FontData<'a>,
         table_directory: TableDirectory<'a>,
     ) -> Result<Self, ReadError> {
-        if [TT_SFNT_VERSION, CFF_SFTN_VERSION].contains(&table_directory.sfnt_version()) {
+        if [TT_SFNT_VERSION, CFF_SFNT_VERSION].contains(&table_directory.sfnt_version()) {
             Ok(FontRef {
                 data,
                 table_directory,
@@ -257,4 +257,19 @@ impl<'a> TableProvider<'a> for FontRef<'a> {
     fn data_for_tag(&self, tag: Tag) -> Option<FontData<'a>> {
         self.table_data(tag)
     }
+
+    fn outline_format(&self) -> Option<OutlineFormat> {
+        Some(match self.table_directory.sfnt_version() {
+            TT_SFNT_VERSION => OutlineFormat::TrueType,
+            CFF_SFNT_VERSION => OutlineFormat::PostScript,
+            _ => return None,
+        })
+    }
+}
+
+/// The type of scalable outlines contained in a font.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum OutlineFormat {
+    TrueType,
+    PostScript,
 }

--- a/read-fonts/src/table_provider.rs
+++ b/read-fonts/src/table_provider.rs
@@ -2,7 +2,7 @@
 
 use types::Tag;
 
-use crate::{tables, FontData, FontRead, ReadError};
+use crate::{tables, FontData, FontRead, OutlineFormat, ReadError};
 
 /// A table that has an associated tag.
 ///
@@ -22,6 +22,10 @@ pub trait TableProvider<'a> {
 
     fn expect_table<T: TopLevelTable + FontRead<'a>>(&self) -> Result<T, ReadError> {
         self.expect_data_for_tag(T::TAG).and_then(FontRead::read)
+    }
+
+    fn outline_format(&self) -> Option<OutlineFormat> {
+        None
     }
 
     fn head(&self) -> Result<tables::head::Head<'a>, ReadError> {


### PR DESCRIPTION
Adds a new `OutlineFormat` enum and `outline_format` method to `TableProvider`. Impl in `FontRef` bases this on `sfntVersion`.

While this was generally accessible from `FontRef`, the skrifa scaler only accesses fonts through `TableProvider` and this info will be necessary for passing some of the Unicode text rendering tests (those that include both `glyf` and `CFF` tables and expect the choice to be made based on `sfntVersion`) in the future.

Also fixes #477