### PR TITLE
[codegen] Always generate Eq/Ord/Hash where possible

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -157,13 +157,6 @@ The following annotations are supported on top-level objects:
   common tables that contain offsets which point to different concrete types
   depending on the containing table, such as the `Layout` subtable shared
   between GPOS and GSUB.
-- `#[capabilities(equality, order, hash)]` Provide a list of additional
-  functionality to be implemented for this type. In Rust this means deriving 
-  additional traits. In the case of records, the trait will be derived
-  in both `read-fonts` and `write-fonts`, but in the case of tables only for
-  `write-fonts` (since tables in `read-fonts` are just byte slices, without
-  semantic information)
-
 
 #### field attributes
 - `#[nullable]`: only allowed on offsets or arrays of offsets, and indicates

--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -68,7 +68,7 @@ pub(crate) fn generate_parse_module(items: &Items) -> Result<proc_macro2::TokenS
     let mut code = Vec::new();
     for item in items.iter() {
         let item_code = match item {
-            Item::Record(item) => record::generate(item)?,
+            Item::Record(item) => record::generate(item, items)?,
             Item::Table(item) => table::generate(item)?,
             Item::GenericGroup(item) => table::generate_group(item)?,
             Item::Format(item) => table::generate_format_group(item)?,

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -66,7 +66,6 @@ pub(crate) struct TableAttrs {
     pub(crate) tag: Option<Attr<syn::LitStr>>,
     /// Custom validation behaviour, must be a fn(&self, &mut ValidationCtx) for the type
     pub(crate) validate: Option<Attr<syn::Ident>>,
-    pub(crate) capabilities: Option<Attr<Capabilities>>,
 }
 
 #[derive(Debug, Clone)]
@@ -78,18 +77,6 @@ pub(crate) struct TableReadArgs {
 pub(crate) struct TableReadArg {
     pub(crate) ident: syn::Ident,
     pub(crate) typ: syn::Ident,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Capabilities {
-    pub(crate) capabilities: Vec<Capability>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum Capability {
-    Order,
-    Equality,
-    Hash,
 }
 
 #[derive(Debug, Clone)]
@@ -1051,7 +1038,6 @@ static SKIP_FONT_WRITE: &str = "skip_font_write";
 static SKIP_CONSTRUCTOR: &str = "skip_constructor";
 static READ_ARGS: &str = "read_args";
 static GENERIC_OFFSET: &str = "generic_offset";
-static CAPABILITIES: &str = "capabilities";
 static TAG: &str = "tag";
 
 impl Parse for TableAttrs {
@@ -1079,8 +1065,6 @@ impl Parse for TableAttrs {
                 this.read_args = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == GENERIC_OFFSET {
                 this.generic_offset = Some(Attr::new(ident.clone(), attr.parse_args()?));
-            } else if ident == CAPABILITIES {
-                this.capabilities = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == TAG {
                 let tag: syn::LitStr = parse_attr_eq_value(&attr)?;
                 if let Err(e) = Tag::new_checked(tag.value().as_bytes()) {
@@ -1143,33 +1127,6 @@ impl Parse for TableReadArg {
         input.parse::<Token![:]>()?;
         let typ = input.parse()?;
         Ok(TableReadArg { ident, typ })
-    }
-}
-
-impl Parse for Capabilities {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut capabilities =
-            Punctuated::<Capability, Token![,]>::parse_separated_nonempty(input)?
-                .into_iter()
-                .collect::<Vec<_>>();
-        capabilities.sort_unstable();
-        capabilities.dedup();
-        Ok(Capabilities { capabilities })
-    }
-}
-
-impl Parse for Capability {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let ident = input.parse::<syn::Ident>()?;
-        match ident.to_string().as_str() {
-            "equality" => Ok(Self::Equality),
-            "order" => Ok(Self::Order),
-            "hash" => Ok(Self::Hash),
-            _ => Err(logged_syn_error(
-                ident.span(),
-                "expected one of 'equality', 'order', or 'hash'",
-            )),
-        }
     }
 }
 
@@ -1700,37 +1657,8 @@ impl FromIterator<(syn::Ident, NeededWhen)> for ReferencedFields {
     }
 }
 
-impl Capabilities {
-    pub(crate) fn extra_traits(&self) -> TokenStream {
-        let iter = self.capabilities.iter().flat_map(Capability::traits);
-        quote! ( #( #iter, )* )
-    }
-}
-
-impl Capability {
-    fn traits(&self) -> impl Iterator<Item = syn::Ident> + '_ {
-        match self {
-            // in order for all branches to return the same type, they are all [Option<Ident>; 2]
-            // and then we filter
-            Capability::Order => [
-                Some(syn::Ident::new("PartialOrd", Span::call_site())),
-                Some(syn::Ident::new("Ord", Span::call_site())),
-            ]
-            .into_iter(),
-            Capability::Equality => [
-                Some(syn::Ident::new("PartialEq", Span::call_site())),
-                Some(syn::Ident::new("Eq", Span::call_site())),
-            ]
-            .into_iter(),
-            Capability::Hash => {
-                [Some(syn::Ident::new("Hash", Span::call_site())), None].into_iter()
-            }
-        }
-        .flatten()
-    }
-}
-
 fn parse_attr_eq_value<T: Parse>(attr: &syn::Attribute) -> syn::Result<T> {
+    /// the tokens '= T' where 'T' is any `Parse`
     struct EqualsThing<T>(T);
 
     impl<T: Parse> Parse for EqualsThing<T> {

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -406,7 +406,7 @@ pub(crate) fn generate_group_compile(
 
     Ok(quote! {
         #( #docs)*
-        #[derive(Debug, Clone)]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub enum #name {
             #( #variant_decls, )*
         }
@@ -499,16 +499,10 @@ pub(crate) fn generate_format_compile(
         .then(|| generate_format_from_obj(item, parse_module))
         .transpose()?;
 
-    let maybe_extra_traits = item
-        .attrs
-        .capabilities
-        .as_ref()
-        .map(|cap| cap.extra_traits());
-
     let constructors = generate_format_constructors(item, items)?;
     Ok(quote! {
         #( #docs )*
-        #[derive(Clone, Debug, #maybe_extra_traits)]
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub enum #name {
             #( #variants ),*
         }

--- a/font-types/src/fword.rs
+++ b/font-types/src/fword.rs
@@ -3,12 +3,12 @@
 use super::Fixed;
 
 /// 16-bit signed quantity in font design units.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FWord(i16);
 
 /// 16-bit unsigned quantity in font design units.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UfWord(u16);
 

--- a/font-types/src/version.rs
+++ b/font-types/src/version.rs
@@ -4,7 +4,7 @@
 ///
 /// This is a legacy type with an unusual representation. See [the spec][] for
 /// additional details.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Version16Dot16(u32);
 
@@ -14,7 +14,7 @@ pub struct Version16Dot16(u32);
 /// represented as a `major_version`, `minor_version` pair. This type encodes
 /// those as a single type, which is useful for some of the generated code that
 /// parses out a version.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MajorMinor {
     /// The major version number

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -126,7 +126,7 @@ impl<'a> std::fmt::Debug for TableDirectory<'a> {
 }
 
 /// Record for a table in a font.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct TableRecord {

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -104,7 +104,7 @@ impl<'a> std::fmt::Debug for Avar<'a> {
 }
 
 /// [SegmentMaps](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SegmentMaps<'a> {
     /// The number of correspondence pairs for this axis.
     pub position_map_count: BigEndian<u16>,
@@ -147,7 +147,7 @@ impl<'a> SomeRecord<'a> for SegmentMaps<'a> {
 }
 
 /// [AxisValueMap](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AxisValueMap {

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -473,7 +473,7 @@ impl<'a> std::fmt::Debug for Cmap2<'a> {
 }
 
 /// Part of [Cmap2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SubHeader {
@@ -1012,7 +1012,7 @@ impl<'a> std::fmt::Debug for Cmap8<'a> {
 }
 
 /// Used in [Cmap8] and [Cmap12]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SequentialMapGroup {
@@ -1441,7 +1441,7 @@ impl<'a> std::fmt::Debug for Cmap13<'a> {
 }
 
 /// Part of [Cmap13]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ConstantMapGroup {
@@ -1837,7 +1837,7 @@ impl<'a> std::fmt::Debug for NonDefaultUvs<'a> {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct UvsMapping {
@@ -1886,7 +1886,7 @@ impl<'a> SomeRecord<'a> for UvsMapping {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct UnicodeRange {

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -295,7 +295,7 @@ impl<'a> std::fmt::Debug for Colr<'a> {
 }
 
 /// [BaseGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BaseGlyph {
@@ -352,7 +352,7 @@ impl<'a> SomeRecord<'a> for BaseGlyph {
 }
 
 /// [Layer](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Layer {
@@ -1035,7 +1035,7 @@ impl<'a> std::fmt::Debug for ClipBoxFormat2<'a> {
 }
 
 /// [ColorIndex](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ColorIndex {
@@ -1084,7 +1084,7 @@ impl<'a> SomeRecord<'a> for ColorIndex {
 }
 
 /// [VarColorIndex](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VarColorIndex {
@@ -1141,7 +1141,7 @@ impl<'a> SomeRecord<'a> for VarColorIndex {
 }
 
 /// [ColorStop](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ColorStop {
@@ -1198,7 +1198,7 @@ impl<'a> SomeRecord<'a> for ColorStop {
 }
 
 /// [VarColorStop](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VarColorStop {

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -266,7 +266,7 @@ impl<'a> std::fmt::Debug for Cpal<'a> {
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ColorRecord {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -268,7 +268,7 @@ impl<'a> std::fmt::Debug for AxisInstanceArrays<'a> {
 }
 
 /// The [VariationAxisRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VariationAxisRecord {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -111,7 +111,7 @@ impl<'a> std::fmt::Debug for Hmtx<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct LongMetric {

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1086,7 +1086,7 @@ impl<'a> std::fmt::Debug for CoverageFormat2<'a> {
 }
 
 /// Used in [CoverageFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct RangeRecord {
@@ -1378,7 +1378,7 @@ impl<'a> std::fmt::Debug for ClassDefFormat2<'a> {
 }
 
 /// Used in [ClassDefFormat2]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ClassRangeRecord {
@@ -1479,7 +1479,7 @@ impl<'a> SomeTable<'a> for ClassDef<'a> {
 }
 
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SequenceLookupRecord {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -140,7 +140,7 @@ impl<'a> std::fmt::Debug for Mvar<'a> {
 }
 
 /// [ValueRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/mvar#table-formats) metrics variation record
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ValueRecord {

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -218,7 +218,7 @@ impl<'a> SomeRecord<'a> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 #[repr(packed)]
 pub struct NameRecord {

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -416,7 +416,7 @@ impl<'a> std::fmt::Debug for FdSelectFormat3<'a> {
 }
 
 /// Range struct for FdSelect format 3.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FdSelectRange3 {
@@ -566,7 +566,7 @@ impl<'a> std::fmt::Debug for FdSelectFormat4<'a> {
 }
 
 /// Range struct for FdSelect format 4.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FdSelectRange4 {

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -188,7 +188,7 @@ impl<'a> std::fmt::Debug for Stat<'a> {
 }
 
 /// [Axis Records](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AxisRecord {
@@ -868,7 +868,7 @@ impl<'a> std::fmt::Debug for AxisValueFormat4<'a> {
 }
 
 /// Part of [AxisValueFormat4]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AxisValueRecord {

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -90,7 +90,7 @@ impl<'a> From<MyEnum2> for FieldType<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct MyRecord {

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -699,7 +699,7 @@ impl<'a> std::fmt::Debug for Dummy<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Shmecord {

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -125,7 +125,7 @@ impl<'a> std::fmt::Debug for BasicTable<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SimpleRecord {
@@ -169,7 +169,7 @@ impl<'a> SomeRecord<'a> for SimpleRecord {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ContainsArrays<'a> {
     pub scalars: &'a [BigEndian<u16>],
     pub records: &'a [SimpleRecord],

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -123,7 +123,7 @@ impl<'a> std::fmt::Debug for TupleVariationHeader<'a> {
 /// The tuple variation store formats reference regions within the font’s
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Tuple<'a> {
     /// Coordinate array specifying a position within the font’s variation space.
     ///
@@ -822,7 +822,7 @@ impl<'a> std::fmt::Debug for VariationRegionList<'a> {
 }
 
 /// The [VariationRegion](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationRegion<'a> {
     /// Array of region axis coordinates records, in the order of axes
     /// given in the 'fvar' table.
@@ -891,7 +891,7 @@ impl<'a> SomeRecord<'a> for VariationRegion<'a> {
 }
 
 /// The [RegionAxisCoordinates](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
-#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 #[repr(packed)]
 pub struct RegionAxisCoordinates {

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -526,7 +526,6 @@ enum u16 DeltaFormat {
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 #[skip_constructor]
-#[capabilities(equality, hash)]
 table Device {
     /// Smallest size to correct, in ppem
     start_size: u16,
@@ -540,7 +539,6 @@ table Device {
 }
 
 /// Variation index table
-#[capabilities(equality, hash)]
 table VariationIndex {
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
@@ -554,7 +552,6 @@ table VariationIndex {
 }
 
 /// Either a [Device] table (in a non-variable font) or a [VariationIndex] table (in a variable font)
-#[capabilities(equality, hash)]
 format DeltaFormat@4 DeviceOrVariationIndex {
     #[match_if($format != DeltaFormat::VariationIndex)]
     Device(Device),
@@ -587,7 +584,6 @@ record FeatureVariationRecord {
 }
 
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
-#[capabilities(equality, order, hash)]
 table ConditionSet {
     /// Number of conditions for this condition set.
     #[compile(array_len($condition_offsets))]
@@ -605,7 +601,6 @@ table ConditionSet {
 //}
 
 /// [Condition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range): Font Variation Axis Range
-#[capabilities(equality, order, hash)]
 table ConditionFormat1 {
     /// Format, = 1
     #[format = 1]

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -47,7 +47,6 @@ record LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[capabilities(equality, order)]
 record NameRecord {
     /// Platform ID.
     platform_id: u16,

--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -37,7 +37,6 @@ table TupleVariationHeader {
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
 #[read_args(axis_count: u16)]
-#[capabilities(hash, equality, order)]
 record Tuple<'a> {
     /// Coordinate array specifying a position within the font’s variation space.
     ///
@@ -109,7 +108,6 @@ table VariationRegionList {
 
 /// The [VariationRegion](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
 #[read_args(axis_count: u16)]
-#[capabilities(hash, equality, order)]
 record VariationRegion<'a> {
     /// Array of region axis coordinates records, in the order of axes
     /// given in the 'fvar' table.
@@ -118,7 +116,6 @@ record VariationRegion<'a> {
 }
 
 /// The [RegionAxisCoordinates](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
-#[capabilities(hash, equality, order)]
 record RegionAxisCoordinates {
     /// The region start coordinate value for the current axis.
     start_coord: F2Dot14,

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [avar (Axis Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/avar) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Avar {
     /// The segment maps array — one segment map for each axis, in the order of axes specified in the 'fvar' table.
     pub axis_segment_maps: Vec<SegmentMaps>,
@@ -68,7 +68,7 @@ impl<'a> FontRead<'a> for Avar {
 }
 
 /// [SegmentMaps](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SegmentMaps {
     /// The array of axis value map records for this axis.
     pub axis_value_maps: Vec<AxisValueMap>,
@@ -116,7 +116,7 @@ impl FromObjRef<read_fonts::tables::avar::SegmentMaps<'_>> for SegmentMaps {
 }
 
 /// [AxisValueMap](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueMap {
     /// A normalized coordinate value obtained using default normalization.
     pub from_coordinate: F2Dot14,

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [BASE](https://learn.microsoft.com/en-us/typography/opentype/spec/base) (Baseline) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Base {
     /// Offset to horizontal Axis table, from beginning of BASE table (may be NULL)
     pub horiz_axis: NullableOffsetMarker<Axis>,
@@ -82,7 +82,7 @@ impl<'a> FontRead<'a> for Base {
 }
 
 /// [Axis Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#axis-tables-horizaxis-and-vertaxis)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Axis {
     /// Offset to BaseTagList table, from beginning of Axis table (may
     /// be NULL)
@@ -142,7 +142,7 @@ impl<'a> FontRead<'a> for Axis {
 }
 
 /// [BaseTagList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basetaglist-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseTagList {
     /// Array of 4-byte baseline identification tags — must be in
     /// alphabetical order
@@ -199,7 +199,7 @@ impl<'a> FontRead<'a> for BaseTagList {
 }
 
 /// [BaseScriptList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptlist-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseScriptList {
     /// Array of BaseScriptRecords, in alphabetical order by
     /// baseScriptTag
@@ -258,7 +258,7 @@ impl<'a> FontRead<'a> for BaseScriptList {
 }
 
 /// [BaseScriptRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptrecord)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseScriptRecord {
     /// 4-byte script identification tag
     pub base_script_tag: Tag,
@@ -309,7 +309,7 @@ impl FromObjRef<read_fonts::tables::base::BaseScriptRecord> for BaseScriptRecord
 }
 
 /// [BaseScript Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescript-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseScript {
     /// Offset to BaseValues table, from beginning of BaseScript table (may be NULL)
     pub base_values: NullableOffsetMarker<BaseValues>,
@@ -387,7 +387,7 @@ impl<'a> FontRead<'a> for BaseScript {
 }
 
 /// [BaseLangSysRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseLangSysRecord {
     /// 4-byte language system identification tag
     pub base_lang_sys_tag: Tag,
@@ -438,7 +438,7 @@ impl FromObjRef<read_fonts::tables::base::BaseLangSysRecord> for BaseLangSysReco
 }
 
 /// [BaseValues](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basevalues-table) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseValues {
     /// Index number of default baseline for this script — equals
     /// index position of baseline tag in baselineTags array of the
@@ -503,7 +503,7 @@ impl<'a> FontRead<'a> for BaseValues {
 }
 
 /// [MinMax](https://learn.microsoft.com/en-us/typography/opentype/spec/base#minmax-table) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MinMax {
     /// Offset to BaseCoord table that defines the minimum extent
     /// value, from the beginning of MinMax table (may be NULL)
@@ -583,7 +583,7 @@ impl<'a> FontRead<'a> for MinMax {
 }
 
 /// [FeatMinMaxRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatMinMaxRecord {
     /// 4-byte feature identification tag — must match feature tag in
     /// FeatureList
@@ -648,7 +648,7 @@ impl FromObjRef<read_fonts::tables::base::FeatMinMaxRecord> for FeatMinMaxRecord
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum BaseCoord {
     Format1(BaseCoordFormat1),
     Format2(BaseCoordFormat2),
@@ -747,7 +747,7 @@ impl From<BaseCoordFormat3> for BaseCoord {
 }
 
 /// [BaseCoordFormat1](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseCoordFormat1 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -793,7 +793,7 @@ impl<'a> FontRead<'a> for BaseCoordFormat1 {
 }
 
 /// [BaseCoordFormat2](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-2)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseCoordFormat2 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -851,7 +851,7 @@ impl<'a> FontRead<'a> for BaseCoordFormat2 {
 }
 
 /// [BaseCoordFormat3](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basecoord-format-3)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseCoordFormat3 {
     /// X or Y value, in design units
     pub coordinate: i16,

--- a/write-fonts/generated/generated_cff.rs
+++ b/write-fonts/generated/generated_cff.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CffHeader {
     /// Header size (bytes).
     pub hdr_size: u8,

--- a/write-fonts/generated/generated_cff2.rs
+++ b/write-fonts/generated/generated_cff2.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cff2Header {
     /// Header size (bytes).
     pub header_size: u8,

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::tables::cmap::PlatformId;
 
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap {
     pub encoding_records: Vec<EncodingRecord>,
 }
@@ -69,7 +69,7 @@ impl<'a> FontRead<'a> for Cmap {
 }
 
 /// [Encoding Record](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EncodingRecord {
     /// Platform ID.
     pub platform_id: PlatformId,
@@ -130,7 +130,7 @@ impl FontWrite for PlatformId {
 }
 
 /// The different cmap subtable formats.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CmapSubtable {
     Format0(Cmap0),
     Format2(Cmap2),
@@ -390,7 +390,7 @@ impl From<Cmap14> for CmapSubtable {
 }
 
 /// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap0 {
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
@@ -445,7 +445,7 @@ impl<'a> FontRead<'a> for Cmap0 {
 }
 
 /// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap2 {
     /// This is the length in bytes of the subtable.
     pub length: u16,
@@ -505,7 +505,7 @@ impl<'a> FontRead<'a> for Cmap2 {
 }
 
 /// Part of [Cmap2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubHeader {
     /// First valid low byte for this SubHeader.
     pub first_code: u16,
@@ -557,7 +557,7 @@ impl FromObjRef<read_fonts::tables::cmap::SubHeader> for SubHeader {
 }
 
 /// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap4 {
     /// This is the length in bytes of the subtable.
     pub length: u16,
@@ -674,7 +674,7 @@ impl<'a> FontRead<'a> for Cmap4 {
 }
 
 /// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap6 {
     /// This is the length in bytes of the subtable.
     pub length: u16,
@@ -757,7 +757,7 @@ impl<'a> FontRead<'a> for Cmap6 {
 }
 
 /// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap8 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -844,7 +844,7 @@ impl<'a> FontRead<'a> for Cmap8 {
 }
 
 /// Used in [Cmap8] and [Cmap12]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequentialMapGroup {
     /// First character code in this group; note that if this group is
     /// for one or more 16-bit character codes (which is determined
@@ -895,7 +895,7 @@ impl FromObjRef<read_fonts::tables::cmap::SequentialMapGroup> for SequentialMapG
 }
 
 /// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap10 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -971,7 +971,7 @@ impl<'a> FontRead<'a> for Cmap10 {
 }
 
 /// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap12 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -1050,7 +1050,7 @@ impl<'a> FontRead<'a> for Cmap12 {
 }
 
 /// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap13 {
     /// Byte length of this subtable (including the header)
     pub length: u32,
@@ -1124,7 +1124,7 @@ impl<'a> FontRead<'a> for Cmap13 {
 }
 
 /// Part of [Cmap13]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConstantMapGroup {
     /// First character code in this group
     pub start_char_code: u32,
@@ -1172,7 +1172,7 @@ impl FromObjRef<read_fonts::tables::cmap::ConstantMapGroup> for ConstantMapGroup
 }
 
 /// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cmap14 {
     /// Byte length of this subtable (including this header)
     pub length: u32,
@@ -1243,7 +1243,7 @@ impl<'a> FontRead<'a> for Cmap14 {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationSelector {
     /// Variation selector
     pub var_selector: Uint24,
@@ -1308,7 +1308,7 @@ impl FromObjRef<read_fonts::tables::cmap::VariationSelector> for VariationSelect
 }
 
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DefaultUvs {
     /// Number of Unicode character ranges.
     pub num_unicode_value_ranges: u32,
@@ -1368,7 +1368,7 @@ impl<'a> FontRead<'a> for DefaultUvs {
 }
 
 /// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonDefaultUvs {
     pub num_uvs_mappings: u32,
     pub uvs_mapping: Vec<UvsMapping>,
@@ -1427,7 +1427,7 @@ impl<'a> FontRead<'a> for NonDefaultUvs {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UvsMapping {
     /// Base Unicode value of the UVS
     pub unicode_value: Uint24,
@@ -1469,7 +1469,7 @@ impl FromObjRef<read_fonts::tables::cmap::UvsMapping> for UvsMapping {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnicodeRange {
     /// First value in this range
     pub start_unicode_value: Uint24,

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [CPAL (Color Palette Table)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-table-header) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cpal {
     /// Number of palette entries in each palette.
     pub num_palette_entries: u16,
@@ -135,7 +135,7 @@ impl<'a> FontRead<'a> for Cpal {
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColorRecord {
     /// Blue value (B0).
     pub blue: u8,

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The OpenType [Table Directory](https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TableDirectory {
     /// 0x00010000 or 0x4F54544F
     pub sfnt_version: u32,
@@ -65,7 +65,7 @@ impl Validate for TableDirectory {
 }
 
 /// Record for a table in a font.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TableRecord {
     /// Table identifier.
     pub tag: Tag,
@@ -106,7 +106,7 @@ impl Validate for TableRecord {
 }
 
 /// [TTC Header](https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TTCHeader {
     /// Font Collection ID string: \"ttcf\"
     pub ttc_tag: Tag,

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [fvar (Font Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/fvar) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Fvar {
     /// Offset in bytes from the beginning of the table to the start of the VariationAxisRecord array. The
     /// InstanceRecord array directly follows.
@@ -70,7 +70,7 @@ impl<'a> FontRead<'a> for Fvar {
 }
 
 /// Shim table to handle combined axis and instance arrays.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisInstanceArrays {
     /// Variation axis record array.
     pub axes: Vec<VariationAxisRecord>,
@@ -134,7 +134,7 @@ impl<'a> FromObjRef<read_fonts::tables::fvar::AxisInstanceArrays<'a>> for AxisIn
 impl<'a> FromTableRef<read_fonts::tables::fvar::AxisInstanceArrays<'a>> for AxisInstanceArrays {}
 
 /// The [VariationAxisRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationAxisRecord {
     /// Tag identifying the design variation for the axis.
     pub axis_tag: Tag,

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::tables::gdef::GlyphClassDef;
 
 /// [GDEF](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#gdef-header) 1.0
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Gdef {
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
@@ -127,7 +127,7 @@ impl FontWrite for GlyphClassDef {
 }
 
 /// [Attachment Point List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#attachment-point-list-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttachList {
     /// Offset to Coverage table - from beginning of AttachList table
     pub coverage: OffsetMarker<CoverageTable>,
@@ -192,7 +192,7 @@ impl<'a> FontRead<'a> for AttachList {
 }
 
 /// Part of [AttachList]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttachPoint {
     /// Array of contour point indices -in increasing numerical order
     pub point_indices: Vec<u16>,
@@ -248,7 +248,7 @@ impl<'a> FontRead<'a> for AttachPoint {
 }
 
 /// [Ligature Caret List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LigCaretList {
     /// Offset to Coverage table - from beginning of LigCaretList table
     pub coverage: OffsetMarker<CoverageTable>,
@@ -313,7 +313,7 @@ impl<'a> FontRead<'a> for LigCaretList {
 }
 
 /// [Ligature Glyph Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-glyph-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LigGlyph {
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
@@ -370,7 +370,7 @@ impl<'a> FontRead<'a> for LigGlyph {
 }
 
 /// [Caret Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caret-value-tables)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CaretValue {
     Format1(CaretValueFormat1),
     Format2(CaretValueFormat2),
@@ -465,7 +465,7 @@ impl From<CaretValueFormat3> for CaretValue {
 }
 
 /// [CaretValue Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CaretValueFormat1 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -511,7 +511,7 @@ impl<'a> FontRead<'a> for CaretValueFormat1 {
 }
 
 /// [CaretValue Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-2)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CaretValueFormat2 {
     /// Contour point index on glyph
     pub caret_value_point_index: u16,
@@ -559,7 +559,7 @@ impl<'a> FontRead<'a> for CaretValueFormat2 {
 }
 
 /// [CaretValue Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caretvalue-format-3)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CaretValueFormat3 {
     /// X or Y value, in design units
     pub coordinate: i16,
@@ -620,7 +620,7 @@ impl<'a> FontRead<'a> for CaretValueFormat3 {
 }
 
 /// [Mark Glyph Sets Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#mark-glyph-sets-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MarkGlyphSets {
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -9,7 +9,7 @@ pub use read_fonts::tables::gpos::ValueFormat;
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Gpos {
     /// Offset to ScriptList table, from beginning of GPOS table
     pub script_list: OffsetMarker<ScriptList>,
@@ -96,7 +96,7 @@ impl<'a> FontRead<'a> for Gpos {
 }
 
 /// A [GPOS Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#gsubLookupTypeEnum) subtable.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PositionLookup {
     Single(Lookup<SinglePos>),
     Pair(Lookup<PairPos>),
@@ -204,7 +204,7 @@ impl FontWrite for ValueFormat {
 
 /// [Anchor Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-tables)
 /// position one glyph with respect to another.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AnchorTable {
     Format1(AnchorFormat1),
     Format2(AnchorFormat2),
@@ -309,7 +309,7 @@ impl From<AnchorFormat3> for AnchorTable {
 }
 
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnchorFormat1 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -362,7 +362,7 @@ impl<'a> FontRead<'a> for AnchorFormat1 {
 }
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnchorFormat2 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -420,7 +420,7 @@ impl<'a> FontRead<'a> for AnchorFormat2 {
 }
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnchorFormat3 {
     /// Horizontal value, in design units
     pub x_coordinate: i16,
@@ -501,7 +501,7 @@ impl<'a> FontRead<'a> for AnchorFormat3 {
 }
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MarkArray {
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
@@ -559,7 +559,7 @@ impl<'a> FontRead<'a> for MarkArray {
 }
 
 /// Part of [MarkArray]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MarkRecord {
     /// Class defined for the associated mark.
     pub mark_class: u16,
@@ -607,7 +607,7 @@ impl FromObjRef<read_fonts::tables::gpos::MarkRecord> for MarkRecord {
 }
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SinglePos {
     Format1(SinglePosFormat1),
     Format2(SinglePosFormat2),
@@ -686,7 +686,7 @@ impl From<SinglePosFormat2> for SinglePos {
 }
 
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SinglePosFormat1 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -748,7 +748,7 @@ impl<'a> FontRead<'a> for SinglePosFormat1 {
 }
 
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SinglePosFormat2 {
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -820,7 +820,7 @@ impl<'a> FontRead<'a> for SinglePosFormat2 {
 }
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PairPos {
     Format1(PairPosFormat1),
     Format2(PairPosFormat2),
@@ -909,7 +909,7 @@ impl From<PairPosFormat2> for PairPos {
 }
 
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PairPosFormat1 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -978,7 +978,7 @@ impl<'a> FontRead<'a> for PairPosFormat1 {
 }
 
 /// Part of [PairPosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PairSet {
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
@@ -1032,7 +1032,7 @@ impl<'a> FromObjRef<read_fonts::tables::gpos::PairSet<'a>> for PairSet {
 impl<'a> FromTableRef<read_fonts::tables::gpos::PairSet<'a>> for PairSet {}
 
 /// Part of [PairSet]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PairValueRecord {
     /// Glyph ID of second glyph in the pair (first glyph is listed in
     /// the Coverage table).
@@ -1087,7 +1087,7 @@ impl FromObjRef<read_fonts::tables::gpos::PairValueRecord> for PairValueRecord {
 }
 
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PairPosFormat2 {
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -1184,7 +1184,7 @@ impl<'a> FontRead<'a> for PairPosFormat2 {
 }
 
 /// Part of [PairPosFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Class1Record {
     /// Array of Class2 records, ordered by classes in classDef2.
     pub class2_records: Vec<Class2Record>,
@@ -1232,7 +1232,7 @@ impl FromObjRef<read_fonts::tables::gpos::Class1Record<'_>> for Class1Record {
 }
 
 /// Part of [PairPosFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Class2Record {
     /// Positioning for first glyph — empty if valueFormat1 = 0.
     pub value_record1: ValueRecord,
@@ -1274,7 +1274,7 @@ impl FromObjRef<read_fonts::tables::gpos::Class2Record> for Class2Record {
 }
 
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CursivePosFormat1 {
     /// Offset to Coverage table, from beginning of CursivePos subtable.
     pub coverage: OffsetMarker<CoverageTable>,
@@ -1341,7 +1341,7 @@ impl<'a> FontRead<'a> for CursivePosFormat1 {
 }
 
 /// Part of [CursivePosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
@@ -1397,7 +1397,7 @@ impl FromObjRef<read_fonts::tables::gpos::EntryExitRecord> for EntryExitRecord {
 }
 
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MarkBasePosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
@@ -1485,7 +1485,7 @@ impl<'a> FontRead<'a> for MarkBasePosFormat1 {
 }
 
 /// Part of [MarkBasePosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseArray {
     /// Array of BaseRecords, in order of baseCoverage Index.
     pub base_records: Vec<BaseRecord>,
@@ -1538,7 +1538,7 @@ impl<'a> FromObjRef<read_fonts::tables::gpos::BaseArray<'a>> for BaseArray {
 impl<'a> FromTableRef<read_fonts::tables::gpos::BaseArray<'a>> for BaseArray {}
 
 /// Part of [BaseArray]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BaseRecord {
     /// Array of offsets (one per mark class) to Anchor tables. Offsets
     /// are from beginning of BaseArray table, ordered by class
@@ -1586,7 +1586,7 @@ impl FromObjRef<read_fonts::tables::gpos::BaseRecord<'_>> for BaseRecord {
 }
 
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MarkLigPosFormat1 {
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
@@ -1674,7 +1674,7 @@ impl<'a> FontRead<'a> for MarkLigPosFormat1 {
 }
 
 /// Part of [MarkLigPosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LigatureArray {
     /// Array of offsets to LigatureAttach tables. Offsets are from
     /// beginning of LigatureArray table, ordered by ligatureCoverage
@@ -1726,7 +1726,7 @@ impl<'a> FromObjRef<read_fonts::tables::gpos::LigatureArray<'a>> for LigatureArr
 impl<'a> FromTableRef<read_fonts::tables::gpos::LigatureArray<'a>> for LigatureArray {}
 
 /// Part of [MarkLigPosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LigatureAttach {
     /// Array of Component records, ordered in writing direction.
     pub component_records: Vec<ComponentRecord>,
@@ -1779,7 +1779,7 @@ impl<'a> FromObjRef<read_fonts::tables::gpos::LigatureAttach<'a>> for LigatureAt
 impl<'a> FromTableRef<read_fonts::tables::gpos::LigatureAttach<'a>> for LigatureAttach {}
 
 /// Part of [MarkLigPosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ComponentRecord {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of LigatureAttach table, ordered by class
@@ -1830,7 +1830,7 @@ impl FromObjRef<read_fonts::tables::gpos::ComponentRecord<'_>> for ComponentReco
 }
 
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MarkMarkPosFormat1 {
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
@@ -1918,7 +1918,7 @@ impl<'a> FontRead<'a> for MarkMarkPosFormat1 {
 }
 
 /// Part of [MarkMarkPosFormat1]Class2Record
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Mark2Array {
     /// Array of Mark2Records, in Coverage order.
     pub mark2_records: Vec<Mark2Record>,
@@ -1971,7 +1971,7 @@ impl<'a> FromObjRef<read_fonts::tables::gpos::Mark2Array<'a>> for Mark2Array {
 impl<'a> FromTableRef<read_fonts::tables::gpos::Mark2Array<'a>> for Mark2Array {}
 
 /// Part of [MarkMarkPosFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Mark2Record {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of Mark2Array table, in class order (offsets may
@@ -2019,7 +2019,7 @@ impl FromObjRef<read_fonts::tables::gpos::Mark2Record<'_>> for Mark2Record {
 }
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtensionPosFormat1<T> {
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
@@ -2076,7 +2076,7 @@ where
 }
 
 /// A [GPOS Extension Positioning](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning) subtable
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ExtensionSubtable {
     Single(ExtensionPosFormat1<SinglePos>),
     Pair(ExtensionPosFormat1<PairPos>),

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Gsub {
     /// Offset to ScriptList table, from beginning of GSUB table
     pub script_list: OffsetMarker<ScriptList>,
@@ -95,7 +95,7 @@ impl<'a> FontRead<'a> for Gsub {
 }
 
 /// A [GSUB Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsubLookupTypeEnum) subtable.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SubstitutionLookup {
     Single(Lookup<SingleSubst>),
     Multiple(Lookup<MultipleSubstFormat1>),
@@ -192,7 +192,7 @@ impl FromObjRef<read_fonts::tables::gsub::SubstitutionLookup<'_>> for Substituti
 impl FromTableRef<read_fonts::tables::gsub::SubstitutionLookup<'_>> for SubstitutionLookup {}
 
 /// LookupType 1: [Single Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-1-single-substitution-subtable) Subtable
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SingleSubst {
     Format1(SingleSubstFormat1),
     Format2(SingleSubstFormat2),
@@ -271,7 +271,7 @@ impl From<SingleSubstFormat2> for SingleSubst {
 }
 
 /// [Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -331,7 +331,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat1 {
 }
 
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SingleSubstFormat2 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -398,7 +398,7 @@ impl<'a> FontRead<'a> for SingleSubstFormat2 {
 }
 
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MultipleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -466,7 +466,7 @@ impl<'a> FontRead<'a> for MultipleSubstFormat1 {
 }
 
 /// Part of [MultipleSubstFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Sequence {
     /// String of glyph IDs to substitute
     pub substitute_glyph_ids: Vec<GlyphId>,
@@ -522,7 +522,7 @@ impl<'a> FontRead<'a> for Sequence {
 }
 
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AlternateSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -596,7 +596,7 @@ impl<'a> FontRead<'a> for AlternateSubstFormat1 {
 }
 
 /// Part of [AlternateSubstFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AlternateSet {
     /// Array of alternate glyph IDs, in arbitrary order
     pub alternate_glyph_ids: Vec<GlyphId>,
@@ -652,7 +652,7 @@ impl<'a> FontRead<'a> for AlternateSet {
 }
 
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LigatureSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
@@ -720,7 +720,7 @@ impl<'a> FontRead<'a> for LigatureSubstFormat1 {
 }
 
 /// Part of [LigatureSubstFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LigatureSet {
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
@@ -777,7 +777,7 @@ impl<'a> FontRead<'a> for LigatureSet {
 }
 
 /// Part of [LigatureSubstFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ligature {
     /// glyph ID of ligature to substitute
     pub ligature_glyph: GlyphId,
@@ -831,7 +831,7 @@ impl<'a> FontRead<'a> for Ligature {
 }
 
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtensionSubstFormat1<T> {
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
@@ -888,7 +888,7 @@ where
 }
 
 /// A [GSUB Extension Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#ES) subtable
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ExtensionSubtable {
     Single(ExtensionSubstFormat1<SingleSubst>),
     Multiple(ExtensionSubstFormat1<MultipleSubstFormat1>),
@@ -978,7 +978,7 @@ impl FromObjRef<read_fonts::tables::gsub::ExtensionSubtable<'_>> for ExtensionSu
 impl FromTableRef<read_fonts::tables::gsub::ExtensionSubtable<'_>> for ExtensionSubtable {}
 
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReverseChainSingleSubstFormat1 {
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::tables::gvar::GvarFlags;
 
 /// The ['gvar' header](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#gvar-header)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Gvar {
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
@@ -61,7 +61,7 @@ impl FontWrite for GvarFlags {
 }
 
 /// Array of tuple records shared across all glyph variation data tables.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SharedTuples {
     pub tuples: Vec<Tuple>,
 }
@@ -111,7 +111,7 @@ impl<'a> FromObjRef<read_fonts::tables::gvar::SharedTuples<'a>> for SharedTuples
 impl<'a> FromTableRef<read_fonts::tables::gvar::SharedTuples<'a>> for SharedTuples {}
 
 /// The [GlyphVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#the-glyphvariationdata-table-array) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GlyphVariationDataHeader {
     /// A packed field. The high 4 bits are flags, and the low 12 bits
     /// are the number of tuple variation tables for this glyph. The

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -15,7 +15,7 @@ impl FontWrite for MacStyle {
 
 /// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
 /// (font header) table.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Head {
     /// Set by font manufacturer.
     pub font_revision: Fixed,

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Hhea {
     /// Typographic ascent.
     pub ascender: FWord,

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Hmtx {
     /// Paired advance width/height and left/top side bearing values for each
     /// glyph. Records are indexed by glyph ID.
@@ -65,7 +65,7 @@ impl<'a> FromObjRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {
 
 impl<'a> FromTableRef<read_fonts::tables::hmtx::Hmtx<'a>> for Hmtx {}
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LongMetric {
     /// Advance width/height, in font design units.
     pub advance: u16,

--- a/write-fonts/generated/generated_hvar.rs
+++ b/write-fonts/generated/generated_hvar.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [HVAR (Horizontal Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/hvar) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Hvar {
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::tables::layout::DeltaFormat;
 
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScriptList {
     /// Array of ScriptRecords, listed alphabetically by script tag
     pub script_records: Vec<ScriptRecord>,
@@ -65,7 +65,7 @@ impl<'a> FontRead<'a> for ScriptList {
 }
 
 /// [Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScriptRecord {
     /// 4-byte script tag identifier
     pub script_tag: Tag,
@@ -113,7 +113,7 @@ impl FromObjRef<read_fonts::tables::layout::ScriptRecord> for ScriptRecord {
 }
 
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Script {
     /// Offset to default LangSys table, from beginning of Script table
     /// — may be NULL
@@ -178,7 +178,7 @@ impl<'a> FontRead<'a> for Script {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LangSysRecord {
     /// 4-byte LangSysTag identifier
     pub lang_sys_tag: Tag,
@@ -229,7 +229,7 @@ impl FromObjRef<read_fonts::tables::layout::LangSysRecord> for LangSysRecord {
 }
 
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LangSys {
     /// Index of a feature required for this language system; if no
     /// required features = 0xFFFF
@@ -301,7 +301,7 @@ impl<'a> FontRead<'a> for LangSys {
 }
 
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatureList {
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
@@ -360,7 +360,7 @@ impl<'a> FontRead<'a> for FeatureList {
 }
 
 /// Part of [FeatureList]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatureRecord {
     /// 4-byte feature identification tag
     pub feature_tag: Tag,
@@ -411,7 +411,7 @@ impl FromObjRef<read_fonts::tables::layout::FeatureRecord> for FeatureRecord {
 }
 
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Feature {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     pub feature_params: NullableOffsetMarker<FeatureParams>,
@@ -470,7 +470,7 @@ impl<'a> FromObjRef<read_fonts::tables::layout::Feature<'a>> for Feature {
 impl<'a> FromTableRef<read_fonts::tables::layout::Feature<'a>> for Feature {}
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LookupList<T> {
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
@@ -530,7 +530,7 @@ where
 }
 
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Lookup<T> {
     /// Lookup qualifiers
     pub lookup_flag: LookupFlag,
@@ -589,7 +589,7 @@ where
 }
 
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CoverageFormat1 {
     /// Array of glyph IDs — in numerical order
     pub glyph_array: Vec<GlyphId>,
@@ -647,7 +647,7 @@ impl<'a> FontRead<'a> for CoverageFormat1 {
 }
 
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CoverageFormat2 {
     /// Array of glyph ranges — ordered by startGlyphID.
     pub range_records: Vec<RangeRecord>,
@@ -706,7 +706,7 @@ impl<'a> FontRead<'a> for CoverageFormat2 {
 }
 
 /// Used in [CoverageFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RangeRecord {
     /// First glyph ID in the range
     pub start_glyph_id: GlyphId,
@@ -753,7 +753,7 @@ impl FromObjRef<read_fonts::tables::layout::RangeRecord> for RangeRecord {
 }
 
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CoverageTable {
     Format1(CoverageFormat1),
     Format2(CoverageFormat2),
@@ -833,7 +833,7 @@ impl From<CoverageFormat2> for CoverageTable {
 }
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassDefFormat1 {
     /// First glyph ID of the classValueArray
     pub start_glyph_id: GlyphId,
@@ -896,7 +896,7 @@ impl<'a> FontRead<'a> for ClassDefFormat1 {
 }
 
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassDefFormat2 {
     /// Array of ClassRangeRecords — ordered by startGlyphID
     pub class_range_records: Vec<ClassRangeRecord>,
@@ -955,7 +955,7 @@ impl<'a> FontRead<'a> for ClassDefFormat2 {
 }
 
 /// Used in [ClassDefFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassRangeRecord {
     /// First glyph ID in the range
     pub start_glyph_id: GlyphId,
@@ -1008,7 +1008,7 @@ impl FromObjRef<read_fonts::tables::layout::ClassRangeRecord> for ClassRangeReco
 }
 
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ClassDef {
     Format1(ClassDefFormat1),
     Format2(ClassDefFormat2),
@@ -1087,7 +1087,7 @@ impl From<ClassDefFormat2> for ClassDef {
 }
 
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequenceLookupRecord {
     /// Index (zero-based) into the input glyph sequence
     pub sequence_index: u16,
@@ -1129,7 +1129,7 @@ impl FromObjRef<read_fonts::tables::layout::SequenceLookupRecord> for SequenceLo
 }
 
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
@@ -1205,7 +1205,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat1 {
 }
 
 /// Part of [SequenceContextFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequenceRuleSet {
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
@@ -1263,7 +1263,7 @@ impl<'a> FontRead<'a> for SequenceRuleSet {
 }
 
 /// Part of [SequenceContextFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequenceRule {
     /// Array of input glyph IDs—starting with the second glyph
     pub input_sequence: Vec<GlyphId>,
@@ -1330,7 +1330,7 @@ impl<'a> FontRead<'a> for SequenceRule {
 }
 
 /// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
@@ -1419,7 +1419,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat2 {
 }
 
 /// Part of [SequenceContextFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassSequenceRuleSet {
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
@@ -1483,7 +1483,7 @@ impl<'a> FontRead<'a> for ClassSequenceRuleSet {
 }
 
 /// Part of [SequenceContextFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassSequenceRule {
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
@@ -1548,7 +1548,7 @@ impl<'a> FontRead<'a> for ClassSequenceRule {
 }
 
 /// [Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SequenceContextFormat3 {
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
@@ -1630,7 +1630,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat3 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SequenceContext {
     Format1(SequenceContextFormat1),
     Format2(SequenceContextFormat2),
@@ -1737,7 +1737,7 @@ impl From<SequenceContextFormat3> for SequenceContext {
 }
 
 /// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedSequenceContextFormat1 {
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
@@ -1816,7 +1816,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat1 {
 }
 
 /// Part of [ChainedSequenceContextFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedSequenceRuleSet {
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
@@ -1882,7 +1882,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRuleSet {
 }
 
 /// Part of [ChainedSequenceContextFormat1]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedSequenceRule {
     /// Array of backtrack glyph IDs
     pub backtrack_sequence: Vec<GlyphId>,
@@ -1976,7 +1976,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRule {
 }
 
 /// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedSequenceContextFormat2 {
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
@@ -2088,7 +2088,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat2 {
 }
 
 /// Part of [ChainedSequenceContextFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedClassSequenceRuleSet {
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
@@ -2157,7 +2157,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet {
 }
 
 /// Part of [ChainedSequenceContextFormat2]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedClassSequenceRule {
     /// Array of backtrack-sequence classes
     pub backtrack_sequence: Vec<u16>,
@@ -2257,7 +2257,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule {
 }
 
 /// [Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChainedSequenceContextFormat3 {
     /// Array of offsets to coverage tables for the backtrack sequence
     pub backtrack_coverages: Vec<OffsetMarker<CoverageTable>>,
@@ -2364,7 +2364,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat3 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ChainedSequenceContext {
     Format1(ChainedSequenceContextFormat1),
     Format2(ChainedSequenceContextFormat2),
@@ -2498,7 +2498,7 @@ impl FontWrite for DeltaFormat {
 }
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Device {
     /// Smallest size to correct, in ppem
     pub start_size: u16,
@@ -2547,7 +2547,7 @@ impl<'a> FontRead<'a> for Device {
 }
 
 /// Variation index table
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationIndex {
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
@@ -2602,7 +2602,7 @@ impl<'a> FontRead<'a> for VariationIndex {
 }
 
 /// Either a [Device] table (in a non-variable font) or a [VariationIndex] table (in a variable font)
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceOrVariationIndex {
     Device(Device),
     VariationIndex(VariationIndex),
@@ -2685,7 +2685,7 @@ impl From<VariationIndex> for DeviceOrVariationIndex {
 }
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatureVariations {
     /// Array of feature variation records.
     pub feature_variation_records: Vec<FeatureVariationRecord>,
@@ -2747,7 +2747,7 @@ impl<'a> FontRead<'a> for FeatureVariations {
 }
 
 /// Part of [FeatureVariations]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatureVariationRecord {
     /// Offset to a condition set table, from beginning of
     /// FeatureVariations table.
@@ -2808,7 +2808,7 @@ impl FromObjRef<read_fonts::tables::layout::FeatureVariationRecord> for FeatureV
 }
 
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
-#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConditionSet {
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
@@ -2866,7 +2866,7 @@ impl<'a> FontRead<'a> for ConditionSet {
 }
 
 /// [Condition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range): Font Variation Axis Range
-#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConditionFormat1 {
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
@@ -2931,7 +2931,7 @@ impl<'a> FontRead<'a> for ConditionFormat1 {
 }
 
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatureTableSubstitution {
     /// Array of feature table substitution records.
     pub substitutions: Vec<FeatureTableSubstitutionRecord>,
@@ -2998,7 +2998,7 @@ impl<'a> FontRead<'a> for FeatureTableSubstitution {
 }
 
 /// Used in [FeatureTableSubstitution]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeatureTableSubstitutionRecord {
     /// The feature table index to match.
     pub feature_index: u16,
@@ -3051,7 +3051,7 @@ impl FromObjRef<read_fonts::tables::layout::FeatureTableSubstitutionRecord>
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SizeParams {
     /// The first value represents the design size in 720/inch units (decipoints).
     ///
@@ -3141,7 +3141,7 @@ impl<'a> FontRead<'a> for SizeParams {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StylisticSetParams {
     /// The 'name' table name ID that specifies a string (or strings, for
     /// multiple languages) for a user-interface label for this feature.
@@ -3195,7 +3195,7 @@ impl<'a> FontRead<'a> for StylisticSetParams {
 }
 
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CharacterVariantParams {
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) for a user-interface label for this

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [`maxp`](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Maxp {
     /// The number of glyphs in the font.
     pub num_glyphs: u16,

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [Naming table version 1](https://docs.microsoft.com/en-us/typography/opentype/spec/name#naming-table-version-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Name {
     /// The name records where count is the number of records.
     pub name_record: BTreeSet<NameRecord>,
@@ -100,7 +100,7 @@ impl<'a> FontRead<'a> for Name {
 }
 
 /// Part of [Name]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LangTagRecord {
     /// Language-tag string offset from start of storage area (in
     /// bytes).
@@ -140,7 +140,7 @@ impl FromObjRef<read_fonts::tables::name::LangTagRecord> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NameRecord {
     /// Platform ID.
     pub platform_id: u16,

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -14,7 +14,7 @@ impl FontWrite for SelectionFlags {
 }
 
 /// [`OS/2`](https://docs.microsoft.com/en-us/typography/opentype/spec/os2)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Os2 {
     /// [Average weighted escapement](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#xavgcharwidth).
     ///

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// [post (PostScript)](https://docs.microsoft.com/en-us/typography/opentype/spec/post#header) table
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Post {
     /// 0x00010000 for version 1.0 0x00020000 for version 2.0
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version

--- a/write-fonts/generated/generated_postscript.rs
+++ b/write-fonts/generated/generated_postscript.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// An array of variable-sized objects in a `CFF` table.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Index1 {
     /// Number of objects stored in INDEX.
     pub count: u16,
@@ -67,7 +67,7 @@ impl<'a> FontRead<'a> for Index1 {
 }
 
 /// An array of variable-sized objects in a `CFF2` table.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Index2 {
     /// Number of objects stored in INDEX.
     pub count: u32,
@@ -128,7 +128,7 @@ impl<'a> FontRead<'a> for Index2 {
 }
 
 /// Associates a glyph identifier with a Font DICT.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FdSelect {
     Format0(FdSelectFormat0),
     Format3(FdSelectFormat3),
@@ -224,7 +224,7 @@ impl From<FdSelectFormat4> for FdSelect {
 }
 
 /// FdSelect format 0.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FdSelectFormat0 {
     /// FD selector array (one entry for each glyph).
     pub fds: Vec<u8>,
@@ -276,7 +276,7 @@ impl<'a> FontRead<'a> for FdSelectFormat0 {
 }
 
 /// FdSelect format 3.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FdSelectFormat3 {
     /// Range3 array.
     pub ranges: Vec<FdSelectRange3>,
@@ -343,7 +343,7 @@ impl<'a> FontRead<'a> for FdSelectFormat3 {
 }
 
 /// Range struct for FdSelect format 3.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FdSelectRange3 {
     /// First glyph index in range.
     pub first: u16,
@@ -382,7 +382,7 @@ impl FromObjRef<read_fonts::tables::postscript::FdSelectRange3> for FdSelectRang
 }
 
 /// FdSelect format 4.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FdSelectFormat4 {
     /// Range4 array.
     pub ranges: Vec<FdSelectRange4>,
@@ -449,7 +449,7 @@ impl<'a> FontRead<'a> for FdSelectFormat4 {
 }
 
 /// Range struct for FdSelect format 4.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FdSelectRange4 {
     /// First glyph index in range.
     pub first: u32,

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::tables::stat::AxisValueTableFlags;
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Stat {
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes array. If designAxisCount is zero, set
@@ -91,7 +91,7 @@ impl<'a> FontRead<'a> for Stat {
 }
 
 /// [Axis Records](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisRecord {
     /// A tag identifying the axis of design variation.
     pub axis_tag: Tag,
@@ -141,7 +141,7 @@ impl FromObjRef<read_fonts::tables::stat::AxisRecord> for AxisRecord {
 }
 
 /// An array of [AxisValue] tables.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueArray {
     /// Array of offsets to axis value tables, in bytes from the start
     /// of the axis value offsets array.
@@ -190,7 +190,7 @@ impl<'a> FromObjRef<read_fonts::tables::stat::AxisValueArray<'a>> for AxisValueA
 impl<'a> FromTableRef<read_fonts::tables::stat::AxisValueArray<'a>> for AxisValueArray {}
 
 /// [Axis Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AxisValue {
     Format1(AxisValueFormat1),
     Format2(AxisValueFormat2),
@@ -341,7 +341,7 @@ impl From<AxisValueFormat4> for AxisValue {
 }
 
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueFormat1 {
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
@@ -412,7 +412,7 @@ impl<'a> FontRead<'a> for AxisValueFormat1 {
 }
 
 /// [Axis value table format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueFormat2 {
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
@@ -497,7 +497,7 @@ impl<'a> FontRead<'a> for AxisValueFormat2 {
 }
 
 /// [Axis value table format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueFormat3 {
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
@@ -574,7 +574,7 @@ impl<'a> FontRead<'a> for AxisValueFormat3 {
 }
 
 /// [Axis value table format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueFormat4 {
     /// Flags — see below for details.
     pub flags: AxisValueTableFlags,
@@ -649,7 +649,7 @@ impl<'a> FontRead<'a> for AxisValueFormat4 {
 }
 
 /// Part of [AxisValueFormat4]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisValueRecord {
     /// Zero-base index into the axis record array identifying the axis
     /// to which this value applies. Must be less than designAxisCount.

--- a/write-fonts/generated/generated_test_enum.rs
+++ b/write-fonts/generated/generated_test_enum.rs
@@ -21,7 +21,7 @@ impl FontWrite for MyEnum2 {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MyRecord {
     pub my_enum1: MyEnum1,
     pub my_enum2: MyEnum2,

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Table1 {
     pub heft: u32,
     pub flex: u16,
@@ -52,7 +52,7 @@ impl<'a> FontRead<'a> for Table1 {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Table2 {
     pub values: Vec<u16>,
 }
@@ -108,7 +108,7 @@ impl<'a> FontRead<'a> for Table2 {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Table3 {
     pub something: u16,
 }
@@ -145,7 +145,7 @@ impl<'a> FontRead<'a> for Table3 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MyTable {
     Format1(Table1),
     MyFormat22(Table2),

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KindsOfOffsets {
     /// The major/minor version of the GDEF table
     pub version: MajorMinor,
@@ -132,7 +132,7 @@ impl<'a> FontRead<'a> for KindsOfOffsets {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KindsOfArraysOfOffsets {
     /// A normal array offset
     pub nonnullables: Vec<OffsetMarker<Dummy>>,
@@ -240,7 +240,7 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KindsOfArrays {
     pub version: u16,
     /// an array of scalars
@@ -359,7 +359,7 @@ impl<'a> FontRead<'a> for KindsOfArrays {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Dummy {
     pub value: u16,
 }
@@ -397,7 +397,7 @@ impl<'a> FontRead<'a> for Dummy {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Shmecord {
     pub length: u16,
     pub breadth: u32,

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BasicTable {
     pub simple_records: Vec<SimpleRecord>,
     pub array_records: Vec<ContainsArrays>,
@@ -78,7 +78,7 @@ impl<'a> FontRead<'a> for BasicTable {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SimpleRecord {
     pub val1: u16,
     pub va2: u32,
@@ -114,7 +114,7 @@ impl FromObjRef<read_fonts::codegen_test::records::SimpleRecord> for SimpleRecor
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ContainsArrays {
     pub scalars: Vec<u16>,
     pub records: Vec<SimpleRecord>,
@@ -170,7 +170,7 @@ impl FromObjRef<read_fonts::codegen_test::records::ContainsArrays<'_>> for Conta
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ContainsOffests {
     pub array: OffsetMarker<Vec<SimpleRecord>>,
     pub other: OffsetMarker<BasicTable, WIDTH_32>,

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 pub use read_fonts::tables::variations::EntryFormat;
 
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TupleVariationHeader {
     /// The size in bytes of the serialized data for this tuple
     /// variation table.
@@ -73,7 +73,7 @@ impl<'a> FromTableRef<read_fonts::tables::variations::TupleVariationHeader<'a>>
 /// The tuple variation store formats reference regions within the font’s
 /// variation space using tuple records. A tuple record identifies a position
 /// in terms of normalized coordinates, which use F2DOT14 values.
-#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Tuple {
     /// Coordinate array specifying a position within the font’s variation space.
     ///
@@ -121,7 +121,7 @@ impl FromObjRef<read_fonts::tables::variations::Tuple<'_>> for Tuple {
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeltaSetIndexMapFormat0 {
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
@@ -189,7 +189,7 @@ impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0 {
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeltaSetIndexMapFormat1 {
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
@@ -257,7 +257,7 @@ impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1 {
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeltaSetIndexMap {
     Format0(DeltaSetIndexMapFormat0),
     Format1(DeltaSetIndexMapFormat1),
@@ -351,7 +351,7 @@ impl FontWrite for EntryFormat {
 }
 
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationRegionList {
     /// Array of variation regions.
     pub variation_regions: Vec<VariationRegion>,
@@ -420,7 +420,7 @@ impl<'a> FontRead<'a> for VariationRegionList {
 }
 
 /// The [VariationRegion](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
-#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationRegion {
     /// Array of region axis coordinates records, in the order of axes
     /// given in the 'fvar' table.
@@ -470,7 +470,7 @@ impl FromObjRef<read_fonts::tables::variations::VariationRegion<'_>> for Variati
 }
 
 /// The [RegionAxisCoordinates](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
-#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RegionAxisCoordinates {
     /// The region start coordinate value for the current axis.
     pub start_coord: F2Dot14,
@@ -520,7 +520,7 @@ impl FromObjRef<read_fonts::tables::variations::RegionAxisCoordinates> for Regio
 }
 
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ItemVariationStore {
     /// Offset in bytes from the start of the item variation store to
     /// the variation region list.
@@ -597,7 +597,7 @@ impl<'a> FontRead<'a> for ItemVariationStore {
 }
 
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ItemVariationData {
     /// The number of delta sets for distinct items.
     pub item_count: u16,

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Vhea {
     /// Typographic ascent.
     pub ascender: FWord,

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -6,7 +6,7 @@
 use crate::codegen_prelude::*;
 
 /// The [vmtx (Vertical Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/vmtx) table
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Vmtx {
     /// Paired advance height and top side bearing values for each
     /// glyph. Records are indexed by glyph ID.

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -274,7 +274,7 @@ impl GlyphDeltas {
 }
 
 /// The serializable representation of a glyph's variation data
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GlyphVariationData {
     tuple_variation_headers: Vec<TupleVariationHeader>,
     // optional; present if multiple variations have the same point numbers
@@ -283,7 +283,7 @@ pub struct GlyphVariationData {
 }
 
 /// The serializable representation of a single glyph tuple variation data
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct GlyphTupleVariationData {
     // this is possibly shared, if multiple are identical for a given glyph
     private_point_numbers: Option<PackedPointNumbers>,

--- a/write-fonts/src/tables/instance_record.rs
+++ b/write-fonts/src/tables/instance_record.rs
@@ -4,7 +4,7 @@
 use crate::codegen_prelude::*;
 
 /// The [InstanceRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#instancerecord)
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InstanceRecord {
     /// The name ID for entries in the 'name' table that provide subfamily names for this instance.
     pub subfamily_name_id: NameId,

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -42,7 +42,7 @@ macro_rules! table_newtype {
         /// lookups that are shared between GPOS/GSUB.
         ///
         /// You can access the inner type via `Deref` or the `as_inner` method.
-        #[derive(Clone, Debug, Default)]
+        #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $name($inner);
 
         impl $name {
@@ -203,7 +203,7 @@ impl FontWrite for LookupType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FeatureParams {
     StylisticSet(StylisticSetParams),
     Size(SizeParams),

--- a/write-fonts/src/tables/post.rs
+++ b/write-fonts/src/tables/post.rs
@@ -7,7 +7,7 @@ include!("../../generated/generated_post.rs");
 //TODO: I imagine we're going to need a builder for this
 
 /// A string in the post table.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PString(String);
 
 impl Post {

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -11,7 +11,7 @@ use crate::{
     write::{FontWrite, TableWriter},
 };
 
-#[derive(Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValueRecord {
     pub x_placement: Option<i16>,
     pub y_placement: Option<i16>,

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -71,7 +71,7 @@ impl VariationRegionList {
 }
 
 /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#packed-point-numbers>
-#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PackedPointNumbers {
     /// Contains deltas for all point numbers
     #[default]
@@ -81,7 +81,7 @@ pub enum PackedPointNumbers {
 }
 
 /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#packed-deltas>
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PackedDeltas {
     deltas: Vec<i16>,
 }


### PR DESCRIPTION
In write-fonts, we will generate these traits for all types.

In read-fonts, the situation is more nuanced. In the case of tables, derive is not an option, because tables in read-fonts wrap some chunk of bytes, but that chunk may contain trailing data that is not necessarily part of the table in question.

More generally, in read-fonts, the semantics of things like 'equality' are ambiguous. If a table contains an offset to subtable, should equality be based on the raw value of the offset, or based recursively on the contents of the child tables?

At some point we may wish to revisit this qusetion, but for now I am punting. We *will* derive extra traits in read-fonts, but only for records, and only when they contain only non-offset scalar values.


closes #532