### PR TITLE
[Skrifa] Avoid initialization of HashSet with system random numbers

### DIFF
--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -324,7 +324,7 @@ impl<'a> ColorGlyph<'a> {
                     painter.push_clip_box(rect);
                 }
 
-                let mut visited_set = HashSet::with_hasher(NonRandomHasherState {});
+                let mut visited_set = HashSet::with_hasher(NonRandomHasherState);
                 visited_set.insert(*paint_id);
                 traverse_with_callbacks(
                     &resolve_paint(&instance, paint)?,

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -57,7 +57,9 @@ use read_fonts::{
 
 use std::{collections::HashSet, fmt::Debug, ops::Range};
 
-use traversal::{get_clipbox_font_units, traverse_v0_range, traverse_with_callbacks};
+use traversal::{
+    get_clipbox_font_units, traverse_v0_range, traverse_with_callbacks, NonRandomHasherState,
+};
 
 pub use transform::Transform;
 
@@ -322,7 +324,7 @@ impl<'a> ColorGlyph<'a> {
                     painter.push_clip_box(rect);
                 }
 
-                let mut visited_set: HashSet<usize> = HashSet::new();
+                let mut visited_set = HashSet::with_hasher(NonRandomHasherState {});
                 visited_set.insert(*paint_id);
                 traverse_with_callbacks(
                     &resolve_paint(&instance, paint)?,


### PR DESCRIPTION
Workaround for [1] and [2] - issues in the Chrome sandbox requiring access to random number generators.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1516634
[2] https://bugs.chromium.org/p/chromium/issues/detail?id=1516641