### PR TITLE
[codegen] Generate From impls for format tables

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -482,6 +482,16 @@ pub(crate) fn generate_format_compile(
         quote!( Self::#var_name(item) => item.table_type(), )
     });
 
+    let from_impls = item.variants.iter().map(|variant| {
+        let var_name = &variant.name;
+        let typ = variant.type_name();
+        quote!( impl From<#typ> for #name {
+            fn from(src: #typ) -> #name {
+                #name::#var_name(src)
+            }
+        } )
+    });
+
     let from_obj_impl = item
         .attrs
         .skip_from_obj
@@ -534,6 +544,8 @@ pub(crate) fn generate_format_compile(
         }
 
         #from_obj_impl
+
+        #( #from_impls )*
 
     })
 }

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -728,6 +728,24 @@ impl<'a> FontRead<'a> for BaseCoord {
     }
 }
 
+impl From<BaseCoordFormat1> for BaseCoord {
+    fn from(src: BaseCoordFormat1) -> BaseCoord {
+        BaseCoord::Format1(src)
+    }
+}
+
+impl From<BaseCoordFormat2> for BaseCoord {
+    fn from(src: BaseCoordFormat2) -> BaseCoord {
+        BaseCoord::Format2(src)
+    }
+}
+
+impl From<BaseCoordFormat3> for BaseCoord {
+    fn from(src: BaseCoordFormat3) -> BaseCoord {
+        BaseCoord::Format3(src)
+    }
+}
+
 /// [BaseCoordFormat1](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-1)
 #[derive(Clone, Debug, Default)]
 pub struct BaseCoordFormat1 {

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -335,6 +335,60 @@ impl<'a> FontRead<'a> for CmapSubtable {
     }
 }
 
+impl From<Cmap0> for CmapSubtable {
+    fn from(src: Cmap0) -> CmapSubtable {
+        CmapSubtable::Format0(src)
+    }
+}
+
+impl From<Cmap2> for CmapSubtable {
+    fn from(src: Cmap2) -> CmapSubtable {
+        CmapSubtable::Format2(src)
+    }
+}
+
+impl From<Cmap4> for CmapSubtable {
+    fn from(src: Cmap4) -> CmapSubtable {
+        CmapSubtable::Format4(src)
+    }
+}
+
+impl From<Cmap6> for CmapSubtable {
+    fn from(src: Cmap6) -> CmapSubtable {
+        CmapSubtable::Format6(src)
+    }
+}
+
+impl From<Cmap8> for CmapSubtable {
+    fn from(src: Cmap8) -> CmapSubtable {
+        CmapSubtable::Format8(src)
+    }
+}
+
+impl From<Cmap10> for CmapSubtable {
+    fn from(src: Cmap10) -> CmapSubtable {
+        CmapSubtable::Format10(src)
+    }
+}
+
+impl From<Cmap12> for CmapSubtable {
+    fn from(src: Cmap12) -> CmapSubtable {
+        CmapSubtable::Format12(src)
+    }
+}
+
+impl From<Cmap13> for CmapSubtable {
+    fn from(src: Cmap13) -> CmapSubtable {
+        CmapSubtable::Format13(src)
+    }
+}
+
+impl From<Cmap14> for CmapSubtable {
+    fn from(src: Cmap14) -> CmapSubtable {
+        CmapSubtable::Format14(src)
+    }
+}
+
 /// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
 #[derive(Clone, Debug, Default)]
 pub struct Cmap0 {

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -446,6 +446,24 @@ impl<'a> FontRead<'a> for CaretValue {
     }
 }
 
+impl From<CaretValueFormat1> for CaretValue {
+    fn from(src: CaretValueFormat1) -> CaretValue {
+        CaretValue::Format1(src)
+    }
+}
+
+impl From<CaretValueFormat2> for CaretValue {
+    fn from(src: CaretValueFormat2) -> CaretValue {
+        CaretValue::Format2(src)
+    }
+}
+
+impl From<CaretValueFormat3> for CaretValue {
+    fn from(src: CaretValueFormat3) -> CaretValue {
+        CaretValue::Format3(src)
+    }
+}
+
 /// [CaretValue Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-1)
 #[derive(Clone, Debug, Default)]
 pub struct CaretValueFormat1 {

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -290,6 +290,24 @@ impl<'a> FontRead<'a> for AnchorTable {
     }
 }
 
+impl From<AnchorFormat1> for AnchorTable {
+    fn from(src: AnchorFormat1) -> AnchorTable {
+        AnchorTable::Format1(src)
+    }
+}
+
+impl From<AnchorFormat2> for AnchorTable {
+    fn from(src: AnchorFormat2) -> AnchorTable {
+        AnchorTable::Format2(src)
+    }
+}
+
+impl From<AnchorFormat3> for AnchorTable {
+    fn from(src: AnchorFormat3) -> AnchorTable {
+        AnchorTable::Format3(src)
+    }
+}
+
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
 #[derive(Clone, Debug, Default)]
 pub struct AnchorFormat1 {
@@ -655,6 +673,18 @@ impl<'a> FontRead<'a> for SinglePos {
     }
 }
 
+impl From<SinglePosFormat1> for SinglePos {
+    fn from(src: SinglePosFormat1) -> SinglePos {
+        SinglePos::Format1(src)
+    }
+}
+
+impl From<SinglePosFormat2> for SinglePos {
+    fn from(src: SinglePosFormat2) -> SinglePos {
+        SinglePos::Format2(src)
+    }
+}
+
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
 #[derive(Clone, Debug, Default)]
 pub struct SinglePosFormat1 {
@@ -863,6 +893,18 @@ impl FromTableRef<read_fonts::tables::gpos::PairPos<'_>> for PairPos {}
 impl<'a> FontRead<'a> for PairPos {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::gpos::PairPos as FontRead>::read(data).map(|x| x.to_owned_table())
+    }
+}
+
+impl From<PairPosFormat1> for PairPos {
+    fn from(src: PairPosFormat1) -> PairPos {
+        PairPos::Format1(src)
+    }
+}
+
+impl From<PairPosFormat2> for PairPos {
+    fn from(src: PairPosFormat2) -> PairPos {
+        PairPos::Format2(src)
     }
 }
 

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -258,6 +258,18 @@ impl<'a> FontRead<'a> for SingleSubst {
     }
 }
 
+impl From<SingleSubstFormat1> for SingleSubst {
+    fn from(src: SingleSubstFormat1) -> SingleSubst {
+        SingleSubst::Format1(src)
+    }
+}
+
+impl From<SingleSubstFormat2> for SingleSubst {
+    fn from(src: SingleSubstFormat2) -> SingleSubst {
+        SingleSubst::Format2(src)
+    }
+}
+
 /// [Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1)
 #[derive(Clone, Debug, Default)]
 pub struct SingleSubstFormat1 {

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -820,6 +820,18 @@ impl<'a> FontRead<'a> for CoverageTable {
     }
 }
 
+impl From<CoverageFormat1> for CoverageTable {
+    fn from(src: CoverageFormat1) -> CoverageTable {
+        CoverageTable::Format1(src)
+    }
+}
+
+impl From<CoverageFormat2> for CoverageTable {
+    fn from(src: CoverageFormat2) -> CoverageTable {
+        CoverageTable::Format2(src)
+    }
+}
+
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 #[derive(Clone, Debug, Default)]
 pub struct ClassDefFormat1 {
@@ -1059,6 +1071,18 @@ impl FromTableRef<read_fonts::tables::layout::ClassDef<'_>> for ClassDef {}
 impl<'a> FontRead<'a> for ClassDef {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::layout::ClassDef as FontRead>::read(data).map(|x| x.to_owned_table())
+    }
+}
+
+impl From<ClassDefFormat1> for ClassDef {
+    fn from(src: ClassDefFormat1) -> ClassDef {
+        ClassDef::Format1(src)
+    }
+}
+
+impl From<ClassDefFormat2> for ClassDef {
+    fn from(src: ClassDefFormat2) -> ClassDef {
+        ClassDef::Format2(src)
     }
 }
 
@@ -1691,6 +1715,24 @@ impl<'a> FontRead<'a> for SequenceContext {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::layout::SequenceContext as FontRead>::read(data)
             .map(|x| x.to_owned_table())
+    }
+}
+
+impl From<SequenceContextFormat1> for SequenceContext {
+    fn from(src: SequenceContextFormat1) -> SequenceContext {
+        SequenceContext::Format1(src)
+    }
+}
+
+impl From<SequenceContextFormat2> for SequenceContext {
+    fn from(src: SequenceContextFormat2) -> SequenceContext {
+        SequenceContext::Format2(src)
+    }
+}
+
+impl From<SequenceContextFormat3> for SequenceContext {
+    fn from(src: SequenceContextFormat3) -> SequenceContext {
+        SequenceContext::Format3(src)
     }
 }
 
@@ -2430,6 +2472,24 @@ impl<'a> FontRead<'a> for ChainedSequenceContext {
     }
 }
 
+impl From<ChainedSequenceContextFormat1> for ChainedSequenceContext {
+    fn from(src: ChainedSequenceContextFormat1) -> ChainedSequenceContext {
+        ChainedSequenceContext::Format1(src)
+    }
+}
+
+impl From<ChainedSequenceContextFormat2> for ChainedSequenceContext {
+    fn from(src: ChainedSequenceContextFormat2) -> ChainedSequenceContext {
+        ChainedSequenceContext::Format2(src)
+    }
+}
+
+impl From<ChainedSequenceContextFormat3> for ChainedSequenceContext {
+    fn from(src: ChainedSequenceContextFormat3) -> ChainedSequenceContext {
+        ChainedSequenceContext::Format3(src)
+    }
+}
+
 impl FontWrite for DeltaFormat {
     fn write_into(&self, writer: &mut TableWriter) {
         let val = *self as u16;
@@ -2609,6 +2669,18 @@ impl<'a> FontRead<'a> for DeviceOrVariationIndex {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         <read_fonts::tables::layout::DeviceOrVariationIndex as FontRead>::read(data)
             .map(|x| x.to_owned_table())
+    }
+}
+
+impl From<Device> for DeviceOrVariationIndex {
+    fn from(src: Device) -> DeviceOrVariationIndex {
+        DeviceOrVariationIndex::Device(src)
+    }
+}
+
+impl From<VariationIndex> for DeviceOrVariationIndex {
+    fn from(src: VariationIndex) -> DeviceOrVariationIndex {
+        DeviceOrVariationIndex::VariationIndex(src)
     }
 }
 

--- a/write-fonts/generated/generated_postscript.rs
+++ b/write-fonts/generated/generated_postscript.rs
@@ -205,6 +205,24 @@ impl<'a> FontRead<'a> for FdSelect {
     }
 }
 
+impl From<FdSelectFormat0> for FdSelect {
+    fn from(src: FdSelectFormat0) -> FdSelect {
+        FdSelect::Format0(src)
+    }
+}
+
+impl From<FdSelectFormat3> for FdSelect {
+    fn from(src: FdSelectFormat3) -> FdSelect {
+        FdSelect::Format3(src)
+    }
+}
+
+impl From<FdSelectFormat4> for FdSelect {
+    fn from(src: FdSelectFormat4) -> FdSelect {
+        FdSelect::Format4(src)
+    }
+}
+
 /// FdSelect format 0.
 #[derive(Clone, Debug, Default)]
 pub struct FdSelectFormat0 {

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -316,6 +316,30 @@ impl<'a> FontRead<'a> for AxisValue {
     }
 }
 
+impl From<AxisValueFormat1> for AxisValue {
+    fn from(src: AxisValueFormat1) -> AxisValue {
+        AxisValue::Format1(src)
+    }
+}
+
+impl From<AxisValueFormat2> for AxisValue {
+    fn from(src: AxisValueFormat2) -> AxisValue {
+        AxisValue::Format2(src)
+    }
+}
+
+impl From<AxisValueFormat3> for AxisValue {
+    fn from(src: AxisValueFormat3) -> AxisValue {
+        AxisValue::Format3(src)
+    }
+}
+
+impl From<AxisValueFormat4> for AxisValue {
+    fn from(src: AxisValueFormat4) -> AxisValue {
+        AxisValue::Format4(src)
+    }
+}
+
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
 #[derive(Clone, Debug, Default)]
 pub struct AxisValueFormat1 {

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -216,3 +216,21 @@ impl<'a> FontRead<'a> for MyTable {
             .map(|x| x.to_owned_table())
     }
 }
+
+impl From<Table1> for MyTable {
+    fn from(src: Table1) -> MyTable {
+        MyTable::Format1(src)
+    }
+}
+
+impl From<Table2> for MyTable {
+    fn from(src: Table2) -> MyTable {
+        MyTable::MyFormat22(src)
+    }
+}
+
+impl From<Table3> for MyTable {
+    fn from(src: Table3) -> MyTable {
+        MyTable::Format3(src)
+    }
+}

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -332,6 +332,18 @@ impl<'a> FontRead<'a> for DeltaSetIndexMap {
     }
 }
 
+impl From<DeltaSetIndexMapFormat0> for DeltaSetIndexMap {
+    fn from(src: DeltaSetIndexMapFormat0) -> DeltaSetIndexMap {
+        DeltaSetIndexMap::Format0(src)
+    }
+}
+
+impl From<DeltaSetIndexMapFormat1> for DeltaSetIndexMap {
+    fn from(src: DeltaSetIndexMapFormat1) -> DeltaSetIndexMap {
+        DeltaSetIndexMap::Format1(src)
+    }
+}
+
 impl FontWrite for EntryFormat {
     fn write_into(&self, writer: &mut TableWriter) {
         writer.write_slice(&self.bits().to_be_bytes())

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -74,10 +74,9 @@ impl<const N: usize, T> OffsetMarker<T, N> {
         OffsetMarker { obj }
     }
 
-    //FIXME: maybe we get rid of this when we have From/Into impl'd?
     /// Set the contents of the marker, replacing any existing contents.
-    pub fn set(&mut self, obj: T) {
-        self.obj = obj;
+    pub fn set(&mut self, obj: impl Into<T>) {
+        self.obj = obj.into();
     }
 
     /// Convert into the inner type
@@ -93,8 +92,18 @@ impl<const N: usize, T> NullableOffsetMarker<T, N> {
     }
 
     /// Set the contents of the marker, replacing any existing contents.
-    pub fn set(&mut self, obj: impl Into<Option<T>>) {
-        self.obj = obj.into()
+    ///
+    /// The argument must be some value; to set the offest to null, use the
+    /// [`clear`] method.
+    ///
+    /// [`clear`]: Self::clear
+    pub fn set(&mut self, obj: impl Into<T>) {
+        self.obj = Some(obj.into())
+    }
+
+    /// Clear the contents of the marker.
+    pub fn clear(&mut self) {
+        self.obj = None;
     }
 
     /// Convert into the inner type


### PR DESCRIPTION
That is, if a table `T` has multiple formats, for each format `S` we generate `From<S>` for `T`.

This is a minor quality-of-life improvement that should let me offer a better API in some parts of write-fonts (it's motivated by the case of Device/VariationIndex tables, but I've been meaning to do this for a while)