### PR TITLE
Scale Bounding boxes

### DIFF
--- a/font-types/src/bbox.rs
+++ b/font-types/src/bbox.rs
@@ -1,4 +1,4 @@
-use core::ops::{Mul, MulAssign};
+use core::ops::Mul;
 
 /// Minimum and maximum extents of a rectangular region.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
@@ -17,11 +17,17 @@ pub struct BoundingBox<T> {
     pub y_max: T,
 }
 
-impl<T> BoundingBox<T> where T: MulAssign + Mul + Copy {
-    pub fn scale(&mut self, factor : T)  {
-        self.x_min *= factor;
-        self.y_min *= factor;
-        self.x_max *= factor;
-        self.y_max *= factor;
+/// Return a BoundingBox scaled by a scale factor of the same type as the stored bounds.
+impl<T> BoundingBox<T>
+where
+    T: Mul<Output = T> + Copy,
+{
+    pub fn scale(&self, factor: T) -> Self {
+        Self {
+            x_min: self.x_min * factor,
+            y_min: self.y_min * factor,
+            x_max: self.x_max * factor,
+            y_max: self.y_max * factor,
+        }
     }
 }

--- a/font-types/src/bbox.rs
+++ b/font-types/src/bbox.rs
@@ -1,3 +1,5 @@
+use core::ops::{Mul, MulAssign};
+
 /// Minimum and maximum extents of a rectangular region.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -13,4 +15,13 @@ pub struct BoundingBox<T> {
     /// which is used by fonts, this represents the top of the
     /// region.
     pub y_max: T,
+}
+
+impl<T> BoundingBox<T> where T: MulAssign + Mul + Copy {
+    pub fn scale(&mut self, factor : T)  {
+        self.x_min *= factor;
+        self.y_min *= factor;
+        self.x_max *= factor;
+        self.y_max *= factor;
+    }
 }

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -282,12 +282,7 @@ impl<'a> ColorGlyph<'a> {
                 let resolved_bounding_box = get_clipbox_font_units(&instance, *glyph_id).ok()?;
                 resolved_bounding_box.map(|bounding_box| {
                     let scale_factor = size.linear_scale((*upem).clone().unwrap_or(0));
-                    BoundingBox {
-                        x_min: bounding_box.x_min * scale_factor,
-                        y_min: bounding_box.y_min * scale_factor,
-                        x_max: bounding_box.x_max * scale_factor,
-                        y_max: bounding_box.y_max * scale_factor,
-                    }
+                    bounding_box.scale(scale_factor)
                 })
             }
             _ => todo!(),


### PR DESCRIPTION
Allowing scaling of bounding boxes, this comes in handily
for example when dealing with clip boxes and scaling them to font size.