### PR TITLE
[skrifa] tthint: fdef/idef storage

### DIFF
--- a/skrifa/src/outline/glyf/hint/definition.rs
+++ b/skrifa/src/outline/glyf/hint/definition.rs
@@ -1,0 +1,230 @@
+//! Management of function and instruction definitions.
+
+use core::ops::Range;
+
+use super::{error::HintErrorKind, program::Program};
+
+/// Code range and properties for a function or instruction definition.
+// Note: this type is designed to support allocation from user memory
+// so make sure the fields are all tightly packed and only use integral
+// types.
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttobjs.h#L158>
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+#[repr(C)]
+pub struct Definition {
+    start: u32,
+    end: u32,
+    // Either function number or opcode
+    key: i32,
+    _pad: u16,
+    program: u8,
+    is_active: u8,
+}
+
+impl Definition {
+    /// Creates a new definition with the given program, code range and
+    /// key.
+    ///
+    /// The key is either a function number or opcode for function and
+    /// instruction definitions respectively.
+    pub fn new(program: Program, code_range: Range<usize>, key: i32) -> Self {
+        Self {
+            program: program as u8,
+            // Table sizes are specified in u32 so valid ranges will
+            // always fit.
+            start: code_range.start as u32,
+            end: code_range.end as u32,
+            key,
+            _pad: 0,
+            is_active: 1,
+        }
+    }
+
+    /// Returns the program that contains this definition.
+    pub fn program(&self) -> Program {
+        match self.program {
+            0 => Program::Font,
+            1 => Program::ControlValue,
+            _ => Program::Glyph,
+        }
+    }
+
+    /// Returns the byte range of the code for this definition in the source
+    /// program.
+    pub fn code_range(&self) -> Range<usize> {
+        self.start as usize..self.end as usize
+    }
+
+    /// Returns the function number or opcode.
+    pub fn key(&self) -> i32 {
+        self.key
+    }
+
+    /// Returns true if this definition entry has been defined by a program.
+    pub fn is_active(&self) -> bool {
+        self.is_active != 0
+    }
+}
+
+/// Map of function number or opcode to code definitions.
+///
+/// The `Ref` vs `Mut` distinction exists because these can be modified
+/// from the font and control value programs but not from a glyph program.
+/// In addition, hinting instance state is immutable once initialized so
+/// this captures that in a type safe way.
+pub enum DefinitionMap<'a> {
+    Ref(&'a [Definition]),
+    Mut(&'a mut [Definition]),
+}
+
+impl<'a> DefinitionMap<'a> {
+    /// Attempts to allocate a new definition entry with the given key.
+    ///
+    /// Overriding a definition is legal, so if an existing active entry
+    /// is found with the same key, that one will be returned. Otherwise,
+    /// an inactive entry will be chosen.
+    pub fn allocate(&mut self, key: i32) -> Result<&mut Definition, HintErrorKind> {
+        let Self::Mut(defs) = self else {
+            return Err(HintErrorKind::DefinitionInGlyphProgram);
+        };
+        // First, see if we can use key as an index.
+        //
+        // For function definitions in well-behaved fonts (that is, where
+        // function numbers fall within 0..max_function_defs) this will
+        // always work.
+        //
+        // For instruction definitions, this will likely never work
+        // because the number of instruction definitions is usually small
+        // (nearly always 0) and the available opcodes are in the higher
+        // ranges of u8 space.
+        let ix = if defs
+            .get(key as usize)
+            .filter(|def| !def.is_active() || def.key == key)
+            .is_some()
+        {
+            // If the entry is inactive or the key matches, we're good.
+            key as usize
+        } else {
+            // Otherwise, walk backward looking for an active entry with
+            // a matching key. Keep track of the inactive entry with the
+            // highest index.
+            let mut last_inactive_ix = None;
+            for (i, def) in defs.iter().enumerate().rev() {
+                if def.is_active() {
+                    if def.key == key {
+                        last_inactive_ix = Some(i);
+                        break;
+                    }
+                } else if last_inactive_ix.is_none() {
+                    last_inactive_ix = Some(i);
+                }
+            }
+            last_inactive_ix.ok_or(HintErrorKind::TooManyDefinitions)?
+        };
+        let def = defs.get_mut(ix).ok_or(HintErrorKind::TooManyDefinitions)?;
+        *def = Definition::new(Program::Font, 0..0, key);
+        Ok(def)
+    }
+
+    /// Returns the definition with the given key.
+    pub fn get(&self, key: i32) -> Result<&Definition, HintErrorKind> {
+        let defs = match self {
+            Self::Mut(defs) => *defs,
+            Self::Ref(defs) => *defs,
+        };
+        // Fast path, try to use key as index.
+        if let Some(def) = defs.get(key as usize) {
+            if def.is_active() && def.key == key {
+                return Ok(def);
+            }
+        }
+        // Otherwise, walk backward doing a linear search.
+        for def in defs.iter().rev() {
+            if def.is_active() && def.key == key {
+                return Ok(def);
+            }
+        }
+        Err(HintErrorKind::InvalidDefintion(key as _))
+    }
+
+    /// Returns a reference to the underlying definition slice.
+    pub fn as_slice(&self) -> &[Definition] {
+        match self {
+            Self::Ref(defs) => defs,
+            Self::Mut(defs) => defs,
+        }
+    }
+
+    /// If the map is mutable, resets all definitions to the default
+    /// value.
+    pub fn reset(&mut self) {
+        if let Self::Mut(defs) = self {
+            defs.fill(Default::default())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alloc(set: &mut DefinitionMap, key: i32) {
+        let def = set.allocate(key).unwrap();
+        *def = Definition::new(Program::Font, 0..0, key);
+    }
+
+    #[test]
+    fn too_many_and_invalid() {
+        let mut buf = vec![Default::default(); 32];
+        let mut map = DefinitionMap::Mut(&mut buf);
+        for i in 0..32 {
+            map.allocate(i).unwrap();
+        }
+        assert!(matches!(
+            map.allocate(33),
+            Err(HintErrorKind::TooManyDefinitions)
+        ));
+        assert!(matches!(
+            map.get(33),
+            Err(HintErrorKind::InvalidDefintion(33))
+        ));
+    }
+
+    #[test]
+    fn allocate_dense() {
+        let mut buf = vec![Default::default(); 32];
+        let mut map = DefinitionMap::Mut(&mut buf);
+        for i in 0..32 {
+            map.allocate(i).unwrap();
+        }
+        for (i, def) in map.as_slice().iter().enumerate() {
+            let key = i as i32;
+            map.get(key).unwrap();
+            assert_eq!(def.key(), key);
+        }
+    }
+
+    #[test]
+    fn allocate_sparse() {
+        let mut buf = vec![Default::default(); 10];
+        let mut map = DefinitionMap::Mut(&mut buf);
+        // The first 4 keys are in order which should be allocated to an entry
+        // where index == key. The next three will be allocated from the end
+        // of the definition storage. The last one will also be allocated to
+        // its own index because it happens to be free.
+        let keys = [0, 1, 2, 3, 123456, -42, -5555, 5];
+        for key in keys {
+            map.allocate(key).unwrap();
+        }
+        let slice = map.as_slice();
+        // For first 4 and last, index == key
+        for i in (0..4).chain(Some(5)) {
+            assert_eq!(slice[i].key, i as i32);
+        }
+        // The rest would be allocated from the end of the array in
+        // reverse order.
+        for (&a, b) in keys[4..7].iter().rev().zip(&slice[slice.len() - 3..]) {
+            assert_eq!(a, b.key());
+        }
+    }
+}

--- a/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
@@ -7,7 +7,7 @@
 use read_fonts::types::Point;
 
 use super::{
-    super::{code_state::ProgramKind, graphics_state::RoundMode, math},
+    super::{graphics_state::RoundMode, math, program::Program},
     Engine, HintErrorKind, OpResult,
 };
 
@@ -562,13 +562,13 @@ impl<'a> Engine<'a> {
         }
         match (self.initial_program, selector) {
             // Typically, this instruction can only be executed in the prep table.
-            (ProgramKind::ControlValue, _) => {
+            (Program::ControlValue, _) => {
                 self.graphics_state.instruct_control &= !(selector_flag as u8);
                 self.graphics_state.instruct_control |= value as u8;
             }
             // Allow an exception in the glyph program for selector 3 which can
             // temporarily disable backward compatibility mode.
-            (ProgramKind::Glyph, 3) => {
+            (Program::Glyph, 3) => {
                 self.graphics_state.backward_compatibility = value != 4;
             }
             _ => {}
@@ -828,7 +828,7 @@ mod tests {
             super::graphics_state::{Zone, ZonePointer},
             MockEngine,
         },
-        HintErrorKind, Point, ProgramKind, RoundMode,
+        HintErrorKind, Point, Program, RoundMode,
     };
     use read_fonts::types::F2Dot14;
 
@@ -1074,7 +1074,7 @@ mod tests {
     fn instctrl() {
         let mut mock = MockEngine::new();
         let mut engine = mock.engine();
-        engine.initial_program = ProgramKind::ControlValue;
+        engine.initial_program = Program::ControlValue;
         // selectors 1..=3 are valid and values for each selector
         // can be 0, which disables the field, or 1 << (selector - 1) to
         // enable it
@@ -1093,7 +1093,7 @@ mod tests {
         }
         // in glyph programs, selector 3 can be used to toggle
         // backward_compatibility
-        engine.initial_program = ProgramKind::Glyph;
+        engine.initial_program = Program::Glyph;
         // enabling this flag opts into "native ClearType mode"
         // which disables backward compatibility
         engine.value_stack.push((3 - 1) << 1).unwrap();

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -11,9 +11,9 @@ use read_fonts::tables::glyf::bytecode::{Decoder, Instruction};
 
 use super::{
     super::Outlines,
-    code_state::ProgramKind,
     error::{HintError, HintErrorKind},
     graphics_state::GraphicsState,
+    program::Program,
     value_stack::ValueStack,
 };
 
@@ -23,7 +23,7 @@ pub type OpResult = Result<(), HintErrorKind>;
 pub struct Engine<'a> {
     graphics_state: GraphicsState<'a>,
     value_stack: ValueStack<'a>,
-    initial_program: ProgramKind,
+    initial_program: Program,
     decoder: Decoder<'a>,
     loop_budget: LoopBudget,
 }
@@ -83,7 +83,7 @@ use mock::MockEngine;
 
 #[cfg(test)]
 mod mock {
-    use super::{Decoder, Engine, GraphicsState, LoopBudget, ProgramKind, ValueStack};
+    use super::{Decoder, Engine, GraphicsState, LoopBudget, Program, ValueStack};
 
     /// Mock engine for testing.
     pub(super) struct MockEngine {
@@ -101,7 +101,7 @@ mod mock {
             Engine {
                 graphics_state: GraphicsState::default(),
                 value_stack: ValueStack::new(&mut self.value_stack),
-                initial_program: ProgramKind::Font,
+                initial_program: Program::Font,
                 decoder: Decoder::new(&[], 0),
                 loop_budget: LoopBudget {
                     limit: 10,

--- a/skrifa/src/outline/glyf/hint/mod.rs
+++ b/skrifa/src/outline/glyf/hint/mod.rs
@@ -1,10 +1,11 @@
 //! TrueType hinting.
 
-mod code_state;
+mod definition;
 mod engine;
 mod error;
 mod graphics_state;
 mod math;
+mod program;
 mod value_stack;
 
 use read_fonts::{

--- a/skrifa/src/outline/glyf/hint/program.rs
+++ b/skrifa/src/outline/glyf/hint/program.rs
@@ -3,7 +3,7 @@
 /// Describes the source for a piece of bytecode.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 #[repr(u8)]
-pub enum ProgramKind {
+pub enum Program {
     /// Program that initializes the function and instruction tables. Stored
     /// in the `fpgm` table.
     #[default]


### PR DESCRIPTION
Adds a new `Definition` type that is used to represent function and instruction definitions. Also includes a `DefinitionMap` type that is used to allocate and retrieve these.

This handles the case where `function_number >= max_function_defs` avoiding the question as to whether this is necessary. Well behaved fonts will hit the fast path and broken ones will fall back to a linear search.

There's a bit of churn around the `code_state` module. This was removed because it was meant to contain the decoder logic which was moved to `read-fonts`.