### PR TITLE
[read-fonts] Better CFF/CFF2 tables

### DIFF
--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -5,15 +5,15 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table
+/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CffMarker {
+pub struct CffHeaderMarker {
     _padding_byte_len: usize,
     trailing_data_byte_len: usize,
 }
 
-impl CffMarker {
+impl CffHeaderMarker {
     fn major_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -40,12 +40,7 @@ impl CffMarker {
     }
 }
 
-impl TopLevelTable for Cff<'_> {
-    /// `CFF `
-    const TAG: Tag = Tag::new(b"CFF ");
-}
-
-impl<'a> FontRead<'a> for Cff<'a> {
+impl<'a> FontRead<'a> for CffHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u8>();
@@ -56,17 +51,17 @@ impl<'a> FontRead<'a> for Cff<'a> {
         cursor.advance_by(_padding_byte_len);
         let trailing_data_byte_len = cursor.remaining_bytes();
         cursor.advance_by(trailing_data_byte_len);
-        cursor.finish(CffMarker {
+        cursor.finish(CffHeaderMarker {
             _padding_byte_len,
             trailing_data_byte_len,
         })
     }
 }
 
-/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table
-pub type Cff<'a> = TableRef<'a, CffMarker>;
+/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
+pub type CffHeader<'a> = TableRef<'a, CffHeaderMarker>;
 
-impl<'a> Cff<'a> {
+impl<'a> CffHeader<'a> {
     /// Format major version (starting at 1).
     pub fn major(&self) -> u8 {
         let range = self.shape.major_byte_range();
@@ -105,9 +100,9 @@ impl<'a> Cff<'a> {
 }
 
 #[cfg(feature = "traversal")]
-impl<'a> SomeTable<'a> for Cff<'a> {
+impl<'a> SomeTable<'a> for CffHeader<'a> {
     fn type_name(&self) -> &str {
-        "Cff"
+        "CffHeader"
     }
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
@@ -123,7 +118,7 @@ impl<'a> SomeTable<'a> for Cff<'a> {
 }
 
 #[cfg(feature = "traversal")]
-impl<'a> std::fmt::Debug for Cff<'a> {
+impl<'a> std::fmt::Debug for CffHeader<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -5,16 +5,16 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table
+/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cff2Marker {
+pub struct Cff2HeaderMarker {
     _padding_byte_len: usize,
     top_dict_data_byte_len: usize,
     trailing_data_byte_len: usize,
 }
 
-impl Cff2Marker {
+impl Cff2HeaderMarker {
     fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -45,12 +45,7 @@ impl Cff2Marker {
     }
 }
 
-impl TopLevelTable for Cff2<'_> {
-    /// `CFF2`
-    const TAG: Tag = Tag::new(b"CFF2");
-}
-
-impl<'a> FontRead<'a> for Cff2<'a> {
+impl<'a> FontRead<'a> for Cff2Header<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         cursor.advance::<u8>();
@@ -63,7 +58,7 @@ impl<'a> FontRead<'a> for Cff2<'a> {
         cursor.advance_by(top_dict_data_byte_len);
         let trailing_data_byte_len = cursor.remaining_bytes();
         cursor.advance_by(trailing_data_byte_len);
-        cursor.finish(Cff2Marker {
+        cursor.finish(Cff2HeaderMarker {
             _padding_byte_len,
             top_dict_data_byte_len,
             trailing_data_byte_len,
@@ -71,10 +66,10 @@ impl<'a> FontRead<'a> for Cff2<'a> {
     }
 }
 
-/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table
-pub type Cff2<'a> = TableRef<'a, Cff2Marker>;
+/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
+pub type Cff2Header<'a> = TableRef<'a, Cff2HeaderMarker>;
 
-impl<'a> Cff2<'a> {
+impl<'a> Cff2Header<'a> {
     /// Format major version (set to 2).
     pub fn major_version(&self) -> u8 {
         let range = self.shape.major_version_byte_range();
@@ -119,9 +114,9 @@ impl<'a> Cff2<'a> {
 }
 
 #[cfg(feature = "traversal")]
-impl<'a> SomeTable<'a> for Cff2<'a> {
+impl<'a> SomeTable<'a> for Cff2Header<'a> {
     fn type_name(&self) -> &str {
-        "Cff2"
+        "Cff2Header"
     }
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
@@ -138,7 +133,7 @@ impl<'a> SomeTable<'a> for Cff2<'a> {
 }
 
 #[cfg(feature = "traversal")]
-impl<'a> std::fmt::Debug for Cff2<'a> {
+impl<'a> std::fmt::Debug for Cff2Header<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }

--- a/read-fonts/src/tables/cff.rs
+++ b/read-fonts/src/tables/cff.rs
@@ -1,3 +1,154 @@
 //! The [CFF](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table
 
 include!("../../generated/generated_cff.rs");
+
+use super::postscript::{Index1, Latin1String, StringId};
+
+/// The [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table.
+pub struct Cff<'a> {
+    header: CffHeader<'a>,
+    names: Index1<'a>,
+    top_dicts: Index1<'a>,
+    strings: Index1<'a>,
+    global_subrs: Index1<'a>,
+}
+
+impl<'a> Cff<'a> {
+    pub fn offset_data(&self) -> FontData<'a> {
+        self.header.offset_data()
+    }
+
+    pub fn header(&self) -> CffHeader<'a> {
+        self.header.clone()
+    }
+
+    /// Returns the name index.
+    ///
+    /// This contains the PostScript names of all fonts in the font set.
+    ///
+    /// See "Name INDEX" at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=13>
+    pub fn names(&self) -> Index1<'a> {
+        self.names.clone()
+    }
+
+    /// Returns the PostScript name for the font in the font set at the
+    /// given index.
+    pub fn name(&self, index: usize) -> Option<Latin1String<'a>> {
+        Some(Latin1String::new(self.names.get(index).ok()?))
+    }
+
+    /// Returns the top dict index.
+    ///
+    /// This contains the top-level DICTs of all fonts in the font set. The
+    /// objects here correspond to those in the name index.
+    ///
+    /// See "Top DICT INDEX" at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=14>
+    pub fn top_dicts(&self) -> Index1<'a> {
+        self.top_dicts.clone()
+    }
+
+    /// Returns the string index.
+    ///
+    /// This contains all of the strings used by fonts within the font set.
+    /// They are referenced by string identifiers represented by the
+    /// [`StringId`] type.
+    ///
+    /// See "String INDEX" at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=17>
+    pub fn strings(&self) -> Index1<'a> {
+        self.strings.clone()
+    }
+
+    /// Returns the associated string for the given identifier.
+    ///
+    /// If the identifier does not represent a standard string, the result is
+    /// looked up in the string index.
+    pub fn string(&self, id: StringId) -> Option<Latin1String<'a>> {
+        match id.standard_string() {
+            Ok(name) => Some(name),
+            Err(ix) => self.strings.get(ix).ok().map(Latin1String::new),
+        }
+    }
+
+    /// Returns the global subroutine index.
+    ///
+    /// This contains sub-programs that are referenced by one or more
+    /// charstrings in the font set.
+    ///
+    /// See "Local/Global Subrs INDEXes" at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=25>
+    pub fn global_subrs(&self) -> Index1<'a> {
+        self.global_subrs.clone()
+    }
+}
+
+impl TopLevelTable for Cff<'_> {
+    const TAG: Tag = Tag::new(b"CFF ");
+}
+
+impl<'a> FontRead<'a> for Cff<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let header = CffHeader::read(data)?;
+        let mut data = FontData::new(header.trailing_data());
+        let names = Index1::read(data)?;
+        data = data
+            .split_off(names.size_in_bytes()?)
+            .ok_or(ReadError::OutOfBounds)?;
+        let top_dicts = Index1::read(data)?;
+        data = data
+            .split_off(top_dicts.size_in_bytes()?)
+            .ok_or(ReadError::OutOfBounds)?;
+        let strings = Index1::read(data)?;
+        data = data
+            .split_off(strings.size_in_bytes()?)
+            .ok_or(ReadError::OutOfBounds)?;
+        let global_subrs = Index1::read(data)?;
+        Ok(Self {
+            header,
+            names,
+            top_dicts,
+            strings,
+            global_subrs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{tables::postscript::StringId, FontRef, TableProvider};
+
+    #[test]
+    fn read_noto_serif_display_cff() {
+        let font = FontRef::new(font_test_data::NOTO_SERIF_DISPLAY_TRIMMED).unwrap();
+        let cff = font.cff().unwrap();
+        assert_eq!(cff.header().major(), 1);
+        assert_eq!(cff.header().minor(), 0);
+        assert_eq!(cff.top_dicts().count(), 1);
+        assert_eq!(cff.names().count(), 1);
+        assert_eq!(cff.global_subrs.count(), 17);
+        let name = Latin1String::new(cff.names().get(0).unwrap());
+        assert_eq!(name, "NotoSerifDisplay-Regular");
+        assert_eq!(cff.strings().count(), 5);
+        // Version
+        assert_eq!(cff.string(StringId::new(391)).unwrap(), "2.9");
+        // Notice
+        assert_eq!(
+            cff.string(StringId::new(392)).unwrap(),
+            "Noto is a trademark of Google LLC."
+        );
+        // Copyright
+        assert_eq!(
+            cff.string(StringId::new(393)).unwrap(),
+            "Copyright 2022 The Noto Project Authors https:github.comnotofontslatin-greek-cyrillic"
+        );
+        // FullName
+        assert_eq!(
+            cff.string(StringId::new(394)).unwrap(),
+            "Noto Serif Display Regular"
+        );
+        // FamilyName
+        assert_eq!(
+            cff.string(StringId::new(395)).unwrap(),
+            "Noto Serif Display"
+        );
+    }
+}

--- a/read-fonts/src/tables/cff2.rs
+++ b/read-fonts/src/tables/cff2.rs
@@ -1,3 +1,80 @@
 //! The [CFF2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table
 
 include!("../../generated/generated_cff2.rs");
+
+use super::postscript::Index2;
+
+/// The [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table
+pub struct Cff2<'a> {
+    header: Cff2Header<'a>,
+    global_subrs: Index2<'a>,
+}
+
+impl<'a> Cff2<'a> {
+    pub fn offset_data(&self) -> FontData<'a> {
+        self.header.offset_data()
+    }
+
+    pub fn header(&self) -> &Cff2Header<'a> {
+        &self.header
+    }
+
+    /// Returns the raw data containing the top dict.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#7-top-dict-data>
+    pub fn top_dict_data(&self) -> &'a [u8] {
+        self.header.top_dict_data()
+    }
+
+    /// Returns the global subroutine index.
+    ///
+    /// This contains sub-programs that are referenced by one or more
+    /// charstrings in the font set.
+    ///
+    /// See "Local/Global Subrs INDEXes" at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=25>
+    pub fn global_subrs(&self) -> Index2<'a> {
+        self.global_subrs.clone()
+    }
+}
+
+impl TopLevelTable for Cff2<'_> {
+    const TAG: Tag = Tag::new(b"CFF2");
+}
+
+impl<'a> FontRead<'a> for Cff2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let header = Cff2Header::read(data)?;
+        let global_subrs = Index2::read(FontData::new(header.trailing_data()))?;
+        Ok(Self {
+            header,
+            global_subrs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FontData, FontRead, FontRef, TableProvider};
+
+    #[test]
+    fn read_example_cff2_table() {
+        let cff2 = Cff2::read(FontData::new(font_test_data::cff2::EXAMPLE)).unwrap();
+        assert_eq!(cff2.header().major_version(), 2);
+        assert_eq!(cff2.header().minor_version(), 0);
+        assert_eq!(cff2.header().header_size(), 5);
+        assert_eq!(cff2.top_dict_data().len(), 7);
+        assert_eq!(cff2.global_subrs().count(), 0);
+    }
+
+    #[test]
+    fn read_cantarell() {
+        let font = FontRef::new(font_test_data::CANTARELL_VF_TRIMMED).unwrap();
+        let cff2 = font.cff2().unwrap();
+        assert_eq!(cff2.header().major_version(), 2);
+        assert_eq!(cff2.header().minor_version(), 0);
+        assert_eq!(cff2.header().header_size(), 5);
+        assert_eq!(cff2.top_dict_data().len(), 7);
+        assert_eq!(cff2.global_subrs().count(), 0);
+    }
+}

--- a/read-fonts/src/tables/postscript/dict.rs
+++ b/read-fonts/src/tables/postscript/dict.rs
@@ -555,9 +555,8 @@ fn parse_bcd(cursor: &mut Cursor) -> Result<Fixed, Error> {
 mod tests {
     use super::*;
     use crate::{
-        tables::{postscript::Index1, variations::ItemVariationStore},
-        types::F2Dot14,
-        FontData, FontRead, FontRef, TableProvider,
+        tables::variations::ItemVariationStore, types::F2Dot14, FontData, FontRead, FontRef,
+        TableProvider,
     };
 
     #[test]
@@ -670,7 +669,13 @@ mod tests {
     #[test]
     fn noto_serif_display_top_dict_entries() {
         use Entry::*;
-        let top_dict_data = noto_serif_display_top_dict_data();
+        let top_dict_data = FontRef::new(font_test_data::NOTO_SERIF_DISPLAY_TRIMMED)
+            .unwrap()
+            .cff()
+            .unwrap()
+            .top_dicts()
+            .get(0)
+            .unwrap();
         let entries: Vec<_> = entries(top_dict_data, None)
             .map(|entry| entry.unwrap())
             .collect();
@@ -686,18 +691,5 @@ mod tests {
             CharstringsOffset(523),
         ];
         assert_eq!(&entries, expected);
-    }
-
-    // TODO: remove this when we can finally read the structure of a CFF table
-    fn noto_serif_display_top_dict_data() -> &'static [u8] {
-        let cff = FontRef::new(font_test_data::NOTO_SERIF_DISPLAY_TRIMMED)
-            .unwrap()
-            .cff()
-            .unwrap();
-        let data = cff.trailing_data();
-        let name_index = Index1::read(FontData::new(data)).unwrap();
-        let top_dict_index =
-            Index1::read(FontData::new(&data[name_index.size_in_bytes().unwrap()..])).unwrap();
-        top_dict_index.get(0).unwrap()
     }
 }

--- a/read-fonts/src/tables/postscript/index.rs
+++ b/read-fonts/src/tables/postscript/index.rs
@@ -49,7 +49,7 @@ impl<'a> Index<'a> {
     }
 
     /// Returns the total size in bytes of the index table.
-    pub fn size_in_bytes(&self) -> Result<usize, Error> {
+    pub fn size_in_bytes(&self) -> Result<usize, ReadError> {
         match self {
             Self::Format1(ix) => ix.size_in_bytes(),
             Self::Format2(ix) => ix.size_in_bytes(),
@@ -87,7 +87,7 @@ impl<'a> From<Index2<'a>> for Index<'a> {
 
 impl<'a> Index1<'a> {
     /// Returns the total size in bytes of the index table.
-    pub fn size_in_bytes(&self) -> Result<usize, Error> {
+    pub fn size_in_bytes(&self) -> Result<usize, ReadError> {
         // 2 byte count + 1 byte off_size
         const HEADER_SIZE: usize = 3;
         // An empty CFF index contains only a 2 byte count field
@@ -95,7 +95,11 @@ impl<'a> Index1<'a> {
         let count = self.count() as usize;
         Ok(match count {
             0 => EMPTY_SIZE,
-            _ => HEADER_SIZE + self.offsets().len() + self.get_offset(count)?,
+            _ => {
+                HEADER_SIZE
+                    + self.offsets().len()
+                    + self.get_offset(count).map_err(|_| ReadError::OutOfBounds)?
+            }
         })
     }
 
@@ -119,7 +123,7 @@ impl<'a> Index1<'a> {
 
 impl<'a> Index2<'a> {
     /// Returns the total size in bytes of the index table.
-    pub fn size_in_bytes(&self) -> Result<usize, Error> {
+    pub fn size_in_bytes(&self) -> Result<usize, ReadError> {
         // 4 byte count + 1 byte off_size
         const HEADER_SIZE: usize = 5;
         // An empty CFF2 index contains only a 4 byte count field
@@ -127,7 +131,11 @@ impl<'a> Index2<'a> {
         let count = self.count() as usize;
         Ok(match count {
             0 => EMPTY_SIZE,
-            _ => HEADER_SIZE + self.offsets().len() + self.get_offset(count)?,
+            _ => {
+                HEADER_SIZE
+                    + self.offsets().len()
+                    + self.get_offset(count).map_err(|_| ReadError::OutOfBounds)?
+            }
         })
     }
 

--- a/resources/codegen_inputs/cff.rs
+++ b/resources/codegen_inputs/cff.rs
@@ -1,8 +1,7 @@
 #![parse_module(read_fonts::tables::cff)]
 
-/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table
-#[tag = "CFF "]
-table Cff {
+/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
+table CffHeader {
     /// Format major version (starting at 1).
     #[compile(1)]
     major: u8,

--- a/resources/codegen_inputs/cff2.rs
+++ b/resources/codegen_inputs/cff2.rs
@@ -1,8 +1,7 @@
 #![parse_module(read_fonts::tables::cff2)]
 
-/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table
-#[tag = "CFF2"]
-table Cff2 {
+/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
+table Cff2Header {
     /// Format major version (set to 2).
     #[compile(2)]
     major_version: u8,

--- a/write-fonts/generated/generated_cff.rs
+++ b/write-fonts/generated/generated_cff.rs
@@ -5,9 +5,9 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table
+/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
 #[derive(Clone, Debug, Default)]
-pub struct Cff {
+pub struct CffHeader {
     /// Header size (bytes).
     pub hdr_size: u8,
     /// Absolute offset size.
@@ -18,8 +18,8 @@ pub struct Cff {
     pub trailing_data: Vec<u8>,
 }
 
-impl Cff {
-    /// Construct a new `Cff`
+impl CffHeader {
+    /// Construct a new `CffHeader`
     pub fn new(hdr_size: u8, off_size: u8, _padding: Vec<u8>, trailing_data: Vec<u8>) -> Self {
         Self {
             hdr_size,
@@ -30,7 +30,7 @@ impl Cff {
     }
 }
 
-impl FontWrite for Cff {
+impl FontWrite for CffHeader {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u8).write_into(writer);
@@ -41,22 +41,18 @@ impl FontWrite for Cff {
         self.trailing_data.write_into(writer);
     }
     fn table_type(&self) -> TableType {
-        TableType::TopLevel(Cff::TAG)
+        TableType::Named("CffHeader")
     }
 }
 
-impl Validate for Cff {
+impl Validate for CffHeader {
     fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
 }
 
-impl TopLevelTable for Cff {
-    const TAG: Tag = Tag::new(b"CFF ");
-}
-
-impl<'a> FromObjRef<read_fonts::tables::cff::Cff<'a>> for Cff {
-    fn from_obj_ref(obj: &read_fonts::tables::cff::Cff<'a>, _: FontData) -> Self {
+impl<'a> FromObjRef<read_fonts::tables::cff::CffHeader<'a>> for CffHeader {
+    fn from_obj_ref(obj: &read_fonts::tables::cff::CffHeader<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
-        Cff {
+        CffHeader {
             hdr_size: obj.hdr_size(),
             off_size: obj.off_size(),
             _padding: obj._padding().to_owned_obj(offset_data),
@@ -65,10 +61,10 @@ impl<'a> FromObjRef<read_fonts::tables::cff::Cff<'a>> for Cff {
     }
 }
 
-impl<'a> FromTableRef<read_fonts::tables::cff::Cff<'a>> for Cff {}
+impl<'a> FromTableRef<read_fonts::tables::cff::CffHeader<'a>> for CffHeader {}
 
-impl<'a> FontRead<'a> for Cff {
+impl<'a> FontRead<'a> for CffHeader {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        <read_fonts::tables::cff::Cff as FontRead>::read(data).map(|x| x.to_owned_table())
+        <read_fonts::tables::cff::CffHeader as FontRead>::read(data).map(|x| x.to_owned_table())
     }
 }

--- a/write-fonts/generated/generated_cff2.rs
+++ b/write-fonts/generated/generated_cff2.rs
@@ -5,9 +5,9 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table
+/// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
 #[derive(Clone, Debug, Default)]
-pub struct Cff2 {
+pub struct Cff2Header {
     /// Header size (bytes).
     pub header_size: u8,
     /// Length of Top DICT structure in bytes.
@@ -20,8 +20,8 @@ pub struct Cff2 {
     pub trailing_data: Vec<u8>,
 }
 
-impl Cff2 {
-    /// Construct a new `Cff2`
+impl Cff2Header {
+    /// Construct a new `Cff2Header`
     pub fn new(
         header_size: u8,
         top_dict_length: u16,
@@ -39,7 +39,7 @@ impl Cff2 {
     }
 }
 
-impl FontWrite for Cff2 {
+impl FontWrite for Cff2Header {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u8).write_into(writer);
@@ -51,13 +51,13 @@ impl FontWrite for Cff2 {
         self.trailing_data.write_into(writer);
     }
     fn table_type(&self) -> TableType {
-        TableType::TopLevel(Cff2::TAG)
+        TableType::Named("Cff2Header")
     }
 }
 
-impl Validate for Cff2 {
+impl Validate for Cff2Header {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
-        ctx.in_table("Cff2", |ctx| {
+        ctx.in_table("Cff2Header", |ctx| {
             ctx.in_field("top_dict_data", |ctx| {
                 if self.top_dict_data.len() > (u16::MAX as usize) {
                     ctx.report("array exceeds max length");
@@ -67,14 +67,10 @@ impl Validate for Cff2 {
     }
 }
 
-impl TopLevelTable for Cff2 {
-    const TAG: Tag = Tag::new(b"CFF2");
-}
-
-impl<'a> FromObjRef<read_fonts::tables::cff2::Cff2<'a>> for Cff2 {
-    fn from_obj_ref(obj: &read_fonts::tables::cff2::Cff2<'a>, _: FontData) -> Self {
+impl<'a> FromObjRef<read_fonts::tables::cff2::Cff2Header<'a>> for Cff2Header {
+    fn from_obj_ref(obj: &read_fonts::tables::cff2::Cff2Header<'a>, _: FontData) -> Self {
         let offset_data = obj.offset_data();
-        Cff2 {
+        Cff2Header {
             header_size: obj.header_size(),
             top_dict_length: obj.top_dict_length(),
             _padding: obj._padding().to_owned_obj(offset_data),
@@ -84,10 +80,10 @@ impl<'a> FromObjRef<read_fonts::tables::cff2::Cff2<'a>> for Cff2 {
     }
 }
 
-impl<'a> FromTableRef<read_fonts::tables::cff2::Cff2<'a>> for Cff2 {}
+impl<'a> FromTableRef<read_fonts::tables::cff2::Cff2Header<'a>> for Cff2Header {}
 
-impl<'a> FontRead<'a> for Cff2 {
+impl<'a> FontRead<'a> for Cff2Header {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        <read_fonts::tables::cff2::Cff2 as FontRead>::read(data).map(|x| x.to_owned_table())
+        <read_fonts::tables::cff2::Cff2Header as FontRead>::read(data).map(|x| x.to_owned_table())
     }
 }


### PR DESCRIPTION
This changes codegen inputs to generate fake "headers" for the CFF/CFF2 tables and then hand defines new top level tables for each that parse all data that doesn't require DICT evaluation.

This makes these tables follow a similar style to the rest of read-fonts.