### PR TITLE
[write-fonts] Do not autocompute VariationRegion::axis_count

### DIFF
--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -94,7 +94,6 @@ flags u8 EntryFormat {
 table VariationRegionList {
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
-    #[compile(self.compute_axis_count())]
     axis_count: u16,
     /// The number of variation region tables in the variation region
     /// list. Must be less than 32,768.

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -359,21 +359,27 @@ impl FontWrite for EntryFormat {
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VariationRegionList {
+    /// The number of variation axes for this font. This must be the
+    /// same number as axisCount in the 'fvar' table.
+    pub axis_count: u16,
     /// Array of variation regions.
     pub variation_regions: Vec<VariationRegion>,
 }
 
 impl VariationRegionList {
     /// Construct a new `VariationRegionList`
-    pub fn new(variation_regions: Vec<VariationRegion>) -> Self {
-        Self { variation_regions }
+    pub fn new(axis_count: u16, variation_regions: Vec<VariationRegion>) -> Self {
+        Self {
+            axis_count,
+            variation_regions,
+        }
     }
 }
 
 impl FontWrite for VariationRegionList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (self.compute_axis_count() as u16).write_into(writer);
+        self.axis_count.write_into(writer);
         (array_len(&self.variation_regions).unwrap() as u16).write_into(writer);
         self.variation_regions.write_into(writer);
     }
@@ -404,6 +410,7 @@ impl<'a> FromObjRef<read_fonts::tables::variations::VariationRegionList<'a>>
     ) -> Self {
         let offset_data = obj.offset_data();
         VariationRegionList {
+            axis_count: obj.axis_count(),
             variation_regions: obj
                 .variation_regions()
                 .iter()

--- a/write-fonts/src/tables/mvar.rs
+++ b/write-fonts/src/tables/mvar.rs
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn simple_smoke_test() {
         let [r1, r2, r3] = test_regions();
-        let mut builder = VariationStoreBuilder::new();
+        let mut builder = VariationStoreBuilder::new(1);
         let delta_ids = vec![
             // deltas for horizontal ascender 'hasc' only defined for 1 region
             builder.add_deltas(vec![(r1, 10)]),

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -51,23 +51,6 @@ impl TupleVariationHeader {
     }
 }
 
-impl VariationRegionList {
-    fn compute_axis_count(&self) -> usize {
-        let count = self
-            .variation_regions
-            .first()
-            .map(|reg| reg.region_axes.len())
-            .unwrap_or(0);
-        //TODO: check this at validation time
-        debug_assert!(self
-            .variation_regions
-            .iter()
-            .map(|reg| reg.region_axes.len())
-            .all(|n| n == count));
-        count
-    }
-}
-
 /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#packed-point-numbers>
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
This can not be correctly computed in the case where we have pruned all regions, so we should require it to be set explicitly and then do that in the builder.

Note: this is *a* fix, but may not be the best one. In particular we will still not know the correct axis count in the case where an `ItemVariationStore` is built without having any deltas added to it. I believe this would still cause a miscompilation. If this is a case that we want to allow (instead of just erroring at compile time, which we could consider?) then we will need to change this API to require the user to pass in an explicit `axis_count` when constructing the builder. I'm not sure how much of a hassle that would be in practice.

So basically: I need a second opinion on this. I'm now leaning towards requiring an explicit axis_count, but the deciding factor will be whether or not 'var store with no deltas in it' is a thing we want to allow.

- fixes #741 