### PR TITLE
Add DeviceOrVariationIndex enum

### DIFF
--- a/docs/codegen-tour.md
+++ b/docs/codegen-tour.md
@@ -439,11 +439,16 @@ You then also declare that you want to create an enum, providing an explicit
 format, and listing which tables should be included:
 
 ```rust
-format u16 MyTable {
+format u16[@N] MyTable {
     Format1(MyTableFormat1),
     Format2(MyTableFormat2),
 }
 ```
+
+the 'format' keyword is followed by the type that represents the format, and
+optionally a position  at which to read it (indicated by the '@' token, followed
+by an unsigned integer literal.) In the vast majority of cases this can be
+omitted, and the format will be read from the first position in the table.
 
 We will then generate an enum, as well as a `FontRead` implementation: this
 implementation will read the format off of the front of the input data, and then

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -641,7 +641,11 @@ impl Parse for TableFormat {
         } else {
             None
         };
-        validate_ident(&format, &["u8", "u16", "i16"], "unexpected format type")?;
+        validate_ident(
+            &format,
+            &["u8", "u16", "i16", "DeltaFormat"],
+            "unexpected format type",
+        )?;
         let name = input.parse::<syn::Ident>()?;
 
         let content;

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -641,6 +641,12 @@ pub(crate) fn generate_format_group(item: &TableFormat) -> syn::Result<TokenStre
         quote!(Self::#name(table) => table)
     });
 
+    let format_offset = item
+        .format_offset
+        .as_ref()
+        .map(|lit| lit.base10_parse::<usize>().unwrap())
+        .unwrap_or(0);
+
     Ok(quote! {
         #( #docs )*
         pub enum #name<'a> {
@@ -649,7 +655,7 @@ pub(crate) fn generate_format_group(item: &TableFormat) -> syn::Result<TokenStre
 
         impl<'a> FontRead<'a> for #name<'a> {
             fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-                let format: #format = data.read_at(0)?;
+                let format: #format = data.read_at(#format_offset)?;
                 match format {
                     #( #match_arms ),*
                     other => Err(ReadError::InvalidFormat(other.into())),

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -489,10 +489,16 @@ pub(crate) fn generate_format_compile(
         .then(|| generate_format_from_obj(item, parse_module))
         .transpose()?;
 
+    let maybe_extra_traits = item
+        .attrs
+        .capabilities
+        .as_ref()
+        .map(|cap| cap.extra_traits());
+
     let constructors = generate_format_constructors(item, items)?;
     Ok(quote! {
         #( #docs )*
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, #maybe_extra_traits)]
         pub enum #name {
             #( #variants ),*
         }

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -1174,7 +1174,7 @@ impl<'a> BaseCoordFormat3<'a> {
     }
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].
-    pub fn device(&self) -> Option<Result<Device<'a>, ReadError>> {
+    pub fn device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
         self.device_offset().resolve(data)
     }

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -919,7 +919,7 @@ pub enum BaseCoord<'a> {
 
 impl<'a> FontRead<'a> for BaseCoord<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             BaseCoordFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             BaseCoordFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -227,7 +227,7 @@ pub enum CmapSubtable<'a> {
 
 impl<'a> FontRead<'a> for CmapSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             Cmap0Marker::FORMAT => Ok(Self::Format0(FontRead::read(data)?)),
             Cmap2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -780,7 +780,7 @@ pub enum ClipBox<'a> {
 
 impl<'a> FontRead<'a> for ClipBox<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u8 = data.read_at(0)?;
+        let format: u8 = data.read_at(0usize)?;
         match format {
             ClipBoxFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             ClipBoxFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
@@ -1518,7 +1518,7 @@ pub enum Paint<'a> {
 
 impl<'a> FontRead<'a> for Paint<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u8 = data.read_at(0)?;
+        let format: u8 = data.read_at(0usize)?;
         match format {
             PaintColrLayersMarker::FORMAT => Ok(Self::ColrLayers(FontRead::read(data)?)),
             PaintSolidMarker::FORMAT => Ok(Self::Solid(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -887,7 +887,7 @@ impl<'a> CaretValueFormat3<'a> {
     }
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].
-    pub fn device(&self) -> Result<Device<'a>, ReadError> {
+    pub fn device(&self) -> Result<DeviceOrVariationIndex<'a>, ReadError> {
         let data = self.data;
         self.device_offset().resolve(data)
     }

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -653,7 +653,7 @@ pub enum CaretValue<'a> {
 
 impl<'a> FontRead<'a> for CaretValue<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             CaretValueFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             CaretValueFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -1109,7 +1109,7 @@ pub enum Glyph<'a> {
 
 impl<'a> FontRead<'a> for Glyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: i16 = data.read_at(0)?;
+        let format: i16 = data.read_at(0usize)?;
         match format {
             format if format >= 0 => Ok(Self::Simple(FontRead::read(data)?)),
             format if format < 0 => Ok(Self::Composite(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -852,7 +852,7 @@ impl<'a> AnchorFormat3<'a> {
     }
 
     /// Attempt to resolve [`x_device_offset`][Self::x_device_offset].
-    pub fn x_device(&self) -> Option<Result<Device<'a>, ReadError>> {
+    pub fn x_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
         self.x_device_offset().resolve(data)
     }
@@ -866,7 +866,7 @@ impl<'a> AnchorFormat3<'a> {
     }
 
     /// Attempt to resolve [`y_device_offset`][Self::y_device_offset].
-    pub fn y_device(&self) -> Option<Result<Device<'a>, ReadError>> {
+    pub fn y_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
         self.y_device_offset().resolve(data)
     }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -569,7 +569,7 @@ pub enum AnchorTable<'a> {
 
 impl<'a> FontRead<'a> for AnchorTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             AnchorFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             AnchorFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
@@ -1043,7 +1043,7 @@ pub enum SinglePos<'a> {
 
 impl<'a> FontRead<'a> for SinglePos<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             SinglePosFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             SinglePosFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
@@ -1326,7 +1326,7 @@ pub enum PairPos<'a> {
 
 impl<'a> FontRead<'a> for PairPos<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             PairPosFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             PairPosFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -223,7 +223,7 @@ pub enum SingleSubst<'a> {
 
 impl<'a> FontRead<'a> for SingleSubst<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             SingleSubstFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             SingleSubstFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1153,7 +1153,7 @@ pub enum CoverageTable<'a> {
 
 impl<'a> FontRead<'a> for CoverageTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             CoverageFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             CoverageFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
@@ -1442,7 +1442,7 @@ pub enum ClassDef<'a> {
 
 impl<'a> FontRead<'a> for ClassDef<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             ClassDefFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             ClassDefFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
@@ -2348,7 +2348,7 @@ pub enum SequenceContext<'a> {
 
 impl<'a> FontRead<'a> for SequenceContext<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             SequenceContextFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             SequenceContextFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
@@ -3490,7 +3490,7 @@ pub enum ChainedSequenceContext<'a> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContext<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             ChainedSequenceContextFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             ChainedSequenceContextFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -206,7 +206,7 @@ pub enum FdSelect<'a> {
 
 impl<'a> FontRead<'a> for FdSelect<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u8 = data.read_at(0)?;
+        let format: u8 = data.read_at(0usize)?;
         match format {
             FdSelectFormat0Marker::FORMAT => Ok(Self::Format0(FontRead::read(data)?)),
             FdSelectFormat3Marker::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -353,7 +353,7 @@ pub enum AxisValue<'a> {
 
 impl<'a> FontRead<'a> for AxisValue<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             AxisValueFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             AxisValueFormat2Marker::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -227,7 +227,7 @@ pub enum MyTable<'a> {
 
 impl<'a> FontRead<'a> for MyTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0)?;
+        let format: u16 = data.read_at(0usize)?;
         match format {
             Table1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             Table2Marker::FORMAT => Ok(Self::MyFormat22(FontRead::read(data)?)),

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -386,7 +386,7 @@ pub enum DeltaSetIndexMap<'a> {
 
 impl<'a> FontRead<'a> for DeltaSetIndexMap<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let format: u8 = data.read_at(0)?;
+        let format: u8 = data.read_at(0usize)?;
         match format {
             DeltaSetIndexMapFormat0Marker::FORMAT => Ok(Self::Format0(FontRead::read(data)?)),
             DeltaSetIndexMapFormat1Marker::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),

--- a/read-fonts/src/tables/base.rs
+++ b/read-fonts/src/tables/base.rs
@@ -1,6 +1,6 @@
 //! The [BASE](https://learn.microsoft.com/en-us/typography/opentype/spec/base) table
 
-use super::{layout::Device, variations::ItemVariationStore};
+use super::{layout::DeviceOrVariationIndex, variations::ItemVariationStore};
 
 include!("../../generated/generated_base.rs");
 

--- a/read-fonts/src/tables/gdef.rs
+++ b/read-fonts/src/tables/gdef.rs
@@ -3,8 +3,8 @@
 //! [GDEF]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef
 
 pub use super::layout::{
-    ChainedSequenceContext, ClassDef, CoverageTable, Device, FeatureList, FeatureVariations,
-    Lookup, LookupList, ScriptList, SequenceContext,
+    ChainedSequenceContext, ClassDef, CoverageTable, Device, DeviceOrVariationIndex, FeatureList,
+    FeatureVariations, Lookup, LookupList, ScriptList, SequenceContext,
 };
 
 use super::variations::ItemVariationStore;

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -9,7 +9,8 @@ use crate::array::ComputedArray;
 
 /// reexport stuff from layout that we use
 pub use super::layout::{
-    ClassDef, CoverageTable, Device, FeatureList, FeatureVariations, Lookup, ScriptList,
+    ClassDef, CoverageTable, Device, DeviceOrVariationIndex, FeatureList, FeatureVariations,
+    Lookup, ScriptList,
 };
 pub use value_record::ValueRecord;
 

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -116,3 +116,11 @@ impl DeltaFormat {
         count + extra
     }
 }
+
+// we as a 'format' in codegen, and the generic error type for an invalid format
+// stores the value as an i64, so we need this conversion.
+impl From<DeltaFormat> for i64 {
+    fn from(value: DeltaFormat) -> Self {
+        value as u16 as _
+    }
+}

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -3,7 +3,7 @@
 use types::{BigEndian, FixedSize, Offset16};
 
 use super::ValueFormat;
-use crate::{tables::layout::Device, ResolveOffset};
+use crate::{tables::layout::DeviceOrVariationIndex, ResolveOffset};
 
 #[cfg(feature = "traversal")]
 use crate::traversal::{Field, FieldType, RecordResolver, SomeRecord};
@@ -90,28 +90,28 @@ impl ValueRecord {
     pub fn x_placement_device<'a>(
         &self,
         data: FontData<'a>,
-    ) -> Option<Result<Device<'a>, ReadError>> {
+    ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         self.x_placement_device.map(|val| val.get().resolve(data))
     }
 
     pub fn y_placement_device<'a>(
         &self,
         data: FontData<'a>,
-    ) -> Option<Result<Device<'a>, ReadError>> {
+    ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         self.y_placement_device.map(|val| val.get().resolve(data))
     }
 
     pub fn x_advance_device<'a>(
         &self,
         data: FontData<'a>,
-    ) -> Option<Result<Device<'a>, ReadError>> {
+    ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         self.x_advance_device.map(|val| val.get().resolve(data))
     }
 
     pub fn y_advance_device<'a>(
         &self,
         data: FontData<'a>,
-    ) -> Option<Result<Device<'a>, ReadError>> {
+    ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         self.y_advance_device.map(|val| val.get().resolve(data))
     }
 }

--- a/read-fonts/src/tests/test_gdef.rs
+++ b/read-fonts/src/tests/test_gdef.rs
@@ -1,7 +1,7 @@
 use types::{GlyphId, MajorMinor};
 
 use super::*;
-use crate::tables::layout::{ClassDefFormat2, DeltaFormat};
+use crate::tables::layout::{ClassDefFormat2, DeltaFormat, DeviceOrVariationIndex};
 use font_test_data::gdef as test_data;
 
 #[test]
@@ -54,7 +54,9 @@ fn lig_caret_list() {
 fn caretvalueformat3() {
     let table = CaretValueFormat3::read(test_data::CARETVALUEFORMAT3_TABLE.into()).unwrap();
     assert_eq!(table.coordinate(), 1206);
-    let device = table.device().unwrap();
+    let DeviceOrVariationIndex::Device(device) = table.device().unwrap() else {
+        panic!("not a device table");
+    };
     assert_eq!(device.start_size(), 12);
     assert_eq!(device.end_size(), 17);
     assert_eq!(device.delta_format(), DeltaFormat::Local4BitDeltas);

--- a/resources/codegen_inputs/base.rs
+++ b/resources/codegen_inputs/base.rs
@@ -175,6 +175,6 @@ table BaseCoordFormat3 {
     /// table (variable font) for X or Y value, from beginning of
     /// BaseCoord table (may be NULL).
     #[nullable]
-    device_offset: Offset16<Device>,
+    device_offset: Offset16<DeviceOrVariationIndex>,
 }
 

--- a/resources/codegen_inputs/gdef.rs
+++ b/resources/codegen_inputs/gdef.rs
@@ -127,7 +127,7 @@ table CaretValueFormat3 {
     /// Offset to Device table (non-variable font) / Variation Index
     /// table (variable font) for X or Y value-from beginning of
     /// CaretValue table
-    device_offset: Offset16<Device>,
+    device_offset: Offset16<DeviceOrVariationIndex>,
 }
 
 /// [Mark Glyph Sets Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#mark-glyph-sets-table)

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -104,12 +104,12 @@ table AnchorFormat3 {
     /// table (variable font) for X coordinate, from beginning of
     /// Anchor table (may be NULL)
     #[nullable]
-    x_device_offset: Offset16<Device>,
+    x_device_offset: Offset16<DeviceOrVariationIndex>,
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for Y coordinate, from beginning of
     /// Anchor table (may be NULL)
     #[nullable]
-    y_device_offset: Offset16<Device>,
+    y_device_offset: Offset16<DeviceOrVariationIndex>,
 }
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -540,6 +540,7 @@ table Device {
 }
 
 /// Variation index table
+#[capabilities(equality, hash)]
 table VariationIndex {
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
@@ -548,7 +549,17 @@ table VariationIndex {
     /// within an item variation data subtable.
     delta_set_inner_index: u16,
     /// Format, = 0x8000
-    delta_format: u16,
+    #[compile(DeltaFormat::VariationIndex)]
+    delta_format: DeltaFormat,
+}
+
+/// Either a [Device] table (in a non-variable font) or a [VariationIndex] table (in a variable font)
+#[capabilities(equality, hash)]
+format DeltaFormat@4 DeviceOrVariationIndex {
+    #[match_if($format != DeltaFormat::VariationIndex)]
+    Device(Device),
+    #[match_if($format == DeltaFormat::VariationIndex)]
+    VariationIndex(VariationIndex),
 }
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -671,7 +671,7 @@ impl BaseCoord {
     }
 
     /// Construct a new `BaseCoordFormat3` subtable
-    pub fn format_3(coordinate: i16, device: Option<Device>) -> Self {
+    pub fn format_3(coordinate: i16, device: Option<DeviceOrVariationIndex>) -> Self {
         Self::Format3(BaseCoordFormat3::new(coordinate, device))
     }
 }
@@ -840,12 +840,12 @@ pub struct BaseCoordFormat3 {
     /// Offset to Device table (non-variable font) / Variation Index
     /// table (variable font) for X or Y value, from beginning of
     /// BaseCoord table (may be NULL).
-    pub device: NullableOffsetMarker<Device>,
+    pub device: NullableOffsetMarker<DeviceOrVariationIndex>,
 }
 
 impl BaseCoordFormat3 {
     /// Construct a new `BaseCoordFormat3`
-    pub fn new(coordinate: i16, device: Option<Device>) -> Self {
+    pub fn new(coordinate: i16, device: Option<DeviceOrVariationIndex>) -> Self {
         Self {
             coordinate,
             device: device.into(),

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -389,7 +389,7 @@ impl CaretValue {
     }
 
     /// Construct a new `CaretValueFormat3` subtable
-    pub fn format_3(coordinate: i16, device: Device) -> Self {
+    pub fn format_3(coordinate: i16, device: DeviceOrVariationIndex) -> Self {
         Self::Format3(CaretValueFormat3::new(coordinate, device))
     }
 }
@@ -548,12 +548,12 @@ pub struct CaretValueFormat3 {
     /// Offset to Device table (non-variable font) / Variation Index
     /// table (variable font) for X or Y value-from beginning of
     /// CaretValue table
-    pub device: OffsetMarker<Device>,
+    pub device: OffsetMarker<DeviceOrVariationIndex>,
 }
 
 impl CaretValueFormat3 {
     /// Construct a new `CaretValueFormat3`
-    pub fn new(coordinate: i16, device: Device) -> Self {
+    pub fn new(coordinate: i16, device: DeviceOrVariationIndex) -> Self {
         Self {
             coordinate,
             device: device.into(),

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -226,8 +226,8 @@ impl AnchorTable {
     pub fn format_3(
         x_coordinate: i16,
         y_coordinate: i16,
-        x_device: Option<Device>,
-        y_device: Option<Device>,
+        x_device: Option<DeviceOrVariationIndex>,
+        y_device: Option<DeviceOrVariationIndex>,
     ) -> Self {
         Self::Format3(AnchorFormat3::new(
             x_coordinate,
@@ -411,11 +411,11 @@ pub struct AnchorFormat3 {
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for X coordinate, from beginning of
     /// Anchor table (may be NULL)
-    pub x_device: NullableOffsetMarker<Device>,
+    pub x_device: NullableOffsetMarker<DeviceOrVariationIndex>,
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for Y coordinate, from beginning of
     /// Anchor table (may be NULL)
-    pub y_device: NullableOffsetMarker<Device>,
+    pub y_device: NullableOffsetMarker<DeviceOrVariationIndex>,
 }
 
 impl AnchorFormat3 {
@@ -423,8 +423,8 @@ impl AnchorFormat3 {
     pub fn new(
         x_coordinate: i16,
         y_coordinate: i16,
-        x_device: Option<Device>,
-        y_device: Option<Device>,
+        x_device: Option<DeviceOrVariationIndex>,
+        y_device: Option<DeviceOrVariationIndex>,
     ) -> Self {
         Self {
             x_coordinate,

--- a/write-fonts/src/tables/base.rs
+++ b/write-fonts/src/tables/base.rs
@@ -1,6 +1,6 @@
 //! The [BASE](https://learn.microsoft.com/en-us/typography/opentype/spec/base) table
 
-use super::layout::Device;
+use super::layout::DeviceOrVariationIndex;
 use super::variations::ItemVariationStore;
 
 include!("../../generated/generated_base.rs");

--- a/write-fonts/src/tables/gdef.rs
+++ b/write-fonts/src/tables/gdef.rs
@@ -5,7 +5,7 @@
 use types::MajorMinor;
 
 use super::{
-    layout::{ClassDef, CoverageTable, Device},
+    layout::{ClassDef, CoverageTable, DeviceOrVariationIndex},
     variations::ItemVariationStore,
 };
 

--- a/write-fonts/src/tables/gpos.rs
+++ b/write-fonts/src/tables/gpos.rs
@@ -8,8 +8,8 @@ use std::collections::HashSet;
 
 //use super::layout::value_record::ValueRecord;
 use super::layout::{
-    ChainedSequenceContext, ClassDef, CoverageTable, Device, FeatureList, FeatureVariations,
-    Lookup, LookupList, LookupSubtable, LookupType, ScriptList, SequenceContext,
+    ChainedSequenceContext, ClassDef, CoverageTable, DeviceOrVariationIndex, FeatureList,
+    FeatureVariations, Lookup, LookupList, LookupSubtable, LookupType, ScriptList, SequenceContext,
 };
 
 #[cfg(test)]

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -6,7 +6,7 @@ use super::ValueFormat;
 use crate::{
     from_obj::{FromObjRef, ToOwnedObj},
     offsets::NullableOffsetMarker,
-    tables::layout::Device,
+    tables::layout::DeviceOrVariationIndex,
     validate::Validate,
     write::{FontWrite, TableWriter},
 };
@@ -17,10 +17,10 @@ pub struct ValueRecord {
     pub y_placement: Option<i16>,
     pub x_advance: Option<i16>,
     pub y_advance: Option<i16>,
-    pub x_placement_device: NullableOffsetMarker<Device>,
-    pub y_placement_device: NullableOffsetMarker<Device>,
-    pub x_advance_device: NullableOffsetMarker<Device>,
-    pub y_advance_device: NullableOffsetMarker<Device>,
+    pub x_placement_device: NullableOffsetMarker<DeviceOrVariationIndex>,
+    pub y_placement_device: NullableOffsetMarker<DeviceOrVariationIndex>,
+    pub x_advance_device: NullableOffsetMarker<DeviceOrVariationIndex>,
+    pub y_advance_device: NullableOffsetMarker<DeviceOrVariationIndex>,
 }
 
 impl ValueRecord {


### PR DESCRIPTION
In the first pass of this stuff I basically ignored the `VariationIndex` table, and just used the `Device` table everywhere. This patch replaces this with a 'format table', `DeviceOrVariationIndex`, that is an enum with `Device` and `VariationIndex` members. We parse these as appropriate based on the `DeltaFormat`.


I have mixed feelings! On the plus side, this is consistent with the rest of the codebase and makes good use of codegen etc. On the downside, this will be more annoying to use without much clear benefit, since you'll need to use a `match` statement or similar in order to access the actual inner table that you want; this is especially annoying since the `Device` table seems to be more or less ignored now.

There are some alternatives that might make this less of a headache:

- I could keep this code, but add some convenience methods to the enum for accessing the inner values, without unwrapping
- I could remove this, just keeping the device table, and leaving it up to the user to interpret the fields correctly as needed.

There are probably other reasonable options, but those two feel like a good place to start the conversation.