### PR TITLE
[read-fonts] Add convenience methods to AnchorTable

### DIFF
--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -28,3 +28,41 @@ pub type PositionSequenceContext<'a> = super::layout::SequenceContext<'a>;
 
 /// A GPOS [ChainedSequenceContext](super::layout::ChainedSequenceContext)
 pub type PositionChainContext<'a> = super::layout::ChainedSequenceContext<'a>;
+
+impl<'a> AnchorTable<'a> {
+    /// Horizontal value, in design units
+    pub fn x_coordinate(&self) -> i16 {
+        match self {
+            AnchorTable::Format1(inner) => inner.x_coordinate(),
+            AnchorTable::Format2(inner) => inner.x_coordinate(),
+            AnchorTable::Format3(inner) => inner.x_coordinate(),
+        }
+    }
+
+    /// Vertical value, in design units
+    pub fn y_coordinate(&self) -> i16 {
+        match self {
+            AnchorTable::Format1(inner) => inner.y_coordinate(),
+            AnchorTable::Format2(inner) => inner.y_coordinate(),
+            AnchorTable::Format3(inner) => inner.y_coordinate(),
+        }
+    }
+
+    /// Attempt to resolve the `Device` or `VariationIndex` table for the
+    /// x_coordinate, if present
+    pub fn x_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        match self {
+            AnchorTable::Format3(inner) => inner.x_device(),
+            _ => None,
+        }
+    }
+
+    /// Attempt to resolve the `Device` or `VariationIndex` table for the
+    /// y_coordinate, if present
+    pub fn y_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        match self {
+            AnchorTable::Format3(inner) => inner.y_device(),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
This should save the client from needing to interact with the enum in the general case.


Way back when I was first doing codegen I thought it might be nice to autogenerate getters for shared fields, but I never got around to it. Maybe it's worth thinking about again?

This was motivated by https://github.com/googlefonts/fontc/pull/492, which was adding a helper method to do the same thing.