### PR TITLE
Remove panicking paths from Tag

### DIFF
--- a/read-fonts/src/tests/layout.rs
+++ b/read-fonts/src/tests/layout.rs
@@ -23,7 +23,7 @@ fn example_2_scripts_and_langs() {
     assert_eq!(table.lang_sys_count(), 1);
 
     let urdu_record = &table.lang_sys_records()[0];
-    assert_eq!(urdu_record.lang_sys_tag(), Tag::new(b"URD"));
+    assert_eq!(urdu_record.lang_sys_tag(), Tag::new(b"URD "));
     let urdu_sys = urdu_record.lang_sys(table.offset_data()).unwrap();
     assert_eq!(urdu_sys.required_feature_index(), 3);
     assert_eq!(urdu_sys.feature_index_count(), 3);

--- a/skrifa/src/scale/glyf/scaler.rs
+++ b/skrifa/src/scale/glyf/scaler.rs
@@ -604,7 +604,7 @@ impl<'a> ScalerFont<'a> {
             .map(|data| data.read_array(0..data.len()).unwrap())
             .unwrap_or_default();
         let cvt = font
-            .data_for_tag(Tag::new(b"cvt"))
+            .data_for_tag(Tag::new(b"cvt "))
             .and_then(|data| data.read_array(0..data.len()).ok())
             .unwrap_or_default();
         let maxp = font.maxp()?;


### PR DESCRIPTION
Copy-pasting the first commit message:

his was ill-considered, and is not a good match for the ways this type
is used in practice.

More broadly, this change represents a loosening of constraints on the
contents of a Tag, to better match what we are actually doing anyway.
Concretely, this means that we are taking the spec as a *suggestion*,
but fully support invalid tags.

This also adds a `validate` method to Tag, which can be used to check
the validity of a tag that was created through one of the unchecked
paths.

The second commit changes our printing behaviour, so that if a tag is non-ascii we will print the numerical value of the non-ascii bytes.