### PR TITLE
[skrifa] tthint: managing the graphics state

### DIFF
--- a/skrifa/src/outline/glyf/hint/code_state/mod.rs
+++ b/skrifa/src/outline/glyf/hint/code_state/mod.rs
@@ -4,5 +4,20 @@ mod args;
 
 pub use args::Args;
 
+/// Describes the source for a piece of bytecode.
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[repr(u8)]
+pub enum ProgramKind {
+    /// Program that initializes the function and instruction tables. Stored
+    /// in the `fpgm` table.
+    #[default]
+    Font = 0,
+    /// Program that initializes CVT and storage based on font size and other
+    /// parameters. Stored in the `prep` table.
+    ControlValue = 1,
+    /// Glyph specified program. Stored per-glyph in the `glyf` table.
+    Glyph = 2,
+}
+
 #[cfg(test)]
 pub(crate) use args::MockArgs;

--- a/skrifa/src/outline/glyf/hint/engine/arith.rs
+++ b/skrifa/src/outline/glyf/hint/engine/arith.rs
@@ -1,8 +1,8 @@
 //! Arithmetic and math instructions.
 //!
+//! Implements 10 instructions.
+//!
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#arithmetic-and-math-instructions>
-
-// 10 instructions
 
 use super::{super::math, Engine, HintErrorKind, OpResult};
 

--- a/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
@@ -514,7 +514,7 @@ impl<'a> Engine<'a> {
         if n < 0 {
             return Err(HintErrorKind::NegativeLoopCounter);
         }
-        // As FreeType, heuristically limit the number of loops to 16 bits.
+        // As in FreeType, heuristically limit the number of loops to 16 bits.
         self.graphics_state.loop_counter = (n as u32).min(0xFFFF);
         Ok(())
     }
@@ -630,13 +630,13 @@ impl<'a> Engine<'a> {
                     *scan_control = false;
                 }
                 if (n & 0x1000) != 0 && is_rotated {
-                    // Bit 12: Set scan_control to FALSE unless the glyph is
-                    // rotated.
+                    // Bit 12: Set scan_control to FALSE based on rotation
+                    // state.
                     *scan_control = false;
                 }
                 if (n & 0x2000) != 0 && is_stretched {
-                    // Bit 13: Set scan_control to FALSE unless the glyph is
-                    // stretched.
+                    // Bit 13: Set scan_control to FALSE based on stretched
+                    // state.
                     *scan_control = false;
                 }
             }
@@ -790,7 +790,7 @@ impl<'a> Engine<'a> {
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4376>
     pub(super) fn op_sds(&mut self) -> OpResult {
         let n = self.value_stack.pop()?;
-        if n > 6 {
+        if n as u32 > 6 {
             Err(HintErrorKind::InvalidStackValue(n))
         } else {
             self.graphics_state.delta_shift = n as u16;

--- a/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
@@ -1,8 +1,8 @@
 //! Managing the graphics state.
 //!
+//! Implements 45 instructions.
+//!
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-graphics-state>
-
-// 45 instructions
 
 use read_fonts::types::Point;
 

--- a/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
@@ -1,0 +1,822 @@
+//! Managing the graphics state.
+//!
+//! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-graphics-state>
+
+// 45 instructions
+
+use read_fonts::types::Point;
+
+use super::{
+    super::{code_state::ProgramKind, graphics_state::RoundMode, math},
+    Engine, HintErrorKind, OpResult,
+};
+
+impl<'a> Engine<'a> {
+    /// Set vectors to coordinate axis.
+    ///
+    /// SVTCA\[a\] (0x00 - 0x01)
+    ///
+    /// Sets both the projection_vector and freedom_vector to the same one of
+    /// the coordinate axes.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-freedom-and-projection-vectors-to-coordinate-axis>
+    ///
+    /// SPVTCA\[a\] (0x02 - 0x03)
+    ///
+    /// Sets the projection_vector to one of the coordinate axes depending on
+    /// the value of the flag a.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-projection_vector-to-coordinate-axis>
+    ///
+    /// SFVTCA\[a\] (0x04 - 0x05)
+    ///
+    /// Sets the freedom_vector to one of the coordinate axes depending on
+    /// the value of the flag a.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-freedom_vector-to-coordinate-axis>
+    ///
+    /// FreeType combines these into a single function using some bit magic on
+    /// the opcode to determine which axes and vectors to set.
+    ///
+    /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4051>
+    pub(super) fn op_svtca(&mut self, opcode: u8) -> OpResult {
+        let opcode = opcode as i32;
+        // The low bit of the opcode determines the axis to set (1 = x, 0 = y).
+        let x = (opcode & 1) << 14;
+        let y = x ^ 0x4000;
+        // Opcodes 0..4 set the projection vector.
+        if opcode < 4 {
+            self.graphics_state.proj_vector.x = x;
+            self.graphics_state.proj_vector.y = y;
+            self.graphics_state.dual_proj_vector.x = x;
+            self.graphics_state.dual_proj_vector.y = y;
+        }
+        // Opcodes with bit 2 unset modify the freedom vector.
+        if opcode & 2 == 0 {
+            self.graphics_state.freedom_vector.x = x;
+            self.graphics_state.freedom_vector.y = y;
+        }
+        self.graphics_state.update_projection_state();
+        Ok(())
+    }
+
+    /// Set vectors to line.
+    ///
+    /// SPVTL\[a\] (0x06 - 0x07)
+    ///
+    /// Sets the projection_vector to a unit vector parallel or perpendicular
+    /// to the line segment from point p1 to point p2.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-projection_vector-to-line>
+    ///
+    /// SFVTL\[a\] (0x08 - 0x09)
+    ///
+    /// Sets the projection_vector to a unit vector parallel or perpendicular
+    /// to the line segment from point p1 to point p2.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-freedom_vector-to-line>
+    ///
+    /// Pops: p1, p2 (point number)
+    ///
+    /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3986>
+    pub(super) fn op_svtl(&mut self, opcode: u8) -> OpResult {
+        let index1 = self.value_stack.pop_usize()?;
+        let index2 = self.value_stack.pop_usize()?;
+        let is_parallel = opcode & 1 == 0;
+        let p1 = self.graphics_state.zp1().point(index2)?;
+        let p2 = self.graphics_state.zp2().point(index1)?;
+        let vector = line_vector(p1, p2, is_parallel);
+        if opcode < 8 {
+            self.graphics_state.proj_vector = vector;
+            self.graphics_state.dual_proj_vector = vector;
+        } else {
+            self.graphics_state.freedom_vector = vector;
+        }
+        self.graphics_state.update_projection_state();
+        Ok(())
+    }
+
+    /// Set freedom vector to projection vector.
+    ///
+    /// SFVTPV[] (0x0E)
+    ///
+    /// Sets the freedom_vector to be the same as the projection_vector.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-freedom_vector-to-projection-vector>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4128>
+    pub(super) fn op_sfvtpv(&mut self) -> OpResult {
+        self.graphics_state.freedom_vector = self.graphics_state.proj_vector;
+        self.graphics_state.update_projection_state();
+        Ok(())
+    }
+
+    /// Set dual projection vector to line.
+    ///
+    /// SDPVTL\[a\] (0x86 - 0x87)
+    ///
+    /// Pops: p1, p2 (point number)
+    ///
+    /// Pops two point numbers from the stack and uses them to specify a line
+    /// that defines a second, dual_projection_vector.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-dual-projection_vector-to-line>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4663>
+    pub(super) fn op_sdpvtl(&mut self, opcode: u8) -> OpResult {
+        let index1 = self.value_stack.pop_usize()?;
+        let index2 = self.value_stack.pop_usize()?;
+        let is_parallel = opcode & 1 == 0;
+        // First set the dual projection vector from *original* points.
+        let p1 = self.graphics_state.zp1().original(index2)?;
+        let p2 = self.graphics_state.zp2().original(index1)?;
+        self.graphics_state.dual_proj_vector = line_vector(p1, p2, is_parallel);
+        // Now set the projection vector from the *current* points.
+        let p1 = self.graphics_state.zp1().point(index2)?;
+        let p2 = self.graphics_state.zp2().point(index1)?;
+        self.graphics_state.proj_vector = line_vector(p1, p2, is_parallel);
+        self.graphics_state.update_projection_state();
+        Ok(())
+    }
+
+    /// Set projection vector from stack.
+    ///
+    /// SPVFS[] (0x0A)
+    ///
+    /// Pops: y, x (2.14 fixed point numbers padded with zeroes)
+    ///
+    /// Sets the direction of the projection_vector, using values x and y taken
+    /// from the stack, so that its projections onto the x and y-axes are x and
+    /// y, which are specified as signed (two’s complement) fixed-point (2.14)
+    /// numbers. The square root of (x2 + y2) must be equal to 0x4000 (hex)
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-projection_vector-from-stack>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4142>
+    pub(super) fn op_spvfs(&mut self) -> OpResult {
+        let y = self.value_stack.pop()? as i16 as i32;
+        let x = self.value_stack.pop()? as i16 as i32;
+        let vector = math::normalize14(x, y);
+        self.graphics_state.proj_vector = vector;
+        self.graphics_state.dual_proj_vector = vector;
+        self.graphics_state.update_projection_state();
+        Ok(())
+    }
+
+    /// Set freedom vector from stack.
+    ///
+    /// SFVFS[] (0x0B)
+    ///
+    /// Pops: y, x (2.14 fixed point numbers padded with zeroes)
+    ///
+    /// Sets the direction of the freedom_vector, using values x and y taken
+    /// from the stack, so that its projections onto the x and y-axes are x and
+    /// y, which are specified as signed (two’s complement) fixed-point (2.14)
+    /// numbers. The square root of (x2 + y2) must be equal to 0x4000 (hex)
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-freedom_vector-from-stack>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4169>
+    pub(super) fn op_sfvfs(&mut self) -> OpResult {
+        let y = self.value_stack.pop()? as i16 as i32;
+        let x = self.value_stack.pop()? as i16 as i32;
+        let vector = math::normalize14(x, y);
+        self.graphics_state.freedom_vector = vector;
+        self.graphics_state.update_projection_state();
+        Ok(())
+    }
+
+    /// Get projection vector.
+    ///
+    /// GPV[] (0x0C)
+    ///
+    /// Pushes: x, y (2.14 fixed point numbers padded with zeroes)
+    ///
+    /// Pushes the x and y components of the projection_vector onto the stack
+    /// as two 2.14 numbers.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#get-projection_vector>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4194>
+    pub(super) fn op_gpv(&mut self) -> OpResult {
+        let vector = self.graphics_state.proj_vector;
+        self.value_stack.push(vector.x)?;
+        self.value_stack.push(vector.y)
+    }
+
+    /// Get freedom vector.
+    ///
+    /// GFV[] (0x0D)
+    ///
+    /// Pushes: x, y (2.14 fixed point numbers padded with zeroes)
+    ///
+    /// Pushes the x and y components of the freedom_vector onto the stack as
+    /// two 2.14 numbers.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#get-freedom_vector>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4209>
+    pub(super) fn op_gfv(&mut self) -> OpResult {
+        let vector = self.graphics_state.freedom_vector;
+        self.value_stack.push(vector.x)?;
+        self.value_stack.push(vector.y)
+    }
+
+    /// Set reference point 0.
+    ///
+    /// SRP0[] (0x10)
+    ///
+    /// Pops: p (point number)
+    ///
+    /// Pops a point number from the stack and sets rp0 to that point number.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-reference-point-0>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4224>
+    pub(super) fn op_srp0(&mut self) -> OpResult {
+        let p = self.value_stack.pop_usize()?;
+        self.graphics_state.rp0 = p;
+        Ok(())
+    }
+
+    /// Set reference point 1.
+    ///
+    /// SRP1[] (0x11)
+    ///
+    /// Pops: p (point number)
+    ///
+    /// Pops a point number from the stack and sets rp1 to that point number.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-reference-point-1>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4238>
+    pub(super) fn op_srp1(&mut self) -> OpResult {
+        let p = self.value_stack.pop_usize()?;
+        self.graphics_state.rp1 = p;
+        Ok(())
+    }
+
+    /// Set reference point 2.
+    ///
+    /// SRP2[] (0x12)
+    ///
+    /// Pops: p (point number)
+    ///
+    /// Pops a point number from the stack and sets rp2 to that point number.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-reference-point-2>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4252>
+    pub(super) fn op_srp2(&mut self) -> OpResult {
+        let p = self.value_stack.pop_usize()?;
+        self.graphics_state.rp2 = p;
+        Ok(())
+    }
+
+    /// Set zone pointer 0.
+    ///
+    /// SZP0[] (0x13)
+    ///
+    /// Pops: n (zone number)
+    ///
+    /// Pops a zone number, n, from the stack and sets zp0 to the zone with
+    /// that number. If n is 0, zp0 points to zone 0. If n is 1, zp0 points
+    /// to zone 1. Any other value for n is an error.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-zone-pointer-0>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4746>
+    pub(super) fn op_szp0(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.zp0 = n.try_into()?;
+        Ok(())
+    }
+
+    /// Set zone pointer 1.
+    ///
+    /// SZP1[] (0x14)
+    ///
+    /// Pops: n (zone number)
+    ///
+    /// Pops a zone number, n, from the stack and sets zp0 to the zone with
+    /// that number. If n is 0, zp1 points to zone 0. If n is 1, zp0 points
+    /// to zone 1. Any other value for n is an error.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-zone-pointer-1>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4776>
+    pub(super) fn op_szp1(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.zp1 = n.try_into()?;
+        Ok(())
+    }
+
+    /// Set zone pointer 2.
+    ///
+    /// SZP2[] (0x15)
+    ///
+    /// Pops: n (zone number)
+    ///
+    /// Pops a zone number, n, from the stack and sets zp0 to the zone with
+    /// that number. If n is 0, zp2 points to zone 0. If n is 1, zp0 points
+    /// to zone 1. Any other value for n is an error.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-zone-pointer-2>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4806>
+    pub(super) fn op_szp2(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.zp2 = n.try_into()?;
+        Ok(())
+    }
+
+    /// Set zone pointers.
+    ///
+    /// SZPS[] (0x16)
+    ///
+    /// Pops: n (zone number)
+    ///
+    /// Pops a zone number from the stack and sets all of the zone pointers to
+    /// point to the zone with that number. If n is 0, all three zone pointers
+    /// will point to zone 0. If n is 1, all three zone pointers will point to
+    /// zone 1. Any other value for n is an error.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-zone-pointers>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4836>
+    pub(super) fn op_szps(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        let zp = n.try_into()?;
+        self.graphics_state.zp0 = zp;
+        self.graphics_state.zp1 = zp;
+        self.graphics_state.zp2 = zp;
+        Ok(())
+    }
+
+    /// Round to half grid.
+    ///
+    /// RTHG[] (0x19)
+    ///
+    /// Sets the round_state variable to state 0 (hg). In this state, the
+    /// coordinates of a point are rounded to the nearest half grid line.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#round-to-half-grid>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4393>
+    pub(super) fn op_rthg(&mut self) -> OpResult {
+        self.graphics_state.round_state.mode = RoundMode::HalfGrid;
+        Ok(())
+    }
+
+    /// Round to grid.
+    ///
+    /// RTG[] (0x18)
+    ///
+    /// Sets the round_state variable to state 1 (g). In this state, distances
+    /// are rounded to the closest grid line.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#round-to-grid>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4407>
+    pub(super) fn op_rtg(&mut self) -> OpResult {
+        self.graphics_state.round_state.mode = RoundMode::Grid;
+        Ok(())
+    }
+
+    /// Round to double grid.
+    ///
+    /// RTDG[] (0x3D)
+    ///
+    /// Sets the round_state variable to state 2 (dg). In this state, distances
+    /// are rounded to the closest half or integer pixel.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#round-to-double-grid>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4420>
+    pub(super) fn op_rtdg(&mut self) -> OpResult {
+        self.graphics_state.round_state.mode = RoundMode::DoubleGrid;
+        Ok(())
+    }
+
+    /// Round down to grid.
+    ///
+    /// RDTG[] (0x7D)
+    ///
+    /// Sets the round_state variable to state 3 (dtg). In this state, distances
+    /// are rounded down to the closest integer grid line.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#round-down-to-grid>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4447>
+    pub(super) fn op_rdtg(&mut self) -> OpResult {
+        self.graphics_state.round_state.mode = RoundMode::DownToGrid;
+        Ok(())
+    }
+
+    /// Round up to grid.
+    ///
+    /// RUTG[] (0x7C)
+    ///
+    /// Sets the round_state variable to state 4 (utg). In this state distances
+    /// are rounded up to the closest integer pixel boundary.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#round-up-to-grid>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4433>
+    pub(super) fn op_rutg(&mut self) -> OpResult {
+        self.graphics_state.round_state.mode = RoundMode::UpToGrid;
+        Ok(())
+    }
+
+    /// Round off.
+    ///
+    /// ROFF[] (0x7A)
+    ///
+    /// Sets the round_state variable to state 5 (off). In this state rounding
+    /// is turned off.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#round-off>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4461>
+    pub(super) fn op_roff(&mut self) -> OpResult {
+        self.graphics_state.round_state.mode = RoundMode::Off;
+        Ok(())
+    }
+
+    /// Super round.
+    ///
+    /// SROUND[] (0x76)
+    ///
+    /// Pops: n (number decomposed to obtain period, phase threshold)
+    ///
+    /// SROUND allows you fine control over the effects of the round_state
+    /// variable by allowing you to set the values of three components of
+    /// the round_state: period, phase, and threshold.
+    ///
+    /// More formally, SROUND maps the domain of 26.6 fixed point numbers into
+    /// a set of discrete values that are separated by equal distances.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#super-round>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4475>
+    pub(super) fn op_sround(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.super_round(0x4000, n);
+        self.graphics_state.round_state.mode = RoundMode::Super;
+        Ok(())
+    }
+
+    /// Super round 45 degrees.
+    ///
+    /// S45ROUND[] (0x77)
+    ///
+    /// Pops: n (number decomposed to obtain period, phase threshold)
+    ///
+    /// S45ROUND is analogous to SROUND. The gridPeriod is SQRT(2)/2 pixels
+    /// rather than 1 pixel. It is useful for measuring at a 45 degree angle
+    /// with the coordinate axes.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#super-round-45-degrees>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4492>
+    pub(super) fn op_s45round(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.super_round(0x2D41, n);
+        self.graphics_state.round_state.mode = RoundMode::Super45;
+        Ok(())
+    }
+
+    /// Helper function for decomposing period, phase and threshold for
+    /// the SROUND[] and SROUND45[] instructions.
+    ///
+    /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2299>
+    fn super_round(&mut self, grid_period: i32, selector: i32) {
+        let round_state = &mut self.graphics_state.round_state;
+        let period = match selector & 0xC0 {
+            0 => grid_period / 2,
+            0x40 => grid_period,
+            0x80 => grid_period * 2,
+            0xC0 => grid_period,
+            _ => round_state.period,
+        };
+        let phase = match selector & 0x30 {
+            0 => 0,
+            0x10 => period / 4,
+            0x20 => period / 2,
+            0x30 => period * 3 / 4,
+            _ => round_state.phase,
+        };
+        let threshold = if (selector & 0x0F) == 0 {
+            period - 1
+        } else {
+            ((selector & 0x0F) - 4) * period / 8
+        };
+        round_state.period = period >> 8;
+        round_state.phase = phase >> 8;
+        round_state.threshold = threshold >> 8;
+    }
+
+    /// Set loop variable.
+    ///
+    /// SLOOP[] (0x17)
+    ///
+    /// Pops: n (value for loop Graphics State variable (integer))
+    ///
+    /// Pops a value, n, from the stack and sets the loop variable count to
+    /// that value. The loop variable works with the SHP\[a\], SHPIX[], IP[],
+    /// FLIPPT[], and ALIGNRP[]. The value n indicates the number of times
+    /// the instruction is to be repeated. After the instruction executes,
+    /// the loop variable is reset to 1.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-loop-variable>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3287>
+    pub(super) fn op_sloop(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        if n < 0 {
+            return Err(HintErrorKind::NegativeLoopCounter);
+        }
+        // As FreeType, heuristically limit the number of loops to 16 bits.
+        self.graphics_state.loop_counter = (n as u32).min(0xFFFF);
+        Ok(())
+    }
+
+    /// Set minimum distance.
+    ///
+    /// SMD[] (0x1A)
+    ///
+    /// Pops: distance: value for minimum_distance (F26Dot6)
+    ///
+    /// Pops a value from the stack and sets the minimum_distance variable
+    /// to that value. The distance is assumed to be expressed in sixty-fourths
+    /// of a pixel.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-minimum_distance>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4266>
+    pub(super) fn op_smd(&mut self) -> OpResult {
+        let distance = self.value_stack.pop()?;
+        self.graphics_state.min_distance = distance;
+        Ok(())
+    }
+
+    /// Instruction execution control.
+    ///
+    /// INSTCTRL[] (0x8E)
+    ///
+    /// Pops: s: selector flag (int32)
+    ///       value: used to set value of instruction_control (uint16 padded)
+    ///
+    /// Sets the instruction control state variable making it possible to turn
+    /// on or off the execution of instructions and to regulate use of
+    /// parameters set in the CVT program. INSTCTRL[ ] can only be executed in
+    /// the CVT program.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#instruction-execution-control>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4871>
+    pub(super) fn op_instctrl(&mut self) -> OpResult {
+        let selector = self.value_stack.pop()? as u32;
+        let value = self.value_stack.pop()? as u32;
+        // Selectors are indices starting with 1; not flags.
+        // Convert index to flag.
+        let selector_flag = 1 << (selector - 1);
+        if !(1..=3).contains(&selector) || (value != 0 && value != selector_flag) {
+            return Ok(());
+        }
+        match (self.initial_program, selector) {
+            // Typically, this instruction can only be executed in the prep table.
+            (ProgramKind::ControlValue, _) => {
+                self.graphics_state.instruct_control &= !(selector_flag as u8);
+                self.graphics_state.instruct_control |= value as u8;
+            }
+            // Allow an exception in the glyph program for selector 3 which can
+            // temporarily disable backward compability mode.
+            (ProgramKind::Glyph, 3) => {
+                self.graphics_state.backward_compatibility = value != 4;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Scan conversion control.
+    ///
+    /// SCANCTRL[] (0x85)
+    ///
+    /// Pops: n: flags indicating when to turn on dropout control mode
+    ///
+    /// SCANCTRL is used to set the value of the Graphics State variable
+    /// scan_control which in turn determines whether the scan converter
+    /// will activate dropout control for this glyph.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#scan-conversion-control>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4933>
+    pub(super) fn op_scanctrl(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        // Bits 0-7 represent the threshold value for ppem.
+        let threshold = n & 0xFF;
+        match threshold {
+            // A value of FF in bits 0-7 means invoke dropout_control for all
+            // sizes.
+            0xFF => self.graphics_state.scan_control = true,
+            // A value of 0 in bits 0-7 means never invoke dropout_control.
+            0 => self.graphics_state.scan_control = false,
+            _ => {
+                let ppem = self.graphics_state.ppem;
+                let is_rotated = self.graphics_state.is_rotated;
+                let is_stretched = self.graphics_state.is_stretched;
+                let scan_control = &mut self.graphics_state.scan_control;
+                // Bits 8-13 are used to turn on dropout_control in cases where
+                // the specified conditions are met. Bits 8, 9 and 10 are used
+                // to turn on the dropout_control mode (assuming other
+                // conditions do not block it). Bits 11, 12, and 13 are used to
+                // turn off the dropout mode unless other conditions force it
+                if (n & 0x100) != 0 && ppem <= threshold {
+                    // Bit 8: Set dropout_control to TRUE if other conditions
+                    // do not block and ppem is less than or equal to the
+                    // threshold value.
+                    *scan_control = true;
+                }
+                if (n & 0x200) != 0 && is_rotated {
+                    // Bit 9: Set dropout_control to TRUE if other conditions
+                    // do not block and the glyph is rotated
+                    *scan_control = true;
+                }
+                if (n & 0x400) != 0 && is_stretched {
+                    // Bit 10: Set dropout_control to TRUE if other conditions
+                    // do not block and the glyph is stretched.
+                    *scan_control = true;
+                }
+                if (n & 0x800) != 0 && ppem > threshold {
+                    // Bit 11: Set dropout_control to FALSE unless ppem is less
+                    // than or equal to the threshold value.
+                    *scan_control = false;
+                }
+                if (n & 0x1000) != 0 && is_rotated {
+                    // Bit 12: Set dropout_control to FALSE unless the glyph is
+                    // rotated.
+                    *scan_control = false;
+                }
+                if (n & 0x2000) != 0 && is_stretched {
+                    // Bit 13: Set dropout_control to FALSE unless the glyph is
+                    // stretched.
+                    *scan_control = false;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Scan type.
+    ///
+    /// SCANTYPE[] (0x8D)
+    ///
+    /// Pops: n: 16 bit integer
+    ///
+    /// Pops a 16-bit integer whose value is used to determine which rules the
+    /// scan converter will use.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#scantype>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4980>
+    pub(super) fn op_scantype(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.scan_type = n & 0xFFFF;
+        Ok(())
+    }
+
+    /// Set control value table cut in.
+    ///
+    /// SCVTCI[] (0x1D)
+    ///
+    /// Pops: n: value for cut_in (F26Dot6)
+    ///
+    /// Sets the control_value_cut_in in the Graphics State. The value n is
+    /// expressed in sixty-fourths of a pixel.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-control-value-table-cut-in>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4280>
+    pub(super) fn op_scvtci(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.control_value_cutin = n;
+        Ok(())
+    }
+
+    /// Set single width cut in.
+    ///
+    /// SSWCI[] (0x1E)
+    ///
+    /// Pops: n: value for single_width_cut_in (F26Dot6)
+    ///
+    /// Sets the single_width_cut_in in the Graphics State. The value n is
+    /// expressed in sixty-fourths of a pixel.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-single_width_cut_in>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4294>
+    pub(super) fn op_sswci(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.single_width_cutin = n;
+        Ok(())
+    }
+
+    /// Set single width.
+    ///
+    /// SSW[] (0x1F)
+    ///
+    /// Pops: n: value for single_width_value (FUnits)
+    ///
+    /// Sets the single_width_value in the Graphics State. The
+    /// single_width_value is expressed in FUnits, which the
+    /// interpreter converts to pixels (F26Dot6).
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-single-width>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4308>
+    pub(super) fn op_ssw(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.single_width = math::mul(n, self.graphics_state.scale);
+        Ok(())
+    }
+
+    /// Set auto flip on.
+    ///
+    /// FLIPON[] (0x4D)
+    ///
+    /// Sets the auto_flip Boolean in the Graphics State to TRUE causing the
+    /// MIRP instructions to ignore the sign of Control Value Table entries.
+    /// The default auto_flip Boolean value is TRUE.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-the-auto_flip-boolean-to-on>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4323>
+    pub(super) fn op_flipon(&mut self) -> OpResult {
+        self.graphics_state.auto_flip = true;
+        Ok(())
+    }
+
+    /// Set auto flip off.
+    ///
+    /// FLIPOFF[] (0x4E)
+    ///
+    /// Set the auto_flip Boolean in the Graphics State to FALSE causing the
+    /// MIRP instructions to use the sign of Control Value Table entries.
+    /// The default auto_flip Boolean value is TRUE.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-the-auto_flip-boolean-to-off>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4336>
+    pub(super) fn op_flipoff(&mut self) -> OpResult {
+        self.graphics_state.auto_flip = false;
+        Ok(())
+    }
+
+    /// Set angle weight.
+    ///
+    /// SANGW[] (0x7E)
+    ///
+    /// Pops: weight: value for angle_weight
+    ///
+    /// SANGW is no longer needed because of dropped support to the AA
+    /// (Adjust Angle) instruction. AA was the only instruction that used
+    /// angle_weight in the global graphics state.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-angle_weight>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4349>
+    pub(super) fn op_sangw(&mut self) -> OpResult {
+        // totally unsupported
+        let _weight = self.value_stack.pop()?;
+        Ok(())
+    }
+
+    /// Set delta base in graphics state.
+    ///
+    /// SDB[] (0x5E)
+    ///
+    /// Pops: n: value for delta_base
+    ///
+    /// Pops a number, n, and sets delta_base to the value n. The default for
+    /// delta_base is 9.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-delta_base-in-the-graphics-state>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4362>
+    pub(super) fn op_sdb(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        self.graphics_state.delta_base = n as u16;
+        Ok(())
+    }
+
+    /// Set delta shift in graphics state.
+    ///
+    /// SDS[] (0x5F)
+    ///
+    /// Pops: n: value for delta_shift
+    ///
+    /// Sets delta_shift to the value n. The default for delta_shift is 3.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#set-delta_shift-in-the-graphics-state>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4376>
+    pub(super) fn op_sds(&mut self) -> OpResult {
+        let n = self.value_stack.pop()?;
+        if n > 6 {
+            Err(HintErrorKind::InvalidStackValue(n))
+        } else {
+            self.graphics_state.delta_shift = n as u16;
+            Ok(())
+        }
+    }
+}
+
+/// Computes a parallel or perpendicular normalized vector for the line
+/// between the two given points.
+///
+/// This is common code for the "set vector to line" instructions.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L4009>
+fn line_vector(p1: Point<i32>, p2: Point<i32>, is_parallel: bool) -> Point<i32> {
+    let mut a = p1.x - p2.x;
+    let mut b = p1.y - p2.y;
+    if a == 0 && b == 0 {
+        // If the points are equal, set to the x axis.
+        a = 0x4000;
+    } else if !is_parallel {
+        // Perform a counter-clockwise rotation by 90 degrees to form a
+        // perpendicular line.
+        let c = b;
+        b = a;
+        a = -c;
+    }
+    math::normalize14(a, b)
+}

--- a/skrifa/src/outline/glyf/hint/engine/logical.rs
+++ b/skrifa/src/outline/glyf/hint/engine/logical.rs
@@ -1,8 +1,8 @@
 //! Logical functions.
 //!
+//! Implements 11 instructions.
+//!
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#logical-functions>
-
-// 11 instructions
 
 use super::{Engine, OpResult};
 

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -1,10 +1,14 @@
 //! TrueType bytecode interpreter.
 
 mod arith;
+mod graphics_state;
 mod logical;
 mod stack;
 
-use super::{error::HintErrorKind, graphics_state::GraphicsState, value_stack::ValueStack};
+use super::{
+    code_state::ProgramKind, error::HintErrorKind, graphics_state::GraphicsState,
+    value_stack::ValueStack,
+};
 
 pub type OpResult = Result<(), HintErrorKind>;
 
@@ -12,6 +16,7 @@ pub type OpResult = Result<(), HintErrorKind>;
 pub struct Engine<'a> {
     graphics_state: GraphicsState<'a>,
     value_stack: ValueStack<'a>,
+    initial_program: ProgramKind,
 }
 
 #[cfg(test)]
@@ -19,7 +24,7 @@ use mock::MockEngine;
 
 #[cfg(test)]
 mod mock {
-    use super::{Engine, GraphicsState, ValueStack};
+    use super::{Engine, GraphicsState, ProgramKind, ValueStack};
 
     /// Mock engine for testing.
     pub(super) struct MockEngine {
@@ -37,6 +42,7 @@ mod mock {
             Engine {
                 graphics_state: GraphicsState::default(),
                 value_stack: ValueStack::new(&mut self.value_stack),
+                initial_program: ProgramKind::Font,
             }
         }
     }

--- a/skrifa/src/outline/glyf/hint/engine/stack.rs
+++ b/skrifa/src/outline/glyf/hint/engine/stack.rs
@@ -1,9 +1,9 @@
 //! Managing the stack and pushing data onto the interpreter stack.
 //!
+//! Implements 26 instructions.
+//!
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-stack>
 //! and <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#pushing-data-onto-the-interpreter-stack>
-
-// 26 instructions
 
 use super::{super::code_state::Args, Engine, OpResult};
 


### PR DESCRIPTION
Add implementations for the "managing the graphics state" group of TrueType instructions (https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-graphics-state).

