### PR TITLE
[skrifa] changes in support of TT hinting

### DIFF
--- a/skrifa/src/scale/glyf/glyph.rs
+++ b/skrifa/src/scale/glyf/glyph.rs
@@ -48,13 +48,13 @@ pub struct ScalerGlyph<'a> {
 impl<'a> ScalerGlyph<'a> {
     /// Returns the minimum size in bytes required to scale an outline based
     /// on the computed sizes.
-    pub fn required_buffer_size(&self) -> usize {
+    pub fn required_buffer_size(&self, with_hinting: bool) -> usize {
         let mut size = 0;
+        let hinting = with_hinting && self.has_hinting;
         // Scaled, unscaled and (for hinting) original scaled points
         size += self.points * size_of::<Point<F26Dot6>>();
         // Unscaled and (if hinted) original scaled points
-        size +=
-            self.max_other_points * size_of::<Point<i32>>() * if self.has_hinting { 2 } else { 1 };
+        size += self.max_other_points * size_of::<Point<i32>>() * if hinting { 2 } else { 1 };
         // Contour end points
         size += self.contours * size_of::<u16>();
         // Point flags
@@ -79,8 +79,12 @@ impl<'a> ScalerGlyph<'a> {
     ///
     /// The size of the buffer must be at least as large as the size returned
     /// by [`Self::required_buffer_size`].
-    pub fn memory_from_buffer(&self, buf: &'a mut [u8]) -> Option<ScalerMemory<'a>> {
-        ScalerMemory::new(self, buf)
+    pub fn memory_from_buffer(
+        &self,
+        buf: &'a mut [u8],
+        with_hinting: bool,
+    ) -> Option<ScalerMemory<'a>> {
+        ScalerMemory::new(self, buf, with_hinting)
     }
 }
 

--- a/skrifa/src/scale/glyf/mem.rs
+++ b/skrifa/src/scale/glyf/mem.rs
@@ -22,11 +22,11 @@ pub struct ScalerMemory<'a> {
 }
 
 impl<'a> ScalerMemory<'a> {
-    pub(super) fn new(glyph: &ScalerGlyph, buf: &'a mut [u8]) -> Option<Self> {
+    pub(super) fn new(glyph: &ScalerGlyph, buf: &'a mut [u8], with_hinting: bool) -> Option<Self> {
         let (scaled, buf) = alloc_slice(buf, glyph.points)?;
         let (unscaled, buf) = alloc_slice(buf, glyph.max_other_points)?;
         // We only need original scaled points when hinting
-        let (original_scaled, buf) = if glyph.has_hinting {
+        let (original_scaled, buf) = if glyph.has_hinting && with_hinting {
             alloc_slice(buf, glyph.max_other_points)?
         } else {
             (Default::default(), buf)
@@ -157,9 +157,9 @@ mod tests {
             has_variations: true,
             has_overlaps: false,
         };
-        let required_size = outline_info.required_buffer_size();
+        let required_size = outline_info.required_buffer_size(false);
         let mut buf = vec![0u8; required_size];
-        let memory = ScalerMemory::new(&outline_info, &mut buf).unwrap();
+        let memory = ScalerMemory::new(&outline_info, &mut buf, false).unwrap();
         assert_eq!(memory.scaled.len(), outline_info.points);
         assert_eq!(memory.unscaled.len(), outline_info.max_other_points);
         // We don't allocate this buffer when hinting is disabled
@@ -190,8 +190,8 @@ mod tests {
         };
         // Required size adds 4 bytes slop to account for internal alignment
         // requirements. So subtract 5 to force a failure.
-        let not_enough = outline_info.required_buffer_size() - 5;
+        let not_enough = outline_info.required_buffer_size(false) - 5;
         let mut buf = vec![0u8; not_enough];
-        assert!(ScalerMemory::new(&outline_info, &mut buf).is_none());
+        assert!(ScalerMemory::new(&outline_info, &mut buf, false).is_none());
     }
 }

--- a/skrifa/src/scale/scaler.rs
+++ b/skrifa/src/scale/scaler.rs
@@ -259,13 +259,13 @@ impl<'a> Outlines<'a> {
     ) -> Result<ScalerMetrics> {
         match self {
             Self::TrueType(scaler, buf) => {
-                let glyph = scaler.glyph(glyph_id, false)?;
-                let buf_size = glyph.required_buffer_size();
+                let glyph = scaler.glyph(glyph_id)?;
+                let buf_size = glyph.required_buffer_size(false);
                 if buf.len() < buf_size {
                     buf.resize(buf_size, 0);
                 }
                 let memory = glyph
-                    .memory_from_buffer(&mut buf[..])
+                    .memory_from_buffer(&mut buf[..], false)
                     .ok_or(Error::InsufficientMemory)?;
                 let outline = scaler.outline(memory, &glyph, size, coords)?;
                 outline.to_path(pen)?;


### PR DESCRIPTION
1. Capture required hinting tables (fpgm, prep, cvt)
2. Make hinting specific memory calculations dependent on a parameter at memory request time rather than at _outline request time_