### PR TITLE
Make fields on BuilderError public

### DIFF
--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -21,9 +21,12 @@ pub struct FontBuilder<'a> {
 /// This wraps a compilation error, adding the tag of the table where it was
 /// encountered.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct BuilderError {
-    tag: Tag,
-    inner: crate::error::Error,
+    /// The tag of the root table where the error occured
+    pub tag: Tag,
+    /// The underlying error
+    pub inner: crate::error::Error,
 }
 
 impl TableDirectory {
@@ -167,7 +170,11 @@ impl Display for BuilderError {
     }
 }
 
-impl std::error::Error for BuilderError {}
+impl std::error::Error for BuilderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This generally makes this error more useful, and makes it possible for an outside user (e.g. fontc) to generate a graphviz dump for a given failure.

~(also bumps version to 0.14.2, so I can release this if approved)~