### PR TITLE
[write-fonts] Split PairPos format 2 subtables

### DIFF
--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -124,3 +124,40 @@ impl From<DeltaFormat> for i64 {
         value as u16 as _
     }
 }
+
+impl ClassDefFormat1<'_> {
+    /// Get the class for this glyph id
+    pub fn get(&self, gid: GlyphId) -> u16 {
+        if gid < self.start_glyph_id() {
+            return 0;
+        }
+        let idx = gid.to_u16() - self.start_glyph_id().to_u16();
+        self.class_value_array()
+            .get(idx as usize)
+            .map(|x| x.get())
+            .unwrap_or(0)
+    }
+}
+
+impl ClassDefFormat2<'_> {
+    /// Get the class for this glyph id
+    pub fn get(&self, gid: GlyphId) -> u16 {
+        self.class_range_records()
+            .iter()
+            .find_map(|record| {
+                (record.start_glyph_id() >= gid && record.end_glyph_id() <= gid)
+                    .then_some(record.class())
+            })
+            .unwrap_or(0)
+    }
+}
+
+impl ClassDef<'_> {
+    /// Get the class for this glyph id
+    pub fn get(&self, gid: GlyphId) -> u16 {
+        match self {
+            ClassDef::Format1(table) => table.get(gid),
+            ClassDef::Format2(table) => table.get(gid),
+        }
+    }
+}

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -11,6 +11,11 @@ use crate::traversal::{Field, FieldType, RecordResolver, SomeRecord};
 use crate::{ComputeSize, FontData, FontReadWithArgs, ReadArgs, ReadError};
 
 impl ValueFormat {
+    /// A mask with all the device/variation index bits set
+    pub const ANY_DEVICE_OR_VARIDX: Self = ValueFormat {
+        bits: 0x0010 | 0x0020 | 0x0040 | 0x0080,
+    };
+
     /// Return the number of bytes required to store a [`ValueRecord`] in this format.
     #[inline]
     pub fn record_byte_len(self) -> usize {
@@ -208,5 +213,20 @@ impl<'a> SomeRecord<'a> for ValueRecord {
             data,
             get_field: Box::new(move |idx, data| self.get_field(idx, data)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity_check_format_const() {
+        let format = ValueFormat::X_ADVANCE_DEVICE
+            | ValueFormat::Y_ADVANCE_DEVICE
+            | ValueFormat::Y_PLACEMENT_DEVICE
+            | ValueFormat::X_PLACEMENT_DEVICE;
+        assert_eq!(format, ValueFormat::ANY_DEVICE_OR_VARIDX);
+        assert_eq!(format.record_byte_len(), 4 * 2);
     }
 }

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -122,7 +122,7 @@ impl<'a> FontBuilder<'a> {
 
         let mut writer = TableWriter::default();
         directory.write_into(&mut writer);
-        let mut data = writer.into_data();
+        let mut data = writer.into_data().bytes;
         for table in self.tables.values() {
             data.extend_from_slice(table);
             let rem = round4(table.len()) - table.len();

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -708,7 +708,6 @@ impl Graph {
     /// [isolate_subgraph]: https://github.com/harfbuzz/harfbuzz/blob/main/src/graph/graph.hh#L508
     fn isolate_subgraph_hb(&mut self, roots: &mut BTreeSet<ObjectId>) -> bool {
         self.update_parents();
-        log::trace!("isolating subgraph with {} roots", roots.len());
 
         // map of object id -> number of incoming edges
         let mut subgraph = BTreeMap::new();
@@ -727,6 +726,7 @@ impl Graph {
         }
 
         let next_space = self.next_space();
+        log::debug!("moved {} roots to {next_space:?}", roots.len(),);
         self.num_roots_per_space.insert(next_space, roots.len());
         let mut id_map = HashMap::new();
         //let mut made_changes = false;
@@ -1059,7 +1059,7 @@ impl Graph {
         match type_ {
             TableType::GposLookup(LookupType::PAIR_POS) => splitting::split_pair_pos(self, lookup),
             TableType::GposLookup(LookupType::MARK_TO_BASE) => {
-                log::info!("table splitting not yet implemented for GPOS Type 4 (mark-to-base)");
+                log::warn!("table splitting not yet implemented for GPOS Type 4 (mark-to-base)");
             }
             _ => (),
         }

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -1,15 +1,14 @@
 //! splitting layout (GPOS) subtables
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
-use font_types::{GlyphId, Offset16};
+use font_types::{FixedSize, GlyphId, Offset16};
+use read_fonts::tables::{gpos as rgpos, layout as rlayout};
 
 use super::{Graph, ObjectId};
-
-use crate::types::FixedSize;
-use crate::{tables::layout as wlayout, write::TableData};
-
-use read_fonts::tables::{gpos as rgpos, layout as rlayout};
+use crate::{
+    tables::layout as wlayout, write::OffsetRecord, write::TableData, FontWrite, TableWriter,
+};
 
 const MAX_TABLE_SIZE: usize = u16::MAX as usize;
 
@@ -28,11 +27,12 @@ fn split_subtables(
         data.reparse::<rgpos::PositionLookup>().is_ok(),
         "table splitting is only relevant for GPOS?"
     );
-    log::debug!("trying to split subtables in {lookup:?}, '{}'", data.type_);
+    log::debug!("trying to split subtables in '{}'", data.type_);
 
     let mut new_subtables = HashMap::new();
-    for subtable in &data.offsets {
+    for (i, subtable) in data.offsets.iter().enumerate() {
         if let Some(split_subtables) = split_fn(graph, subtable.object) {
+            log::trace!("produced {} splits for subtable {i}", split_subtables.len());
             new_subtables.insert(subtable.object, split_subtables);
         }
     }
@@ -40,7 +40,7 @@ fn split_subtables(
     if new_subtables.is_empty() {
         // just put the old data back unchanged; nothing to see here
         graph.objects.insert(lookup, data);
-        log::debug!("nothing to split, continuing");
+        log::debug!("Splitting produced no new subtables");
         return;
     }
 
@@ -49,6 +49,7 @@ fn split_subtables(
         // - 1 because each group of new subtables replaces an old subtable
         .map(|ids| ids.len() - 1)
         .sum::<usize>();
+    log::debug!("Splitting produced {n_new_subtables} new subtables");
 
     let n_total_subtables: u16 = (data.offsets.len() + n_new_subtables).try_into().unwrap();
     // we just want the lookup type/flag/etc, but we need a generic FontRead type
@@ -73,10 +74,7 @@ fn split_pair_pos_subtable(graph: &mut Graph, lookup: ObjectId) -> Option<Vec<Ob
     let format: u16 = data.read_at(0).unwrap();
     match format {
         1 => split_pair_pos_format_1(graph, lookup),
-        2 => {
-            log::info!("table splitting not yet implemented for PairPos format 2");
-            None
-        }
+        2 => split_pair_pos_format_2(graph, lookup),
         other => {
             log::warn!("unexpected pairpos format '{other}'");
             None
@@ -129,7 +127,7 @@ fn split_pair_pos_format_1(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<
         accumulated += accumulated_delta;
         let total = accumulated + coverage_size.min(partial_coverage_size);
         if total > MAX_TABLE_SIZE {
-            log::debug!("adding split at {i}");
+            log::trace!("adding split at {i}");
             split_points.push(i);
             accumulated = BASE_SIZE + accumulated_delta;
             partial_coverage_size = 6; // + one glyph, because this table didn't fit
@@ -186,6 +184,247 @@ fn split_off_ppf1(graph: &mut Graph, subtable: ObjectId, start: u16, end: u16) -
         new_ppf1.add_offset(off.object, 2, 0)
     }
     new_ppf1
+}
+
+// based off of
+// <https://github.com/harfbuzz/harfbuzz/blob/f380a32825a1b2c51bbe21dc7acb9b3cc0921f69/src/graph/pairpos-graph.hh#L207>
+fn split_pair_pos_format_2(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<ObjectId>> {
+    const BASE_SIZE: usize = 8 * u16::RAW_BYTE_LEN;
+    let data = &graph.objects[&subtable];
+
+    let pp2 = data.reparse::<rgpos::PairPosFormat2>().unwrap();
+    let cur_len = data.bytes.len();
+    log::info!(
+        "PairPos f.2 subtable has {} class1 and {} class2, current size {cur_len} ",
+        pp2.class1_count(),
+        pp2.class2_count()
+    );
+    // we can't get these from the reparsed table because its offsets
+    // are not valid until compiled into the final table
+    let coverage_id = data.offsets[0].object;
+    let class_def1_id = data.offsets[1].object;
+    let class_def2_id = data.offsets[2].object;
+    let class_def2_size = graph.objects[&class_def2_id].bytes.len();
+    let coverage = &graph.objects[&coverage_id];
+    let coverage = coverage.reparse::<rlayout::CoverageTable>().unwrap();
+
+    let class_def1 = &graph.objects[&class_def1_id];
+    let class_def1 = class_def1.reparse::<rlayout::ClassDef>().unwrap();
+    let estimator = ClassDefSizeEstimator::new(coverage, class_def1);
+
+    let class2_count = pp2.class2_count();
+    let class1_record_size = class2_count as usize
+        * (pp2.value_format1().record_byte_len() + pp2.value_format2().record_byte_len());
+
+    let mut accumulated = BASE_SIZE;
+    let mut coverage_size = 4;
+    let mut class_def_1_size = 4;
+    let mut max_coverage_size = coverage_size;
+    let mut max_class_def_1_size = class_def_1_size;
+
+    let mut split_points = Vec::new();
+    let has_device_tables = (pp2.value_format1() | pp2.value_format2())
+        .intersects(rgpos::ValueFormat::ANY_DEVICE_OR_VARIDX);
+
+    let mut visited = HashSet::new();
+    let mut next_device_offset = 3; // start after coverage + classs defs
+    for (idx, class1rec) in pp2.class1_records().iter().enumerate() {
+        let mut accumulated_delta = class1_record_size;
+        coverage_size += estimator.increment_coverage_size(idx as _);
+        class_def_1_size += estimator.increment_class_def_size(idx as _);
+        max_coverage_size = max_coverage_size.max(coverage_size);
+        max_class_def_1_size = max_class_def_1_size.max(class_def_1_size);
+
+        // NOTE:
+        //I'm finding that we generate slightly more splits than I would expect,
+        //and I want to look into that, but i also want to get this merged.
+        // Please remind me to open an issue to investigate size measurement
+        // more thoroughly. In particular, look into why we just take subgraph
+        // size for pairpos1 (ignoring duplicates) but try to account for duplicates
+        // in pairpos2?
+        // tracked at <https://github.com/googlefonts/fontations/issues/601>
+        if has_device_tables {
+            for class2rec in class1rec.unwrap().class2_records.iter() {
+                let class2rec = class2rec.as_ref().unwrap();
+                accumulated_delta += size_of_value_record_children(
+                    &class2rec.value_record1,
+                    graph,
+                    &data.offsets,
+                    &mut next_device_offset,
+                    &mut visited,
+                );
+                accumulated_delta += size_of_value_record_children(
+                    &class2rec.value_record2,
+                    graph,
+                    &data.offsets,
+                    &mut next_device_offset,
+                    &mut visited,
+                );
+            }
+        }
+
+        accumulated += accumulated_delta;
+        let largest_obj = coverage_size.max(class_def_1_size).max(class_def2_size);
+        let total = accumulated + coverage_size + class_def_1_size + class_def2_size
+            // largest obj packs last and can overflow
+            - largest_obj;
+
+        if total > MAX_TABLE_SIZE {
+            split_points.push(idx);
+            // split does not include this class, so add it for the next iteration
+            accumulated = BASE_SIZE + accumulated_delta;
+            coverage_size = 4 + estimator.increment_coverage_size(idx as _);
+            class_def_1_size = 4 + estimator.increment_class_def_size(idx as _);
+            visited.clear();
+        }
+    }
+
+    log::debug!("identified {} split points", split_points.len());
+    if split_points.is_empty() {
+        return None;
+    }
+
+    split_points.push(pp2.class1_count() as usize - 1);
+    // now we have a list of split points, and just need to do the splitting.
+    // note: harfbuzz does a thing here with a context type and an 'actuate_splits'
+    // method.
+
+    let mut new_subtables = Vec::new();
+    let mut prev_subtable_start = 0;
+    let mut next_device_offset = 3; // after coverage & two class defs
+    for subtable_start in split_points {
+        let subtable_end = subtable_start - 1;
+        let (new_subtable, offsets_used) = split_off_ppf2(
+            graph,
+            subtable,
+            prev_subtable_start,
+            subtable_end,
+            next_device_offset,
+        );
+        prev_subtable_start = subtable_start;
+        next_device_offset += offsets_used;
+        new_subtables.push(graph.add_object(new_subtable));
+    }
+
+    Some(new_subtables)
+}
+
+// returns the new table, + the number of non-null device offsets encountered.
+fn split_off_ppf2(
+    graph: &mut Graph,
+    subtable: ObjectId,
+    start: usize,
+    end: usize,
+    first_device_idx: usize,
+) -> (TableData, usize) {
+    // we have to do this bit manually (instead of via reparsing) because of borrowk
+    let coverage = graph.objects[&subtable].offsets.first().unwrap().object;
+    let coverage = graph.objects.get(&coverage).unwrap();
+    let coverage = coverage.reparse::<rlayout::CoverageTable>().unwrap();
+    let class_def_1 = graph.objects[&subtable].offsets[1].object;
+    let class_def_1 = graph.objects.get(&class_def_1).unwrap();
+    let class_def_1 = class_def_1.reparse::<rlayout::ClassDef>().unwrap();
+
+    let n_records = (end - start) + 1;
+    log::trace!("splitting off {n_records} class1records ({start}..={end})");
+
+    let class_map = coverage
+        .iter()
+        .filter_map(|gid| {
+            let glyph_class = class_def_1.get(gid);
+            (start..=end)
+                .contains(&(glyph_class as usize))
+                // classes are used as indexes, so adjust them
+                .then_some((gid, glyph_class.saturating_sub(start as u16)))
+        })
+        .collect::<HashMap<_, _>>();
+
+    let new_coverage = class_map
+        .keys()
+        .copied()
+        .collect::<wlayout::CoverageTable>();
+    let new_coverage = make_table_data(&new_coverage);
+    let new_cov_id = graph.add_object(new_coverage);
+    let new_class_def1 = class_map
+        .iter()
+        .map(|tup| (*tup.0, *tup.1))
+        .collect::<wlayout::ClassDef>();
+    let new_class_def1 = make_table_data(&new_class_def1);
+    let new_class_def1_id = graph.add_object(new_class_def1);
+    // we reuse class2 without changing it. maybe we could be changing it?
+    let class_def_2_id = graph.objects[&subtable].offsets[2].object;
+
+    let data = &graph.objects[&subtable];
+    let table = data.reparse::<rgpos::PairPosFormat2>().unwrap();
+
+    let mut new_ppf2 = TableData::new(data.type_);
+    new_ppf2.write(table.pos_format());
+    new_ppf2.add_offset(new_cov_id, 2, 0);
+    new_ppf2.write(table.value_format1());
+    new_ppf2.write(table.value_format2());
+    new_ppf2.add_offset(new_class_def1_id, 2, 0);
+    new_ppf2.add_offset(class_def_2_id, 2, 0);
+
+    // now we need to copy over the class1records
+    let mut seen_offsets = 0;
+    for class2rec in table
+        .class1_records()
+        .iter()
+        .skip(start)
+        .take(n_records)
+        .flat_map(|c1rec| {
+            c1rec
+                .unwrap()
+                .class2_records()
+                .iter()
+                .map(|rec| rec.unwrap())
+        })
+    {
+        let rec_offset_start = first_device_idx + seen_offsets;
+        let rec_offsets = &graph.objects[&subtable].offsets[rec_offset_start..];
+        let rec1_seen = copy_value_rec(&mut new_ppf2, class2rec.value_record1(), rec_offsets);
+        let rec_offsets = &rec_offsets[rec1_seen..];
+        seen_offsets += rec1_seen;
+        seen_offsets += copy_value_rec(&mut new_ppf2, class2rec.value_record2(), rec_offsets);
+    }
+    (new_ppf2, seen_offsets)
+}
+
+// returns the number of non-null offsets encountered in this record
+fn copy_value_rec(
+    target: &mut TableData,
+    rec: &rgpos::ValueRecord,
+    dev_offsets: &[OffsetRecord],
+) -> usize {
+    let mut seen_offsets = 0;
+    // a little macro to help us copy over all the fields.
+    // - first we copy over the non-device tables
+    // - then for the device tables, if they are present we copy over
+    // the id.
+    macro_rules! write_opt_field {
+        ($fld:ident) => {
+            if let Some(val) = rec.$fld() {
+                target.write(val);
+            }
+        };
+        ($fld:ident, off) => {
+            if !rec.$fld.get().is_null() {
+                // we write this in a funny way to dodge a clippy warning
+                seen_offsets += 1;
+                target.add_offset(dev_offsets[seen_offsets - 1].object, 2, 0);
+            }
+        };
+    }
+    write_opt_field!(x_placement);
+    write_opt_field!(y_placement);
+    write_opt_field!(x_advance);
+    write_opt_field!(y_advance);
+
+    write_opt_field!(x_placement_device, off);
+    write_opt_field!(y_placement_device, off);
+    write_opt_field!(x_advance_device, off);
+    write_opt_field!(y_advance_device, off);
+    seen_offsets
 }
 
 fn split_coverage(coverage: &rlayout::CoverageTable, start: u16, end: u16) -> TableData {
@@ -252,17 +491,144 @@ fn split_range_record(
     ))
 }
 
+struct ClassDefSizeEstimator {
+    consecutive_gids: bool,
+    num_ranges_per_class: HashMap<u16, u16>,
+    glyphs_per_class: HashMap<u16, BTreeSet<GlyphId>>,
+}
+
+const GLYPH_SIZE: usize = std::mem::size_of::<u16>();
+
+impl ClassDefSizeEstimator {
+    fn new(coverage: rlayout::CoverageTable, classdef: rlayout::ClassDef) -> Self {
+        let mut consecutive_gids = true;
+        let mut last_gid = None;
+        let mut glyphs_per_class = HashMap::new();
+        for (gid, class) in coverage.iter().map(|gid| (gid, classdef.get(gid))) {
+            if let Some(last) = last_gid.take() {
+                if last + 1 != gid.to_u16() {
+                    consecutive_gids = false;
+                }
+            }
+            last_gid = Some(gid.to_u16());
+            glyphs_per_class
+                .entry(class)
+                .or_insert(BTreeSet::default())
+                .insert(gid);
+        }
+
+        // now compute the number of ranges manually, skipping class 0
+        let mut num_ranges_per_class = HashMap::with_capacity(glyphs_per_class.len());
+        for (class, glyphs) in glyphs_per_class.iter().filter(|x| *x.0 != 0) {
+            let num_ranges = count_num_ranges(glyphs);
+            num_ranges_per_class.insert(*class, num_ranges);
+        }
+        ClassDefSizeEstimator {
+            consecutive_gids,
+            num_ranges_per_class,
+            glyphs_per_class,
+        }
+    }
+
+    fn n_glyphs_in_class(&self, class: u16) -> usize {
+        self.glyphs_per_class
+            .get(&class)
+            .map(BTreeSet::len)
+            .unwrap_or_default()
+    }
+
+    fn increment_coverage_size(&self, class: u16) -> usize {
+        GLYPH_SIZE * self.n_glyphs_in_class(class)
+    }
+
+    fn increment_class_def_size(&self, class: u16) -> usize {
+        // classdef2 uses 6 bytes for each range (start, end, class)
+        const SIZE_PER_RANGE: usize = 6;
+        let class_def_2_size = SIZE_PER_RANGE
+            * self
+                .num_ranges_per_class
+                .get(&class)
+                .copied()
+                .unwrap_or_default() as usize;
+        if self.consecutive_gids {
+            class_def_2_size.min(self.n_glyphs_in_class(class) * GLYPH_SIZE)
+        } else {
+            class_def_2_size
+        }
+    }
+}
+
+fn count_num_ranges(glyphs: &BTreeSet<GlyphId>) -> u16 {
+    let mut count = 0;
+    let mut last = None;
+    for gid in glyphs {
+        match (last.take(), gid.to_u16()) {
+            (Some(prev), current) if current == prev + 1 => (), // in same range
+            _ => count += 1, // first glyph or glyph that starts new range
+        }
+        last = Some(gid.to_u16());
+    }
+    count
+}
+
+fn size_of_value_record_children(
+    record: &rgpos::ValueRecord,
+    graph: &Graph,
+    offsets: &[OffsetRecord],
+    // gets incremented every time we see a device offset
+    next_offset_idx: &mut usize,
+    seen: &mut HashSet<ObjectId>,
+) -> usize {
+    let subtables = [
+        record.x_placement_device.get(),
+        record.y_placement_device.get(),
+        record.x_advance_device.get(),
+        record.y_advance_device.get(),
+    ];
+    subtables
+        .iter()
+        .filter_map(|offset| (!offset.is_null()).then_some(*offset.offset()))
+        .map(|_| {
+            let obj = offsets[*next_offset_idx].object;
+            if seen.insert(obj) {
+                *next_offset_idx += 1;
+                graph.objects[&obj].bytes.len()
+            } else {
+                0
+            }
+        })
+        .sum()
+}
+
+// a helper to convert a write-fonts table into graph-ready bytes.
+//
+// NOTE: the table must not contain any offsets. intended for coverage/classdef
+fn make_table_data(table: &dyn FontWrite) -> TableData {
+    let mut writer = TableWriter::default();
+    table.write_into(&mut writer);
+
+    let mut r = writer.into_data();
+    r.type_ = table.table_type();
+    r
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::BTreeMap, ops::Range};
 
-    use read_fonts::{tables::layout::LookupFlag, FontData, FontRead};
+    use read_fonts::{
+        tables::{gpos::ValueFormat, layout::LookupFlag},
+        FontData, FontRead,
+    };
 
     use super::*;
     use crate::{
         tables::{
-            gpos::{PairPos, PairSet, PairValueRecord, ValueRecord},
-            layout::{CoverageTableBuilder, VariationIndex},
+            gpos::{
+                Class1Record, Class2Record, Gpos, PairPos, PairSet, PairValueRecord,
+                PositionLookup, ValueRecord,
+            },
+            layout::{CoverageTableBuilder, DeviceOrVariationIndex, VariationIndex},
         },
         FontWrite, TableWriter,
     };
@@ -493,5 +859,105 @@ mod tests {
         let lookup = wlayout::Lookup::new(LookupFlag::empty(), vec![table], 0);
         let lookuplist = wlayout::LookupList::new(vec![lookup]);
         assert!(crate::dump_table(&lookuplist).is_ok());
+    }
+
+    #[test]
+    fn count_glyph_ranges() {
+        fn make_input(glyphs: &[u16]) -> BTreeSet<GlyphId> {
+            glyphs.iter().copied().map(GlyphId::new).collect()
+        }
+
+        assert_eq!(count_num_ranges(&make_input(&[])), 0);
+        assert_eq!(count_num_ranges(&make_input(&[1])), 1);
+        assert_eq!(count_num_ranges(&make_input(&[1, 2, 3])), 1);
+        assert_eq!(count_num_ranges(&make_input(&[1, 2, 3])), 1);
+        assert_eq!(count_num_ranges(&make_input(&[1, 2, 3, 5])), 2);
+        assert_eq!(count_num_ranges(&make_input(&[1, 2, 3, 5, 6, 7, 10])), 3);
+    }
+
+    #[test]
+    fn split_pair_pos2() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // okay so... I want a big pairpos format 2 table.
+        // this means, mainly, that I want lots of different classes.
+
+        fn next_class2_rec(i: usize) -> Class2Record {
+            // idk how better to cast bits directly
+            let val = i16::from_be_bytes(((i % u16::MAX as usize) as u16).to_be_bytes());
+            // we add a device table every twelve records, arbitrary, we
+            // want some but not a ton
+            let value_format = ValueFormat::X_ADVANCE
+                | ValueFormat::Y_ADVANCE
+                | ValueFormat::X_PLACEMENT
+                | ValueFormat::Y_PLACEMENT
+                | ValueFormat::Y_ADVANCE_DEVICE;
+            let add_device = i % 500 == 0;
+            let mut record = ValueRecord::new()
+                .with_explicit_value_format(value_format)
+                .with_x_advance(val)
+                .with_y_advance(val)
+                .with_x_placement(val)
+                .with_y_placement(val);
+            if add_device {
+                record = record.with_y_advance_device(DeviceOrVariationIndex::variation_index(
+                    0xde, val as u16,
+                ));
+            }
+
+            Class2Record {
+                value_record1: record.clone(),
+                value_record2: record,
+            }
+        }
+
+        fn make_class_def(
+            n_classes: u16,
+            n_glyphs_per_class: u16,
+            first_gid: u16,
+        ) -> wlayout::ClassDef {
+            let n_glyphs = n_classes * n_glyphs_per_class;
+            (first_gid..first_gid + n_glyphs)
+                .map(|gid| {
+                    let class = (gid - 1) / n_glyphs_per_class;
+                    (GlyphId::new(gid), class)
+                })
+                .collect()
+        }
+        const CLASS1_COUNT: u16 = 100;
+        const CLASS2_COUNT: u16 = 100;
+
+        let class_def1 = make_class_def(CLASS1_COUNT, 4, 1);
+        let class_def2 = make_class_def(CLASS2_COUNT, 3, 1);
+
+        assert_eq!(class_def1.class_count(), CLASS1_COUNT);
+        assert_eq!(class_def2.class_count(), CLASS2_COUNT);
+        let coverage = class_def1
+            .iter()
+            .map(|(gid, _)| gid)
+            .collect::<wlayout::CoverageTable>();
+
+        let class1recs = (0..CLASS1_COUNT)
+            .map(|i| {
+                Class1Record::new(
+                    (0..CLASS2_COUNT)
+                        .map(|j| next_class2_rec(i as usize * CLASS1_COUNT as usize + j as usize))
+                        .collect(),
+                )
+            })
+            .collect();
+
+        let table = PairPos::format_2(coverage, class_def1, class_def2, class1recs);
+
+        let lookup = wlayout::Lookup::new(LookupFlag::empty(), vec![table], 0);
+        let lookup = PositionLookup::Pair(lookup);
+
+        let lookup_list = wlayout::LookupList::new(vec![lookup]);
+        let gpos = Gpos::new(Default::default(), Default::default(), lookup_list);
+        let mut graph = TableWriter::make_graph(&gpos);
+
+        graph.basic_sort();
+        //graph.write_graph_viz("pairpos-test-0.dot").unwrap();
+        assert!(graph.pack_objects());
+        //graph.write_graph_viz("pairpos-test-1.dot").unwrap();
     }
 }

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -328,8 +328,8 @@ fn split_off_ppf2(
     let class_def_1 = graph.objects.get(&class_def_1).unwrap();
     let class_def_1 = class_def_1.reparse::<rlayout::ClassDef>().unwrap();
 
-    let n_records = (end - start) + 1;
-    log::trace!("splitting off {n_records} class1records ({start}..={end})");
+    let class1_count = (end - start) + 1;
+    log::trace!("splitting off {class1_count} class1records ({start}..={end})");
 
     let class_map = coverage
         .iter()
@@ -369,6 +369,8 @@ fn split_off_ppf2(
     new_ppf2.write(value_format2);
     new_ppf2.add_offset(new_class_def1_id, 2, 0);
     new_ppf2.add_offset(class_def_2_id, 2, 0);
+    new_ppf2.write(class1_count as u16);
+    new_ppf2.write(table.class2_count());
 
     // now we need to copy over the class1records
     let mut seen_offsets = 0;
@@ -376,7 +378,7 @@ fn split_off_ppf2(
         .class1_records()
         .iter()
         .skip(start)
-        .take(n_records)
+        .take(class1_count)
         .flat_map(|c1rec| {
             c1rec
                 .unwrap()

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -279,10 +279,12 @@ fn split_pair_pos_format_2(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<
         }
 
         accumulated += accumulated_delta;
-        let largest_obj = coverage_size.max(class_def_1_size).max(class_def2_size);
-        let total = accumulated + coverage_size + class_def_1_size + class_def2_size
-            // largest obj packs last and can overflow
-            - largest_obj;
+        let _largest_obj = coverage_size.max(class_def_1_size).max(class_def2_size);
+        let total = accumulated + coverage_size + class_def_1_size + class_def2_size;
+        //NOTE: harfbuzz has this optimization but I was seeing an overflow with
+        //the last object in some cases, so currently disabled
+        // largest obj packs last and can overflow
+        //- _largest_obj;
 
         if total > MAX_TABLE_SIZE {
             split_points.push(idx);

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -1,4 +1,13 @@
 //! splitting layout (GPOS) subtables
+//!
+//! The implementations here are directly adapted from the code in hb-repacker,
+//! with a few minor differences:
+//!
+//! - we don't use a context/interface for the tables, instead using a generic
+//! 'split_subtables' method similar to 'actuate_subtable_split' and passing
+//! it a method for each lookup type
+//! - harfbuzz splits off new subtables but retains the original subtable,
+//!   shrinking it to fit. We skip this step, and generate all new subtables.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -20,6 +29,9 @@ pub(super) fn split_pair_pos(graph: &mut Graph, lookup: ObjectId) {
 }
 
 /// A common impl handling updating the lookup with the new subtables
+///
+/// This is roughly equivalent to `actuate_subtable_split` in hb-repacker:
+/// <https://github.com/harfbuzz/harfbuzz/blob/d5cb1a315380e9bd78ff377a586b78bc42abafa6/src/graph/split-helpers.hh#L34>
 fn split_subtables(
     graph: &mut Graph,
     lookup: ObjectId,

--- a/write-fonts/src/tables/glyf/glyf_loca_builder.rs
+++ b/write-fonts/src/tables/glyf/glyf_loca_builder.rs
@@ -82,7 +82,7 @@ impl GlyfLocaBuilder {
     /// [`head`]: crate::tables::head::Head::index_to_loc_format
     #[must_use]
     pub fn build(self) -> (Glyf, Loca, LocaFormat) {
-        let glyph_data = self.glyph_writer.into_data();
+        let glyph_data = self.glyph_writer.into_data().bytes;
         let loca = Loca::new(self.raw_loca);
         let format = loca.format();
         (Glyf(glyph_data), loca, format)

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -196,7 +196,7 @@ impl TableData {
 
     /// the 'adjustment' param is used to modify the written position.
     pub(crate) fn add_offset(&mut self, object: ObjectId, width: usize, adjustment: u32) {
-        const PLACEHOLDER_BYTES: &[u8] = &[0xff, 0xff, 0xff, 0xff];
+        const PLACEHOLDER_BYTES: &[u8] = &[0xff; 4];
         self.offsets.push(OffsetRecord {
             pos: self.bytes.len() as u32,
             len: match width {


### PR DESCRIPTION
Based on top of #595.

This implements subtable splitting for PairPos format 2 (class-based) subtables. It is based on the implementation in hb-repacker.

This is one of the more complicated tables to split, and writing this patch uncovered a number of other bugs in the existing implementation, which have been fixed separately.

With this patch, we are once again compiling our target fonts.

