### PR TITLE
[font-types] Ensure Tag impls DeserializeOwned

### DIFF
--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -259,9 +259,22 @@ impl<'de> serde::Deserialize<'de> for Tag {
     where
         D: serde::Deserializer<'de>,
     {
+        struct TagStrVisitor;
+        impl<'de> serde::de::Visitor<'de> for TagStrVisitor {
+            type Value = Tag;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(formatter, "a four-byte ascii string")
+            }
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                v.parse().map_err(serde::de::Error::custom)
+            }
+        }
         if deserializer.is_human_readable() {
-            <&str>::deserialize(deserializer)
-                .and_then(|s| s.parse().map_err(serde::de::Error::custom))
+            deserializer.deserialize_str(TagStrVisitor)
         } else {
             <[u8; 4]>::deserialize(deserializer).map(|raw| Tag::new(&raw))
         }
@@ -347,5 +360,13 @@ mod serde_tests {
         };
 
         serde_json::to_string(&ser_me).unwrap();
+    }
+
+    // ensure that we impl DeserializeOwned
+    #[test]
+    fn deser_json_owned() {
+        let json = r#"{"tag":"yolo"}"#;
+        let de_me: TestMe = serde_json::from_reader(json.as_bytes()).unwrap();
+        assert_eq!(de_me.tag, Tag::new(b"yolo"));
     }
 }


### PR DESCRIPTION
I ran into a bit of a surprise when trying to update fontc to the our latest release: it was unable to deserialize our Tag type, complaining that,

> Error("axes[0].tag: invalid type: string \"wght\", expected a borrowed string")

This caused some headscratching, since I couldn't reproduce it in tests. It turned out to be a funny set of things:

- My implementation involved temporarily deserializing to a &str
- The implementation of Deserialize for &str only works when the input can be borrowed
- The deserialization code in fontc uses yaml::from_reader
- from_reader involves reading from a byte stream, which is transient
- ergo you cannot deserialize &str from a reader

The solution is to do a slightly more principled Deserialize implementation, where I explicitly implement the Visitor trait.