### PR TITLE
[skrifa] tthint working checkpoint 

### DIFF
--- a/skrifa/src/outline/embedded_hinting.rs
+++ b/skrifa/src/outline/embedded_hinting.rs
@@ -1,8 +1,8 @@
 //! Support for applying embedded hinting instructions.
 
 use super::{
-    cff, AdjustedMetrics, DrawError, Hinting, LocationRef, NormalizedCoord, OutlineCollectionKind,
-    OutlineGlyph, OutlineGlyphCollection, OutlineKind, OutlinePen, Size,
+    cff, glyf, AdjustedMetrics, DrawError, Hinting, LocationRef, NormalizedCoord,
+    OutlineCollectionKind, OutlineGlyph, OutlineGlyphCollection, OutlineKind, OutlinePen, Size,
 };
 
 /// Modes that control hinting when using embedded instructions.
@@ -133,8 +133,21 @@ impl EmbeddedHintingInstance {
         // Reuse memory if the font contains the same outline format
         let current_kind = core::mem::replace(&mut self.kind, HinterKind::None);
         match &outlines.kind {
-            OutlineCollectionKind::Glyf(_) => {
-                self.kind = HinterKind::Glyf;
+            OutlineCollectionKind::Glyf(glyf) => {
+                let mut hint_instance = match current_kind {
+                    HinterKind::Glyf(instance) => instance,
+                    _ => Box::<glyf::HintInstance>::default(),
+                };
+                let ppem = size.ppem();
+                let scale = glyf.compute_scale(ppem).1.to_bits();
+                hint_instance.reconfigure(
+                    glyf,
+                    scale,
+                    ppem.unwrap_or_default() as i32,
+                    mode,
+                    &self.coords,
+                )?;
+                self.kind = HinterKind::Glyf(hint_instance);
             }
             OutlineCollectionKind::Cff(cff) => {
                 let mut subfonts = match current_kind {
@@ -153,21 +166,41 @@ impl EmbeddedHintingInstance {
         Ok(())
     }
 
+    /// Returns true if hinting should actually be applied for this instance.
+    ///
+    /// Some TrueType fonts disable hinting dynamically based on the instance
+    /// configuration.
+    pub fn is_enabled(&self) -> bool {
+        match &self.kind {
+            HinterKind::Glyf(instance) => instance.is_enabled(),
+            HinterKind::Cff(_) => true,
+            _ => false,
+        }
+    }
+
     pub(super) fn draw(
         &self,
         glyph: &OutlineGlyph,
         memory: Option<&mut [u8]>,
         pen: &mut impl OutlinePen,
+        is_pedantic: bool,
     ) -> Result<AdjustedMetrics, DrawError> {
         let ppem = self.size.ppem();
         let coords = self.coords.as_slice();
         match (&self.kind, &glyph.kind) {
-            (HinterKind::Glyf, OutlineKind::Glyf(glyf, outline)) => {
+            (HinterKind::Glyf(instance), OutlineKind::Glyf(glyf, outline)) => {
                 super::with_glyf_memory(outline, Hinting::Embedded, memory, |buf| {
                     let mem = outline
                         .memory_from_buffer(buf, Hinting::Embedded)
                         .ok_or(DrawError::InsufficientMemory)?;
-                    let scaled_outline = glyf.draw(mem, outline, ppem, coords)?;
+                    let scaled_outline = glyf.draw_hinted(
+                        mem,
+                        outline,
+                        ppem,
+                        coords,
+                        |mut hint_outline| instance.hint(glyf, &mut hint_outline),
+                        is_pedantic,
+                    )?;
                     scaled_outline.to_path(pen)?;
                     Ok(AdjustedMetrics {
                         has_overlaps: outline.has_overlaps,
@@ -193,6 +226,6 @@ enum HinterKind {
     /// Represents a hinting instance that is associated with an empty outline
     /// collection.
     None,
-    Glyf,
+    Glyf(Box<glyf::HintInstance>),
     Cff(Vec<cff::Subfont>),
 }

--- a/skrifa/src/outline/error.rs
+++ b/skrifa/src/outline/error.rs
@@ -1,5 +1,6 @@
 //! Error types associated with outlines.
 
+use core::fmt;
 use read_fonts::types::GlyphId;
 
 pub use read_fonts::{
@@ -7,7 +8,7 @@ pub use read_fonts::{
     ReadError,
 };
 
-use core::fmt;
+pub use super::glyf::HintError;
 
 /// Errors that may occur when drawing glyphs.
 #[derive(Clone, Debug)]
@@ -21,7 +22,7 @@ pub enum DrawError {
     /// Exceeded a recursion limit when loading a glyph.
     RecursionLimitExceeded(GlyphId),
     /// Error occured during hinting.
-    HintingFailed(GlyphId),
+    HintingFailed(HintError),
     /// An anchor point had invalid indices.
     InvalidAnchorPoint(GlyphId, u16),
     /// Error occurred while loading a PostScript (CFF/CFF2) glyph.
@@ -30,6 +31,12 @@ pub enum DrawError {
     ToPath(ToPathError),
     /// Error occured when reading font data.
     Read(ReadError),
+}
+
+impl From<HintError> for DrawError {
+    fn from(value: HintError) -> Self {
+        Self::HintingFailed(value)
+    }
 }
 
 impl From<ToPathError> for DrawError {
@@ -61,7 +68,7 @@ impl fmt::Display for DrawError {
                 "Recursion limit ({}) exceeded when loading composite component {gid}",
                 super::GLYF_COMPOSITE_RECURSION_LIMIT,
             ),
-            Self::HintingFailed(gid) => write!(f, "Bad hinting bytecode for glyph {gid}"),
+            Self::HintingFailed(e) => write!(f, "{e}"),
             Self::InvalidAnchorPoint(gid, index) => write!(
                 f,
                 "Invalid anchor point index ({index}) for composite glyph {gid}",

--- a/skrifa/src/outline/glyf/hint/engine/definition.rs
+++ b/skrifa/src/outline/glyf/hint/engine/definition.rs
@@ -77,8 +77,12 @@ impl<'a> Engine<'a> {
     pub(super) fn op_loopcall(&mut self) -> OpResult {
         let f = self.value_stack.pop()?;
         let count = self.value_stack.pop()?;
-        self.loop_budget.doing_loop_call(count as usize)?;
-        self.do_call(DefKind::Function, count as u32, f)
+        if count > 0 {
+            self.loop_budget.doing_loop_call(count as usize)?;
+            self.do_call(DefKind::Function, count as u32, f)
+        } else {
+            Ok(())
+        }
     }
 
     /// Instruction definition.

--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -2,10 +2,7 @@
 
 use read_fonts::tables::glyf::bytecode::Opcode;
 
-use super::{
-    super::{program::Program, HintingMode},
-    Engine, HintError, HintErrorKind, Instruction,
-};
+use super::{super::program::Program, Engine, HintError, HintErrorKind, Instruction};
 
 /// Maximum number of instructions we will execute in `Engine::run()`. This
 /// is used to ensure termination of a hinting program.

--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -2,7 +2,10 @@
 
 use read_fonts::tables::glyf::bytecode::Opcode;
 
-use super::{Engine, HintError, HintErrorKind, Instruction};
+use super::{
+    super::{program::Program, HintingMode},
+    Engine, HintError, HintErrorKind, Instruction,
+};
 
 /// Maximum number of instructions we will execute in `Engine::run()`. This
 /// is used to ensure termination of a hinting program.
@@ -10,6 +13,46 @@ use super::{Engine, HintError, HintErrorKind, Instruction};
 const MAX_RUN_INSTRUCTIONS: usize = 1_000_000;
 
 impl<'a> Engine<'a> {
+    /// Resets state for the specified program and executes all instructions.
+    pub fn run_program(&mut self, program: Program) -> Result<(), HintError> {
+        self.reset(program);
+        self.run()
+    }
+
+    /// Set internal state for running the specified program.
+    pub fn reset(&mut self, program: Program) {
+        self.program.reset(program);
+        // Reset overall graphics state, keeping the retained bits.
+        self.graphics_state.reset();
+        self.loop_budget.reset();
+        // Program specific setup.
+        match program {
+            Program::Font => {
+                self.definitions.functions.reset();
+                self.definitions.instructions.reset();
+            }
+            Program::ControlValue => {
+                self.graphics_state.backward_compatibility = false;
+            }
+            Program::Glyph => {
+                // Instruct control bit 1 says we reset retained graphics state
+                // to default values.
+                if self.graphics_state.instruct_control & 2 != 0 {
+                    self.graphics_state.reset_retained();
+                }
+                // Set backward compatibility mode
+                if self.graphics_state.mode.preserve_linear_metrics() {
+                    self.graphics_state.backward_compatibility = true;
+                } else if self.graphics_state.mode.is_smooth() {
+                    self.graphics_state.backward_compatibility =
+                        (self.graphics_state.instruct_control & 0x4) == 0;
+                } else {
+                    self.graphics_state.backward_compatibility = false;
+                }
+            }
+        }
+    }
+
     /// Decodes and dispatches all instructions until completion or error.
     pub fn run(&mut self) -> Result<(), HintError> {
         let mut count = 0;

--- a/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
@@ -151,7 +151,7 @@ impl<'a> Engine<'a> {
     pub(super) fn op_spvfs(&mut self) -> OpResult {
         let y = self.value_stack.pop()? as i16 as i32;
         let x = self.value_stack.pop()? as i16 as i32;
-        let vector = if x == 0 && y == 0 {
+        let vector = if (x, y) == (0, 0) {
             self.graphics_state.proj_vector
         } else {
             math::normalize14(x, y)
@@ -178,7 +178,7 @@ impl<'a> Engine<'a> {
     pub(super) fn op_sfvfs(&mut self) -> OpResult {
         let y = self.value_stack.pop()? as i16 as i32;
         let x = self.value_stack.pop()? as i16 as i32;
-        let vector = if x == 0 && y == 0 {
+        let vector = if (x, y) == (0, 0) {
             self.graphics_state.freedom_vector
         } else {
             math::normalize14(x, y)

--- a/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics_state.rs
@@ -151,7 +151,11 @@ impl<'a> Engine<'a> {
     pub(super) fn op_spvfs(&mut self) -> OpResult {
         let y = self.value_stack.pop()? as i16 as i32;
         let x = self.value_stack.pop()? as i16 as i32;
-        let vector = math::normalize14(x, y);
+        let vector = if x == 0 && y == 0 {
+            self.graphics_state.proj_vector
+        } else {
+            math::normalize14(x, y)
+        };
         self.graphics_state.proj_vector = vector;
         self.graphics_state.dual_proj_vector = vector;
         self.graphics_state.update_projection_state();
@@ -174,7 +178,11 @@ impl<'a> Engine<'a> {
     pub(super) fn op_sfvfs(&mut self) -> OpResult {
         let y = self.value_stack.pop()? as i16 as i32;
         let x = self.value_stack.pop()? as i16 as i32;
-        let vector = math::normalize14(x, y);
+        let vector = if x == 0 && y == 0 {
+            self.graphics_state.freedom_vector
+        } else {
+            math::normalize14(x, y)
+        };
         self.graphics_state.freedom_vector = vector;
         self.graphics_state.update_projection_state();
         Ok(())

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -25,7 +25,7 @@ use super::{
     cvt::Cvt,
     definition::DefinitionState,
     error::{HintError, HintErrorKind},
-    graphics_state::{GraphicsState, RetainedGraphicsState},
+    graphics_state::{GraphicsState, RetainedGraphicsState, Zone},
     program::ProgramState,
     storage::Storage,
     value_stack::ValueStack,
@@ -47,6 +47,45 @@ pub struct Engine<'a> {
 }
 
 impl<'a> Engine<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        outlines: &Outlines,
+        program: ProgramState<'a>,
+        graphics: RetainedGraphicsState,
+        definitions: DefinitionState<'a>,
+        cvt: impl Into<Cvt<'a>>,
+        storage: impl Into<Storage<'a>>,
+        value_stack: ValueStack<'a>,
+        twilight: Zone<'a>,
+        glyph: Zone<'a>,
+        axis_count: u16,
+        coords: &'a [F2Dot14],
+        is_composite: bool,
+    ) -> Self {
+        let point_count = if glyph.points.is_empty() {
+            None
+        } else {
+            Some(glyph.points.len())
+        };
+        let graphics = GraphicsState {
+            retained: graphics,
+            zones: [twilight, glyph],
+            is_composite,
+            ..Default::default()
+        };
+        Self {
+            program,
+            graphics_state: graphics,
+            definitions,
+            cvt: cvt.into(),
+            storage: storage.into(),
+            value_stack,
+            loop_budget: LoopBudget::new(outlines, point_count),
+            axis_count,
+            coords,
+        }
+    }
+
     pub fn backward_compatibility(&self) -> bool {
         self.graphics_state.backward_compatibility
     }
@@ -85,6 +124,11 @@ impl LoopBudget {
             backward_jumps: 0,
             loop_calls: 0,
         }
+    }
+
+    fn reset(&mut self) {
+        self.backward_jumps = 0;
+        self.loop_calls = 0;
     }
 
     fn doing_backward_jump(&mut self) -> Result<(), HintErrorKind> {
@@ -158,7 +202,7 @@ mod mock {
             );
             let (points, original) = self.points.split_at_mut(32);
             let glyph_zone = Zone::new(
-                &mut self.unscaled,
+                &self.unscaled,
                 original,
                 points,
                 &mut self.point_flags,

--- a/skrifa/src/outline/glyf/hint/graphics_state/mod.rs
+++ b/skrifa/src/outline/glyf/hint/graphics_state/mod.rs
@@ -134,6 +134,37 @@ impl<'a> GraphicsState<'a> {
             self.scale
         }
     }
+
+    /// Resets the non-retained portions of the graphics state.
+    pub fn reset(&mut self) {
+        let GraphicsState {
+            retained,
+            zones,
+            is_composite,
+            ..
+        } = core::mem::take(self);
+        *self = GraphicsState {
+            retained,
+            zones,
+            is_composite,
+            ..Default::default()
+        };
+        self.update_projection_state();
+    }
+
+    /// Resets the retained portion of the graphics state to default
+    /// values while saving the user instance settings.
+    pub fn reset_retained(&mut self) {
+        let scale = self.scale;
+        let ppem = self.ppem;
+        let mode = self.mode;
+        self.retained = RetainedGraphicsState {
+            scale,
+            ppem,
+            mode,
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for GraphicsState<'_> {

--- a/skrifa/src/outline/glyf/hint/graphics_state/zone.rs
+++ b/skrifa/src/outline/glyf/hint/graphics_state/zone.rs
@@ -63,7 +63,7 @@ pub struct Zone<'a> {
 impl<'a> Zone<'a> {
     /// Creates a new hinting zone.
     pub fn new(
-        unscaled: &'a mut [Point<i32>],
+        unscaled: &'a [Point<i32>],
         original: &'a mut [Point<F26Dot6>],
         points: &'a mut [Point<F26Dot6>],
         flags: &'a mut [PointFlags],
@@ -338,6 +338,17 @@ impl<'a> GraphicsState<'a> {
         self.zp0 = ZonePointer::default();
         self.zp1 = ZonePointer::default();
         self.zp2 = ZonePointer::default();
+    }
+
+    /// Takes an array of (zone pointer, point index) pairs and returns true if
+    /// all accesses would be valid.
+    pub fn in_bounds<const N: usize>(&self, pairs: [(ZonePointer, usize); N]) -> bool {
+        for (zp, index) in pairs {
+            if index > self.zone(zp).points.len() {
+                return false;
+            }
+        }
+        true
     }
 
     #[inline(always)]

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -1,0 +1,194 @@
+//! Instance state for TrueType hinting.
+
+use super::{
+    super::Outlines,
+    cow_slice::CowSlice,
+    definition::{Definition, DefinitionMap, DefinitionState},
+    engine::Engine,
+    error::HintError,
+    graphics_state::{RetainedGraphicsState, Zone},
+    program::{Program, ProgramState},
+    value_stack::ValueStack,
+    HintOutline, HintingMode, PointFlags,
+};
+use raw::types::{F26Dot6, F2Dot14, Fixed, Point};
+
+#[derive(Clone, Default)]
+pub struct HintInstance {
+    functions: Vec<Definition>,
+    instructions: Vec<Definition>,
+    cvt: Vec<i32>,
+    storage: Vec<i32>,
+    graphics: RetainedGraphicsState,
+    twilight_scaled: Vec<Point<F26Dot6>>,
+    twilight_original_scaled: Vec<Point<F26Dot6>>,
+    twilight_flags: Vec<PointFlags>,
+    axis_count: u16,
+    max_stack: usize,
+}
+
+impl HintInstance {
+    pub fn reconfigure(
+        &mut self,
+        outlines: &Outlines,
+        scale: i32,
+        ppem: i32,
+        mode: HintingMode,
+        coords: &[F2Dot14],
+    ) -> Result<(), HintError> {
+        self.setup(outlines, scale);
+        let twilight_contours = [self.twilight_scaled.len() as u16];
+        let twilight = Zone::new(
+            &[],
+            &mut self.twilight_original_scaled,
+            &mut self.twilight_scaled,
+            &mut self.twilight_flags,
+            &twilight_contours,
+        );
+        let glyph = Zone::default();
+        let mut stack_buf = vec![0; self.max_stack];
+        let value_stack = ValueStack::new(&mut stack_buf);
+        let graphics = RetainedGraphicsState {
+            scale,
+            ppem,
+            mode,
+            ..Default::default()
+        };
+        let mut engine = Engine::new(
+            outlines,
+            ProgramState::new(outlines.fpgm, outlines.prep, &[], Program::Font),
+            graphics,
+            DefinitionState::new(
+                DefinitionMap::Mut(&mut self.functions),
+                DefinitionMap::Mut(&mut self.instructions),
+            ),
+            CowSlice::new_mut(&mut self.cvt),
+            CowSlice::new_mut(&mut self.storage),
+            value_stack,
+            twilight,
+            glyph,
+            self.axis_count,
+            coords,
+            false,
+        );
+        // Run the font program (fpgm)
+        engine.run_program(Program::Font)?;
+        // Run the control value program (prep)
+        engine.run_program(Program::ControlValue)?;
+        // Save the retained state from the CV program
+        self.graphics = *engine.retained_graphics_state();
+        Ok(())
+    }
+
+    /// Returns true if we should actually apply hinting.
+    ///
+    /// Hinting can be completely disabled by the control value program.
+    pub fn is_enabled(&self) -> bool {
+        // If bit 0 is set, disables hinting entirely
+        self.graphics.instruct_control & 1 == 0
+    }
+
+    pub fn hint(&self, outlines: &Outlines, outline: &mut HintOutline) -> Result<(), HintError> {
+        // Twilight zone
+        let twilight_count = outline.twilight_scaled.len();
+        let twilight_contours = [twilight_count as u16];
+        outline
+            .twilight_original_scaled
+            .copy_from_slice(&self.twilight_original_scaled);
+        outline
+            .twilight_scaled
+            .copy_from_slice(&self.twilight_scaled);
+        outline.twilight_flags.copy_from_slice(&self.twilight_flags);
+        let twilight = Zone::new(
+            &[],
+            outline.twilight_original_scaled,
+            outline.twilight_scaled,
+            outline.twilight_flags,
+            &twilight_contours,
+        );
+        // Glyph zone
+        let glyph = Zone::new(
+            outline.unscaled,
+            outline.original_scaled,
+            outline.scaled,
+            outline.flags,
+            outline.contours,
+        );
+        let value_stack = ValueStack::new(outline.stack);
+        let cvt = CowSlice::new(&self.cvt, outline.cvt).unwrap();
+        let storage = CowSlice::new(&self.storage, outline.storage).unwrap();
+        let mut engine = Engine::new(
+            outlines,
+            ProgramState::new(
+                outlines.fpgm,
+                outlines.prep,
+                outline.bytecode,
+                Program::Glyph,
+            ),
+            self.graphics,
+            DefinitionState::new(
+                DefinitionMap::Ref(&self.functions),
+                DefinitionMap::Ref(&self.instructions),
+            ),
+            cvt,
+            storage,
+            value_stack,
+            twilight,
+            glyph,
+            self.axis_count,
+            outline.coords,
+            outline.is_composite,
+        );
+        engine.run_program(Program::Glyph)?;
+        // If we're not running in backward compatibility mode, capture
+        // modified phantom points.
+        if !engine.backward_compatibility() {
+            for (i, p) in (outline.scaled[outline.scaled.len() - 4..])
+                .iter()
+                .enumerate()
+            {
+                outline.phantom[i] = *p;
+            }
+        }
+        Ok(())
+    }
+
+    /// Captures limits, resizes buffers and scales the CVT.
+    fn setup(&mut self, outlines: &Outlines, scale: i32) {
+        let axis_count = outlines
+            .gvar
+            .as_ref()
+            .map(|gvar| gvar.axis_count())
+            .unwrap_or_default();
+        self.functions.clear();
+        self.functions
+            .resize(outlines.max_function_defs as usize, Definition::default());
+        self.instructions.resize(
+            outlines.max_instruction_defs as usize,
+            Definition::default(),
+        );
+        self.cvt.clear();
+        let scale = Fixed::from_bits(scale >> 6);
+        self.cvt.extend(
+            outlines
+                .cvt
+                .iter()
+                .map(|value| (Fixed::from_bits(value.get() as i32 * 64) * scale).to_bits()),
+        );
+        self.storage.clear();
+        self.storage.resize(outlines.max_storage as usize, 0);
+        let max_twilight_points = outlines.max_twilight_points as usize;
+        self.twilight_scaled.clear();
+        self.twilight_scaled
+            .resize(max_twilight_points, Default::default());
+        self.twilight_original_scaled.clear();
+        self.twilight_original_scaled
+            .resize(max_twilight_points, Default::default());
+        self.twilight_flags.clear();
+        self.twilight_flags
+            .resize(max_twilight_points, Default::default());
+        self.axis_count = axis_count;
+        self.max_stack = outlines.max_stack_elements as usize;
+        self.graphics = RetainedGraphicsState::default();
+    }
+}

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -139,7 +139,10 @@ impl HintInstance {
             outline.coords,
             outline.is_composite,
         );
-        engine.run_program(Program::Glyph)?;
+        engine.run_program(Program::Glyph).map_err(|mut e| {
+            e.glyph_id = Some(outline.glyph_id);
+            e
+        })?;
         // If we're not running in backward compatibility mode, capture
         // modified phantom points.
         if !engine.backward_compatibility() {

--- a/skrifa/src/outline/glyf/hint/mod.rs
+++ b/skrifa/src/outline/glyf/hint/mod.rs
@@ -7,6 +7,7 @@ mod definition;
 mod engine;
 mod error;
 mod graphics_state;
+mod instance;
 mod math;
 mod program;
 mod storage;
@@ -18,6 +19,9 @@ use read_fonts::{
     tables::glyf::PointFlags,
     types::{F26Dot6, F2Dot14, GlyphId, Point},
 };
+
+pub use error::HintError;
+pub use instance::HintInstance;
 
 /// Outline data that is passed to the hinter.
 pub struct HintOutline<'a> {

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -174,7 +174,7 @@ impl<'a> DrawSettings<'a> {
     /// defined by the current configuration of the given hinting instance.
     pub fn hinted(instance: &'a EmbeddedHintingInstance, is_pedantic: bool) -> Self {
         Self {
-            instance: DrawInstance::EmbeddedHinted {
+            instance: DrawInstance::Hinted {
                 instance,
                 is_pedantic,
             },
@@ -197,7 +197,7 @@ impl<'a> DrawSettings<'a> {
 
 enum DrawInstance<'a> {
     Unhinted(Size, LocationRef<'a>),
-    EmbeddedHinted {
+    Hinted {
         instance: &'a EmbeddedHintingInstance,
         is_pedantic: bool,
     },
@@ -288,7 +288,7 @@ impl<'a> OutlineGlyph<'a> {
     /// | For draw settings                  | Use hinting           |
     /// |------------------------------------|-----------------------|
     /// | [`DrawSettings::unhinted`]         | [`Hinting::None`]     |
-    /// | [`DrawSettings::embedded_hinting`] | [`Hinting::Embedded`] |
+    /// | [`DrawSettings::hinted`]           | [`Hinting::Embedded`] |
     pub fn draw_memory_size(&self, hinting: Hinting) -> usize {
         match &self.kind {
             OutlineKind::Glyf(_, outline) => outline.required_buffer_size(hinting),
@@ -308,7 +308,7 @@ impl<'a> OutlineGlyph<'a> {
             DrawInstance::Unhinted(size, location) => {
                 self.draw_unhinted(size, location, settings.memory, pen)
             }
-            DrawInstance::EmbeddedHinted {
+            DrawInstance::Hinted {
                 instance,
                 is_pedantic,
             } => {

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -163,13 +163,21 @@ impl<'a> DrawSettings<'a> {
         }
     }
 
-    /// Creates settings for a hinted draw operation using embedded hinting.
+    /// Creates settings for a hinted draw operation using hinting data
+    /// contained in the font.
+    ///
+    /// If `is_pedantic` is true then any error that occurs during hinting will
+    /// cause drawing to fail. This is equivalent to the `FT_LOAD_PEDANTIC` flag
+    /// in FreeType.
     ///
     /// The font size, location in variation space and hinting mode are
     /// defined by the current configuration of the given hinting instance.
-    pub fn embedded_hinting(instance: &'a EmbeddedHintingInstance) -> Self {
+    pub fn hinted(instance: &'a EmbeddedHintingInstance, is_pedantic: bool) -> Self {
         Self {
-            instance: DrawInstance::EmbeddedHinted(instance),
+            instance: DrawInstance::EmbeddedHinted {
+                instance,
+                is_pedantic,
+            },
             memory: None,
         }
     }
@@ -189,7 +197,10 @@ impl<'a> DrawSettings<'a> {
 
 enum DrawInstance<'a> {
     Unhinted(Size, LocationRef<'a>),
-    EmbeddedHinted(&'a EmbeddedHintingInstance),
+    EmbeddedHinted {
+        instance: &'a EmbeddedHintingInstance,
+        is_pedantic: bool,
+    },
 }
 
 impl<'a, L> From<(Size, L)> for DrawSettings<'a>
@@ -209,7 +220,7 @@ impl From<Size> for DrawSettings<'_> {
 
 impl<'a> From<&'a EmbeddedHintingInstance> for DrawSettings<'a> {
     fn from(value: &'a EmbeddedHintingInstance) -> Self {
-        DrawSettings::embedded_hinting(value)
+        DrawSettings::hinted(value, false)
     }
 }
 
@@ -297,7 +308,16 @@ impl<'a> OutlineGlyph<'a> {
             DrawInstance::Unhinted(size, location) => {
                 self.draw_unhinted(size, location, settings.memory, pen)
             }
-            DrawInstance::EmbeddedHinted(hinter) => hinter.draw(self, settings.memory, pen),
+            DrawInstance::EmbeddedHinted {
+                instance,
+                is_pedantic,
+            } => {
+                if instance.is_enabled() {
+                    instance.draw(self, settings.memory, pen, is_pedantic)
+                } else {
+                    self.draw_unhinted(instance.size(), instance.location(), settings.memory, pen)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This wires up the TrueType hinting code in a working state that matches FreeType for all of Noto and Google Fonts collections with the following exceptions:

1. Some fonts with buggy bytecode
2. Fonts with control value programs that are not idempotent over multiple runs (these are newish Win11 fonts)
3. Variable fonts with a cvar table (https://github.com/googlefonts/fontations/issues/831)