### PR TITLE
[skrifa] tthint: finish outline instructions

### DIFF
--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -63,7 +63,7 @@ impl<'a> Engine<'a> {
             GPV => self.op_gpv()?,
             GFV => self.op_gfv()?,
             SFVTPV => self.op_sfvtpv()?,
-            // ISECT => {}
+            ISECT => self.op_isect()?,
             SRP0 => self.op_srp0()?,
             SRP1 => self.op_srp1()?,
             SRP2 => self.op_srp2()?,
@@ -86,7 +86,7 @@ impl<'a> Engine<'a> {
             DEPTH => self.op_depth()?,
             CINDEX => self.op_cindex()?,
             MINDEX => self.op_mindex()?,
-            // ALIGNPTS => {}
+            ALIGNPTS => self.op_alignpts()?,
             // ? 0x28
             UTP => self.op_utp()?,
             LOOPCALL => self.op_loopcall()?,
@@ -94,15 +94,15 @@ impl<'a> Engine<'a> {
             FDEF => self.op_fdef()?,
             ENDF => self.op_endf()?,
             MDAP0 | MDAP1 => self.op_mdap(raw_opcode)?,
-            // IUP0 | IUP1 => {}
+            IUP0 | IUP1 => self.op_iup(raw_opcode)?,
             SHP0 | SHP1 => self.op_shp(raw_opcode)?,
             SHC0 | SHC1 => self.op_shc(raw_opcode)?,
             SHZ0 | SHZ1 => self.op_shz(raw_opcode)?,
             SHPIX => self.op_shpix()?,
-            // IP => {}
+            IP => self.op_ip()?,
             MSIRP0 | MSIRP1 => self.op_msirp(raw_opcode)?,
             MIAP0 | MIAP1 => self.op_miap(raw_opcode)?,
-            // ALIGNRP => {}
+            ALIGNRP => self.op_alignrp()?,
             NPUSHB | NPUSHW => self.op_push(&ins.inline_operands)?,
             WS => self.op_ws()?,
             RS => self.op_rs()?,
@@ -115,7 +115,10 @@ impl<'a> Engine<'a> {
             MPS => self.op_mps()?,
             FLIPON => self.op_flipon()?,
             FLIPOFF => self.op_flipoff()?,
-            // DEBUG => {}
+            // Unused but pops a value from the stack.
+            DEBUG => {
+                self.value_stack.pop()?;
+            }
             LT => self.op_lt()?,
             LTEQ => self.op_lteq()?,
             GT => self.op_gt()?,
@@ -175,12 +178,11 @@ impl<'a> Engine<'a> {
             _ => {
                 // FreeType handles MIRP, MDRP and pushes here.
                 // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L7629>
-                // if opcode >= MIRP00000 {
-                //     self.op_mirp(raw_opcode)?
-                // } else if opcode >= MDRP00000 {
-                //     self.op_mdrp(raw_opcode)?
-                // } else
-                if opcode >= PUSHB000 {
+                if opcode >= MIRP00000 {
+                    self.op_mirp(raw_opcode)?
+                } else if opcode >= MDRP00000 {
+                    self.op_mdrp(raw_opcode)?
+                } else if opcode >= PUSHB000 {
                     self.op_push(&ins.inline_operands)?;
                 } else {
                     return self.op_unknown(opcode as u8);

--- a/skrifa/src/outline/glyf/hint/graphics_state/mod.rs
+++ b/skrifa/src/outline/glyf/hint/graphics_state/mod.rs
@@ -4,9 +4,8 @@ mod projection;
 mod round;
 mod zone;
 
-use super::HintingMode;
+use super::{F26Dot6, HintingMode, Point};
 use core::ops::{Deref, DerefMut};
-use read_fonts::types::Point;
 
 pub use {
     round::{RoundMode, RoundState},
@@ -172,7 +171,7 @@ pub struct RetainedGraphicsState {
     /// taken from the original outline is sufficiently small.
     ///
     /// See <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM04/Chap4.html#control_value_cut-in>
-    pub control_value_cutin: i32,
+    pub control_value_cutin: F26Dot6,
     /// Establishes the base value used to calculate the range of point sizes
     /// to which a given DELTAC[] or DELTAP[] instruction will apply.
     ///
@@ -192,7 +191,7 @@ pub struct RetainedGraphicsState {
     /// rounded.
     ///
     /// See <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM04/Chap4.html#minimum%20distance>
-    pub min_distance: i32,
+    pub min_distance: F26Dot6,
     /// Determines whether the interpreter will activate dropout control for
     /// the current glyph.
     ///
@@ -204,13 +203,13 @@ pub struct RetainedGraphicsState {
     /// CVT distance or an actual distance in favor of the single width value.
     ///
     /// See <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM04/Chap4.html#single_width_cut_in>
-    pub single_width_cutin: i32,
+    pub single_width_cutin: F26Dot6,
     /// The value used in place of the control value table distance or the
     /// actual distance value when the difference between that distance and
     /// the single width value is less than the single width cut-in.
     ///
     /// See <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM04/Chap4.html#single_width_value>
-    pub single_width: i32,
+    pub single_width: F26Dot6,
     /// The user requested hinting mode.
     pub mode: HintingMode,
     /// The scale factor for the current instance. Conversion from font units
@@ -231,16 +230,16 @@ impl Default for RetainedGraphicsState {
             auto_flip: true,
             // 17/16 pixels in 26.6
             // (17 * 64 / 16) = 68
-            control_value_cutin: 68,
+            control_value_cutin: F26Dot6::from_bits(68),
             delta_base: 9,
             delta_shift: 3,
             instruct_control: 0,
             // 1 pixel in 26.6
-            min_distance: 64,
+            min_distance: F26Dot6::from_bits(64),
             scan_control: false,
             scan_type: 0,
-            single_width_cutin: 0,
-            single_width: 0,
+            single_width_cutin: F26Dot6::ZERO,
+            single_width: F26Dot6::ZERO,
             mode: Default::default(),
             scale: 0,
             ppem: 0,


### PR DESCRIPTION
Finishes up the "managing outlines" instruction group. Adds implementations for 70 opcodes.

Also changes a few other graphics state types to `F26Dot6`.

Instructions added to #803