### PR TITLE
[codegen] Fix getter plural names containing  'data'

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1374,8 +1374,13 @@ pub(crate) fn remove_offset_from_field_name(name: &str) -> Cow<str> {
         let temp = name.trim_end_matches("_offsets");
         // hacky attempt to respect pluralization rules. we can update this
         // as we encounter actual tables, instead of trying to be systematic
-        let plural_es = temp.ends_with("attach");
-        let suffix = if plural_es { "es" } else { "s" };
+        let suffix = if temp.ends_with("attach") {
+            "es"
+        } else if temp.ends_with("data") {
+            ""
+        } else {
+            "s"
+        };
         Cow::Owned(format!("{temp}{suffix}"))
     } else {
         Cow::Borrowed(name.trim_end_matches("_offset"))

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -1026,7 +1026,7 @@ impl<'a> ItemVariationStore<'a> {
     }
 
     /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
-    pub fn item_variation_datas(
+    pub fn item_variation_data(
         &self,
     ) -> ArrayOfNullableOffsets<'a, ItemVariationData<'a>, Offset32> {
         let data = self.data;

--- a/read-fonts/src/tables/postscript/blend.rs
+++ b/read-fonts/src/tables/postscript/blend.rs
@@ -92,8 +92,8 @@ impl<'a> BlendState<'a> {
         self.data = None;
         self.region_indices = &[];
         let store = &self.store;
-        let varation_datas = store.item_variation_datas();
-        let data = varation_datas
+        let varation_data = store.item_variation_data();
+        let data = varation_data
             .get(self.store_index as usize)
             .ok_or(Error::InvalidVariationStoreIndex(self.store_index))??;
         let region_indices = data.region_indexes();

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -546,7 +546,7 @@ impl<'a> ItemVariationStore<'a> {
         index: DeltaSetIndex,
         coords: &[F2Dot14],
     ) -> Result<i32, ReadError> {
-        let data = match self.item_variation_datas().get(index.outer as usize) {
+        let data = match self.item_variation_data().get(index.outer as usize) {
             Some(data) => data?,
             None => return Ok(0),
         };

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -527,18 +527,18 @@ pub struct ItemVariationStore {
     pub variation_region_list: OffsetMarker<VariationRegionList, WIDTH_32>,
     /// Offsets in bytes from the start of the item variation store to
     /// each item variation data subtable.
-    pub item_variation_datas: Vec<NullableOffsetMarker<ItemVariationData, WIDTH_32>>,
+    pub item_variation_data: Vec<NullableOffsetMarker<ItemVariationData, WIDTH_32>>,
 }
 
 impl ItemVariationStore {
     /// Construct a new `ItemVariationStore`
     pub fn new(
         variation_region_list: VariationRegionList,
-        item_variation_datas: Vec<Option<ItemVariationData>>,
+        item_variation_data: Vec<Option<ItemVariationData>>,
     ) -> Self {
         Self {
             variation_region_list: variation_region_list.into(),
-            item_variation_datas: item_variation_datas.into_iter().map(Into::into).collect(),
+            item_variation_data: item_variation_data.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -548,8 +548,8 @@ impl FontWrite for ItemVariationStore {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.variation_region_list.write_into(writer);
-        (array_len(&self.item_variation_datas).unwrap() as u16).write_into(writer);
-        self.item_variation_datas.write_into(writer);
+        (array_len(&self.item_variation_data).unwrap() as u16).write_into(writer);
+        self.item_variation_data.write_into(writer);
     }
     fn table_type(&self) -> TableType {
         TableType::Named("ItemVariationStore")
@@ -562,11 +562,11 @@ impl Validate for ItemVariationStore {
             ctx.in_field("variation_region_list", |ctx| {
                 self.variation_region_list.validate_impl(ctx);
             });
-            ctx.in_field("item_variation_datas", |ctx| {
-                if self.item_variation_datas.len() > (u16::MAX as usize) {
+            ctx.in_field("item_variation_data", |ctx| {
+                if self.item_variation_data.len() > (u16::MAX as usize) {
                     ctx.report("array exceeds max length");
                 }
-                self.item_variation_datas.validate_impl(ctx);
+                self.item_variation_data.validate_impl(ctx);
             });
         })
     }
@@ -579,7 +579,7 @@ impl<'a> FromObjRef<read_fonts::tables::variations::ItemVariationStore<'a>> for 
     ) -> Self {
         ItemVariationStore {
             variation_region_list: obj.variation_region_list().to_owned_table(),
-            item_variation_datas: obj.item_variation_datas().to_owned_table(),
+            item_variation_data: obj.item_variation_data().to_owned_table(),
         }
     }
 }


### PR DESCRIPTION
Seeing 'variation_datas' was making me irrationally angry.
