### PR TITLE
[write-fonts] Allow to construct DeltaSetIndexMap from VariationIndex iterator

### DIFF
--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -644,6 +644,12 @@ fn encode_chunk(chunk: &[i8], mask: u8, bits: usize) -> u16 {
     out
 }
 
+impl From<VariationIndex> for u32 {
+    fn from(value: VariationIndex) -> Self {
+        ((value.delta_set_outer_index as u32) << 16) | value.delta_set_inner_index as u32
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -386,14 +386,11 @@ impl DeltaSetIndexMap {
         assert!(inner_bits <= 16);
 
         let ored = (ored >> (16 - inner_bits)) | (ored & ((1 << inner_bits) - 1));
-        let entry_size = if ored <= 0x000000FF {
-            1
-        } else if ored <= 0x0000FFFF {
-            2
-        } else if ored <= 0x00FFFFFF {
-            3
-        } else {
-            4
+        let entry_size = match ored {
+            0..=0xFF => 1,
+            0x100..=0xFFFF => 2,
+            0x10000..=0xFFFFFF => 3,
+            _ => 4,
         };
 
         EntryFormat::from_bits((entry_size - 1) << 4 | (inner_bits - 1)).unwrap()


### PR DESCRIPTION
fontc needs to build a DeltaSetIndexMap for the HVAR table and would like to not bother with encoding details like entry format or whether to build Format0 or Format1 depending on the number of mappings, etc.

The VariationStoreBuilder returns, alongside the ItemVariationStore, a VariationIndexRemapping (which maps from TemporaryDeltaSetId (u32) to VariationIndex).
After this PR, fontc can simply collect all these VariationIndex values into a new DeltaSetIndexMap.