### PR TITLE
[ivs_builder] Fix all-zero delta sets not being de-duplicated

### DIFF
--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -1339,20 +1339,24 @@ mod tests {
 
     #[test]
     fn no_duplicate_zero_delta_sets() {
-        let r0 = VariationRegion::new(vec![reg_coords(0.0, 1.0, 1.0)]);
+        let r0 = VariationRegion::new(vec![reg_coords(0.0, 5.0, 1.0)]);
+        let r1 = VariationRegion::new(vec![reg_coords(0.5, 1.0, 1.0)]);
         let mut builder = VariationStoreBuilder::new();
         let varidxes = vec![
             // first glyph has no variations (e.g. .notdef only defined at default location)
             // but we still need to add it to the variation store to reserve an index so
             // we add an empty delta set
             builder.add_deltas::<i32>(Vec::new()),
-            builder.add_deltas(vec![(r0.clone(), 100)]),
-            // this glyph has an explicit master that is the same as the default (delta is 0);
+            builder.add_deltas(vec![(r0.clone(), 50), (r1.clone(), 100)]),
+            // this glyph has explicit masters that are *all* the same as the default (delta is 0);
             // we expect the builder to reuse the same no-op delta set as the first glyph
-            builder.add_deltas(vec![(r0.clone(), 0)]),
+            builder.add_deltas(vec![(r0.clone(), 0), (r1.clone(), 0)]),
             // this glyph repeats the same delta set as the second glyph, thus we expect
             // the builder to map it to the same delta set index
-            builder.add_deltas(vec![(r0.clone(), 100)]),
+            builder.add_deltas(vec![(r0.clone(), 50), (r1.clone(), 100)]),
+            // this glyph happens to have one master that's the same as the default (delta is 0);
+            // nothing special here, we expect a new delta set to be created
+            builder.add_deltas(vec![(r0.clone(), 0), (r1.clone(), 100)]),
         ];
         let (store, key_map) = builder.build();
 
@@ -1361,17 +1365,18 @@ mod tests {
             .map(|idx| key_map.get(idx).unwrap().into())
             .collect::<Vec<_>>();
 
-        assert_eq!(store.variation_region_list.variation_regions.len(), 1);
+        assert_eq!(store.variation_region_list.variation_regions.len(), 2);
         assert_eq!(store.item_variation_data.len(), 1);
 
         let var_data = store.item_variation_data[0].as_ref().unwrap();
 
-        assert_eq!(var_data.item_count, 2);
+        assert_eq!(var_data.item_count, 3);
         assert_eq!(var_data.word_delta_count, 0);
-        assert_eq!(var_data.region_indexes, vec![0]);
-        assert_eq!(var_data.delta_sets, vec![0, 100],);
-        // glyph 0 and 2 should map to the same no-op 0 delta, while
-        // glyph 1 and 3 should map to delta 100
-        assert_eq!(varidx_map, vec![0, 1, 0, 1]);
+        assert_eq!(var_data.region_indexes, vec![0, 1]);
+        assert_eq!(var_data.delta_sets, vec![0, 0, 0, 100, 50, 100],);
+        // glyph 0 and 2 should map to the same no-op [0, 0] deltaset, while
+        // glyph 1 and 3 should map to deltaset [50, 100];
+        // glyph 4 should map to deltaset [0, 100]
+        assert_eq!(varidx_map, vec![0, 2, 0, 2, 1]);
     }
 }

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -78,8 +78,15 @@ impl VariationStoreBuilder {
     ) -> TemporaryDeltaSetId {
         let mut delta_set = Vec::with_capacity(deltas.len());
         for (region, delta) in deltas {
+            let delta = delta.into();
+            // a delta of zero is the same as not including this region;
+            // so we elide the region for consistency, and this delta can be
+            // merged into another encoding if that's better.
+            if delta == 0 {
+                continue;
+            }
             let region_idx = self.canonical_index_for_region(region) as u16;
-            delta_set.push((region_idx, delta.into()));
+            delta_set.push((region_idx, delta));
         }
         delta_set.sort_unstable();
         self.delta_sets.add(DeltaSet(delta_set))

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -78,17 +78,17 @@ impl VariationStoreBuilder {
     ) -> TemporaryDeltaSetId {
         let mut delta_set = Vec::with_capacity(deltas.len());
         for (region, delta) in deltas {
-            let delta = delta.into();
-            // a delta of zero is the same as not including this region;
-            // so we elide the region for consistency, and this delta can be
-            // merged into another encoding if that's better.
-            if delta == 0 {
-                continue;
-            }
             let region_idx = self.canonical_index_for_region(region) as u16;
-            delta_set.push((region_idx, delta));
+            delta_set.push((region_idx, delta.into()));
         }
         delta_set.sort_unstable();
+        // treat a deltaset containing all zeros the same as an empty one;
+        // e.g. a glyph that only has one instance at the default location (no deltas)
+        // vs another that defines multiple instances but all of them are at the
+        // default location (all deltas are zero).
+        if delta_set.iter().all(|(_, delta)| *delta == 0) {
+            delta_set.clear();
+        }
         self.delta_sets.add(DeltaSet(delta_set))
     }
 

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -1361,9 +1361,6 @@ mod tests {
             .map(|idx| key_map.get(idx).unwrap().into())
             .collect::<Vec<_>>();
 
-        println!("{:#?}", store);
-        println!("{:#?}", varidx_map);
-
         assert_eq!(store.variation_region_list.variation_regions.len(), 1);
         assert_eq!(store.item_variation_data.len(), 1);
 


### PR DESCRIPTION
this test currently fails because the VarStore ends up with two identical [0] delta-sets instead of one. The builder is treating glyphs without any variations (add_deltas([]) and glyphs with explicitly defined 0 deltas (add_deltas([0]) as different, whereas it should treat them the same and have all point to the same no-op delta-set row.
