### PR TITLE
[write-fonts] Add Glyph::Empty

### DIFF
--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -235,6 +235,10 @@ impl FontWrite for SimpleGlyph {
         assert!(self.contours.len() < i16::MAX as usize);
         assert!(self._instructions.len() < u16::MAX as usize);
         let n_contours = self.contours.len() as i16;
+        if n_contours == 0 {
+            // we don't bother writing empty glyphs
+            return;
+        }
         n_contours.write_into(writer);
         self.bbox.write_into(writer);
         // now write end points of contours:


### PR DESCRIPTION
This is a cleaner way of representing the idea of a glyph with no outlines, but which should still be added to loca.

I played around with also adding this in read-fonts, but it doesn't really play well with codegen or parsing, there, because we expect a format enum to have a table for each variant, and in the empty case we have no data from which to parse a table.


- closes  #561
- this may require some minor changes in fontc, when it lands

JMM