### PR TITLE
[read-fonts] Fix possible crash in PackedPointNumbersIter

### DIFF
--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -362,7 +362,7 @@ impl Iterator for PackedPointNumbersIter<'_> {
         // if our count is zero, we keep incrementing forever
         if self.count == 0 {
             let result = self.last_val;
-            self.last_val += 1;
+            self.last_val = self.last_val.checked_add(1)?;
             return Some(result);
         }
 
@@ -826,5 +826,14 @@ mod tests {
         assert_eq!(points.iter().collect::<Vec<_>>(), &[1, 3]);
         assert_eq!(points.total_len(), 4);
         assert_eq!(data.len(), INPUT.len() - 4);
+    }
+
+    #[test]
+    fn packed_points_dont_panic() {
+        // a single '0' byte means that there are deltas for all points
+        static ALL_POINTS: FontData = FontData::new(&[0]);
+        let (all_points, _) = PackedPointNumbers::split_off_front(ALL_POINTS);
+        // in which case the iterator just keeps incrementing until u16::MAX
+        assert_eq!(all_points.iter().count(), u16::MAX as _);
     }
 }


### PR DESCRIPTION
This would only be encountered if the user manually tried to iterate packed points with a single 0x0 byte (signifying that there are points for all deltas) and did not also know how many points there were; but there's no reason not to be more careful here and at least stop iterating after u16::MAX items.

JMM