### PR TITLE
[skrifa] public color API

### DIFF
--- a/skrifa/src/color/instance.rs
+++ b/skrifa/src/color/instance.rs
@@ -18,6 +18,7 @@ pub type PaintId = usize;
 /// resolving paints.
 ///
 /// See [`resolve_paint`], [`ColorStops::resolve`] and [`resolve_clip_box`].
+#[derive(Clone)]
 pub struct ColrInstance<'a> {
     colr: Colr<'a>,
     index_map: Option<DeltaSetIndexMap<'a>>,

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -144,3 +144,25 @@ impl<'a> ColorOutlineCollection<'a> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::MetadataProvider;
+    use read_fonts::{types::GlyphId, FontRef};
+
+    #[test]
+    fn colr_outline_iter_and_version() {
+        let font = FontRef::new(font_test_data::COLRV0V1_VARIABLE).unwrap();
+        let outlines = font.color_outlines();
+        // This font contains one COLRv0 glyph:
+        // <GlyphID id="166" name="colored_circles_v0"/>
+        let colrv0_outlines = [GlyphId::new(166)];
+        for (gid, outline) in outlines.iter() {
+            let expected_version = if colrv0_outlines.contains(&gid) { 0 } else { 1 };
+            assert_eq!(outline.version(), expected_version);
+        }
+        // <!-- BaseGlyphRecordCount=1 -->
+        // <!-- BaseGlyphCount=157 -->
+        assert_eq!(outlines.iter().count(), 158);
+    }
+}

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -1,0 +1,127 @@
+//! Color outline support.
+
+// Remove me when code is filled in
+#![allow(unused_variables, dead_code)]
+
+mod instance;
+
+use core::ops::Range;
+
+use crate::{instance::LocationRef, metrics::BoundingBox};
+use read_fonts::{tables::colr, types::GlyphId, ReadError, TableProvider};
+
+use instance::{resolve_paint, PaintId};
+
+/// Interface for receiving a sequence of commands that represent a flattened
+/// paint graph in a color outline.
+// Placeholder
+pub trait ColorPainter {}
+
+/// Affine transformation matrix.
+#[derive(Copy, Clone, Debug)]
+pub struct Transform {
+    xx: f32,
+    yx: f32,
+    xy: f32,
+    yy: f32,
+    dx: f32,
+    dy: f32,
+}
+
+/// Reference to a paint graph that represents a color glyph outline.
+#[derive(Clone)]
+pub struct ColorOutline<'a> {
+    colr: colr::Colr<'a>,
+    glyph_id: GlyphId,
+    kind: ColorOutlineKind<'a>,
+}
+
+impl<'a> ColorOutline<'a> {
+    /// Returns the glyph identifier that was used to retrieve this outline.
+    pub fn glyph_id(&self) -> GlyphId {
+        self.glyph_id
+    }
+
+    /// Evaluates the paint graph at the specified location in variation space
+    /// and returns the bounding box for the full scene.
+    ///
+    /// The `glyph_bounds` closure will be invoked for each clip node in the
+    /// graph and should return the bounding box for the given glyph, location
+    /// and transform.
+    pub fn bounding_box(
+        &self,
+        location: impl Into<LocationRef<'a>>,
+        glyph_bounds: impl FnMut(GlyphId, &LocationRef, Transform) -> Option<BoundingBox>,
+    ) -> Option<BoundingBox> {
+        None
+    }
+
+    /// Evaluates the paint graph at the specified location in variation space
+    /// and emits the results to the given painter.
+    pub fn paint(
+        &self,
+        location: impl Into<LocationRef<'a>>,
+        painter: &mut impl ColorPainter,
+    ) -> Result<(), ReadError> {
+        let instance = instance::ColrInstance::new(self.colr.clone(), location.into().coords());
+        match &self.kind {
+            ColorOutlineKind::V0(layer_range) => {
+                for layer_ix in layer_range.clone() {
+                    let (glyph_id, palette_ix) = instance.v0_layer(layer_ix)?;
+                }
+            }
+            ColorOutlineKind::V1(paint, paint_id) => {
+                let paint = resolve_paint(&instance, paint)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+enum ColorOutlineKind<'a> {
+    V0(Range<usize>),
+    V1(colr::Paint<'a>, PaintId),
+}
+
+/// Collection of color outlines.
+#[derive(Clone)]
+pub struct ColorOutlineCollection<'a> {
+    glyph_count: u16,
+    colr: Option<colr::Colr<'a>>,
+}
+
+impl<'a> ColorOutlineCollection<'a> {
+    /// Creates a new color outline collection for the given font.
+    pub fn new(font: &impl TableProvider<'a>) -> Self {
+        let glyph_count = font
+            .maxp()
+            .map(|maxp| maxp.num_glyphs())
+            .unwrap_or_default();
+        let colr = font.colr().ok();
+        Self { glyph_count, colr }
+    }
+
+    /// Returns the color outline for the given glyph identifier.
+    pub fn get(&self, glyph_id: GlyphId) -> Option<ColorOutline<'a>> {
+        let colr = self.colr.clone()?;
+        let kind = if let Ok(Some((paint, paint_id))) = colr.v1_base_glyph(glyph_id) {
+            ColorOutlineKind::V1(paint, paint_id)
+        } else {
+            let layer_range = colr.v0_base_glyph(glyph_id).ok()??;
+            ColorOutlineKind::V0(layer_range)
+        };
+        Some(ColorOutline {
+            colr,
+            glyph_id,
+            kind,
+        })
+    }
+
+    /// Returns an iterator over all of the color outlines in the
+    /// collection.
+    pub fn iter(&self) -> impl Iterator<Item = ColorOutline<'a>> + 'a + Clone {
+        let copy = self.clone();
+        (0..self.glyph_count).filter_map(move |gid| copy.get(GlyphId::new(gid)))
+    }
+}

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -24,10 +24,12 @@ pub mod scale;
 pub mod setting;
 pub mod string;
 
+mod color;
 mod provider;
 mod small_array;
 mod variation;
 
+pub use color::{ColorOutline, ColorOutlineCollection, ColorPainter, Transform};
 pub use variation::{Axis, AxisCollection, NamedInstance, NamedInstanceCollection};
 
 /// Useful collection of common types suitable for glob importing.

--- a/skrifa/src/provider.rs
+++ b/skrifa/src/provider.rs
@@ -1,6 +1,7 @@
 use super::{
     attribute::Attributes,
     charmap::Charmap,
+    color::ColorOutlineCollection,
     instance::{LocationRef, Size},
     metrics::{GlyphMetrics, Metrics},
     string::{LocalizedStrings, StringId},
@@ -46,6 +47,11 @@ pub trait MetadataProvider<'a>: raw::TableProvider<'a> + Sized {
     /// Returns the character to nominal glyph identifier mapping.
     fn charmap(&self) -> Charmap<'a> {
         Charmap::new(self)
+    }
+
+    /// Returns the collection of color outlines.
+    fn color_outlines(&self) -> ColorOutlineCollection<'a> {
+        ColorOutlineCollection::new(self)
     }
 }
 

--- a/skrifa/src/scale/colr/mod.rs
+++ b/skrifa/src/scale/colr/mod.rs
@@ -1,6 +1,0 @@
-mod instance;
-
-pub use instance::{
-    resolve_clip_box, resolve_paint, ColorStops, ColrInstance, PaintId, ResolvedColorStop,
-    ResolvedPaint,
-};

--- a/skrifa/src/scale/mod.rs
+++ b/skrifa/src/scale/mod.rs
@@ -148,7 +148,6 @@
 #![allow(dead_code)]
 
 mod cff;
-mod colr;
 mod error;
 mod glyf;
 mod scaler;


### PR DESCRIPTION
https://github.com/googlefonts/fontations/pull/697#discussion_r1394224889 requests moving the color instance code from the scale module to the top level "metadata section" of the crate. This PR contains a proposal for such an API that meshes well with the current design of `MetadataProvider`.

This depends on #697 but is pulled out here for separate discussion.

One key point is the method for bounding box computation. It'd be nice to avoid a hard dependency on anything in the `scale` module so the function here takes a closure for that purpose.

@drott thoughts? There's some overlap with your `ColorPainter` work but I think this provides a nice entry point for that.
