### PR TITLE
[skrifa] make cff emit an actual close command

### DIFF
--- a/skrifa/src/scale/cff/scaler.rs
+++ b/skrifa/src/scale/cff/scaler.rs
@@ -533,11 +533,7 @@ where
 
     fn close(&mut self) {
         if self.pending_move.is_none() {
-            if let Some((start_x, start_y)) = self.start {
-                if self.start != self.last {
-                    self.inner.line_to(start_x, start_y);
-                }
-            }
+            self.inner.close();
             self.start = None;
             self.last = None;
         }
@@ -655,10 +651,7 @@ mod tests {
         let font = FontRef::new(font_data).unwrap();
         let outlines = read_fonts::scaler_test::parse_glyph_outlines(expected_outlines);
         let scaler = super::Scaler::new(&font).unwrap();
-        let mut path = read_fonts::scaler_test::Path {
-            elements: vec![],
-            is_cff: true,
-        };
+        let mut path = read_fonts::scaler_test::Path::default();
         for expected_outline in &outlines {
             if expected_outline.size == 0.0 && !expected_outline.coords.is_empty() {
                 continue;

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -224,7 +224,6 @@ mod tests {
         compare_glyphs(
             font_test_data::VAZIRMATN_VAR,
             font_test_data::VAZIRMATN_VAR_GLYPHS,
-            false,
         );
     }
 
@@ -233,7 +232,6 @@ mod tests {
         compare_glyphs(
             font_test_data::CANTARELL_VF_TRIMMED,
             font_test_data::CANTARELL_VF_TRIMMED_GLYPHS,
-            true,
         );
     }
 
@@ -242,7 +240,6 @@ mod tests {
         compare_glyphs(
             font_test_data::NOTO_SERIF_DISPLAY_TRIMMED,
             font_test_data::NOTO_SERIF_DISPLAY_TRIMMED_GLYPHS,
-            true,
         );
     }
 
@@ -250,10 +247,7 @@ mod tests {
     fn overlap_flags() {
         let font = FontRef::new(font_test_data::VAZIRMATN_VAR).unwrap();
         let mut cx = Context::new();
-        let mut path = scaler_test::Path {
-            elements: vec![],
-            is_cff: false,
-        };
+        let mut path = scaler_test::Path::default();
         let mut scaler = cx.new_scaler().build(&font);
         let glyph_count = font.maxp().unwrap().num_glyphs();
         // GID 2 is a composite glyph with the overlap bit on a component
@@ -271,14 +265,11 @@ mod tests {
         );
     }
 
-    fn compare_glyphs(font_data: &[u8], expected_outlines: &str, is_cff: bool) {
+    fn compare_glyphs(font_data: &[u8], expected_outlines: &str) {
         let font = FontRef::new(font_data).unwrap();
         let outlines = scaler_test::parse_glyph_outlines(expected_outlines);
         let mut cx = Context::new();
-        let mut path = scaler_test::Path {
-            elements: vec![],
-            is_cff,
-        };
+        let mut path = scaler_test::Path::default();
         for expected_outline in &outlines {
             if expected_outline.size == 0.0 && !expected_outline.coords.is_empty() {
                 continue;


### PR DESCRIPTION
Our CFF scaler didn't match TrueType in that it was emitting a closing line instead of an actual close command. This makes them consistent and updates testing infra to accommodate the change.