### PR TITLE
[write-fonts] Make gpos/gsub lookuplist types public

### DIFF
--- a/write-fonts/src/tables/gpos.rs
+++ b/write-fonts/src/tables/gpos.rs
@@ -25,7 +25,7 @@ mod value_record;
 pub use value_record::ValueRecord;
 
 /// A GPOS lookup list table.
-type PositionLookupList = LookupList<PositionLookup>;
+pub type PositionLookupList = LookupList<PositionLookup>;
 
 super::layout::table_newtype!(
     PositionSequenceContext,

--- a/write-fonts/src/tables/gsub.rs
+++ b/write-fonts/src/tables/gsub.rs
@@ -14,7 +14,7 @@ use super::layout::{
 mod tests;
 
 /// A GSUB lookup list table.
-type SubstitutionLookupList = LookupList<SubstitutionLookup>;
+pub type SubstitutionLookupList = LookupList<SubstitutionLookup>;
 
 super::layout::table_newtype!(
     SubstitutionSequenceContext,


### PR DESCRIPTION
The equivalent types in read-fonts are public already.

JMM