### PR TITLE
[skrifa] use gvar for metric deltas if hvar is missing

### DIFF
--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -48,4 +48,4 @@ pub use read_fonts::types::{GlyphId, Tag};
 pub use provider::MetadataProvider;
 
 /// Limit for recursion when loading TrueType composite glyphs.
-pub(crate) const GLYF_COMPOSITE_RECURSION_LIMIT: usize = 32;
+const GLYF_COMPOSITE_RECURSION_LIMIT: usize = 32;

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -46,3 +46,6 @@ pub use read_fonts::types::{GlyphId, Tag};
 
 #[doc(inline)]
 pub use provider::MetadataProvider;
+
+/// Limit for recursion when loading TrueType composite glyphs.
+pub(crate) const GLYF_COMPOSITE_RECURSION_LIMIT: usize = 32;

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -402,7 +402,7 @@ impl<'a> GvarMetricDeltas<'a> {
         // count), so that we know where the deltas for phantom points start
         // in the variation data.
         let (glyph_id, point_count) = self.find_glyph_and_point_count(glyph_id, 0)?;
-        // [lsb, advance]
+        // [left_extent_delta, right_extent_delta]
         let mut metric_deltas = [Fixed::ZERO; 2];
         let phantom_range = point_count..point_count + 2;
         let var_data = self.gvar.glyph_variation_data(glyph_id).ok()?;
@@ -416,6 +416,7 @@ impl<'a> GvarMetricDeltas<'a> {
                 }
             }
         }
+        metric_deltas[1] -= metric_deltas[0];
         Some(metric_deltas.map(|x| x.to_i32()))
     }
 

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -164,10 +164,8 @@ use super::{
     font::UniqueId,
     instance::{NormalizedCoord, Size},
     setting::VariationSetting,
+    GLYF_COMPOSITE_RECURSION_LIMIT,
 };
-
-/// Limit for recursion when loading TrueType composite glyphs.
-const GLYF_COMPOSITE_RECURSION_LIMIT: usize = 32;
 
 /// Modes for hinting.
 ///


### PR DESCRIPTION
@drott found that skrifa is computing incorrect advance widths for some variable fonts. Turns out that we didn't handle the case where the `HVAR` table is missing. This updates `GlyphMetrics` to fall back to `gvar` in that case.