### PR TITLE
Revert "[Skrifa] Avoid initialization of HashSet with system random numbers (#751)

### DIFF
--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -57,9 +57,7 @@ use read_fonts::{
 
 use std::{collections::HashSet, fmt::Debug, ops::Range};
 
-use traversal::{
-    get_clipbox_font_units, traverse_v0_range, traverse_with_callbacks, NonRandomHasherState,
-};
+use traversal::{get_clipbox_font_units, traverse_v0_range, traverse_with_callbacks};
 
 pub use transform::Transform;
 
@@ -348,7 +346,7 @@ impl<'a> ColorGlyph<'a> {
                     painter.push_clip_box(rect);
                 }
 
-                let mut visited_set = HashSet::with_hasher(NonRandomHasherState);
+                let mut visited_set: HashSet<usize> = HashSet::new();
                 visited_set.insert(*paint_id);
                 traverse_with_callbacks(
                     &resolve_paint(&instance, paint)?,

--- a/skrifa/src/color/traversal.rs
+++ b/skrifa/src/color/traversal.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::Ordering, collections::hash_map::DefaultHasher, collections::HashSet, hash::BuildHasher,
-    ops::Range,
-};
+use std::{cmp::Ordering, collections::HashSet, ops::Range};
 
 use read_fonts::{
     tables::colr::{CompositeMode, Extend},
@@ -15,16 +12,6 @@ use super::{
     },
     Brush, ColorPainter, ColorStop, PaintCachedColorGlyph, PaintError, Transform,
 };
-
-// Workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=1516634.
-pub(crate) struct NonRandomHasherState;
-
-impl BuildHasher for NonRandomHasherState {
-    type Hasher = DefaultHasher;
-    fn build_hasher(&self) -> DefaultHasher {
-        DefaultHasher::new()
-    }
-}
 
 pub(crate) fn get_clipbox_font_units(
     colr_instance: &ColrInstance,
@@ -123,7 +110,7 @@ pub(crate) fn traverse_with_callbacks(
     paint: &ResolvedPaint,
     instance: &ColrInstance,
     painter: &mut impl ColorPainter,
-    visited_set: &mut HashSet<usize, NonRandomHasherState>,
+    visited_set: &mut HashSet<usize>,
 ) -> Result<(), PaintError> {
     match paint {
         ResolvedPaint::ColrLayers { range } => {


### PR DESCRIPTION
This reverts commit eef6a26640ace05d48c4e2150e303e5c6ac32201.

See details in [1] and [2]. Rust upstream landed a change switching to a different, sandbox-compatible call for PRNG, except on Windows
7. Windows 7 is no longer supported by Chromium. Chromium is our only known sandboxed environment where this call would fail. Remove the workaround.

[1] https://issues.chromium.org/40277768
[2] https://github.com/rust-lang/rust/commit/08caefbb103d1809113172d16eaf8f66c2edc2f1