### PR TITLE
bump patch for read-fonts, write-fonts and skrifa

### DIFF
--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-skrifa = { version = "0.15.2", path = "../skrifa" }
+skrifa = { version = "0.15.3", path = "../skrifa" }
 freetype-rs = "0.32.0"
 memmap2 = "0.5.10"
 rayon = "1.8.0"

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 xflags = "0.3.0"
-read-fonts = { path = "../read-fonts",version = "0.15.1" }
+read-fonts = { path = "../read-fonts",version = "0.15.2" }
 font-types = { path = "../font-types",version = "0.4.2" }
 ansi_term = "0.12.1"
 atty = "0.2"

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
@@ -9,11 +9,11 @@ readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
-read-fonts = { version = "0.15.1", path = "../read-fonts" }
+read-fonts = { version = "0.15.2", path = "../read-fonts" }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.15.1", path = "../read-fonts", features = [
+read-fonts = { version = "0.15.2", path = "../read-fonts", features = [
     "scaler_test",
     "serde",
 ] }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -15,7 +15,7 @@ serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
 font-types = { version = "0.4.2", path = "../font-types" }
-read-fonts = { version = "0.15.1", path = "../read-fonts" }
+read-fonts = { version = "0.15.2", path = "../read-fonts" }
 log = "0.4"
 kurbo = "0.10.2"
 dot2 = { version = "1.0", optional = true }
@@ -26,7 +26,7 @@ indexmap = "2.0"
 diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.15.1", path = "../read-fonts", features = [ "codegen_test"] }
+read-fonts = { version = "0.15.2", path = "../read-fonts", features = [ "codegen_test"] }
 env_logger = "0.10.0"
 rstest = "0.18.0"
 pretty_assertions.workspace = true


### PR DESCRIPTION
```
     Changes for read-fonts from read-fonts-v0.15.1 to 0.15.2
             5ecb3e4 bump patch for read-fonts, write-fonts and skrifa
             74bdb79 [read-fonts] fix ClassDefFormat2::get() (#755)
             2cd4ac5 [clippy] Push the rock back up the hill
     Changes for write-fonts from write-fonts-v0.21.1 to 0.21.2
             5ecb3e4 bump patch for read-fonts, write-fonts and skrifa
             884a132 [write-fonts] Use stable sort_by_key when computing gvar shared tuples
             5476e99 [write-fonts/gvar] repro shared tuples unstable order
     Changes for skrifa from skrifa-v0.15.2 to 0.15.3
             5ecb3e4 bump patch for read-fonts, write-fonts and skrifa
```