### PR TITLE
bump write-fonts minor version to 0.14.0

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."


### PR DESCRIPTION
Bumped minor because https://github.com/googlefonts/fontations/pull/565 introduced a breaking change to iup_delta_optimize

full changelog from `cargo release changes`:

     Changes for write-fonts from write-fonts-v0.13.0 to 0.14.0
             36a8929 iup: when all deltas equal (0,0) return all Nones
             1fce739 iup_delta_optimize: contour_ends contains endpoint indices, not contour lengths
             8f3cc9b iup: add failing test case for Oswald glyph 'two'
             35d6d13 add pretty_assertions to write-fonts' dev-dependencies
             472cfa3 [write-fonts] Migrate LocaFormat tests from fontc