### PR TITLE
[skrifa] support Size::new(0)

### DIFF
--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -1304,7 +1304,7 @@ mod tests {
         let font = FontRef::new(font_test_data::CANTARELL_VF_TRIMMED).unwrap();
         let cff_font = super::super::Outlines::new(&font).unwrap();
         let state = cff_font
-            .subfont(0, 8.0, &[F2Dot14::from_f32(-1.0); 2])
+            .subfont(0, Some(8.0), &[F2Dot14::from_f32(-1.0); 2])
             .unwrap()
             .hint_state;
         let mut initial_map = HintMap::new(state.scale);

--- a/skrifa/src/outline/embedded_hinting.rs
+++ b/skrifa/src/outline/embedded_hinting.rs
@@ -93,9 +93,9 @@ impl EmbeddedHintingInstance {
                     _ => vec![],
                 };
                 subfonts.clear();
-                let size = size.ppem().unwrap_or_default();
+                let ppem = size.ppem();
                 for i in 0..cff.subfont_count() {
-                    subfonts.push(cff.subfont(i, size, &self.coords)?);
+                    subfonts.push(cff.subfont(i, ppem, &self.coords)?);
                 }
                 self.kind = HinterKind::Cff(subfonts);
             }
@@ -110,7 +110,7 @@ impl EmbeddedHintingInstance {
         memory: Option<&mut [u8]>,
         pen: &mut impl OutlinePen,
     ) -> Result<AdjustedMetrics, DrawError> {
-        let ppem = self.size.ppem().unwrap_or_default();
+        let ppem = self.size.ppem();
         let coords = self.coords.as_slice();
         match (&self.kind, &glyph.kind) {
             (HinterKind::Glyf, OutlineKind::Glyf(glyf, outline)) => {

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -135,7 +135,7 @@ impl<'a> Outlines<'a> {
         &self,
         memory: OutlineMemory<'a>,
         outline: &Outline,
-        size: f32,
+        size: Option<f32>,
         coords: &'a [F2Dot14],
     ) -> Result<ScaledOutline<'a>, DrawError> {
         Scaler::new(self.clone(), memory, size, coords, |_| true, false)
@@ -146,7 +146,7 @@ impl<'a> Outlines<'a> {
         &self,
         memory: OutlineMemory<'a>,
         outline: &Outline,
-        size: f32,
+        size: Option<f32>,
         coords: &'a [F2Dot14],
         hint_fn: impl FnMut(HintOutline) -> bool,
     ) -> Result<ScaledOutline<'a>, DrawError> {
@@ -285,19 +285,18 @@ where
     fn new(
         outlines: Outlines<'a>,
         memory: OutlineMemory<'a>,
-        size: f32,
+        size: Option<f32>,
         coords: &'a [F2Dot14],
         hint_fn: H,
         is_hinted: bool,
     ) -> Self {
-        let (is_scaled, scale) = if size > 0.0 && outlines.units_per_em > 0 {
-            (
+        let (is_scaled, scale) = match size {
+            Some(ppem) if outlines.units_per_em > 0 => (
                 true,
-                F26Dot6::from_bits((size * 64.) as i32)
+                F26Dot6::from_bits((ppem * 64.) as i32)
                     / F26Dot6::from_bits(outlines.units_per_em as i32),
-            )
-        } else {
-            (false, F26Dot6::from_bits(0x10000))
+            ),
+            _ => (false, F26Dot6::from_bits(0x10000)),
         };
         Self {
             outlines,

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -230,7 +230,7 @@ impl<'a> OutlineGlyph<'a> {
         memory: Option<&mut [u8]>,
         pen: &mut impl OutlinePen,
     ) -> Result<AdjustedMetrics, DrawError> {
-        let ppem = size.ppem().unwrap_or_default();
+        let ppem = size.ppem();
         let coords = location.into().coords();
         match &self.kind {
             OutlineKind::Glyf(glyf, outline) => {
@@ -462,15 +462,17 @@ mod tests {
             if expected_outline.size == 0.0 && !expected_outline.coords.is_empty() {
                 continue;
             }
+            let size = if expected_outline.size != 0.0 {
+                Size::new(expected_outline.size)
+            } else {
+                Size::unscaled()
+            };
             path.elements.clear();
             font.outline_glyphs()
                 .get(expected_outline.glyph_id)
                 .unwrap()
                 .draw(
-                    DrawSettings::unhinted(
-                        Size::new(expected_outline.size),
-                        expected_outline.coords.as_slice(),
-                    ),
+                    DrawSettings::unhinted(size, expected_outline.coords.as_slice()),
                     &mut path,
                 )
                 .unwrap();

--- a/skrifa/src/scale.rs
+++ b/skrifa/src/scale.rs
@@ -463,9 +463,14 @@ mod tests {
                 continue;
             }
             path.elements.clear();
+            let size = if expected_outline.size != 0.0 {
+                Size::new(expected_outline.size)
+            } else {
+                Size::unscaled()
+            };
             let mut scaler = cx
                 .new_scaler()
-                .size(Size::new(expected_outline.size))
+                .size(size)
                 .normalized_coords(&expected_outline.coords)
                 .build(&font);
             scaler


### PR DESCRIPTION
The `Size::new(ppem: f32)` constructor interpreted a ppem of 0.0 as a request for no scaling which might be surprising behavior for users. This changes the internal representation of size to hold an `Option` so that a ppem of 0.0 works as expected.

Fixes #627