### PR TITLE
[font-types] Make serde feature explicitly require std

### DIFF
--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -311,6 +311,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn display() {
         let bad_tag = Tag::new(&[0x19, b'z', b'@', 0x7F]);
         assert_eq!(bad_tag.to_string(), "{0x19}z@{0x7F}");


### PR DESCRIPTION
Previously it would have been possible to disable default features and also enable the serde feature, which would have caused compilation to fail. This now makes explicit that the serde feature requires std.

JMM