### PR TITLE
[write-fonts] Use short offsets in gvar where appropriate

### DIFF
--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -38,7 +38,8 @@ impl FontReadWithArgs<'_> for U16Or32 {
 }
 
 impl U16Or32 {
-    fn get(self) -> u32 {
+    #[inline]
+    pub fn get(self) -> u32 {
         self.0
     }
 }


### PR DESCRIPTION
This was something I skipped in my initial implementation, but should save us a few kb in the common case.

closes #615 