### PR TITLE
Add trait for remapping temporary delta set index ids to their final values

### DIFF
--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -42,6 +42,20 @@ pub struct VariationIndexRemapping {
     map: HashMap<TemporaryDeltaSetId, VariationIndex>,
 }
 
+/// Remapping temporary delta set identifiers to the final values.
+///
+/// This is called after the [`ItemVariationStore`] has been built, at which
+/// point any table containing a delta set index needs to be updated to point
+/// to the final value.
+///
+/// This trait should be implemented by any table that contains delta set indices,
+/// as well as for any of table containing such a table, which should recursively
+/// call it on the relevant subtables.
+pub trait RemapVariationIndices {
+    /// Remap any `TemporaryDeltaSetId`s to their final `VariationIndex` values
+    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping);
+}
+
 /// Always sorted, so we can ensure equality
 ///
 /// Each tuple is (region index, delta value)

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -74,6 +74,14 @@ impl VariationStoreBuilder {
         Default::default()
     }
 
+    /// Returns `true` if no deltas have been added to this builder
+    pub fn is_empty(&self) -> bool {
+        match &self.delta_sets {
+            DeltaSetStorage::Direct(val) => val.is_empty(),
+            DeltaSetStorage::Deduplicated(val) => val.is_empty(),
+        }
+    }
+
     /// Create a builder that does not share deltas between entries.
     ///
     /// This is used in HVAR, where it is possible to use glyph ids as the


### PR DESCRIPTION
I'm currently reworking the fea-rs API so that it has native types for variable `ValueRecord`s and `AnchorTable`s, which will let actually create the various lookup builders for marks & kerning before feature generation.

Previously fea-rs used the native write-fonts types for value records, and it was responsible for remapping the temporary indices before generating the final lookups. Now it converts to the native types later in the process, and it makes sense to just have a mechanism for walking all the lookups and remapping everything there.