### PR TITLE
 Allow specifying explicit value format

### DIFF
--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -1,9 +1,10 @@
 //! A GPOS ValueRecord
 
+use font_types::Nullable;
 use types::{BigEndian, FixedSize, Offset16};
 
 use super::ValueFormat;
-use crate::{tables::layout::DeviceOrVariationIndex, ResolveOffset};
+use crate::{tables::layout::DeviceOrVariationIndex, ResolveNullableOffset};
 
 #[cfg(feature = "traversal")]
 use crate::traversal::{Field, FieldType, RecordResolver, SomeRecord};
@@ -28,10 +29,10 @@ pub struct ValueRecord {
     pub y_placement: Option<BigEndian<i16>>,
     pub x_advance: Option<BigEndian<i16>>,
     pub y_advance: Option<BigEndian<i16>>,
-    pub x_placement_device: Option<BigEndian<Offset16>>,
-    pub y_placement_device: Option<BigEndian<Offset16>>,
-    pub x_advance_device: Option<BigEndian<Offset16>>,
-    pub y_advance_device: Option<BigEndian<Offset16>>,
+    pub x_placement_device: BigEndian<Nullable<Offset16>>,
+    pub y_placement_device: BigEndian<Nullable<Offset16>>,
+    pub x_advance_device: BigEndian<Nullable<Offset16>>,
+    pub y_advance_device: BigEndian<Nullable<Offset16>>,
 }
 
 impl ValueRecord {
@@ -57,16 +58,16 @@ impl ValueRecord {
             this.y_advance = Some(cursor.read_be()?);
         }
         if format.contains(ValueFormat::X_PLACEMENT_DEVICE) {
-            this.x_placement_device = Some(cursor.read_be()?);
+            this.x_placement_device = cursor.read_be()?;
         }
         if format.contains(ValueFormat::Y_PLACEMENT_DEVICE) {
-            this.y_placement_device = Some(cursor.read_be()?);
+            this.y_placement_device = cursor.read_be()?;
         }
         if format.contains(ValueFormat::X_ADVANCE_DEVICE) {
-            this.x_advance_device = Some(cursor.read_be()?);
+            this.x_advance_device = cursor.read_be()?;
         }
         if format.contains(ValueFormat::Y_ADVANCE_DEVICE) {
-            this.y_advance_device = Some(cursor.read_be()?);
+            this.y_advance_device = cursor.read_be()?;
         }
         Ok(this)
     }
@@ -91,28 +92,28 @@ impl ValueRecord {
         &self,
         data: FontData<'a>,
     ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
-        self.x_placement_device.map(|val| val.get().resolve(data))
+        self.x_placement_device.get().resolve(data)
     }
 
     pub fn y_placement_device<'a>(
         &self,
         data: FontData<'a>,
     ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
-        self.y_placement_device.map(|val| val.get().resolve(data))
+        self.y_placement_device.get().resolve(data)
     }
 
     pub fn x_advance_device<'a>(
         &self,
         data: FontData<'a>,
     ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
-        self.x_advance_device.map(|val| val.get().resolve(data))
+        self.x_advance_device.get().resolve(data)
     }
 
     pub fn y_advance_device<'a>(
         &self,
         data: FontData<'a>,
     ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
-        self.y_advance_device.map(|val| val.get().resolve(data))
+        self.y_advance_device.get().resolve(data)
     }
 }
 
@@ -133,14 +134,18 @@ impl std::fmt::Debug for ValueRecord {
         self.y_placement.map(|y| f.field("y_placement", &y));
         self.x_advance.map(|x| f.field("x_advance", &x));
         self.y_advance.map(|y| f.field("y_advance", &y));
-        self.x_placement_device
-            .map(|x| f.field("x_placement_device", &x));
-        self.y_placement_device
-            .map(|y| f.field("y_placement_device", &y));
-        self.x_advance_device
-            .map(|x| f.field("x_advance_device", &x));
-        self.y_advance_device
-            .map(|y| f.field("y_advance_device", &y));
+        if !self.x_placement_device.get().is_null() {
+            f.field("x_placement_device", &self.x_placement_device.get());
+        }
+        if !self.y_placement_device.get().is_null() {
+            f.field("y_placement_device", &self.y_placement_device.get());
+        }
+        if !self.x_advance_device.get().is_null() {
+            f.field("x_advance_device", &self.x_advance_device.get());
+        }
+        if !self.y_advance_device.get().is_null() {
+            f.field("y_advance_device", &self.y_advance_device.get());
+        }
         f.finish()
     }
 }
@@ -164,18 +169,10 @@ impl<'a> ValueRecord {
             self.y_placement.is_some().then_some("y_placement"),
             self.x_advance.is_some().then_some("x_advance"),
             self.y_advance.is_some().then_some("y_advance"),
-            self.x_placement_device
-                .is_some()
-                .then_some("x_placement_device"),
-            self.y_placement_device
-                .is_some()
-                .then_some("y_placement_device"),
-            self.x_advance_device
-                .is_some()
-                .then_some("x_advance_device"),
-            self.y_advance_device
-                .is_some()
-                .then_some("y_advance_device"),
+            (!self.x_placement_device.get().is_null()).then_some("x_placement_device"),
+            (!self.y_placement_device.get().is_null()).then_some("y_placement_device"),
+            (!self.x_advance_device.get().is_null()).then_some("x_advance_device"),
+            (!self.y_advance_device.get().is_null()).then_some("y_advance_device"),
         ];
 
         let name = fields.iter().filter_map(|x| *x).nth(idx)?;
@@ -184,22 +181,18 @@ impl<'a> ValueRecord {
             "y_placement" => self.y_placement().unwrap().into(),
             "x_advance" => self.x_advance().unwrap().into(),
             "y_advance" => self.y_advance().unwrap().into(),
-            "x_placement_device" => FieldType::offset(
-                self.x_placement_device.unwrap().get(),
-                self.x_placement_device(data),
-            ),
-            "y_placement_device" => FieldType::offset(
-                self.y_placement_device.unwrap().get(),
-                self.y_placement_device(data),
-            ),
-            "x_advance_device" => FieldType::offset(
-                self.x_advance_device.unwrap().get(),
-                self.x_advance_device(data),
-            ),
-            "y_advance_device" => FieldType::offset(
-                self.y_advance_device.unwrap().get(),
-                self.y_advance_device(data),
-            ),
+            "x_placement_device" => {
+                FieldType::offset(self.x_placement_device.get(), self.x_placement_device(data))
+            }
+            "y_placement_device" => {
+                FieldType::offset(self.y_placement_device.get(), self.y_placement_device(data))
+            }
+            "x_advance_device" => {
+                FieldType::offset(self.x_advance_device.get(), self.x_advance_device(data))
+            }
+            "y_advance_device" => {
+                FieldType::offset(self.y_advance_device.get(), self.y_advance_device(data))
+            }
             _ => panic!("hmm"),
         };
 

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -14,6 +14,26 @@ use crate::{
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub struct ValueRecord {
+    // Okay so... this demands some explanation.
+    //
+    // In general, we compute the format for a value record by looking at what
+    // fields are present in the record. This works 99% of the time.
+    //
+    // The problem, though, is that in certain cases we need to create empty
+    // value records that have an explicit format. In particular this occurs
+    // in class-based pairpos tables, where it is possible that two classes
+    // have no relationship, but we still need to put a record of the
+    // appropriate size in the array of value records.
+    //
+    // In this case, we cannot infer the correct format, because when
+    // we see any null offsets we will assume that those fields should not
+    // be present in the record, where in fact we want to have explicit
+    // null offsets.
+    //
+    // To handle this, we allow the user to pass an explicit format when
+    // constructing a value record. If this field is present, we will use it
+    // instead of computing the format.
+    explicit_format: Option<ValueFormat>,
     pub x_placement: Option<i16>,
     pub y_placement: Option<i16>,
     pub x_advance: Option<i16>,
@@ -69,8 +89,25 @@ impl ValueRecord {
         self
     }
 
+    pub fn with_explicit_value_format(mut self, format: ValueFormat) -> Self {
+        self.set_explicit_value_format(format);
+        self
+    }
+
+    /// Set an explicit ValueFormat, overriding the computed format.
+    ///
+    /// Use this method if you wish to write a ValueFormat that includes
+    /// explicit null offsets for any of the device or variation index tables.
+    pub fn set_explicit_value_format(&mut self, format: ValueFormat) {
+        self.explicit_format = Some(format)
+    }
+
     /// The [ValueFormat] of this record.
     pub fn format(&self) -> ValueFormat {
+        if let Some(format) = self.explicit_format {
+            return format;
+        }
+
         macro_rules! flag_if_true {
             ($field:expr, $flag:expr) => {
                 $field
@@ -98,27 +135,36 @@ impl ValueRecord {
 
 impl FontWrite for ValueRecord {
     fn write_into(&self, writer: &mut TableWriter) {
+        let format = self.format();
         macro_rules! write_field {
-            ($field:expr) => {
-                if let Some(v) = $field {
-                    v.write_into(writer);
+            ($field:expr, $flag:expr) => {
+                if format.contains($flag) {
+                    $field.unwrap_or_default().write_into(writer);
                 }
             };
-            ($field:expr, off) => {
-                if let Some(v) = $field.as_ref() {
-                    writer.write_offset(v, 2);
+            ($field:expr, $flag:expr, off) => {
+                if format.contains($flag) {
+                    $field.write_into(writer);
                 }
             };
         }
 
-        write_field!(self.x_placement);
-        write_field!(self.y_placement);
-        write_field!(self.x_advance);
-        write_field!(self.y_advance);
-        write_field!(self.x_placement_device, off);
-        write_field!(self.y_placement_device, off);
-        write_field!(self.x_advance_device, off);
-        write_field!(self.y_advance_device, off);
+        write_field!(self.x_placement, ValueFormat::X_PLACEMENT);
+        write_field!(self.y_placement, ValueFormat::Y_PLACEMENT);
+        write_field!(self.x_advance, ValueFormat::X_ADVANCE);
+        write_field!(self.y_advance, ValueFormat::Y_ADVANCE);
+        write_field!(
+            self.x_placement_device,
+            ValueFormat::X_PLACEMENT_DEVICE,
+            off
+        );
+        write_field!(
+            self.y_placement_device,
+            ValueFormat::Y_PLACEMENT_DEVICE,
+            off
+        );
+        write_field!(self.x_advance_device, ValueFormat::X_ADVANCE_DEVICE, off);
+        write_field!(self.y_advance_device, ValueFormat::Y_ADVANCE_DEVICE, off);
     }
 }
 
@@ -152,6 +198,7 @@ impl Validate for ValueRecord {
 impl FromObjRef<read_fonts::tables::gpos::ValueRecord> for ValueRecord {
     fn from_obj_ref(from: &read_fonts::tables::gpos::ValueRecord, data: FontData) -> Self {
         ValueRecord {
+            explicit_format: None,
             x_placement: from.x_placement(),
             y_placement: from.y_placement(),
             x_advance: from.x_advance(),
@@ -161,5 +208,24 @@ impl FromObjRef<read_fonts::tables::gpos::ValueRecord> for ValueRecord {
             x_advance_device: from.x_advance_device(data).to_owned_obj(data),
             y_advance_device: from.y_advance_device(data).to_owned_obj(data),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn serialize_explicit_value_record() {
+        let mut my_record = ValueRecord {
+            x_advance: Some(5),
+            ..Default::default()
+        };
+        my_record.set_explicit_value_format(ValueFormat::X_ADVANCE | ValueFormat::X_ADVANCE_DEVICE);
+        let bytes = crate::dump_table(&my_record).unwrap();
+        assert_eq!(bytes.len(), 4);
+        let read_back =
+            read_fonts::tables::gpos::ValueRecord::read(FontData::new(&bytes), my_record.format())
+                .unwrap();
+        assert!(read_back.x_advance_device.get().is_null());
     }
 }


### PR DESCRIPTION
This enables us to correctly write a valuerecord with a specific format, writing null offsets as needed.

Working on this also revealed that we did not correctly represent null offsets during reading either, and so that is also addressed here.


based on #538, since this adds a non-public field to `ValueRecord` we can no longer use the `..Default::default()` trick to construct records.