### PR TITLE
[chore] Symlink license files to crate roots

### DIFF
--- a/font-types/LICENSE-APACHE
+++ b/font-types/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/font-types/LICENSE-MIT
+++ b/font-types/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/read-fonts/LICENSE-APACHE
+++ b/read-fonts/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/read-fonts/LICENSE-MIT
+++ b/read-fonts/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/skrifa/LICENSE-APACHE
+++ b/skrifa/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/skrifa/LICENSE-MIT
+++ b/skrifa/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/write-fonts/LICENSE-APACHE
+++ b/write-fonts/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/write-fonts/LICENSE-MIT
+++ b/write-fonts/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This will ensure that license files are packaged with the crate when it is published, which is required by a downstream user.

- ~didn't bother doing this for `write-fonts`, since I do not anticipate that being used by chrome in the near future.~
- ~QQ: should/can these just be symlinks? I'm not sure how that works with git and searching was inconclusive.~
- fixes #711 


So my first version of this was just copying files, and this version is symlinking. @anthrotype points out that symlinks may [cause some issues on windows](https://www.scivision.dev/git-windows-symlink/)? I'm not sure how much windows use we expect, and there is an obvious fix available, so my instinct is to just go with this.
