### PR TITLE
Improved Lookup API

### DIFF
--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -191,6 +191,23 @@ impl<'a> FontRead<'a> for PositionLookup<'a> {
     }
 }
 
+impl<'a> PositionLookup<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> Lookup<'a, ()> {
+        match self {
+            PositionLookup::Single(inner) => inner.to_untyped(),
+            PositionLookup::Pair(inner) => inner.to_untyped(),
+            PositionLookup::Cursive(inner) => inner.to_untyped(),
+            PositionLookup::MarkToBase(inner) => inner.to_untyped(),
+            PositionLookup::MarkToLig(inner) => inner.to_untyped(),
+            PositionLookup::MarkToMark(inner) => inner.to_untyped(),
+            PositionLookup::Contextual(inner) => inner.to_untyped(),
+            PositionLookup::ChainContextual(inner) => inner.to_untyped(),
+            PositionLookup::Extension(inner) => inner.to_untyped(),
+        }
+    }
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> PositionLookup<'a> {
     fn dyn_inner(&self) -> &(dyn SomeTable<'a> + 'a) {
@@ -3604,6 +3621,19 @@ impl<'a> ExtensionPosFormat1<'a, ()> {
     }
 }
 
+impl<'a, T> ExtensionPosFormat1<'a, T> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> ExtensionPosFormat1<'a, ()> {
+        let TableRef { data, .. } = self;
+        TableRef {
+            shape: ExtensionPosFormat1Marker {
+                offset_type: std::marker::PhantomData,
+            },
+            data: *data,
+        }
+    }
+}
+
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
 pub type ExtensionPosFormat1<'a, T> = TableRef<'a, ExtensionPosFormat1Marker<T>>;
 
@@ -3692,6 +3722,22 @@ impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
             7 => Ok(ExtensionSubtable::Contextual(untyped.into_concrete())),
             8 => Ok(ExtensionSubtable::ChainContextual(untyped.into_concrete())),
             other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+}
+
+impl<'a> ExtensionSubtable<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> ExtensionPosFormat1<'a, ()> {
+        match self {
+            ExtensionSubtable::Single(inner) => inner.to_untyped(),
+            ExtensionSubtable::Pair(inner) => inner.to_untyped(),
+            ExtensionSubtable::Cursive(inner) => inner.to_untyped(),
+            ExtensionSubtable::MarkToBase(inner) => inner.to_untyped(),
+            ExtensionSubtable::MarkToLig(inner) => inner.to_untyped(),
+            ExtensionSubtable::MarkToMark(inner) => inner.to_untyped(),
+            ExtensionSubtable::Contextual(inner) => inner.to_untyped(),
+            ExtensionSubtable::ChainContextual(inner) => inner.to_untyped(),
         }
     }
 }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -193,17 +193,20 @@ impl<'a> FontRead<'a> for PositionLookup<'a> {
 
 impl<'a> PositionLookup<'a> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> Lookup<'a, ()> {
+    /// Return the inner table, removing the specific generics.
+    ///
+    /// This lets us return a single concrete type we can call methods on.
+    pub(crate) fn of_unit_type(&self) -> Lookup<'a, ()> {
         match self {
-            PositionLookup::Single(inner) => inner.to_untyped(),
-            PositionLookup::Pair(inner) => inner.to_untyped(),
-            PositionLookup::Cursive(inner) => inner.to_untyped(),
-            PositionLookup::MarkToBase(inner) => inner.to_untyped(),
-            PositionLookup::MarkToLig(inner) => inner.to_untyped(),
-            PositionLookup::MarkToMark(inner) => inner.to_untyped(),
-            PositionLookup::Contextual(inner) => inner.to_untyped(),
-            PositionLookup::ChainContextual(inner) => inner.to_untyped(),
-            PositionLookup::Extension(inner) => inner.to_untyped(),
+            PositionLookup::Single(inner) => inner.of_unit_type(),
+            PositionLookup::Pair(inner) => inner.of_unit_type(),
+            PositionLookup::Cursive(inner) => inner.of_unit_type(),
+            PositionLookup::MarkToBase(inner) => inner.of_unit_type(),
+            PositionLookup::MarkToLig(inner) => inner.of_unit_type(),
+            PositionLookup::MarkToMark(inner) => inner.of_unit_type(),
+            PositionLookup::Contextual(inner) => inner.of_unit_type(),
+            PositionLookup::ChainContextual(inner) => inner.of_unit_type(),
+            PositionLookup::Extension(inner) => inner.of_unit_type(),
         }
     }
 }
@@ -3623,7 +3626,8 @@ impl<'a> ExtensionPosFormat1<'a, ()> {
 
 impl<'a, T> ExtensionPosFormat1<'a, T> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> ExtensionPosFormat1<'a, ()> {
+    /// Replace the specific generic type on this implementation with `()`
+    pub(crate) fn of_unit_type(&self) -> ExtensionPosFormat1<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
             shape: ExtensionPosFormat1Marker {
@@ -3728,16 +3732,19 @@ impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
 
 impl<'a> ExtensionSubtable<'a> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> ExtensionPosFormat1<'a, ()> {
+    /// Return the inner table, removing the specific generics.
+    ///
+    /// This lets us return a single concrete type we can call methods on.
+    pub(crate) fn of_unit_type(&self) -> ExtensionPosFormat1<'a, ()> {
         match self {
-            ExtensionSubtable::Single(inner) => inner.to_untyped(),
-            ExtensionSubtable::Pair(inner) => inner.to_untyped(),
-            ExtensionSubtable::Cursive(inner) => inner.to_untyped(),
-            ExtensionSubtable::MarkToBase(inner) => inner.to_untyped(),
-            ExtensionSubtable::MarkToLig(inner) => inner.to_untyped(),
-            ExtensionSubtable::MarkToMark(inner) => inner.to_untyped(),
-            ExtensionSubtable::Contextual(inner) => inner.to_untyped(),
-            ExtensionSubtable::ChainContextual(inner) => inner.to_untyped(),
+            ExtensionSubtable::Single(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Pair(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Cursive(inner) => inner.of_unit_type(),
+            ExtensionSubtable::MarkToBase(inner) => inner.of_unit_type(),
+            ExtensionSubtable::MarkToLig(inner) => inner.of_unit_type(),
+            ExtensionSubtable::MarkToMark(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Contextual(inner) => inner.of_unit_type(),
+            ExtensionSubtable::ChainContextual(inner) => inner.of_unit_type(),
         }
     }
 }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -189,6 +189,22 @@ impl<'a> FontRead<'a> for SubstitutionLookup<'a> {
     }
 }
 
+impl<'a> SubstitutionLookup<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> Lookup<'a, ()> {
+        match self {
+            SubstitutionLookup::Single(inner) => inner.to_untyped(),
+            SubstitutionLookup::Multiple(inner) => inner.to_untyped(),
+            SubstitutionLookup::Alternate(inner) => inner.to_untyped(),
+            SubstitutionLookup::Ligature(inner) => inner.to_untyped(),
+            SubstitutionLookup::Contextual(inner) => inner.to_untyped(),
+            SubstitutionLookup::ChainContextual(inner) => inner.to_untyped(),
+            SubstitutionLookup::Extension(inner) => inner.to_untyped(),
+            SubstitutionLookup::Reverse(inner) => inner.to_untyped(),
+        }
+    }
+}
+
 #[cfg(feature = "traversal")]
 impl<'a> SubstitutionLookup<'a> {
     fn dyn_inner(&self) -> &(dyn SomeTable<'a> + 'a) {
@@ -1244,6 +1260,19 @@ impl<'a> ExtensionSubstFormat1<'a, ()> {
     }
 }
 
+impl<'a, T> ExtensionSubstFormat1<'a, T> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> ExtensionSubstFormat1<'a, ()> {
+        let TableRef { data, .. } = self;
+        TableRef {
+            shape: ExtensionSubstFormat1Marker {
+                offset_type: std::marker::PhantomData,
+            },
+            data: *data,
+        }
+    }
+}
+
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
 pub type ExtensionSubstFormat1<'a, T> = TableRef<'a, ExtensionSubstFormat1Marker<T>>;
 
@@ -1330,6 +1359,21 @@ impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
             6 => Ok(ExtensionSubtable::ChainContextual(untyped.into_concrete())),
             8 => Ok(ExtensionSubtable::Reverse(untyped.into_concrete())),
             other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+}
+
+impl<'a> ExtensionSubtable<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> ExtensionSubstFormat1<'a, ()> {
+        match self {
+            ExtensionSubtable::Single(inner) => inner.to_untyped(),
+            ExtensionSubtable::Multiple(inner) => inner.to_untyped(),
+            ExtensionSubtable::Alternate(inner) => inner.to_untyped(),
+            ExtensionSubtable::Ligature(inner) => inner.to_untyped(),
+            ExtensionSubtable::Contextual(inner) => inner.to_untyped(),
+            ExtensionSubtable::ChainContextual(inner) => inner.to_untyped(),
+            ExtensionSubtable::Reverse(inner) => inner.to_untyped(),
         }
     }
 }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -191,16 +191,19 @@ impl<'a> FontRead<'a> for SubstitutionLookup<'a> {
 
 impl<'a> SubstitutionLookup<'a> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> Lookup<'a, ()> {
+    /// Return the inner table, removing the specific generics.
+    ///
+    /// This lets us return a single concrete type we can call methods on.
+    pub(crate) fn of_unit_type(&self) -> Lookup<'a, ()> {
         match self {
-            SubstitutionLookup::Single(inner) => inner.to_untyped(),
-            SubstitutionLookup::Multiple(inner) => inner.to_untyped(),
-            SubstitutionLookup::Alternate(inner) => inner.to_untyped(),
-            SubstitutionLookup::Ligature(inner) => inner.to_untyped(),
-            SubstitutionLookup::Contextual(inner) => inner.to_untyped(),
-            SubstitutionLookup::ChainContextual(inner) => inner.to_untyped(),
-            SubstitutionLookup::Extension(inner) => inner.to_untyped(),
-            SubstitutionLookup::Reverse(inner) => inner.to_untyped(),
+            SubstitutionLookup::Single(inner) => inner.of_unit_type(),
+            SubstitutionLookup::Multiple(inner) => inner.of_unit_type(),
+            SubstitutionLookup::Alternate(inner) => inner.of_unit_type(),
+            SubstitutionLookup::Ligature(inner) => inner.of_unit_type(),
+            SubstitutionLookup::Contextual(inner) => inner.of_unit_type(),
+            SubstitutionLookup::ChainContextual(inner) => inner.of_unit_type(),
+            SubstitutionLookup::Extension(inner) => inner.of_unit_type(),
+            SubstitutionLookup::Reverse(inner) => inner.of_unit_type(),
         }
     }
 }
@@ -1262,7 +1265,8 @@ impl<'a> ExtensionSubstFormat1<'a, ()> {
 
 impl<'a, T> ExtensionSubstFormat1<'a, T> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> ExtensionSubstFormat1<'a, ()> {
+    /// Replace the specific generic type on this implementation with `()`
+    pub(crate) fn of_unit_type(&self) -> ExtensionSubstFormat1<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
             shape: ExtensionSubstFormat1Marker {
@@ -1365,15 +1369,18 @@ impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
 
 impl<'a> ExtensionSubtable<'a> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> ExtensionSubstFormat1<'a, ()> {
+    /// Return the inner table, removing the specific generics.
+    ///
+    /// This lets us return a single concrete type we can call methods on.
+    pub(crate) fn of_unit_type(&self) -> ExtensionSubstFormat1<'a, ()> {
         match self {
-            ExtensionSubtable::Single(inner) => inner.to_untyped(),
-            ExtensionSubtable::Multiple(inner) => inner.to_untyped(),
-            ExtensionSubtable::Alternate(inner) => inner.to_untyped(),
-            ExtensionSubtable::Ligature(inner) => inner.to_untyped(),
-            ExtensionSubtable::Contextual(inner) => inner.to_untyped(),
-            ExtensionSubtable::ChainContextual(inner) => inner.to_untyped(),
-            ExtensionSubtable::Reverse(inner) => inner.to_untyped(),
+            ExtensionSubtable::Single(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Multiple(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Alternate(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Ligature(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Contextual(inner) => inner.of_unit_type(),
+            ExtensionSubtable::ChainContextual(inner) => inner.of_unit_type(),
+            ExtensionSubtable::Reverse(inner) => inner.of_unit_type(),
         }
     }
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -699,7 +699,8 @@ impl<'a> LookupList<'a, ()> {
 
 impl<'a, T> LookupList<'a, T> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> LookupList<'a, ()> {
+    /// Replace the specific generic type on this implementation with `()`
+    pub(crate) fn of_unit_type(&self) -> LookupList<'a, ()> {
         let TableRef { data, shape } = self;
         TableRef {
             shape: LookupListMarker {
@@ -844,7 +845,8 @@ impl<'a> Lookup<'a, ()> {
 
 impl<'a, T> Lookup<'a, T> {
     #[allow(dead_code)]
-    pub(crate) fn to_untyped(&self) -> Lookup<'a, ()> {
+    /// Replace the specific generic type on this implementation with `()`
+    pub(crate) fn of_unit_type(&self) -> Lookup<'a, ()> {
         let TableRef { data, shape } = self;
         TableRef {
             shape: LookupMarker {

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -697,6 +697,20 @@ impl<'a> LookupList<'a, ()> {
     }
 }
 
+impl<'a, T> LookupList<'a, T> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> LookupList<'a, ()> {
+        let TableRef { data, shape } = self;
+        TableRef {
+            shape: LookupListMarker {
+                lookup_offsets_byte_len: shape.lookup_offsets_byte_len,
+                offset_type: std::marker::PhantomData,
+            },
+            data: *data,
+        }
+    }
+}
+
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
 pub type LookupList<'a, T> = TableRef<'a, LookupListMarker<T>>;
 
@@ -824,6 +838,20 @@ impl<'a> Lookup<'a, ()> {
                 offset_type: std::marker::PhantomData,
             },
             data,
+        }
+    }
+}
+
+impl<'a, T> Lookup<'a, T> {
+    #[allow(dead_code)]
+    pub(crate) fn to_untyped(&self) -> Lookup<'a, ()> {
+        let TableRef { data, shape } = self;
+        TableRef {
+            shape: LookupMarker {
+                subtable_offsets_byte_len: shape.subtable_offsets_byte_len,
+                offset_type: std::marker::PhantomData,
+            },
+            data: *data,
         }
     }
 }

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -76,16 +76,16 @@ pub enum PositionSubtables<'a> {
 
 impl<'a> PositionLookup<'a> {
     pub fn lookup_flag(&self) -> LookupFlag {
-        self.to_untyped().lookup_flag()
+        self.of_unit_type().lookup_flag()
     }
 
     /// Different enumerations for GSUB and GPOS
     pub fn lookup_type(&self) -> u16 {
-        self.to_untyped().lookup_type()
+        self.of_unit_type().lookup_type()
     }
 
     pub fn mark_filtering_set(&self) -> u16 {
-        self.to_untyped().mark_filtering_set()
+        self.of_unit_type().mark_filtering_set()
     }
 
     /// Return the subtables for this lookup.
@@ -93,7 +93,7 @@ impl<'a> PositionLookup<'a> {
     /// This method handles both extension and non-extension lookups, and saves
     /// the caller needing to dig into the `PositionLookup` enum itself.
     pub fn subtables(&self) -> Result<PositionSubtables<'a>, ReadError> {
-        let raw_lookup = self.to_untyped();
+        let raw_lookup = self.of_unit_type();
         let offsets = raw_lookup.subtable_offsets();
         let data = raw_lookup.offset_data();
         match raw_lookup.lookup_type() {

--- a/read-fonts/src/tables/gsub.rs
+++ b/read-fonts/src/tables/gsub.rs
@@ -6,6 +6,7 @@ pub use super::layout::{
     ChainedSequenceContext, ClassDef, CoverageTable, Device, FeatureList, FeatureVariations,
     Lookup, LookupList, ScriptList, SequenceContext,
 };
+use super::layout::{ExtensionLookup, LookupFlag, Subtables};
 
 #[cfg(test)]
 #[path = "../tests/test_gsub.rs"]
@@ -21,3 +22,101 @@ pub type SubstitutionSequenceContext<'a> = super::layout::SequenceContext<'a>;
 
 /// A GSUB [ChainedSequenceContext]
 pub type SubstitutionChainContext<'a> = super::layout::ChainedSequenceContext<'a>;
+
+impl<'a, T: FontRead<'a>> ExtensionLookup<'a, T> for ExtensionSubstFormat1<'a, T> {
+    fn extension(&self) -> Result<T, ReadError> {
+        self.extension()
+    }
+}
+
+type SubSubtables<'a, T> = Subtables<'a, T, ExtensionSubstFormat1<'a, T>>;
+
+/// The subtables from a GPOS lookup.
+///
+/// This type is a convenience that removes the need to dig into the
+/// [`SubstitutionLookup`] enum in order to access subtables, and it also abstracts
+/// away the distinction between extension and non-extension lookups.
+pub enum SubstitutionSubtables<'a> {
+    Single(SubSubtables<'a, SingleSubst<'a>>),
+    Multiple(SubSubtables<'a, MultipleSubstFormat1<'a>>),
+    Alternate(SubSubtables<'a, AlternateSubstFormat1<'a>>),
+    Ligature(SubSubtables<'a, LigatureSubstFormat1<'a>>),
+    Contextual(SubSubtables<'a, SubstitutionSequenceContext<'a>>),
+    ChainContextual(SubSubtables<'a, SubstitutionChainContext<'a>>),
+    Reverse(SubSubtables<'a, ReverseChainSingleSubstFormat1<'a>>),
+}
+
+impl<'a> SubstitutionLookup<'a> {
+    pub fn lookup_flag(&self) -> LookupFlag {
+        self.to_untyped().lookup_flag()
+    }
+
+    /// Different enumerations for GSUB and GPOS
+    pub fn lookup_type(&self) -> u16 {
+        self.to_untyped().lookup_type()
+    }
+
+    pub fn mark_filtering_set(&self) -> u16 {
+        self.to_untyped().mark_filtering_set()
+    }
+
+    /// Return the subtables for this lookup.
+    ///
+    /// This method handles both extension and non-extension lookups, and saves
+    /// the caller needing to dig into the `SubstitutionLookup` enum itself.
+    pub fn subtables(&self) -> Result<SubstitutionSubtables<'a>, ReadError> {
+        let raw_lookup = self.to_untyped();
+        let offsets = raw_lookup.subtable_offsets();
+        let data = raw_lookup.offset_data();
+        match raw_lookup.lookup_type() {
+            1 => Ok(SubstitutionSubtables::Single(Subtables::new(offsets, data))),
+            2 => Ok(SubstitutionSubtables::Multiple(Subtables::new(
+                offsets, data,
+            ))),
+            3 => Ok(SubstitutionSubtables::Alternate(Subtables::new(
+                offsets, data,
+            ))),
+            4 => Ok(SubstitutionSubtables::Ligature(Subtables::new(
+                offsets, data,
+            ))),
+            5 => Ok(SubstitutionSubtables::Contextual(Subtables::new(
+                offsets, data,
+            ))),
+            6 => Ok(SubstitutionSubtables::ChainContextual(Subtables::new(
+                offsets, data,
+            ))),
+            8 => Ok(SubstitutionSubtables::Reverse(Subtables::new(
+                offsets, data,
+            ))),
+            7 => {
+                let first = offsets.first().ok_or(ReadError::OutOfBounds)?.get();
+                let ext: ExtensionSubstFormat1<()> = first.resolve(data)?;
+                match ext.extension_lookup_type() {
+                    1 => Ok(SubstitutionSubtables::Single(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    2 => Ok(SubstitutionSubtables::Multiple(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    3 => Ok(SubstitutionSubtables::Alternate(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    4 => Ok(SubstitutionSubtables::Ligature(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    5 => Ok(SubstitutionSubtables::Contextual(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    6 => Ok(SubstitutionSubtables::ChainContextual(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    8 => Ok(SubstitutionSubtables::Reverse(Subtables::new_ext(
+                        offsets, data,
+                    ))),
+                    other => Err(ReadError::InvalidFormat(other as _)),
+                }
+            }
+            other => Err(ReadError::InvalidFormat(other as _)),
+        }
+    }
+}

--- a/read-fonts/src/tables/gsub.rs
+++ b/read-fonts/src/tables/gsub.rs
@@ -48,16 +48,16 @@ pub enum SubstitutionSubtables<'a> {
 
 impl<'a> SubstitutionLookup<'a> {
     pub fn lookup_flag(&self) -> LookupFlag {
-        self.to_untyped().lookup_flag()
+        self.of_unit_type().lookup_flag()
     }
 
     /// Different enumerations for GSUB and GPOS
     pub fn lookup_type(&self) -> u16 {
-        self.to_untyped().lookup_type()
+        self.of_unit_type().lookup_type()
     }
 
     pub fn mark_filtering_set(&self) -> u16 {
-        self.to_untyped().mark_filtering_set()
+        self.of_unit_type().mark_filtering_set()
     }
 
     /// Return the subtables for this lookup.
@@ -65,7 +65,7 @@ impl<'a> SubstitutionLookup<'a> {
     /// This method handles both extension and non-extension lookups, and saves
     /// the caller needing to dig into the `SubstitutionLookup` enum itself.
     pub fn subtables(&self) -> Result<SubstitutionSubtables<'a>, ReadError> {
-        let raw_lookup = self.to_untyped();
+        let raw_lookup = self.of_unit_type();
         let offsets = raw_lookup.subtable_offsets();
         let data = raw_lookup.offset_data();
         match raw_lookup.lookup_type() {


### PR DESCRIPTION
This adds a new convenience API on top of the `PositionLookup` and `SubstitutionLookup` types, which obviates (in the common case) the need to dig into these enums in order to access their contents. In particular, it provides a uniform interface for accessing lookup subtables, regardless of whether or not the lookup in question is behind an extension table.

The main idea here is that the level lookup types now have a `subtables` method, which returns an enum, with a variant for each non-extension lookup type; this enum provides access to an array-like object that allows access and iteration of the underlying subtables.

In practice, this makes working with lookups *significantly* easier; for instance after updating `layout-normalizer` to use this API, I was able to replace about ~100 lines with ~10.