### PR TITLE
[read/write-fonts] make STAT offset_to_axis_values nullable

### DIFF
--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -121,13 +121,13 @@ impl<'a> Stat<'a> {
     /// start of the design axes value offsets array. If axisValueCount
     /// is zero, set to zero; if axisValueCount is greater than zero,
     /// must be greater than zero.
-    pub fn offset_to_axis_value_offsets(&self) -> Offset32 {
+    pub fn offset_to_axis_value_offsets(&self) -> Nullable<Offset32> {
         let range = self.shape.offset_to_axis_value_offsets_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`offset_to_axis_value_offsets`][Self::offset_to_axis_value_offsets].
-    pub fn offset_to_axis_values(&self) -> Result<AxisValueArray<'a>, ReadError> {
+    pub fn offset_to_axis_values(&self) -> Option<Result<AxisValueArray<'a>, ReadError>> {
         let data = self.data;
         let args = self.axis_value_count();
         self.offset_to_axis_value_offsets()

--- a/read-fonts/src/tables/stat.rs
+++ b/read-fonts/src/tables/stat.rs
@@ -19,7 +19,7 @@ mod tests {
         assert_eq!(axis_record.axis_tag(), Tag::new(b"wght"));
         assert_eq!(axis_record.axis_name_id(), NameId::new(257));
         assert_eq!(axis_record.axis_ordering(), 0);
-        let axis_values = table.offset_to_axis_values().unwrap();
+        let axis_values = table.offset_to_axis_values().unwrap().unwrap();
         let axis_values = axis_values
             .axis_values()
             .iter()

--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -30,8 +30,9 @@ table Stat {
     /// start of the design axes value offsets array. If axisValueCount
     /// is zero, set to zero; if axisValueCount is greater than zero,
     /// must be greater than zero.
+    #[nullable]
     #[read_offset_with($axis_value_count)]
-    #[compile_type(OffsetMarker<Vec<OffsetMarker<AxisValue>>, WIDTH_32>)]
+    #[compile_type(NullableOffsetMarker<Vec<OffsetMarker<AxisValue>>, WIDTH_32>)]
     #[to_owned(convert_axis_value_offsets(obj.offset_to_axis_values()))]
     offset_to_axis_value_offsets: Offset32<AxisValueArray>,
     /// Name ID used as fallback when projection of names into a

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -20,7 +20,7 @@ pub struct Stat {
     /// start of the design axes value offsets array. If axisValueCount
     /// is zero, set to zero; if axisValueCount is greater than zero,
     /// must be greater than zero.
-    pub offset_to_axis_values: OffsetMarker<Vec<OffsetMarker<AxisValue>>, WIDTH_32>,
+    pub offset_to_axis_values: NullableOffsetMarker<Vec<OffsetMarker<AxisValue>>, WIDTH_32>,
     /// Name ID used as fallback when projection of names into a
     /// particular font model produces a subfamily name containing only
     /// elidable elements.


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontc/issues/582

OTS gives a warning that our offset_to_axis_values is != 0 even though the count of axis_values == 0. This fixes it.

NOTE: this is a breaking change in that read-fonts offset_to_axis_values now returns an `Option<Result<...>>` instead of just a Result.