### PR TITLE
[write-fonts] Add builder methods to ValueRecord

### DIFF
--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -1567,10 +1567,7 @@ mod tests {
             let coverage = glyph_range.clone().map(GlyphId::new).collect();
             let pair_sets = glyph_range
                 .map(|id| {
-                    let value_rec = gpos::ValueRecord {
-                        x_advance: Some(id as _),
-                        ..Default::default()
-                    };
+                    let value_rec = gpos::ValueRecord::new().with_x_advance(id as _);
                     gpos::PairSet::new(
                         (id..id + 165)
                             .map(|id2| {

--- a/write-fonts/src/tables/gpos.rs
+++ b/write-fonts/src/tables/gpos.rs
@@ -176,13 +176,7 @@ mod tests {
         let cov_one = CoverageTable::format_1(vec![GlyphId::new(2)]);
         let cov_two = CoverageTable::format_1(vec![GlyphId::new(4)]);
         let sub1 = SinglePos::format_1(cov_one, ValueRecord::default());
-        let sub2 = SinglePos::format_1(
-            cov_two,
-            ValueRecord {
-                x_advance: Some(500),
-                ..Default::default()
-            },
-        );
+        let sub2 = SinglePos::format_1(cov_two, ValueRecord::default().with_x_advance(500));
         let lookup = Lookup::new(LookupFlag::default(), vec![sub1, sub2], 0);
         let bytes = crate::dump_table(&lookup).unwrap();
 

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub struct ValueRecord {
     pub x_placement: Option<i16>,
     pub y_placement: Option<i16>,
@@ -24,6 +25,50 @@ pub struct ValueRecord {
 }
 
 impl ValueRecord {
+    pub fn new() -> ValueRecord {
+        ValueRecord::default()
+    }
+
+    pub fn with_x_placement(mut self, val: i16) -> Self {
+        self.x_placement = Some(val);
+        self
+    }
+
+    pub fn with_y_placement(mut self, val: i16) -> Self {
+        self.y_placement = Some(val);
+        self
+    }
+
+    pub fn with_x_advance(mut self, val: i16) -> Self {
+        self.x_advance = Some(val);
+        self
+    }
+
+    pub fn with_y_advance(mut self, val: i16) -> Self {
+        self.y_advance = Some(val);
+        self
+    }
+
+    pub fn with_x_placement_device(mut self, val: impl Into<DeviceOrVariationIndex>) -> Self {
+        self.x_placement_device = val.into().into();
+        self
+    }
+
+    pub fn with_y_placement_device(mut self, val: impl Into<DeviceOrVariationIndex>) -> Self {
+        self.y_placement_device = val.into().into();
+        self
+    }
+
+    pub fn with_x_advance_device(mut self, val: impl Into<DeviceOrVariationIndex>) -> Self {
+        self.x_advance_device = val.into().into();
+        self
+    }
+
+    pub fn with_y_advance_device(mut self, val: impl Into<DeviceOrVariationIndex>) -> Self {
+        self.y_advance_device = val.into().into();
+        self
+    }
+
     /// The [ValueFormat] of this record.
     pub fn format(&self) -> ValueFormat {
         macro_rules! flag_if_true {


### PR DESCRIPTION
These are annoying to construct, and are additionally annoying now that we support both Device & VariationIndex tables; hopefully builder methods will improve this situation.

There is also an additional, more pressing motivation for this work: I am going to need to add support for records that have explicit (non computed) value formats, which will involve adding a private field to ValueRecord, which means a pattern I've used elsewhere of relying on ..Default::default() to fill in missing vlaues will break.