### PR TITLE
[write-fonts] reproduce and fix non deterministic gvar serialization

### DIFF
--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -273,7 +273,6 @@ impl GlyphVariations {
         // so that we match the behavior of fonttools
         let (pts, _) = max_by_first_key(
             point_number_counts
-                .clone()
                 .into_iter()
                 // no use sharing points if they only occur once
                 .filter(|(_, (_, count))| *count > 1),

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -970,6 +970,143 @@ mod tests {
         );
     }
 
+    #[test]
+    fn compute_shared_points_is_deterministic() {
+        // The deltas for glyph "etatonos.sc.ss06" in GoogleSans-VF are such that the
+        // TupleVariationStore's shared set of point numbers could potentionally be
+        // computed as either PackedPointNumbers::All or PackedPointNumbers::Some([1, 3])
+        // without affecting the size (or correctness) of the serialized data.
+        // However we want to ensure that the result is deterministic, and doesn't
+        // depend on e.g. HashMap random iteration order.
+        // https://github.com/googlefonts/fontc/issues/647
+        let _ = env_logger::builder().is_test(true).try_init();
+        let variations = GlyphVariations::new(
+            GlyphId::NOTDEF,
+            vec![
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(-1.0),
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(0.0),
+                    ]),
+                    vec![
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::required(-17, -4),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::required(-28, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(1.0),
+                        F2Dot14::from_f32(0.0),
+                    ]),
+                    vec![
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::required(0, -10),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::required(34, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(-1.0),
+                    ]),
+                    vec![
+                        GlyphDelta::required(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(1.0),
+                    ]),
+                    vec![
+                        GlyphDelta::required(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(-1.0),
+                        F2Dot14::from_f32(1.0),
+                        F2Dot14::from_f32(0.0),
+                    ]),
+                    vec![
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::required(-1, 10),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::required(-9, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(-1.0),
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(-1.0),
+                    ]),
+                    vec![
+                        GlyphDelta::required(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+                GlyphDeltas::new(
+                    Tuple::new(vec![
+                        F2Dot14::from_f32(-1.0),
+                        F2Dot14::from_f32(0.0),
+                        F2Dot14::from_f32(1.0),
+                    ]),
+                    vec![
+                        GlyphDelta::required(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                        GlyphDelta::optional(0, 0),
+                    ],
+                    None,
+                ),
+            ],
+        );
+
+        assert_eq!(
+            variations.compute_shared_points(),
+            // Also PackedPointNumbers::All would work, but Some([1, 3]) happens
+            // to be the first one that fits the bill when iterating over the
+            // tuple variations in the order they are listed for this glyph.
+            Some(PackedPointNumbers::Some(vec![1, 3]))
+        );
+    }
+
     // when using short offsets we store (real offset / 2), so all offsets must
     // be even, which means when we have an odd number of bytes we have to pad.
     fn make_31_bytes_of_variation_data() -> Vec<GlyphDeltas> {

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -4,6 +4,8 @@ include!("../../generated/generated_gvar.rs");
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
+
 use crate::{collections::HasLen, OffsetMarker};
 
 use super::variations::{
@@ -230,7 +232,7 @@ impl GlyphVariations {
     ///
     /// (issue <https://github.com/googlefonts/fontations/issues/634>)
     fn compute_shared_points(&self) -> Option<PackedPointNumbers> {
-        let mut point_number_counts = HashMap::new();
+        let mut point_number_counts = IndexMap::new();
         // count how often each set of numbers occurs
         for deltas in &self.variations {
             // for each set points, get compiled size + number of occurances


### PR DESCRIPTION
Meant to reproduce the issue discussed at https://github.com/googlefonts/fontc/issues/647

If we are lucky enough the CI should fail, otherwise flip the coin again and you'll see...