### PR TITLE
[{read,write}-fonts] Allow DeltaSetIndexMap repeated trailing entries to be omitted

### DIFF
--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -526,10 +526,7 @@ impl<'a> DeltaSetIndexMap<'a> {
         // mapCount, then the last logical entry of the mapping array is used."
         // https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats
         // #associating-target-items-to-variation-data
-        let mut index = index;
-        if index >= map_count {
-            index = map_count.saturating_sub(1);
-        }
+        let index = index.min(map_count.saturating_sub(1));
         let offset = index as usize * entry_size as usize;
         let entry = match entry_size {
             1 => data.read_at::<u8>(offset)? as u32,

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -516,12 +516,20 @@ impl EntryFormat {
 impl<'a> DeltaSetIndexMap<'a> {
     /// Returns the delta set index for the specified value.
     pub fn get(&self, index: u32) -> Result<DeltaSetIndex, ReadError> {
-        let (entry_format, data) = match self {
-            Self::Format0(fmt) => (fmt.entry_format(), fmt.map_data()),
-            Self::Format1(fmt) => (fmt.entry_format(), fmt.map_data()),
+        let (entry_format, map_count, data) = match self {
+            Self::Format0(fmt) => (fmt.entry_format(), fmt.map_count() as u32, fmt.map_data()),
+            Self::Format1(fmt) => (fmt.entry_format(), fmt.map_count(), fmt.map_data()),
         };
         let entry_size = entry_format.entry_size();
         let data = FontData::new(data);
+        // "if an index into the mapping array is used that is greater than or equal to
+        // mapCount, then the last logical entry of the mapping array is used."
+        // https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats
+        // #associating-target-items-to-variation-data
+        let mut index = index;
+        if index >= map_count {
+            index = map_count.saturating_sub(1);
+        }
         let offset = index as usize * entry_size as usize;
         let entry = match entry_size {
             1 => data.read_at::<u8>(offset)? as u32,

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -419,7 +419,7 @@ impl DeltaSetIndexMap {
             map_count -= 1;
         }
 
-        let mut map_data: Vec<u8> = Vec::with_capacity(map_count * entry_size as usize);
+        let mut map_data = Vec::with_capacity(map_count * entry_size as usize);
         for idx in mapping.iter().take(map_count) {
             let idx = ((idx & 0xFFFF0000) >> outer_shift) | (idx & inner_mask);
             // append entry_size bytes to map_data in BigEndian order


### PR DESCRIPTION
Fixes #667