### PR TITLE
bump minor versions of read-fonts and write-fonts

### DIFF
--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 xflags = "0.3.0"
-read-fonts = { path = "../read-fonts",version = "0.12.0" }
+read-fonts = { path = "../read-fonts",version = "0.13.0" }
 font-types = { path = "../font-types",version = "0.4.0" }
 ansi_term = "0.12.1"
 atty = "0.2"

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -14,8 +14,8 @@ scale = []
 hinting = []
 
 [dependencies]
-read-fonts = { version = "0.12.0", path = "../read-fonts" }
+read-fonts = { version = "0.13.0", path = "../read-fonts" }
 
 [dev-dependencies]
 font-test-data= { path = "../font-test-data" }
-read-fonts = { version = "0.12.0", path = "../read-fonts", features = ["scaler_test"] }
+read-fonts = { version = "0.13.0", path = "../read-fonts", features = ["scaler_test"] }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -15,7 +15,7 @@ serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
 font-types = { version = "0.4.0", path = "../font-types" }
-read-fonts = { version = "0.12.0", path = "../read-fonts" }
+read-fonts = { version = "0.13.0", path = "../read-fonts" }
 log = "0.4"
 kurbo = "0.10.2"
 dot2 = { version = "1.0", optional = true }
@@ -26,7 +26,7 @@ indexmap = "2.0"
 diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.12.0", path = "../read-fonts", features = [ "codegen_test"] }
+read-fonts = { version = "0.13.0", path = "../read-fonts", features = [ "codegen_test"] }
 env_logger = "0.10.0"
 rstest = "0.18.0"
 pretty_assertions.workspace = true


### PR DESCRIPTION
```
$ cargo release changes
     Changes for read-fonts from read-fonts-v0.12.0 to 0.13.0
             05f97e0 address a few review comments
             648241a [hvar] test advance_with_delta() doesn't error when gid >= map_count
             82b93a5 [{read,write}-fonts] Allow DeltaSetIndexMap repeated trailing entries to be omitted
             05d977f review feedback
             d4c4505 add a test font and some bitmap loading tests
             b4d8653 appease clippy
             181a2b2 add EBDT formats
             37bf82b [codegen] Add missing debug impls to generic groups
             b3a6f07 [read-fonts] Add 'get' method to coverage tables
             55b496d [rustdoc] Now with smarter link detection?
             282d90b [clippy] Push the rock back up the hill
             10c0184 read location info and the png data formats
             7098368 some codegen hacks for SbitLineMetrics
             5128be2 [WIP] CBLC parsing
     Changes for write-fonts from write-fonts-v0.17.0 to 0.18.0
             97fb03b modify no_duplicate_zero_delta_sets test to clarify delta=0 matters
             fa377df [ivs_builder] only treat deltaset as empty when all deltas == 0
             f7c17e3 remove print statements
             d1c0834 [ivs_builder] Skip regions with zero deltas
             149e2c0 [ivs_builder] add test for all-zero delta sets not being de-duplicated
             77ab3e6 [write-fonts] Also match fonttools when sorting encodings
             7f1a198 [write-fonts] Match fonttools sorting in var store
             05f97e0 address a few review comments
             82b93a5 [{read,write}-fonts] Allow DeltaSetIndexMap repeated trailing entries to be omitted
             6cd8faf use more idiomatic match statement as per review
             4ba3bcd [write-fonts] implement FromIter for DeltaSetIndexMap
             acabc97 [write-fonts] implement From trait to convert VariationIndex => u32
             316fda8 [write-fonts] Tweak VariationStoreBuilder for HVAR case
             4f6c4db [iup] Fix mismatch in behaviour with fonttools
             9bc011b [write-fonts] Fix incorrect region indexes in ItemVarStore
             89d54e3 Add test for bug in VariationStoreBuilder VarData's region_indexes
             55b496d [rustdoc] Now with smarter link detection?
             282d90b [clippy] Push the rock back up the hill
             7633f09 [write-fonts] Split up the splitting module
```