### PR TITLE
[skrifa] tthint: cvt and storage area

### DIFF
--- a/skrifa/src/outline/glyf/hint/cow_slice.rs
+++ b/skrifa/src/outline/glyf/hint/cow_slice.rs
@@ -1,4 +1,4 @@
-//! Copy-on-write contain for CVT and storage area.
+//! Copy-on-write buffer for CVT and storage area.
 
 /// Backing store for the CVT and storage area.
 ///
@@ -77,7 +77,7 @@ impl<'a> CowSlice<'a> {
 
     /// Writes a value to the given index.
     ///
-    /// If the immutable buffer hasn't been initialized, first performs a full
+    /// If the mutable buffer hasn't been initialized, first performs a full
     /// buffer copy.
     pub fn set(&mut self, index: usize, value: i32) -> Option<()> {
         // Copy from immutable to mutable buffer if we haven't already

--- a/skrifa/src/outline/glyf/hint/cow_slice.rs
+++ b/skrifa/src/outline/glyf/hint/cow_slice.rs
@@ -1,0 +1,149 @@
+//! Copy-on-write contain for CVT and storage area.
+
+/// Backing store for the CVT and storage area.
+///
+/// The CVT and storage area are initialized in the control value program
+/// with values that are relevant to a particular size and hinting
+/// configuration. However, some fonts contain code in glyph programs
+/// that write to these buffers. Any modifications made in a glyph program
+/// should not affect future glyphs and thus should not persist beyond
+/// execution of that program. To solve this problem, a copy of the buffer
+/// is made on the first write in a glyph program and all changes are
+/// discarded on completion.
+///
+/// For more context, see <https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/23>
+///
+/// # Implementation notes
+///
+/// The current implementation defers the copy but not the allocation. This
+/// is to support the guarantee of no heap allocation when operating on user
+/// provided memory. Investigation of hinted Noto fonts suggests that writing
+/// to CVT/Storage in glyph programs is common for ttfautohinted fonts so the
+/// speculative allocation is likely worthwhile.
+pub struct CowSlice<'a> {
+    data: &'a [i32],
+    data_mut: &'a mut [i32],
+    /// True if we've initialized the mutable slice
+    use_mut: bool,
+}
+
+impl<'a> CowSlice<'a> {
+    /// Creates a new copy-on-write slice with the given buffers.
+    ///
+    /// The `data` buffer is expected to contain the initial data and the content
+    /// of `data_mut` is ignored unless the [`set`](Self::set) method is called
+    /// in which case a copy will be made from `data` to `data_mut` and the
+    /// mutable buffer will be used for all further access.
+    ///
+    /// Returns [`CowSliceSizeMismatchError`] if `data.len() != data_mut.len()`.
+    pub fn new(
+        data: &'a [i32],
+        data_mut: &'a mut [i32],
+    ) -> Result<Self, CowSliceSizeMismatchError> {
+        if data.len() != data_mut.len() {
+            return Err(CowSliceSizeMismatchError(data.len(), data_mut.len()));
+        }
+        Ok(Self {
+            data,
+            data_mut,
+            use_mut: false,
+        })
+    }
+
+    /// Creates a new copy-on-write slice with the given mutable buffer.
+    ///
+    /// This avoids an extra copy and allocation in contexts where the data is
+    /// already assumed to be mutable (i.e. when executing `fpgm` and `prep`
+    /// programs).
+    pub fn new_mut(data_mut: &'a mut [i32]) -> Self {
+        Self {
+            use_mut: true,
+            data: &[],
+            data_mut,
+        }
+    }
+
+    /// Returns the value at the given index.
+    ///
+    /// If mutable data has been initialized, reads from that buffer. Otherwise
+    /// reads from the immutable buffer.
+    pub fn get(&self, index: usize) -> Option<i32> {
+        if self.use_mut {
+            self.data_mut.get(index).copied()
+        } else {
+            self.data.get(index).copied()
+        }
+    }
+
+    /// Writes a value to the given index.
+    ///
+    /// If the immutable buffer hasn't been initialized, first performs a full
+    /// buffer copy.
+    pub fn set(&mut self, index: usize, value: i32) -> Option<()> {
+        // Copy from immutable to mutable buffer if we haven't already
+        if !self.use_mut {
+            self.data_mut.copy_from_slice(self.data);
+            self.use_mut = true;
+        }
+        *self.data_mut.get_mut(index)? = value;
+        Some(())
+    }
+}
+
+/// Error returned when the sizes of the immutable and mutable buffers
+/// mismatch when constructing a [`CowSlice`].
+#[derive(Clone, Debug)]
+pub struct CowSliceSizeMismatchError(usize, usize);
+
+impl std::fmt::Display for CowSliceSizeMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "size mismatch for immutable and mutable buffers: data.len() = {}, data_mut.len() = {}",
+            self.0, self.1
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CowSlice, CowSliceSizeMismatchError};
+
+    #[test]
+    fn size_mismatch_error() {
+        let data_mut = &mut [0, 0];
+        let result = CowSlice::new(&[1, 2, 3], data_mut);
+        assert!(matches!(result, Err(CowSliceSizeMismatchError(3, 2))))
+    }
+
+    #[test]
+    fn copy_on_write() {
+        let data = std::array::from_fn::<_, 16, _>(|i| i as i32);
+        let mut data_mut = [0i32; 16];
+        let mut slice = CowSlice::new(&data, &mut data_mut).unwrap();
+        // Not mutable yet
+        assert!(!slice.use_mut);
+        for i in 0..data.len() {
+            assert_eq!(slice.get(i).unwrap(), i as i32);
+        }
+        // Modify all values
+        for i in 0..data.len() {
+            let value = slice.get(i).unwrap();
+            slice.set(i, value * 2).unwrap();
+        }
+        // Now we're mutable
+        assert!(slice.use_mut);
+        for i in 0..data.len() {
+            assert_eq!(slice.get(i).unwrap(), i as i32 * 2);
+        }
+    }
+
+    #[test]
+    fn out_of_bounds() {
+        let data_mut = &mut [1, 2];
+        let slice = CowSlice::new_mut(data_mut);
+        assert_eq!(slice.get(0), Some(1));
+        assert_eq!(slice.get(1), Some(2));
+        assert_eq!(slice.get(2), None);
+    }
+}

--- a/skrifa/src/outline/glyf/hint/cvt.rs
+++ b/skrifa/src/outline/glyf/hint/cvt.rs
@@ -1,0 +1,29 @@
+//! Control value table.
+
+use super::{cow_slice::CowSlice, error::HintErrorKind};
+
+/// Backing store for the control value table.
+///
+/// This is just a wrapper for [`CowSlice`] that converts out of bounds
+/// accesses to appropriate errors.
+pub struct Cvt<'a>(CowSlice<'a>);
+
+impl<'a> Cvt<'a> {
+    pub fn get(&self, index: usize) -> Result<i32, HintErrorKind> {
+        self.0
+            .get(index)
+            .ok_or(HintErrorKind::InvalidCvtIndex(index))
+    }
+
+    pub fn set(&mut self, index: usize, value: i32) -> Result<(), HintErrorKind> {
+        self.0
+            .set(index, value)
+            .ok_or(HintErrorKind::InvalidCvtIndex(index))
+    }
+}
+
+impl<'a> From<CowSlice<'a>> for Cvt<'a> {
+    fn from(value: CowSlice<'a>) -> Self {
+        Self(value)
+    }
+}

--- a/skrifa/src/outline/glyf/hint/engine/cvt.rs
+++ b/skrifa/src/outline/glyf/hint/engine/cvt.rs
@@ -1,0 +1,162 @@
+//! Managing the control value table.
+//!
+//! Implements 3 instructions.
+//!
+//! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-control-value-table>
+
+use super::{super::math::mul, Engine, OpResult};
+
+impl<'a> Engine<'a> {
+    /// Write control value table in pixel units.
+    ///
+    /// WCVTP[] (0x44)
+    ///
+    /// Pops: value: number in pixels (F26Dot6 fixed point number),
+    ///       location: Control Value Table location (uint32)
+    ///
+    /// Pops a location and a value from the stack and puts that value in the
+    /// specified location in the Control Value Table. This instruction assumes
+    /// the value is in pixels and not in FUnits.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#write-control-value-table-in-pixel-units>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3044>
+    pub(super) fn op_wcvtp(&mut self) -> OpResult {
+        let value = self.value_stack.pop()?;
+        let location = self.value_stack.pop_usize()?;
+        let result = self.cvt.set(location, value);
+        if self.graphics_state.is_pedantic {
+            result
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Write control value table in font units.
+    ///
+    /// WCVTF[] (0x70)
+    ///
+    /// Pops: value: number in pixels (F26Dot6 fixed point number),
+    ///       location: Control Value Table location (uint32)
+    ///
+    /// Pops a location and a value from the stack and puts the specified
+    /// value in the specified address in the Control Value Table. This
+    /// instruction assumes the value is expressed in FUnits and not pixels.
+    /// The value is scaled before being written to the table.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#write-control-value-table-in-funits>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3067>
+    pub(super) fn op_wcvtf(&mut self) -> OpResult {
+        let value = self.value_stack.pop()?;
+        let location = self.value_stack.pop_usize()?;
+        let result = self
+            .cvt
+            .set(location, mul(value, self.graphics_state.scale));
+        if self.graphics_state.is_pedantic {
+            result
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Read control value table.
+    ///
+    /// RCVT[] (0x45)
+    ///
+    /// Pops: location: CVT entry number
+    /// Pushes: value: CVT value (F26Dot6)
+    ///
+    /// Pops a location from the stack and pushes the value in the location
+    /// specified in the Control Value Table onto the stack.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#read-control-value-table>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3090>
+    pub(super) fn op_rcvt(&mut self) -> OpResult {
+        let location = self.value_stack.pop()? as usize;
+        let maybe_value = self.cvt.get(location);
+        let value = if self.graphics_state.is_pedantic {
+            maybe_value?
+        } else {
+            maybe_value.unwrap_or(0)
+        };
+        self.value_stack.push(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{super::math, HintErrorKind, MockEngine};
+
+    #[test]
+    fn write_read() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        for i in 0..8 {
+            engine.value_stack.push(i).unwrap();
+            engine.value_stack.push(i * 2).unwrap();
+            engine.op_wcvtp().unwrap();
+        }
+        for i in 0..8 {
+            engine.value_stack.push(i).unwrap();
+            engine.op_rcvt().unwrap();
+            assert_eq!(engine.value_stack.pop().unwrap(), i * 2);
+        }
+    }
+
+    #[test]
+    fn write_scaled_read() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        let scale = 64;
+        engine.graphics_state.scale = scale;
+        for i in 0..8 {
+            engine.value_stack.push(i).unwrap();
+            engine.value_stack.push(i * 2).unwrap();
+            // WCVTF takes a value in font units and converts to pixels
+            // with the current scale
+            engine.op_wcvtf().unwrap();
+        }
+        for i in 0..8 {
+            engine.value_stack.push(i).unwrap();
+            engine.op_rcvt().unwrap();
+            let value = engine.value_stack.pop().unwrap();
+            assert_eq!(value, math::mul(i * 2, scale));
+        }
+    }
+
+    #[test]
+    fn pedantry() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        let oob_index = 1000;
+        // Disable pedantic mode: OOB writes are ignored, OOB reads
+        // push 0
+        engine.graphics_state.is_pedantic = false;
+        engine.value_stack.push(oob_index).unwrap();
+        engine.value_stack.push(0).unwrap();
+        engine.op_wcvtp().unwrap();
+        engine.value_stack.push(oob_index).unwrap();
+        engine.value_stack.push(0).unwrap();
+        engine.op_wcvtf().unwrap();
+        engine.value_stack.push(oob_index).unwrap();
+        engine.op_rcvt().unwrap();
+        // Enable pedantic mode: OOB reads/writes error
+        engine.graphics_state.is_pedantic = true;
+        engine.value_stack.push(oob_index).unwrap();
+        engine.value_stack.push(0).unwrap();
+        assert_eq!(
+            engine.op_wcvtp(),
+            Err(HintErrorKind::InvalidCvtIndex(oob_index as _))
+        );
+        engine.value_stack.push(oob_index).unwrap();
+        engine.value_stack.push(0).unwrap();
+        assert_eq!(
+            engine.op_wcvtf(),
+            Err(HintErrorKind::InvalidCvtIndex(oob_index as _))
+        );
+        engine.value_stack.push(oob_index).unwrap();
+        assert_eq!(
+            engine.op_rcvt(),
+            Err(HintErrorKind::InvalidCvtIndex(oob_index as _))
+        );
+    }
+}

--- a/skrifa/src/outline/glyf/hint/engine/storage.rs
+++ b/skrifa/src/outline/glyf/hint/engine/storage.rs
@@ -1,0 +1,110 @@
+//! Managing the storage area.
+//!
+//! Implements 2 instructions.
+//!
+//! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-storage-area>
+
+use super::{Engine, OpResult};
+
+impl<'a> Engine<'a> {
+    /// Read store.
+    ///
+    /// RS[] (0x43)
+    ///
+    /// Pops: location: Storage Area location
+    /// Pushes: value: Storage Area value
+    ///
+    /// This instruction reads a 32 bit value from the Storage Area location
+    /// popped from the stack and pushes the value read onto the stack. It pops
+    /// an address from the stack and pushes the value found in that Storage
+    /// Area location to the top of the stack. The number of available storage
+    /// locations is specified in the maxProfile table in the font file.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#read-store>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2975>
+    pub(super) fn op_rs(&mut self) -> OpResult {
+        let location = self.value_stack.pop_usize()?;
+        let maybe_value = self.storage.get(location);
+        let value = if self.graphics_state.is_pedantic {
+            maybe_value?
+        } else {
+            maybe_value.unwrap_or(0)
+        };
+        self.value_stack.push(value)
+    }
+
+    /// Write store.
+    ///
+    /// WS[] (0x42)
+    ///
+    /// Pops: value: Storage Area value,
+    ///       location: Storage Area location
+    ///
+    /// This instruction writes a 32 bit value into the storage location
+    /// indexed by locations. It works by popping a value and then a location
+    /// from the stack. The value is placed in the Storage Area location
+    /// specified by that address. The number of storage locations is specified
+    /// in the maxProfile table in the font file.
+    ///
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#write-store>
+    /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3000>
+    pub(super) fn op_ws(&mut self) -> OpResult {
+        let value = self.value_stack.pop()?;
+        let location = self.value_stack.pop_usize()?;
+        let result = self.storage.set(location, value);
+        if self.graphics_state.is_pedantic {
+            result
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{HintErrorKind, MockEngine};
+
+    #[test]
+    fn write_read() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        for i in 0..8 {
+            engine.value_stack.push(i).unwrap();
+            engine.value_stack.push(i * 2).unwrap();
+            engine.op_ws().unwrap();
+        }
+        for i in 0..8 {
+            engine.value_stack.push(i).unwrap();
+            engine.op_rs().unwrap();
+            assert_eq!(engine.value_stack.pop().unwrap(), i * 2);
+        }
+    }
+
+    #[test]
+    fn pedantry() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        let oob_index = 1000;
+        // Disable pedantic mode: OOB writes are ignored, OOB reads
+        // push 0
+        engine.graphics_state.is_pedantic = false;
+        engine.value_stack.push(oob_index).unwrap();
+        engine.value_stack.push(0).unwrap();
+        engine.op_ws().unwrap();
+        engine.value_stack.push(oob_index).unwrap();
+        engine.op_rs().unwrap();
+        // Enable pedantic mode: OOB reads/writes error
+        engine.graphics_state.is_pedantic = true;
+        engine.value_stack.push(oob_index).unwrap();
+        engine.value_stack.push(0).unwrap();
+        assert_eq!(
+            engine.op_ws(),
+            Err(HintErrorKind::InvalidStorageIndex(oob_index as _))
+        );
+        engine.value_stack.push(oob_index).unwrap();
+        assert_eq!(
+            engine.op_rs(),
+            Err(HintErrorKind::InvalidStorageIndex(oob_index as _))
+        );
+    }
+}

--- a/skrifa/src/outline/glyf/hint/error.rs
+++ b/skrifa/src/outline/glyf/hint/error.rs
@@ -6,7 +6,7 @@ use super::program::Program;
 use crate::GlyphId;
 
 /// Errors that may occur when interpreting TrueType bytecode.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum HintErrorKind {
     UnexpectedEndOfBytecode,
     UnhandledOpcode(Opcode),

--- a/skrifa/src/outline/glyf/hint/mod.rs
+++ b/skrifa/src/outline/glyf/hint/mod.rs
@@ -1,12 +1,15 @@
 //! TrueType hinting.
 
 mod call_stack;
+mod cow_slice;
+mod cvt;
 mod definition;
 mod engine;
 mod error;
 mod graphics_state;
 mod math;
 mod program;
+mod storage;
 mod value_stack;
 
 use read_fonts::{

--- a/skrifa/src/outline/glyf/hint/storage.rs
+++ b/skrifa/src/outline/glyf/hint/storage.rs
@@ -1,0 +1,29 @@
+//! Storage area.
+
+use super::{cow_slice::CowSlice, error::HintErrorKind};
+
+/// Backing store for the storage area.
+///
+/// This is just a wrapper for [`CowSlice`] that converts out of bounds
+/// accesses to appropriate errors.
+pub struct Storage<'a>(CowSlice<'a>);
+
+impl<'a> Storage<'a> {
+    pub fn get(&self, index: usize) -> Result<i32, HintErrorKind> {
+        self.0
+            .get(index)
+            .ok_or(HintErrorKind::InvalidStorageIndex(index))
+    }
+
+    pub fn set(&mut self, index: usize, value: i32) -> Result<(), HintErrorKind> {
+        self.0
+            .set(index, value)
+            .ok_or(HintErrorKind::InvalidStorageIndex(index))
+    }
+}
+
+impl<'a> From<CowSlice<'a>> for Storage<'a> {
+    fn from(value: CowSlice<'a>) -> Self {
+        Self(value)
+    }
+}


### PR DESCRIPTION
Implements both "managing the control value table" (https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-control-value-table) and "managing the storage area" (https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-the-storage-area) sets of instructions.

Supports copy-on-write for these buffers to address the FT issue fixed in this MR: https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/23

Also of note is the "pedantic" flag that just ignores OOB accesses when disabled. Unfortunately, this is necessary to match FT with some fonts :(