### PR TITLE
[skrifa] tthint: embrace the 26.6

### DIFF
--- a/skrifa/src/outline/glyf/hint/cvt.rs
+++ b/skrifa/src/outline/glyf/hint/cvt.rs
@@ -12,7 +12,7 @@ impl<'a> Cvt<'a> {
     pub fn get(&self, index: usize) -> Result<F26Dot6, HintErrorKind> {
         self.0
             .get(index)
-            .map(|value| F26Dot6::from_bits(value))
+            .map(F26Dot6::from_bits)
             .ok_or(HintErrorKind::InvalidCvtIndex(index))
     }
 

--- a/skrifa/src/outline/glyf/hint/cvt.rs
+++ b/skrifa/src/outline/glyf/hint/cvt.rs
@@ -1,6 +1,6 @@
 //! Control value table.
 
-use super::{cow_slice::CowSlice, error::HintErrorKind};
+use super::{cow_slice::CowSlice, error::HintErrorKind, F26Dot6};
 
 /// Backing store for the control value table.
 ///
@@ -9,15 +9,16 @@ use super::{cow_slice::CowSlice, error::HintErrorKind};
 pub struct Cvt<'a>(CowSlice<'a>);
 
 impl<'a> Cvt<'a> {
-    pub fn get(&self, index: usize) -> Result<i32, HintErrorKind> {
+    pub fn get(&self, index: usize) -> Result<F26Dot6, HintErrorKind> {
         self.0
             .get(index)
+            .map(|value| F26Dot6::from_bits(value))
             .ok_or(HintErrorKind::InvalidCvtIndex(index))
     }
 
-    pub fn set(&mut self, index: usize, value: i32) -> Result<(), HintErrorKind> {
+    pub fn set(&mut self, index: usize, value: F26Dot6) -> Result<(), HintErrorKind> {
         self.0
-            .set(index, value)
+            .set(index, value.to_bits())
             .ok_or(HintErrorKind::InvalidCvtIndex(index))
     }
 }

--- a/skrifa/src/outline/glyf/hint/engine/logical.rs
+++ b/skrifa/src/outline/glyf/hint/engine/logical.rs
@@ -4,7 +4,7 @@
 //!
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#logical-functions>
 
-use super::{Engine, OpResult};
+use super::{Engine, F26Dot6, OpResult};
 
 impl<'a> Engine<'a> {
     /// Less than.
@@ -129,8 +129,9 @@ impl<'a> Engine<'a> {
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2799>
     pub(super) fn op_odd(&mut self) -> OpResult {
         let round_state = self.graphics_state.round_state;
-        self.value_stack
-            .apply_unary(|e1| Ok((round_state.round(e1) & 127 == 64) as i32))
+        self.value_stack.apply_unary(|e1| {
+            Ok((round_state.round(F26Dot6::from_bits(e1)).to_bits() & 127 == 64) as i32)
+        })
     }
 
     /// Even.
@@ -150,8 +151,9 @@ impl<'a> Engine<'a> {
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2813>
     pub(super) fn op_even(&mut self) -> OpResult {
         let round_state = self.graphics_state.round_state;
-        self.value_stack
-            .apply_unary(|e1| Ok((round_state.round(e1) & 127 == 0) as i32))
+        self.value_stack.apply_unary(|e1| {
+            Ok((round_state.round(F26Dot6::from_bits(e1)).to_bits() & 127 == 0) as i32)
+        })
     }
 
     /// Logical and.

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -13,7 +13,10 @@ mod outline;
 mod stack;
 mod storage;
 
-use read_fonts::{tables::glyf::bytecode::Instruction, types::F2Dot14};
+use read_fonts::{
+    tables::glyf::bytecode::Instruction,
+    types::{F26Dot6, F2Dot14, Point},
+};
 
 use super::{
     super::Outlines,
@@ -105,7 +108,7 @@ mod mock {
             program::{Program, ProgramState},
             Point, PointFlags,
         },
-        Engine, GraphicsState, LoopBudget, ValueStack,
+        Engine, F26Dot6, GraphicsState, LoopBudget, ValueStack,
     };
 
     /// Mock engine for testing.
@@ -113,7 +116,8 @@ mod mock {
         cvt_storage: Vec<i32>,
         value_stack: Vec<i32>,
         definitions: Vec<Definition>,
-        points: Vec<Point<i32>>,
+        unscaled: Vec<Point<i32>>,
+        points: Vec<Point<F26Dot6>>,
         point_flags: Vec<PointFlags>,
         contours: Vec<u16>,
     }
@@ -124,7 +128,8 @@ mod mock {
                 cvt_storage: vec![0; 32],
                 value_stack: vec![0; 32],
                 definitions: vec![Default::default(); 8],
-                points: vec![Default::default(); 96],
+                unscaled: vec![Default::default(); 32],
+                points: vec![Default::default(); 64],
                 point_flags: vec![Default::default(); 32],
                 contours: vec![32],
             }
@@ -140,10 +145,9 @@ mod mock {
                 DefinitionMap::Mut(function_defs),
                 DefinitionMap::Mut(instruction_defs),
             );
-            let (points, rest) = self.points.split_at_mut(32);
-            let (original, unscaled) = rest.split_at_mut(32);
+            let (points, original) = self.points.split_at_mut(32);
             let glyph_zone = Zone::new(
-                unscaled,
+                &mut self.unscaled,
                 original,
                 points,
                 &mut self.point_flags,

--- a/skrifa/src/outline/glyf/hint/value_stack.rs
+++ b/skrifa/src/outline/glyf/hint/value_stack.rs
@@ -1,5 +1,6 @@
 //! Value stack for TrueType interpreter.
 //!
+use raw::types::F26Dot6;
 use read_fonts::tables::glyf::bytecode::InlineOperands;
 
 use super::error::HintErrorKind;
@@ -85,6 +86,11 @@ impl<'a> ValueStack<'a> {
         let value = self.peek().ok_or(ValueStackUnderflow)?;
         self.top -= 1;
         Ok(value)
+    }
+
+    /// Convenience method for instructions that expect values in 26.6 format.
+    pub fn pop_f26dot6(&mut self) -> Result<F26Dot6, HintErrorKind> {
+        Ok(F26Dot6::from_bits(self.pop()?))
     }
 
     /// Convenience method for instructions that pop values that are used as an


### PR DESCRIPTION
This changes the `points` and `original` arrays in `Zone` to have an element type of `Point<F26Dot6>` as that is the type used in the outline scaler. The intention is to avoid a bit of unsafe code that was coming in a later PR and just better match the spec in general. Decided to do this now to avoid more pain later.

Lots of churn for the modified types but no functional changes.