### PR TITLE
[write-fonts] Add 'PendingVariationIndex' table

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -157,6 +157,8 @@ The following annotations are supported on top-level objects:
   common tables that contain offsets which point to different concrete types
   depending on the containing table, such as the `Layout` subtable shared
   between GPOS and GSUB.
+- `#[write_fonts_only]` Indicate that this table should only be generated for
+  `write-fonts` (i.e. should be ignored in `read-fonts`).
 
 #### field attributes
 - `#[nullable]`: only allowed on offsets or arrays of offsets, and indicates

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -64,6 +64,7 @@ pub(crate) struct TableAttrs {
     pub(crate) read_args: Option<Attr<TableReadArgs>>,
     pub(crate) generic_offset: Option<Attr<syn::Ident>>,
     pub(crate) tag: Option<Attr<syn::LitStr>>,
+    pub(crate) write_only: Option<syn::Path>,
     /// Custom validation behaviour, must be a fn(&self, &mut ValidationCtx) for the type
     pub(crate) validate: Option<Attr<syn::Ident>>,
 }
@@ -130,6 +131,7 @@ pub(crate) struct GroupVariant {
 pub(crate) struct VariantAttrs {
     pub(crate) docs: Vec<syn::Attribute>,
     pub(crate) match_stmt: Option<Attr<InlineExpr>>,
+    pub(crate) write_only: Option<syn::Path>,
 }
 
 impl FormatVariant {
@@ -922,6 +924,7 @@ impl Parse for FormatVariant {
 }
 
 static MATCH_IF: &str = "match_if";
+static WRITE_FONTS_ONLY: &str = "write_fonts_only";
 
 impl Parse for VariantAttrs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
@@ -940,6 +943,8 @@ impl Parse for VariantAttrs {
                 this.docs.push(attr);
             } else if ident == MATCH_IF {
                 this.match_stmt = Some(Attr::new(ident.clone(), attr.parse_args()?));
+            } else if ident == WRITE_FONTS_ONLY {
+                this.write_only = Some(attr.path().clone());
             } else {
                 return Err(logged_syn_error(
                     ident.span(),
@@ -1061,6 +1066,8 @@ impl Parse for TableAttrs {
                 this.skip_font_write = Some(attr.path().clone());
             } else if ident == SKIP_CONSTRUCTOR {
                 this.skip_constructor = Some(attr.path().clone());
+            } else if ident == WRITE_FONTS_ONLY {
+                this.write_only = Some(attr.path().clone());
             } else if ident == READ_ARGS {
                 this.read_args = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == GENERIC_OFFSET {

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -551,12 +551,32 @@ table VariationIndex {
     delta_format: DeltaFormat,
 }
 
+/// A type representing a temporary identifier for a set of variation deltas.
+///
+/// The final indices used in the VariationIndex table are not known until
+/// all deltas have been collected. This variant is used to assign a
+/// temporary identifier during compilation.
+///
+/// This type is not part of the spec and will never appear in an actual font file.
+/// It is intended to serve as a sentinel value, and will panic when written,
+/// ensuring that all VariationIndex tables have been correctly mapped before
+/// the font is compiled.
+#[write_fonts_only]
+#[skip_from_obj]
+#[skip_font_write]
+table PendingVariationIndex {
+    /// A unique identifier for a given set of deltas.
+    delta_set_id: u32,
+}
+
 /// Either a [Device] table (in a non-variable font) or a [VariationIndex] table (in a variable font)
 format DeltaFormat@4 DeviceOrVariationIndex {
     #[match_if($format != DeltaFormat::VariationIndex)]
     Device(Device),
     #[match_if($format == DeltaFormat::VariationIndex)]
     VariationIndex(VariationIndex),
+    #[write_fonts_only]
+    PendingVariationIndex(PendingVariationIndex),
 }
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -603,6 +603,16 @@ impl DeviceOrVariationIndex {
     }
 }
 
+impl FontWrite for PendingVariationIndex {
+    fn write_into(&self, _writer: &mut TableWriter) {
+        panic!(
+            "Attempted to write PendingVariationIndex.\n\
+            VariationIndex tables should always be resolved before compilation.\n\
+            Please report this bug at <https://github.com/googlefonts/fontations/issues>"
+        )
+    }
+}
+
 fn encode_delta(format: DeltaFormat, values: &[i8]) -> Vec<u16> {
     let (chunk_size, mask, bits) = match format {
         DeltaFormat::Local2BitDeltas => (8, 0b11, 2),


### PR DESCRIPTION
Per discussion at https://github.com/cmyr/fea-rs/pull/185#discussion_r1269749806, this is adds a new type and a new enum variant that can be used to store the temporary ids assigned to `VariationIndex` tables during compilation. I quite like this; it simplifies the code in the VarStore builder, and it guarantees we never accidentally write one of these temporary values.

----

This is intended as a sentinal, which can be assigned a unique ID during compilation, and then remapped to the final VariationIndex values once the ItemVariationStore has been compiled.

This type will panic if we attempt to serialize it, which will ensure that we never accidentally write temporary values to our VariationIndex tables.

Although this is not part of the spec I am generating this in codegen since it's much easier than trying to do it manually; making this work required adding a new attribute, `#[write_fonts_only]`, to communicate to codegen that we should not generate any parsing code for this type (since it is not a real type that should ever exist in an actual font file).