### PR TITLE
[read-fonts] Add consts & bitor impls to LookupFlag

### DIFF
--- a/read-fonts/src/tables/lookupflag.rs
+++ b/read-fonts/src/tables/lookupflag.rs
@@ -3,12 +3,48 @@
 //! This is kind-of-but-not-quite-exactly a bit enumeration, and so we implement
 //! it manually.
 
+use core::ops::{BitOr, BitOrAssign};
+
 /// The [LookupFlag](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#lookupFlag) bit enumeration.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupFlag(u16);
 
+//NOTE: this impl has the potential to make garbage if used on two lookupflag
+//instances which have different mark attachment masks set, but as that field
+//is not really used in compilation, which is where this impl will be helpful,
+//the risk that this is the source of an actual bug seems very low,
+impl BitOr for LookupFlag {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for LookupFlag {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0
+    }
+}
+
 impl LookupFlag {
+    /// This bit relates only to the correct processing of GPOS type 3 (cursive attachment) lookups
+    ///
+    /// When this bit is set, the last glyph in a given sequence to which the cursive
+    /// attachment lookup is applied, will be positioned on the baseline.
+    pub const RIGHT_TO_LEFT: Self = LookupFlag(0x0001);
+    /// If set, skips over base glyphs
+    pub const IGNORE_BASE_GLYPHS: Self = LookupFlag(0x002);
+    /// If set, skips over ligatures
+    pub const IGNORE_LIGATURES: Self = LookupFlag(0x004);
+    /// If set, skips over all combining marks
+    pub const IGNORE_MARKS: Self = LookupFlag(0x008);
+    /// If set, indicates that the lookup table structure is followed by a MarkFilteringSet field.
+    ///
+    /// The layout engine skips over all mark glyphs not in the mark filtering set indicated.
+    pub const USE_MARK_FILTERING_SET: Self = LookupFlag(0x010);
+
     /// Return new, empty flags
     pub fn empty() -> Self {
         Self(0)


### PR DESCRIPTION
This was annoying to use from fontc, and these two bits of functionality should make that cleaner.