### PR TITLE
[font-types] inline more things

### DIFF
--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -135,6 +135,8 @@ macro_rules! fixed_mul_div {
     ($ty:ty) => {
         impl $ty {
             /// Multiplies `self` by `a` and divides the product by `b`.
+            // This one is specifically not always inlined due to size and
+            // frequency of use. We leave it to compiler discretion.
             #[inline]
             pub const fn mul_div(&self, a: Self, b: Self) -> Self {
                 let mut sign = 1;

--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -30,57 +30,68 @@ macro_rules! fixed_impl {
             const FRACT_BITS: usize = $fract_bits;
 
             /// Creates a new fixed point value from the underlying bit representation.
+            #[inline(always)]
             pub const fn from_bits(bits: $ty) -> Self {
                 Self(bits)
             }
 
             /// Returns the underlying bit representation of the value.
+            #[inline(always)]
             pub const fn to_bits(self) -> $ty {
                 self.0
             }
 
             //TODO: is this actually useful?
             /// Returns the nearest integer value.
+            #[inline(always)]
             pub const fn round(self) -> Self {
                 Self(self.0.wrapping_add(Self::ROUND) & Self::INT_MASK)
             }
 
             /// Returns the absolute value of the number.
+            #[inline(always)]
             pub const fn abs(self) -> Self {
                 Self(self.0.abs())
             }
 
             /// Returns the largest integer less than or equal to the number.
+            #[inline(always)]
             pub const fn floor(self) -> Self {
                 Self(self.0 & Self::INT_MASK)
             }
 
             /// Returns the fractional part of the number.
+            #[inline(always)]
             pub const fn fract(self) -> Self {
                 Self(self.0 - self.floor().0)
             }
 
             /// Wrapping addition.
+            #[inline(always)]
             pub fn wrapping_add(self, other: Self) -> Self {
                 Self(self.0.wrapping_add(other.0))
             }
 
             /// Saturating addition.
+            #[inline(always)]
             pub const fn saturating_add(self, other: Self) -> Self {
                 Self(self.0.saturating_add(other.0))
             }
 
             /// Wrapping substitution.
+            #[inline(always)]
             pub const fn wrapping_sub(self, other: Self) -> Self {
                 Self(self.0.wrapping_sub(other.0))
             }
 
             /// Saturating substitution.
+            #[inline(always)]
             pub const fn saturating_sub(self, other: Self) -> Self {
                 Self(self.0.saturating_sub(other.0))
             }
 
             /// The representation of this number as a big-endian byte array.
+            #[inline(always)]
             pub const fn to_be_bytes(self) -> [u8; $bits / 8] {
                 self.0.to_be_bytes()
             }
@@ -96,6 +107,7 @@ macro_rules! fixed_impl {
         }
 
         impl AddAssign for $name {
+            #[inline(always)]
             fn add_assign(&mut self, other: Self) {
                 *self = *self + other;
             }
@@ -110,6 +122,7 @@ macro_rules! fixed_impl {
         }
 
         impl SubAssign for $name {
+            #[inline(always)]
             fn sub_assign(&mut self, other: Self) {
                 *self = *self - other;
             }
@@ -122,6 +135,7 @@ macro_rules! fixed_mul_div {
     ($ty:ty) => {
         impl $ty {
             /// Multiplies `self` by `a` and divides the product by `b`.
+            #[inline]
             pub const fn mul_div(&self, a: Self, b: Self) -> Self {
                 let mut sign = 1;
                 let mut su = self.0 as u64;
@@ -162,6 +176,7 @@ macro_rules! fixed_mul_div {
         }
 
         impl MulAssign for $ty {
+            #[inline(always)]
             fn mul_assign(&mut self, rhs: Self) {
                 *self = *self * rhs;
             }
@@ -192,6 +207,7 @@ macro_rules! fixed_mul_div {
         }
 
         impl DivAssign for $ty {
+            #[inline(always)]
             fn div_assign(&mut self, rhs: Self) {
                 *self = *self / rhs;
             }
@@ -269,17 +285,20 @@ crate::newtype_scalar!(Fixed, [u8; 4]);
 
 impl Fixed {
     /// Creates a 16.16 fixed point value from a 32 bit integer.
+    #[inline(always)]
     pub const fn from_i32(i: i32) -> Self {
         Self(i << 16)
     }
 
     /// Converts a 16.16 fixed point value to a 32 bit integer, rounding off
     /// the fractional bits.
+    #[inline(always)]
     pub const fn to_i32(self) -> i32 {
         self.0.wrapping_add(0x8000) >> 16
     }
 
     /// Converts a 16.16 to 26.6 fixed point value.
+    #[inline(always)]
     pub const fn to_f26dot6(self) -> F26Dot6 {
         F26Dot6(self.0.wrapping_add(0x200) >> 10)
     }
@@ -291,26 +310,50 @@ impl Fixed {
     ///
     /// "5. Convert the final, normalized 16.16 coordinate value to 2.14 by this method: add 0x00000002,
     /// and sign-extend shift to the right by 2."
+    #[inline(always)]
     pub const fn to_f2dot14(self) -> F2Dot14 {
         F2Dot14((self.0.wrapping_add(2) >> 2) as _)
+    }
+
+    /// Converts a 16.16 fixed point value to a single precision floating
+    /// point value.
+    ///
+    /// This operation is lossy. Use `to_f64()` for a lossless conversion.
+    #[inline(always)]
+    pub fn to_f32(self) -> f32 {
+        const SCALE_FACTOR: f32 = 1.0 / 65536.0;
+        self.0 as f32 * SCALE_FACTOR
     }
 }
 
 impl F26Dot6 {
     /// Creates a 26.6 fixed point value from a 32 bit integer.
+    #[inline(always)]
     pub const fn from_i32(i: i32) -> Self {
         Self(i << 6)
     }
 
     /// Converts a 26.6 fixed point value to a 32 bit integer, rounding off
     /// the fractional bits.
+    #[inline(always)]
     pub const fn to_i32(self) -> i32 {
         self.0.wrapping_add(32) >> 6
+    }
+
+    /// Converts a 26.6 fixed point value to a single precision floating
+    /// point value.
+    ///
+    /// This operation is lossy. Use `to_f64()` for a lossless conversion.
+    #[inline(always)]
+    pub fn to_f32(self) -> f32 {
+        const SCALE_FACTOR: f32 = 1.0 / 64.0;
+        self.0 as f32 * SCALE_FACTOR
     }
 }
 
 impl F2Dot14 {
     /// Converts a 2.14 to 16.16 fixed point value.
+    #[inline(always)]
     pub const fn to_fixed(self) -> Fixed {
         Fixed(self.0 as i32 * 4)
     }

--- a/font-types/src/point.rs
+++ b/font-types/src/point.rs
@@ -12,6 +12,7 @@ pub struct Point<T> {
 
 impl<T> Point<T> {
     /// Creates a new point with the given x and y coordinates.
+    #[inline(always)]
     pub const fn new(x: T, y: T) -> Self {
         Self { x, y }
     }
@@ -25,6 +26,7 @@ impl<T> Point<T> {
     }
 
     /// Maps `Point<T>` to `Point<U>` by applying a function to each coordinate.
+    #[inline(always)]
     pub fn map<U>(self, mut f: impl FnMut(T) -> U) -> Point<U> {
         Point {
             x: f(self.x),
@@ -39,6 +41,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn add(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x + rhs.x,
@@ -51,6 +54,7 @@ impl<T> AddAssign for Point<T>
 where
     T: AddAssign,
 {
+    #[inline(always)]
     fn add_assign(&mut self, rhs: Self) {
         self.x += rhs.x;
         self.y += rhs.y;
@@ -63,6 +67,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn sub(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x - rhs.x,
@@ -75,6 +80,7 @@ impl<T> SubAssign for Point<T>
 where
     T: SubAssign,
 {
+    #[inline(always)]
     fn sub_assign(&mut self, rhs: Self) {
         self.x -= rhs.x;
         self.y -= rhs.y;
@@ -87,6 +93,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn mul(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x * rhs.x,
@@ -101,6 +108,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn mul(self, rhs: T) -> Self::Output {
         Self {
             x: self.x * rhs,
@@ -113,6 +121,7 @@ impl<T> MulAssign for Point<T>
 where
     T: MulAssign,
 {
+    #[inline(always)]
     fn mul_assign(&mut self, rhs: Self) {
         self.x *= rhs.x;
         self.y *= rhs.y;
@@ -123,6 +132,7 @@ impl<T> MulAssign<T> for Point<T>
 where
     T: MulAssign + Copy,
 {
+    #[inline(always)]
     fn mul_assign(&mut self, rhs: T) {
         self.x *= rhs;
         self.y *= rhs;
@@ -135,6 +145,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x / rhs.x,
@@ -149,6 +160,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: T) -> Self::Output {
         Self {
             x: self.x / rhs,
@@ -161,6 +173,7 @@ impl<T> DivAssign for Point<T>
 where
     T: DivAssign,
 {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: Self) {
         self.x /= rhs.x;
         self.y /= rhs.y;
@@ -171,6 +184,7 @@ impl<T> DivAssign<T> for Point<T>
 where
     T: DivAssign + Copy,
 {
+    #[inline(always)]
     fn div_assign(&mut self, rhs: T) {
         self.x /= rhs;
         self.y /= rhs;
@@ -183,6 +197,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         Self {
             x: -self.x,

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -629,9 +629,6 @@ pub fn to_path(
     contours: &[u16],
     sink: &mut impl Pen,
 ) -> Result<(), ToPathError> {
-    fn to_f32(x: F26Dot6) -> f32 {
-        x.to_f64() as f32
-    }
     // FreeType uses integer division to compute midpoints.
     // See: https://github.com/freetype/freetype/blob/de8b92dd7ec634e9e2b25ef534c54a3537555c11/src/base/ftoutln.c#L123
     fn midpoint(a: Point<F26Dot6>, b: Point<F26Dot6>) -> Point<F26Dot6> {
@@ -665,7 +662,7 @@ pub fn to_path(
             }
             step_point = false;
         }
-        let p = v_start.map(to_f32);
+        let p = v_start.map(F26Dot6::to_f32);
         if count > 0 && !last_was_close {
             sink.close();
         }
@@ -679,7 +676,7 @@ pub fn to_path(
             step_point = true;
             flag = flags[cur_ix];
             if flag.is_on_curve() {
-                let p = points[cur_ix].map(to_f32);
+                let p = points[cur_ix].map(F26Dot6::to_f32);
                 sink.line_to(p.x, p.y);
                 count += 1;
                 last_was_close = false;
@@ -692,8 +689,8 @@ pub fn to_path(
                     let cur_point = points[cur_ix];
                     flag = flags[cur_ix];
                     if flag.is_on_curve() {
-                        let control = v_control.map(to_f32);
-                        let point = cur_point.map(to_f32);
+                        let control = v_control.map(F26Dot6::to_f32);
+                        let point = cur_point.map(F26Dot6::to_f32);
                         sink.quad_to(control.x, control.y, point.x, point.y);
                         count += 1;
                         last_was_close = false;
@@ -704,16 +701,16 @@ pub fn to_path(
                         return Err(ToPathError::ExpectedQuad(cur_ix));
                     }
                     let v_middle = midpoint(v_control, cur_point);
-                    let control = v_control.map(to_f32);
-                    let point = v_middle.map(to_f32);
+                    let control = v_control.map(F26Dot6::to_f32);
+                    let point = v_middle.map(F26Dot6::to_f32);
                     sink.quad_to(control.x, control.y, point.x, point.y);
                     count += 1;
                     last_was_close = false;
                     v_control = cur_point;
                 }
                 if do_close_quad {
-                    let control = v_control.map(to_f32);
-                    let point = v_start.map(to_f32);
+                    let control = v_control.map(F26Dot6::to_f32);
+                    let point = v_start.map(F26Dot6::to_f32);
                     sink.quad_to(control.x, control.y, point.x, point.y);
                     count += 1;
                     last_was_close = false;
@@ -724,11 +721,11 @@ pub fn to_path(
                 if cur_ix + 1 > last_ix || !flags[cur_ix + 1].is_off_curve_cubic() {
                     return Err(ToPathError::ExpectedCubic(cur_ix + 1));
                 }
-                let control0 = points[cur_ix].map(to_f32);
-                let control1 = points[cur_ix + 1].map(to_f32);
+                let control0 = points[cur_ix].map(F26Dot6::to_f32);
+                let control1 = points[cur_ix + 1].map(F26Dot6::to_f32);
                 cur_ix += 2;
                 if cur_ix <= last_ix {
-                    let point = points[cur_ix].map(to_f32);
+                    let point = points[cur_ix].map(F26Dot6::to_f32);
                     sink.curve_to(
                         control0.x, control0.y, control1.x, control1.y, point.x, point.y,
                     );
@@ -736,7 +733,7 @@ pub fn to_path(
                     last_was_close = false;
                     continue;
                 }
-                let point = v_start.map(to_f32);
+                let point = v_start.map(F26Dot6::to_f32);
                 sink.curve_to(
                     control0.x, control0.y, control1.x, control1.y, point.x, point.y,
                 );


### PR DESCRIPTION
Based on #490, add more inline attributes to functions in `font-types`. This was measurably affecting performance in the TrueType scaler.

Also adds lossy f32 conversions to the fixed point types and updates `glyf::to_path` to use them.

JMM