### PR TITLE
[codegen] derive Clone for format tables

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -686,6 +686,7 @@ pub(crate) fn generate_format_group(item: &TableFormat) -> syn::Result<TokenStre
 
     Ok(quote! {
         #( #docs )*
+        #[derive(Clone)]
         pub enum #name<'a> {
             #( #variants ),*
         }

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -925,6 +925,7 @@ impl<'a> SomeRecord<'a> for FeatMinMaxRecord {
     }
 }
 
+#[derive(Clone)]
 pub enum BaseCoord<'a> {
     Format1(BaseCoordFormat1<'a>),
     Format2(BaseCoordFormat2<'a>),

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -842,6 +842,7 @@ impl<'a> std::fmt::Debug for IndexSubtableArray<'a> {
 }
 
 /// [IndexSubtables](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtables) format type.
+#[derive(Clone)]
 pub enum IndexSubtable<'a> {
     Format1(IndexSubtable1<'a>),
     Format2(IndexSubtable2<'a>),

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -218,6 +218,7 @@ impl<'a> From<PlatformId> for FieldType<'a> {
 }
 
 /// The different cmap subtable formats.
+#[derive(Clone)]
 pub enum CmapSubtable<'a> {
     Format0(Cmap0<'a>),
     Format2(Cmap2<'a>),

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -779,6 +779,7 @@ impl<'a> SomeRecord<'a> for Clip {
 }
 
 /// [ClipBox](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
+#[derive(Clone)]
 pub enum ClipBox<'a> {
     Format1(ClipBoxFormat1<'a>),
     Format2(ClipBoxFormat2<'a>),
@@ -1488,6 +1489,7 @@ impl<'a> From<Extend> for FieldType<'a> {
 }
 
 /// [Paint](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#paint-tables) tables
+#[derive(Clone)]
 pub enum Paint<'a> {
     ColrLayers(PaintColrLayers<'a>),
     Solid(PaintSolid<'a>),

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -646,6 +646,7 @@ impl<'a> std::fmt::Debug for LigGlyph<'a> {
 }
 
 /// [Caret Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#caret-value-tables)
+#[derive(Clone)]
 pub enum CaretValue<'a> {
     Format1(CaretValueFormat1<'a>),
     Format2(CaretValueFormat2<'a>),

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -1104,6 +1104,7 @@ impl<'a> From<CompositeGlyphFlags> for FieldType<'a> {
 }
 
 /// Simple or composite glyph.
+#[derive(Clone)]
 pub enum Glyph<'a> {
     Simple(SimpleGlyph<'a>),
     Composite(CompositeGlyph<'a>),

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -569,6 +569,7 @@ impl<'a> From<ValueFormat> for FieldType<'a> {
 
 /// [Anchor Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-tables)
 /// position one glyph with respect to another.
+#[derive(Clone)]
 pub enum AnchorTable<'a> {
     Format1(AnchorFormat1<'a>),
     Format2(AnchorFormat2<'a>),
@@ -1047,6 +1048,7 @@ impl<'a> SomeRecord<'a> for MarkRecord {
 }
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
+#[derive(Clone)]
 pub enum SinglePos<'a> {
     Format1(SinglePosFormat1<'a>),
     Format2(SinglePosFormat2<'a>),
@@ -1330,6 +1332,7 @@ impl<'a> std::fmt::Debug for SinglePosFormat2<'a> {
 }
 
 /// [Lookup Type 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-1-single-adjustment-positioning-subtable): Single Adjustment Positioning Subtable
+#[derive(Clone)]
 pub enum PairPos<'a> {
     Format1(PairPosFormat1<'a>),
     Format2(PairPosFormat2<'a>),

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -223,6 +223,7 @@ impl<'a> std::fmt::Debug for SubstitutionLookup<'a> {
 }
 
 /// LookupType 1: [Single Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-1-single-substitution-subtable) Subtable
+#[derive(Clone)]
 pub enum SingleSubst<'a> {
     Format1(SingleSubstFormat1<'a>),
     Format2(SingleSubstFormat2<'a>),

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1149,6 +1149,7 @@ impl<'a> SomeRecord<'a> for RangeRecord {
 }
 
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
+#[derive(Clone)]
 pub enum CoverageTable<'a> {
     Format1(CoverageFormat1<'a>),
     Format2(CoverageFormat2<'a>),
@@ -1438,6 +1439,7 @@ impl<'a> SomeRecord<'a> for ClassRangeRecord {
 }
 
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
+#[derive(Clone)]
 pub enum ClassDef<'a> {
     Format1(ClassDefFormat1<'a>),
     Format2(ClassDefFormat2<'a>),
@@ -2343,6 +2345,7 @@ impl<'a> std::fmt::Debug for SequenceContextFormat3<'a> {
     }
 }
 
+#[derive(Clone)]
 pub enum SequenceContext<'a> {
     Format1(SequenceContextFormat1<'a>),
     Format2(SequenceContextFormat2<'a>),
@@ -3485,6 +3488,7 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat3<'a> {
     }
 }
 
+#[derive(Clone)]
 pub enum ChainedSequenceContext<'a> {
     Format1(ChainedSequenceContextFormat1<'a>),
     Format2(ChainedSequenceContextFormat2<'a>),
@@ -3760,6 +3764,7 @@ impl<'a> std::fmt::Debug for VariationIndex<'a> {
 }
 
 /// Either a [Device] table (in a non-variable font) or a [VariationIndex] table (in a variable font)
+#[derive(Clone)]
 pub enum DeviceOrVariationIndex<'a> {
     Device(Device<'a>),
     VariationIndex(VariationIndex<'a>),

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -198,6 +198,7 @@ impl<'a> std::fmt::Debug for Index2<'a> {
 }
 
 /// Associates a glyph identifier with a Font DICT.
+#[derive(Clone)]
 pub enum FdSelect<'a> {
     Format0(FdSelectFormat0<'a>),
     Format3(FdSelectFormat3<'a>),

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -344,6 +344,7 @@ impl<'a> std::fmt::Debug for AxisValueArray<'a> {
 }
 
 /// [Axis Value Tables](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables)
+#[derive(Clone)]
 pub enum AxisValue<'a> {
     Format1(AxisValueFormat1<'a>),
     Format2(AxisValueFormat2<'a>),

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -219,6 +219,7 @@ impl<'a> std::fmt::Debug for Table3<'a> {
     }
 }
 
+#[derive(Clone)]
 pub enum MyTable<'a> {
     Format1(Table1<'a>),
     MyFormat22(Table2<'a>),

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -379,6 +379,7 @@ impl<'a> std::fmt::Debug for DeltaSetIndexMapFormat1<'a> {
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table
+#[derive(Clone)]
 pub enum DeltaSetIndexMap<'a> {
     Format0(DeltaSetIndexMapFormat0<'a>),
     Format1(DeltaSetIndexMapFormat1<'a>),


### PR DESCRIPTION
This derives `Clone` for format switching tables matching what we do for other records and tables.

Been meaning to fix this for a while and I've been coding around it, but I now foresee a future issue with variable color stops where this will be a real pain.

If it looks good, JMM.