### PR TITLE
[ci] Disable clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,19 +30,20 @@ jobs:
       - name: check no println! or eprintln! statements
         run: resources/scripts/check_no_println.sh
 
-  clippy-lint:
-    name: Clippy lints
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+  # disabled temporarily pending fixing a crash in clippy
+  #clippy-lint:
+    #name: Clippy lints
+    #runs-on: ubuntu-latest
+    #steps:
+      #- uses: actions/checkout@v3
+      #- name: install stable toolchain
+        #uses: dtolnay/rust-toolchain@stable
 
-      - name: cargo clippy --all-features
-        run: cargo clippy --all-features --all-targets -- -D warnings
+      #- name: cargo clippy --all-features
+        #run: cargo clippy --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy --no-default-features
-        run: cargo clippy --all-targets --no-default-features -- -D warnings
+      #- name: cargo clippy --no-default-features
+        #run: cargo clippy --all-targets --no-default-features -- -D warnings
 
   test-stable:
     name: cargo test stable


### PR DESCRIPTION
There's a new clippy with new lints, but when we fix these lints we're crashing the compiler, so let's just turn it off until this gets resolved.

I've opened https://github.com/rust-lang/rust-clippy/issues/11619 upstream, and we can turn clippy back on when that gets resolved.