### PR TITLE
[write-fonts] Add DeviceOrVariationIndex::device

### DIFF
--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -596,6 +596,13 @@ impl Device {
     }
 }
 
+impl DeviceOrVariationIndex {
+    /// Create a new [`Device`] subtable
+    pub fn device(start_size: u16, end_size: u16, values: &[i8]) -> Self {
+        DeviceOrVariationIndex::Device(Device::new(start_size, end_size, values))
+    }
+}
+
 fn encode_delta(format: DeltaFormat, values: &[i8]) -> Vec<u16> {
     let (chunk_size, mask, bits) = match format {
         DeltaFormat::Local2BitDeltas => (8, 0b11, 2),


### PR DESCRIPTION
Normally these constructors are generated automatically (if the constructor for the particular variant is autogenerated) but because Device has a hand-written constructor, we also need to manually add this.

JMM