### PR TITLE
[codegen] Add wrappers on enums for shared methods

### DIFF
--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -71,7 +71,7 @@ pub(crate) fn generate_parse_module(items: &Items) -> Result<proc_macro2::TokenS
             Item::Record(item) => record::generate(item, items)?,
             Item::Table(item) => table::generate(item)?,
             Item::GenericGroup(item) => table::generate_group(item)?,
-            Item::Format(item) => table::generate_format_group(item)?,
+            Item::Format(item) => table::generate_format_group(item, items)?,
             Item::RawEnum(item) => flags_enums::generate_raw_enum(item),
             Item::Flags(item) => flags_enums::generate_flags(item),
             Item::Extern(..) => Default::default(),

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -1,6 +1,8 @@
 //! raw parsing code
 
-use std::{backtrace::Backtrace, collections::HashMap, fmt::Display, ops::Deref, str::FromStr};
+use std::{
+    backtrace::Backtrace, collections::HashMap, fmt::Display, hash::Hash, ops::Deref, str::FromStr,
+};
 
 use font_types::Tag;
 use indexmap::IndexMap;
@@ -326,7 +328,7 @@ impl InlineExpr {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum FieldType {
     Offset {
         typ: syn::Ident,
@@ -352,7 +354,7 @@ pub(crate) enum FieldType {
     VarLenArray(CustomArray),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum OffsetTarget {
     Table(syn::Ident),
     Array(Box<FieldType>),
@@ -364,6 +366,21 @@ pub(crate) struct CustomArray {
     span: Span,
     inner: syn::Ident,
     lifetime: Option<syn::Lifetime>,
+}
+
+impl PartialEq for CustomArray {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner && self.lifetime == other.lifetime
+    }
+}
+
+impl Eq for CustomArray {}
+
+impl Hash for CustomArray {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
+        self.lifetime.hash(state);
+    }
 }
 
 impl CustomArray {

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -932,6 +932,26 @@ pub enum BaseCoord<'a> {
     Format3(BaseCoordFormat3<'a>),
 }
 
+impl<'a> BaseCoord<'a> {
+    /// Format identifier — format = 1
+    pub fn base_coord_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.base_coord_format(),
+            Self::Format2(item) => item.base_coord_format(),
+            Self::Format3(item) => item.base_coord_format(),
+        }
+    }
+
+    /// X or Y value, in design units
+    pub fn coordinate(&self) -> i16 {
+        match self {
+            Self::Format1(item) => item.coordinate(),
+            Self::Format2(item) => item.coordinate(),
+            Self::Format3(item) => item.coordinate(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for BaseCoord<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -851,6 +851,41 @@ pub enum IndexSubtable<'a> {
     Format5(IndexSubtable5<'a>),
 }
 
+impl<'a> IndexSubtable<'a> {
+    /// Format of this IndexSubTable.
+    pub fn index_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.index_format(),
+            Self::Format2(item) => item.index_format(),
+            Self::Format3(item) => item.index_format(),
+            Self::Format4(item) => item.index_format(),
+            Self::Format5(item) => item.index_format(),
+        }
+    }
+
+    /// Format of EBDT image data.
+    pub fn image_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.image_format(),
+            Self::Format2(item) => item.image_format(),
+            Self::Format3(item) => item.image_format(),
+            Self::Format4(item) => item.image_format(),
+            Self::Format5(item) => item.image_format(),
+        }
+    }
+
+    /// Offset to image data in EBDT table.
+    pub fn image_data_offset(&self) -> u32 {
+        match self {
+            Self::Format1(item) => item.image_data_offset(),
+            Self::Format2(item) => item.image_data_offset(),
+            Self::Format3(item) => item.image_data_offset(),
+            Self::Format4(item) => item.image_data_offset(),
+            Self::Format5(item) => item.image_data_offset(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for IndexSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -231,6 +231,23 @@ pub enum CmapSubtable<'a> {
     Format14(Cmap14<'a>),
 }
 
+impl<'a> CmapSubtable<'a> {
+    /// Format number is set to 0.
+    pub fn format(&self) -> u16 {
+        match self {
+            Self::Format0(item) => item.format(),
+            Self::Format2(item) => item.format(),
+            Self::Format4(item) => item.format(),
+            Self::Format6(item) => item.format(),
+            Self::Format8(item) => item.format(),
+            Self::Format10(item) => item.format(),
+            Self::Format12(item) => item.format(),
+            Self::Format13(item) => item.format(),
+            Self::Format14(item) => item.format(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for CmapSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -785,6 +785,48 @@ pub enum ClipBox<'a> {
     Format2(ClipBoxFormat2<'a>),
 }
 
+impl<'a> ClipBox<'a> {
+    /// Set to 1.
+    pub fn format(&self) -> u8 {
+        match self {
+            Self::Format1(item) => item.format(),
+            Self::Format2(item) => item.format(),
+        }
+    }
+
+    /// Minimum x of clip box.
+    pub fn x_min(&self) -> FWord {
+        match self {
+            Self::Format1(item) => item.x_min(),
+            Self::Format2(item) => item.x_min(),
+        }
+    }
+
+    /// Minimum y of clip box.
+    pub fn y_min(&self) -> FWord {
+        match self {
+            Self::Format1(item) => item.y_min(),
+            Self::Format2(item) => item.y_min(),
+        }
+    }
+
+    /// Maximum x of clip box.
+    pub fn x_max(&self) -> FWord {
+        match self {
+            Self::Format1(item) => item.x_max(),
+            Self::Format2(item) => item.x_max(),
+        }
+    }
+
+    /// Maximum y of clip box.
+    pub fn y_max(&self) -> FWord {
+        match self {
+            Self::Format1(item) => item.y_max(),
+            Self::Format2(item) => item.y_max(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for ClipBox<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u8 = data.read_at(0usize)?;
@@ -1523,6 +1565,46 @@ pub enum Paint<'a> {
     SkewAroundCenter(PaintSkewAroundCenter<'a>),
     VarSkewAroundCenter(PaintVarSkewAroundCenter<'a>),
     Composite(PaintComposite<'a>),
+}
+
+impl<'a> Paint<'a> {
+    /// Set to 1.
+    pub fn format(&self) -> u8 {
+        match self {
+            Self::ColrLayers(item) => item.format(),
+            Self::Solid(item) => item.format(),
+            Self::VarSolid(item) => item.format(),
+            Self::LinearGradient(item) => item.format(),
+            Self::VarLinearGradient(item) => item.format(),
+            Self::RadialGradient(item) => item.format(),
+            Self::VarRadialGradient(item) => item.format(),
+            Self::SweepGradient(item) => item.format(),
+            Self::VarSweepGradient(item) => item.format(),
+            Self::Glyph(item) => item.format(),
+            Self::ColrGlyph(item) => item.format(),
+            Self::Transform(item) => item.format(),
+            Self::VarTransform(item) => item.format(),
+            Self::Translate(item) => item.format(),
+            Self::VarTranslate(item) => item.format(),
+            Self::Scale(item) => item.format(),
+            Self::VarScale(item) => item.format(),
+            Self::ScaleAroundCenter(item) => item.format(),
+            Self::VarScaleAroundCenter(item) => item.format(),
+            Self::ScaleUniform(item) => item.format(),
+            Self::VarScaleUniform(item) => item.format(),
+            Self::ScaleUniformAroundCenter(item) => item.format(),
+            Self::VarScaleUniformAroundCenter(item) => item.format(),
+            Self::Rotate(item) => item.format(),
+            Self::VarRotate(item) => item.format(),
+            Self::RotateAroundCenter(item) => item.format(),
+            Self::VarRotateAroundCenter(item) => item.format(),
+            Self::Skew(item) => item.format(),
+            Self::VarSkew(item) => item.format(),
+            Self::SkewAroundCenter(item) => item.format(),
+            Self::VarSkewAroundCenter(item) => item.format(),
+            Self::Composite(item) => item.format(),
+        }
+    }
 }
 
 impl<'a> FontRead<'a> for Paint<'a> {

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -653,6 +653,17 @@ pub enum CaretValue<'a> {
     Format3(CaretValueFormat3<'a>),
 }
 
+impl<'a> CaretValue<'a> {
+    /// Format identifier: format = 1
+    pub fn caret_value_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.caret_value_format(),
+            Self::Format2(item) => item.caret_value_format(),
+            Self::Format3(item) => item.caret_value_format(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for CaretValue<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -1110,6 +1110,50 @@ pub enum Glyph<'a> {
     Composite(CompositeGlyph<'a>),
 }
 
+impl<'a> Glyph<'a> {
+    /// If the number of contours is greater than or equal to zero,
+    /// this is a simple glyph. If negative, this is a composite glyph
+    /// — the value -1 should be used for composite glyphs.
+    pub fn number_of_contours(&self) -> i16 {
+        match self {
+            Self::Simple(item) => item.number_of_contours(),
+            Self::Composite(item) => item.number_of_contours(),
+        }
+    }
+
+    /// Minimum x for coordinate data.
+    pub fn x_min(&self) -> i16 {
+        match self {
+            Self::Simple(item) => item.x_min(),
+            Self::Composite(item) => item.x_min(),
+        }
+    }
+
+    /// Minimum y for coordinate data.
+    pub fn y_min(&self) -> i16 {
+        match self {
+            Self::Simple(item) => item.y_min(),
+            Self::Composite(item) => item.y_min(),
+        }
+    }
+
+    /// Maximum x for coordinate data.
+    pub fn x_max(&self) -> i16 {
+        match self {
+            Self::Simple(item) => item.x_max(),
+            Self::Composite(item) => item.x_max(),
+        }
+    }
+
+    /// Maximum y for coordinate data.
+    pub fn y_max(&self) -> i16 {
+        match self {
+            Self::Simple(item) => item.y_max(),
+            Self::Composite(item) => item.y_max(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for Glyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: i16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -576,6 +576,35 @@ pub enum AnchorTable<'a> {
     Format3(AnchorFormat3<'a>),
 }
 
+impl<'a> AnchorTable<'a> {
+    /// Format identifier, = 1
+    pub fn anchor_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.anchor_format(),
+            Self::Format2(item) => item.anchor_format(),
+            Self::Format3(item) => item.anchor_format(),
+        }
+    }
+
+    /// Horizontal value, in design units
+    pub fn x_coordinate(&self) -> i16 {
+        match self {
+            Self::Format1(item) => item.x_coordinate(),
+            Self::Format2(item) => item.x_coordinate(),
+            Self::Format3(item) => item.x_coordinate(),
+        }
+    }
+
+    /// Vertical value, in design units
+    pub fn y_coordinate(&self) -> i16 {
+        match self {
+            Self::Format1(item) => item.y_coordinate(),
+            Self::Format2(item) => item.y_coordinate(),
+            Self::Format3(item) => item.y_coordinate(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for AnchorTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;
@@ -1054,6 +1083,32 @@ pub enum SinglePos<'a> {
     Format2(SinglePosFormat2<'a>),
 }
 
+impl<'a> SinglePos<'a> {
+    /// Format identifier: format = 1
+    pub fn pos_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.pos_format(),
+            Self::Format2(item) => item.pos_format(),
+        }
+    }
+
+    /// Offset to Coverage table, from beginning of SinglePos subtable.
+    pub fn coverage_offset(&self) -> Offset16 {
+        match self {
+            Self::Format1(item) => item.coverage_offset(),
+            Self::Format2(item) => item.coverage_offset(),
+        }
+    }
+
+    /// Defines the types of data in the ValueRecord.
+    pub fn value_format(&self) -> ValueFormat {
+        match self {
+            Self::Format1(item) => item.value_format(),
+            Self::Format2(item) => item.value_format(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for SinglePos<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;
@@ -1336,6 +1391,42 @@ impl<'a> std::fmt::Debug for SinglePosFormat2<'a> {
 pub enum PairPos<'a> {
     Format1(PairPosFormat1<'a>),
     Format2(PairPosFormat2<'a>),
+}
+
+impl<'a> PairPos<'a> {
+    /// Format identifier: format = 1
+    pub fn pos_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.pos_format(),
+            Self::Format2(item) => item.pos_format(),
+        }
+    }
+
+    /// Offset to Coverage table, from beginning of PairPos subtable.
+    pub fn coverage_offset(&self) -> Offset16 {
+        match self {
+            Self::Format1(item) => item.coverage_offset(),
+            Self::Format2(item) => item.coverage_offset(),
+        }
+    }
+
+    /// Defines the types of data in valueRecord1 — for the first
+    /// glyph in the pair (may be zero).
+    pub fn value_format1(&self) -> ValueFormat {
+        match self {
+            Self::Format1(item) => item.value_format1(),
+            Self::Format2(item) => item.value_format1(),
+        }
+    }
+
+    /// Defines the types of data in valueRecord2 — for the second
+    /// glyph in the pair (may be zero).
+    pub fn value_format2(&self) -> ValueFormat {
+        match self {
+            Self::Format1(item) => item.value_format2(),
+            Self::Format2(item) => item.value_format2(),
+        }
+    }
 }
 
 impl<'a> FontRead<'a> for PairPos<'a> {

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -229,6 +229,25 @@ pub enum SingleSubst<'a> {
     Format2(SingleSubstFormat2<'a>),
 }
 
+impl<'a> SingleSubst<'a> {
+    /// Format identifier: format = 1
+    pub fn subst_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.subst_format(),
+            Self::Format2(item) => item.subst_format(),
+        }
+    }
+
+    /// Offset to Coverage table, from beginning of substitution
+    /// subtable
+    pub fn coverage_offset(&self) -> Offset16 {
+        match self {
+            Self::Format1(item) => item.coverage_offset(),
+            Self::Format2(item) => item.coverage_offset(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for SingleSubst<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1155,6 +1155,16 @@ pub enum CoverageTable<'a> {
     Format2(CoverageFormat2<'a>),
 }
 
+impl<'a> CoverageTable<'a> {
+    /// Format identifier — format = 1
+    pub fn coverage_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.coverage_format(),
+            Self::Format2(item) => item.coverage_format(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for CoverageTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;
@@ -1443,6 +1453,16 @@ impl<'a> SomeRecord<'a> for ClassRangeRecord {
 pub enum ClassDef<'a> {
     Format1(ClassDefFormat1<'a>),
     Format2(ClassDefFormat2<'a>),
+}
+
+impl<'a> ClassDef<'a> {
+    /// Format identifier — format = 1
+    pub fn class_format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.class_format(),
+            Self::Format2(item) => item.class_format(),
+        }
+    }
 }
 
 impl<'a> FontRead<'a> for ClassDef<'a> {
@@ -2350,6 +2370,17 @@ pub enum SequenceContext<'a> {
     Format1(SequenceContextFormat1<'a>),
     Format2(SequenceContextFormat2<'a>),
     Format3(SequenceContextFormat3<'a>),
+}
+
+impl<'a> SequenceContext<'a> {
+    /// Format identifier: format = 1
+    pub fn format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.format(),
+            Self::Format2(item) => item.format(),
+            Self::Format3(item) => item.format(),
+        }
+    }
 }
 
 impl<'a> FontRead<'a> for SequenceContext<'a> {
@@ -3493,6 +3524,17 @@ pub enum ChainedSequenceContext<'a> {
     Format1(ChainedSequenceContextFormat1<'a>),
     Format2(ChainedSequenceContextFormat2<'a>),
     Format3(ChainedSequenceContextFormat3<'a>),
+}
+
+impl<'a> ChainedSequenceContext<'a> {
+    /// Format identifier: format = 1
+    pub fn format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.format(),
+            Self::Format2(item) => item.format(),
+            Self::Format3(item) => item.format(),
+        }
+    }
 }
 
 impl<'a> FontRead<'a> for ChainedSequenceContext<'a> {

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -205,6 +205,17 @@ pub enum FdSelect<'a> {
     Format4(FdSelectFormat4<'a>),
 }
 
+impl<'a> FdSelect<'a> {
+    /// Format = 0.
+    pub fn format(&self) -> u8 {
+        match self {
+            Self::Format0(item) => item.format(),
+            Self::Format3(item) => item.format(),
+            Self::Format4(item) => item.format(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for FdSelect<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u8 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -352,6 +352,39 @@ pub enum AxisValue<'a> {
     Format4(AxisValueFormat4<'a>),
 }
 
+impl<'a> AxisValue<'a> {
+    /// Format identifier — set to 1.
+    pub fn format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.format(),
+            Self::Format2(item) => item.format(),
+            Self::Format3(item) => item.format(),
+            Self::Format4(item) => item.format(),
+        }
+    }
+
+    /// Flags — see below for details.
+    pub fn flags(&self) -> AxisValueTableFlags {
+        match self {
+            Self::Format1(item) => item.flags(),
+            Self::Format2(item) => item.flags(),
+            Self::Format3(item) => item.flags(),
+            Self::Format4(item) => item.flags(),
+        }
+    }
+
+    /// The name ID for entries in the 'name' table that provide a
+    /// display string for this attribute value.
+    pub fn value_name_id(&self) -> NameId {
+        match self {
+            Self::Format1(item) => item.value_name_id(),
+            Self::Format2(item) => item.value_name_id(),
+            Self::Format3(item) => item.value_name_id(),
+            Self::Format4(item) => item.value_name_id(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for AxisValue<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -226,6 +226,16 @@ pub enum MyTable<'a> {
     Format3(Table3<'a>),
 }
 
+impl<'a> MyTable<'a> {
+    pub fn format(&self) -> u16 {
+        match self {
+            Self::Format1(item) => item.format(),
+            Self::MyFormat22(item) => item.format(),
+            Self::Format3(item) => item.format(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for MyTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -385,6 +385,33 @@ pub enum DeltaSetIndexMap<'a> {
     Format1(DeltaSetIndexMapFormat1<'a>),
 }
 
+impl<'a> DeltaSetIndexMap<'a> {
+    /// DeltaSetIndexMap format: set to 0.
+    pub fn format(&self) -> u8 {
+        match self {
+            Self::Format0(item) => item.format(),
+            Self::Format1(item) => item.format(),
+        }
+    }
+
+    /// A packed field that describes the compressed representation of
+    /// delta-set indices. See details below.
+    pub fn entry_format(&self) -> EntryFormat {
+        match self {
+            Self::Format0(item) => item.entry_format(),
+            Self::Format1(item) => item.entry_format(),
+        }
+    }
+
+    /// The delta-set index mapping data. See details below.
+    pub fn map_data(&self) -> &'a [u8] {
+        match self {
+            Self::Format0(item) => item.map_data(),
+            Self::Format1(item) => item.map_data(),
+        }
+    }
+}
+
 impl<'a> FontRead<'a> for DeltaSetIndexMap<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let format: u8 = data.read_at(0usize)?;

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -5,25 +5,6 @@ use types::{F26Dot6, Pen, Point};
 
 include!("../../generated/generated_glyf.rs");
 
-macro_rules! field_getter {
-    ($field:ident, $ty:ty) => {
-        pub fn $field(&self) -> $ty {
-            match self {
-                Self::Simple(table) => table.$field(),
-                Self::Composite(table) => table.$field(),
-            }
-        }
-    };
-}
-
-impl<'a> Glyph<'a> {
-    field_getter!(number_of_contours, i16);
-    field_getter!(x_min, i16);
-    field_getter!(x_max, i16);
-    field_getter!(y_min, i16);
-    field_getter!(y_max, i16);
-}
-
 /// Marker bits for point flags that are set during variation delta
 /// processing and hinting.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -30,24 +30,6 @@ pub type PositionSequenceContext<'a> = super::layout::SequenceContext<'a>;
 pub type PositionChainContext<'a> = super::layout::ChainedSequenceContext<'a>;
 
 impl<'a> AnchorTable<'a> {
-    /// Horizontal value, in design units
-    pub fn x_coordinate(&self) -> i16 {
-        match self {
-            AnchorTable::Format1(inner) => inner.x_coordinate(),
-            AnchorTable::Format2(inner) => inner.x_coordinate(),
-            AnchorTable::Format3(inner) => inner.x_coordinate(),
-        }
-    }
-
-    /// Vertical value, in design units
-    pub fn y_coordinate(&self) -> i16 {
-        match self {
-            AnchorTable::Format1(inner) => inner.y_coordinate(),
-            AnchorTable::Format2(inner) => inner.y_coordinate(),
-            AnchorTable::Format3(inner) => inner.y_coordinate(),
-        }
-    }
-
     /// Attempt to resolve the `Device` or `VariationIndex` table for the
     /// x_coordinate, if present
     pub fn x_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {


### PR DESCRIPTION
This is for tables that have multiple formats, where all the formats have an identically named method; we will now generate a wrapper method on the enum itself that forwards to the inner methods.

In this patch this is only implemented for raw fields, and we do not generate the typed offset getters. This is quite a bit more complicated, and we can look into that as followup.


-----


This ended up producing less code than I had expected, and most of that code is just exposing the `format` field. The two main 'real' cases are the bbox on glyphs and the coords on anchor tables, both of which we had previously hand-written implementations for.

The main thing that we are missing here (pending support for offset getters) is resolving coverage tables on multi-format layout subtables.


progress on #687 

