### PR TITLE
Make font-test-data publish

### DIFF
--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -3,9 +3,11 @@ name = "font-test-data"
 version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
-description = "test data for the fontations crates"
-publish = false
+description = "Test data for the fontations crates"
+
+# It is useful to publish this so tools that pull from crates can see it
+#publish = false
 
 # cargo-release settings
-[package.metadata.release]
-release = false
+#[package.metadata.release]
+#release = false


### PR DESCRIPTION
This is very helpful when importing fontations into internal repositories. If it isn't published I have to either eschew the normal tools or do things like regex transformation to delete the tests.

IMHO publishing this crate is the least bad option.

JMM if happy.