### PR TITLE
bump minor version for read-fonts and write-fonts

### DIFF
--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-skrifa = { version = "0.13.0", path = "../skrifa" }
+skrifa = { version = "0.14.0", path = "../skrifa" }
 freetype-rs = "0.32.0"
 memmap2 = "0.5.10"
 rayon = "1.8.0"

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 xflags = "0.3.0"
-read-fonts = { path = "../read-fonts",version = "0.13.2" }
+read-fonts = { path = "../read-fonts",version = "0.14.0" }
 font-types = { path = "../font-types",version = "0.4.1" }
 ansi_term = "0.12.1"
 atty = "0.2"

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
-read-fonts = { version = "0.13.2", path = "../read-fonts" }
+read-fonts = { version = "0.14.0", path = "../read-fonts" }
 
 [dev-dependencies]
 font-test-data= { path = "../font-test-data" }
-read-fonts = { version = "0.13.2", path = "../read-fonts", features = ["scaler_test"] }
+read-fonts = { version = "0.14.0", path = "../read-fonts", features = ["scaler_test"] }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -15,7 +15,7 @@ serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
 font-types = { version = "0.4.1", path = "../font-types" }
-read-fonts = { version = "0.13.2", path = "../read-fonts" }
+read-fonts = { version = "0.14.0", path = "../read-fonts" }
 log = "0.4"
 kurbo = "0.10.2"
 dot2 = { version = "1.0", optional = true }
@@ -26,7 +26,7 @@ indexmap = "2.0"
 diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.13.2", path = "../read-fonts", features = [ "codegen_test"] }
+read-fonts = { version = "0.14.0", path = "../read-fonts", features = [ "codegen_test"] }
 env_logger = "0.10.0"
 rstest = "0.18.0"
 pretty_assertions.workspace = true


### PR DESCRIPTION
bumping minor because STAT.offset_to_axis_values is now nullable after https://github.com/googlefonts/fontations/pull/716

     Changes for read-fonts from read-fonts-v0.13.2 to 0.14.0
             f99b59d [read|write-fonts] make offset_to_axis_values nullable
     Changes for write-fonts from write-fonts-v0.18.0 to 0.19.0
             f99b59d [read|write-fonts] make offset_to_axis_values nullable
             dec4e1b [graph] Move assert to after space check
             e1b9cea [splitting] More careful in handling TableType
             48670bb [write-fonts] add SegmentMaps::is_identity method (#715)
             08d6264 [chore] Bump patch version on read-fonts & font-types
             c745d86 [chore] symlink license files to crate roots
             16daacf Bump read-fonts to 0.13.1
             d04b9bb Enable old gpos spec tests
             0a66324 [write-fonts] Full pack/split test for MarkBase
             edf8bdd [write-fonts] More & better testing of MarkBase splitting
             74bb1b0 [write-fonts] Test for splitting of mark & base arrays
             e4e1c68 [write-fonts] Preliminary impl of MarkBase splitting