### PR TITLE
Add links that would have saved me time

### DIFF
--- a/skrifa/src/instance.rs
+++ b/skrifa/src/instance.rs
@@ -73,6 +73,8 @@ impl Size {
 
 /// Reference to an ordered sequence of normalized variation coordinates.
 ///
+/// To convert from user coordinates see [`skrifa::AxisCollection::location`].
+///
 /// This type represents a position in the variation space where each
 /// coordinate corresponds to an axis (in the same order as the `fvar` table)
 /// and is a normalized value in the range `[-1..1]`.
@@ -134,6 +136,8 @@ impl<'a> IntoIterator for &'_ LocationRef<'a> {
 const MAX_INLINE_COORDS: usize = 8;
 
 /// Ordered sequence of normalized variation coordinates.
+///
+/// To produce from user coordinates see [`skrifa::AxisCollection::location`].
 ///
 /// This is an owned version of [`LocationRef`]. See the documentation on that
 /// type for more detail.

--- a/skrifa/src/variation.rs
+++ b/skrifa/src/variation.rs
@@ -78,6 +78,9 @@ impl Axis {
 
 /// Collection of axes in a variable font.
 ///
+/// Converts user ([fvar](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar))
+/// locations to normalized locations. See [`Self::location`].
+///
 /// See the [`Axis`] type for more detail.
 #[derive(Clone)]
 pub struct AxisCollection<'a> {


### PR DESCRIPTION
Producing a (normalized) Location from user coordinates is non-obvious if you happen to start at the Location types.