### PR TITLE
Improve PairPos validation

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -159,6 +159,9 @@ The following annotations are supported on top-level objects:
   between GPOS and GSUB.
 - `#[write_fonts_only]` Indicate that this table should only be generated for
   `write-fonts` (i.e. should be ignored in `read-fonts`).
+- `#[validate(method)]` Provide a method to perform additional pre-compilation
+  validation for this type. The method must be manually implemented on the type,
+  with the signature `fn(&self, &mut ValidationCtx)`.
 
 #### field attributes
 - `#[nullable]`: only allowed on offsets or arrays of offsets, and indicates

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -232,6 +232,7 @@ record PairValueRecord {
 }
 
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
+#[validate(check_length_and_format_conformance)]
 table PairPosFormat2 {
     /// Format identifier: format = 2
     #[format = 2]

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -201,6 +201,7 @@ table PairPosFormat1 {
     /// of PairPos subtable, ordered by Coverage Index.
     #[count($pair_set_count)]
     #[read_offset_with($value_format1, $value_format2)]
+    #[validate(check_format_consistency)]
     pair_set_offsets: [Offset16<PairSet>],
 }
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -953,7 +953,7 @@ impl Validate for PairPosFormat1 {
                 if self.pair_sets.len() > (u16::MAX as usize) {
                     ctx.report("array exceeds max length");
                 }
-                self.pair_sets.validate_impl(ctx);
+                self.check_format_consistency(ctx);
             });
         })
     }

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -1154,6 +1154,7 @@ impl Validate for PairPosFormat2 {
                 }
                 self.class1_records.validate_impl(ctx);
             });
+            self.check_length_and_format_conformance(ctx);
         })
     }
 }

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -454,6 +454,12 @@ impl FromIterator<(GlyphId, u16)> for ClassDefBuilder {
     }
 }
 
+impl FromIterator<(GlyphId, u16)> for ClassDef {
+    fn from_iter<T: IntoIterator<Item = (GlyphId, u16)>>(iter: T) -> Self {
+        ClassDefBuilder::from_iter(iter).build()
+    }
+}
+
 impl ClassDefBuilder {
     fn prefer_format_1(&self) -> bool {
         // calculate our format2 size:

--- a/write-fonts/src/tables/value_record.rs
+++ b/write-fonts/src/tables/value_record.rs
@@ -227,8 +227,8 @@ mod tests {
     use read_fonts::FontRead;
 
     use crate::tables::{
-        gpos::{Class1Record, Class2Record, PairPos, PairPosFormat2, SinglePos, SinglePosFormat1},
-        layout::{ClassDefBuilder, CoverageTableBuilder, VariationIndex},
+        gpos::{SinglePos, SinglePosFormat1},
+        layout::{CoverageTableBuilder, VariationIndex},
     };
 
     use super::*;
@@ -260,35 +260,5 @@ mod tests {
         assert!(
             matches!(read_back.value_record.x_advance_device.as_ref(), Some(DeviceOrVariationIndex::VariationIndex(var_idx)) if var_idx.delta_set_inner_index == 0xee)
         )
-    }
-
-    #[test]
-    fn compile_devices_pairpos2() {
-        let rec1 = ValueRecord::new().with_x_advance_device(VariationIndex::new(0xff, 0xee));
-        let rec2 = ValueRecord::new().with_x_advance_device(VariationIndex::new(0xaa, 0xbb));
-        let class1 =
-            ClassDefBuilder::from_iter([(GlyphId::new(5), 2), (GlyphId::new(6), 2)]).build();
-        let class2 =
-            ClassDefBuilder::from_iter([(GlyphId::new(8), 3), (GlyphId::new(9), 3)]).build();
-        let class1recs = vec![Class1Record::new(vec![Class2Record::new(rec1, rec2)])];
-        let a_table = PairPos::format_2(
-            CoverageTableBuilder::from_glyphs(vec![GlyphId::new(42)]).build(),
-            class1,
-            class2,
-            class1recs,
-        );
-
-        let bytes = crate::dump_table(&a_table).unwrap();
-        let read_back = PairPosFormat2::read(bytes.as_slice().into()).unwrap();
-        let DeviceOrVariationIndex::VariationIndex(dev2) = read_back.class1_records[0]
-            .class2_records[0]
-            .value_record2
-            .x_advance_device
-            .as_ref()
-            .unwrap()
-        else {
-            panic!("not a variation index")
-        };
-        assert_eq!(dev2.delta_set_outer_index, 0xaa);
     }
 }


### PR DESCRIPTION
In write-fonts we have a 'validation' pass before compilation, which is an opportunity to go and inspect the tables we're writing and make sure that the data is sane. A bunch of these checks are generated automatically, but a lot of the validation logic we would want is case-specific; in this case we have a mechanism for naming additional methods to be called in particular places during validation.

We haven't made a ton of use of this custom validation logic, but we probably should, since it helps us be much more confident in the data that we're writing.

This adds some custom validation logic to the two PairPos subtable formats; there was something fishy happening here that was messing up my table packing.

Another thing I'm reminding of while doing this work is how tricky it is to construct these tables correctly without the assistance of a builder; there's a bunch of builders in `fea-rs`, and they should probably eventually migrate to `write-fonts`.