### PR TITLE
[write-fonts] Include children in pairpos f1 size

### DIFF
--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -285,10 +285,6 @@ impl Graph {
         out
     }
 
-    fn can_potentially_promote_subtables(&self) -> bool {
-        [TableType::GSUB, TableType::GPOS].contains(&self.objects[&self.root].type_)
-    }
-
     /// Attempt to pack the graph.
     ///
     /// This involves finding an order for objects such that all offsets are
@@ -309,10 +305,8 @@ impl Graph {
             return true;
         }
 
-        if self.can_potentially_promote_subtables() {
-            self.try_splitting_subtables();
-            self.try_promoting_subtables();
-        }
+        self.try_splitting_subtables();
+        self.try_promoting_subtables();
 
         log::info!("assigning spaces");
         self.assign_spaces_hb();

--- a/write-fonts/src/table_type.rs
+++ b/write-fonts/src/table_type.rs
@@ -6,7 +6,6 @@
 use std::fmt::Display;
 
 use font_types::Tag;
-use read_fonts::TopLevelTable;
 
 use crate::tables::layout::LookupType;
 
@@ -32,9 +31,6 @@ pub enum TableType {
 }
 
 impl TableType {
-    pub(crate) const GSUB: TableType = TableType::TopLevel(crate::tables::gsub::Gsub::TAG);
-    pub(crate) const GPOS: TableType = TableType::TopLevel(crate::tables::gpos::Gpos::TAG);
-
     #[cfg(feature = "dot2")]
     pub(crate) fn is_mock(&self) -> bool {
         *self == TableType::MockTable
@@ -122,8 +118,14 @@ mod tests {
 
     #[test]
     fn tagged_table_type() {
-        assert_eq!(gsub::Gsub::default().table_type(), TableType::GSUB);
-        assert_eq!(gpos::Gpos::default().table_type(), TableType::GPOS);
+        assert_eq!(
+            gsub::Gsub::default().table_type(),
+            TableType::TopLevel(Tag::new(b"GSUB"))
+        );
+        assert_eq!(
+            gpos::Gpos::default().table_type(),
+            TableType::TopLevel(Tag::new(b"GPOS"))
+        );
 
         assert_eq!(
             crate::tables::name::Name::default().table_type(),


### PR DESCRIPTION
This fixes a bug where we were not including the size of subtables when deciding on split points for pairpos format 1 tables.

This also removes the 'can_potentially_promote_subtables' check; if we reach this point we have already overflowed, which means we are probably in GPOS and GSUB, and this method complicated testing, since splitting & expansion wouldn't be triggered on a lookup subtable if it was not an ancestor of GPOS/GSUB.