### PR TITLE
[skrifa] post tthint cleanup

### DIFF
--- a/skrifa/src/outline/glyf/hint/call_stack.rs
+++ b/skrifa/src/outline/glyf/hint/call_stack.rs
@@ -26,18 +26,6 @@ pub struct CallStack {
 }
 
 impl CallStack {
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    pub fn records(&self) -> &[CallRecord] {
-        &self.records[..self.len]
-    }
-
     pub fn clear(&mut self) {
         self.len = 0;
     }

--- a/skrifa/src/outline/glyf/hint/definition.rs
+++ b/skrifa/src/outline/glyf/hint/definition.rs
@@ -49,15 +49,16 @@ impl Definition {
         }
     }
 
+    /// Returns the function number or opcode.
+    #[cfg(test)]
+    pub fn key(&self) -> i32 {
+        self.key
+    }
+
     /// Returns the byte range of the code for this definition in the source
     /// program.
     pub fn code_range(&self) -> Range<usize> {
         self.start as usize..self.end as usize
-    }
-
-    /// Returns the function number or opcode.
-    pub fn key(&self) -> i32 {
-        self.key
     }
 
     /// Returns true if this definition entry has been defined by a program.
@@ -148,7 +149,8 @@ impl<'a> DefinitionMap<'a> {
     }
 
     /// Returns a reference to the underlying definition slice.
-    pub fn as_slice(&self) -> &[Definition] {
+    #[cfg(test)]
+    fn as_slice(&self) -> &[Definition] {
         match self {
             Self::Ref(defs) => defs,
             Self::Mut(defs) => defs,
@@ -212,7 +214,7 @@ mod tests {
         for (i, def) in map.as_slice().iter().enumerate() {
             let key = i as i32;
             map.get(key).unwrap();
-            assert_eq!(def.key(), key);
+            assert_eq!(def.key, key);
         }
     }
 
@@ -229,7 +231,7 @@ mod tests {
             map.allocate(key).unwrap();
         }
         for key in keys {
-            assert_eq!(map.get(key).unwrap().key(), key);
+            assert_eq!(map.get(key).unwrap().key, key);
         }
     }
 
@@ -253,11 +255,11 @@ mod tests {
         // Check backing store directly to ensure the expected allocation
         // pattern.
         let expected = [0, 1, 2, 3, 0, 5, 7, -5555, -42, 123456];
-        let mapped_keys: Vec<_> = map.as_slice().iter().map(|def| def.key()).collect();
+        let mapped_keys: Vec<_> = map.as_slice().iter().map(|def| def.key).collect();
         assert_eq!(&expected, mapped_keys.as_slice());
         // Check that all keys are mapped
         for key in keys {
-            assert_eq!(map.get(key).unwrap().key(), key);
+            assert_eq!(map.get(key).unwrap().key, key);
         }
     }
 }

--- a/skrifa/src/outline/glyf/hint/engine/cvt.rs
+++ b/skrifa/src/outline/glyf/hint/engine/cvt.rs
@@ -24,7 +24,7 @@ impl<'a> Engine<'a> {
         let value = self.value_stack.pop_f26dot6()?;
         let location = self.value_stack.pop_usize()?;
         let result = self.cvt.set(location, value);
-        if self.graphics_state.is_pedantic {
+        if self.graphics.is_pedantic {
             result
         } else {
             Ok(())
@@ -50,9 +50,9 @@ impl<'a> Engine<'a> {
         let location = self.value_stack.pop_usize()?;
         let result = self.cvt.set(
             location,
-            F26Dot6::from_bits(mul(value, self.graphics_state.scale)),
+            F26Dot6::from_bits(mul(value, self.graphics.scale)),
         );
-        if self.graphics_state.is_pedantic {
+        if self.graphics.is_pedantic {
             result
         } else {
             Ok(())
@@ -74,7 +74,7 @@ impl<'a> Engine<'a> {
     pub(super) fn op_rcvt(&mut self) -> OpResult {
         let location = self.value_stack.pop()? as usize;
         let maybe_value = self.cvt.get(location);
-        let value = if self.graphics_state.is_pedantic {
+        let value = if self.graphics.is_pedantic {
             maybe_value?
         } else {
             maybe_value.unwrap_or_default()
@@ -108,7 +108,7 @@ mod tests {
         let mut mock = MockEngine::new();
         let mut engine = mock.engine();
         let scale = 64;
-        engine.graphics_state.scale = scale;
+        engine.graphics.scale = scale;
         for i in 0..8 {
             engine.value_stack.push(i).unwrap();
             engine.value_stack.push(i * 2).unwrap();
@@ -131,7 +131,7 @@ mod tests {
         let oob_index = 1000;
         // Disable pedantic mode: OOB writes are ignored, OOB reads
         // push 0
-        engine.graphics_state.is_pedantic = false;
+        engine.graphics.is_pedantic = false;
         engine.value_stack.push(oob_index).unwrap();
         engine.value_stack.push(0).unwrap();
         engine.op_wcvtp().unwrap();
@@ -141,7 +141,7 @@ mod tests {
         engine.value_stack.push(oob_index).unwrap();
         engine.op_rcvt().unwrap();
         // Enable pedantic mode: OOB reads/writes error
-        engine.graphics_state.is_pedantic = true;
+        engine.graphics.is_pedantic = true;
         engine.value_stack.push(oob_index).unwrap();
         engine.value_stack.push(0).unwrap();
         assert_eq!(

--- a/skrifa/src/outline/glyf/hint/engine/definition.rs
+++ b/skrifa/src/outline/glyf/hint/engine/definition.rs
@@ -132,7 +132,7 @@ impl<'a> Engine<'a> {
                 Opcode::FDEF | Opcode::IDEF => return Err(HintErrorKind::NestedDefinition),
                 Opcode::ENDF => {
                     let range = start..ins.pc + 1;
-                    if self.graphics_state.is_pedantic && range.len() > MAX_DEFINITION_SIZE {
+                    if self.graphics.is_pedantic && range.len() > MAX_DEFINITION_SIZE {
                         *def = Default::default();
                         return Err(HintErrorKind::DefinitionTooLarge);
                     }
@@ -501,7 +501,7 @@ mod tests {
         font_code.extend(core::iter::repeat(op(NEG)).take(MAX_DEFINITION_SIZE + 1));
         font_code.push(op(ENDF));
         engine.set_font_code(&font_code);
-        engine.graphics_state.is_pedantic = true;
+        engine.graphics.is_pedantic = true;
         engine.value_stack.push(1).unwrap();
         let err = engine.run().unwrap_err();
         assert!(matches!(err.kind, HintErrorKind::DefinitionTooLarge));

--- a/skrifa/src/outline/glyf/hint/engine/delta.rs
+++ b/skrifa/src/outline/glyf/hint/engine/delta.rs
@@ -4,7 +4,7 @@
 //!
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-exceptions>
 
-use super::{super::graphics_state::CoordAxis, Engine, F26Dot6, OpResult};
+use super::{super::graphics::CoordAxis, Engine, F26Dot6, OpResult};
 use read_fonts::tables::glyf::bytecode::Opcode;
 
 impl<'a> Engine<'a> {
@@ -28,7 +28,7 @@ impl<'a> Engine<'a> {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#delta-exception-p1>
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L6509>
     pub(super) fn op_deltap(&mut self, opcode: Opcode) -> OpResult {
-        let gs = &mut self.graphics_state;
+        let gs = &mut self.graphics;
         let ppem = gs.ppem as u32;
         let n = self.value_stack.pop_usize()?;
         let bias = match opcode {
@@ -91,7 +91,7 @@ impl<'a> Engine<'a> {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#delta-exception-c1>
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L6604>
     pub(super) fn op_deltac(&mut self, opcode: Opcode) -> OpResult {
-        let gs = &mut self.graphics_state;
+        let gs = &mut self.graphics;
         let ppem = gs.ppem as u32;
         let n = self.value_stack.pop_usize()?;
         let bias = match opcode {

--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -20,7 +20,7 @@ impl<'a> Engine<'a> {
     pub fn reset(&mut self, program: Program) {
         self.program.reset(program);
         // Reset overall graphics state, keeping the retained bits.
-        self.graphics_state.reset();
+        self.graphics.reset();
         self.loop_budget.reset();
         // Program specific setup.
         match program {
@@ -29,22 +29,22 @@ impl<'a> Engine<'a> {
                 self.definitions.instructions.reset();
             }
             Program::ControlValue => {
-                self.graphics_state.backward_compatibility = false;
+                self.graphics.backward_compatibility = false;
             }
             Program::Glyph => {
                 // Instruct control bit 1 says we reset retained graphics state
                 // to default values.
-                if self.graphics_state.instruct_control & 2 != 0 {
-                    self.graphics_state.reset_retained();
+                if self.graphics.instruct_control & 2 != 0 {
+                    self.graphics.reset_retained();
                 }
                 // Set backward compatibility mode
-                if self.graphics_state.mode.preserve_linear_metrics() {
-                    self.graphics_state.backward_compatibility = true;
-                } else if self.graphics_state.mode.is_smooth() {
-                    self.graphics_state.backward_compatibility =
-                        (self.graphics_state.instruct_control & 0x4) == 0;
+                if self.graphics.mode.preserve_linear_metrics() {
+                    self.graphics.backward_compatibility = true;
+                } else if self.graphics.mode.is_smooth() {
+                    self.graphics.backward_compatibility =
+                        (self.graphics.instruct_control & 0x4) == 0;
                 } else {
-                    self.graphics_state.backward_compatibility = false;
+                    self.graphics.backward_compatibility = false;
                 }
             }
         }

--- a/skrifa/src/outline/glyf/hint/engine/logical.rs
+++ b/skrifa/src/outline/glyf/hint/engine/logical.rs
@@ -128,7 +128,7 @@ impl<'a> Engine<'a> {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#odd>
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2799>
     pub(super) fn op_odd(&mut self) -> OpResult {
-        let round_state = self.graphics_state.round_state;
+        let round_state = self.graphics.round_state;
         self.value_stack.apply_unary(|e1| {
             Ok((round_state.round(F26Dot6::from_bits(e1)).to_bits() & 127 == 64) as i32)
         })
@@ -150,7 +150,7 @@ impl<'a> Engine<'a> {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#even>
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2813>
     pub(super) fn op_even(&mut self) -> OpResult {
-        let round_state = self.graphics_state.round_state;
+        let round_state = self.graphics.round_state;
         self.value_stack.apply_unary(|e1| {
             Ok((round_state.round(F26Dot6::from_bits(e1)).to_bits() & 127 == 0) as i32)
         })

--- a/skrifa/src/outline/glyf/hint/engine/misc.rs
+++ b/skrifa/src/outline/glyf/hint/engine/misc.rs
@@ -31,13 +31,13 @@ impl<'a> Engine<'a> {
         }
         // Glyph rotated (selector bit: 1, result bit: 8)
         const GLYPH_ROTATED_SELECTOR_BIT: i32 = 1 << 1;
-        if (selector & GLYPH_ROTATED_SELECTOR_BIT) != 0 && self.graphics_state.is_rotated {
+        if (selector & GLYPH_ROTATED_SELECTOR_BIT) != 0 && self.graphics.is_rotated {
             const GLYPH_ROTATED_RESULT_BIT: i32 = 1 << 8;
             result |= GLYPH_ROTATED_RESULT_BIT;
         }
         // Glyph stretched (selector bit: 2, result bit: 9)
         const GLYPH_STRETCHED_SELECTOR_BIT: i32 = 1 << 2;
-        if (selector & GLYPH_STRETCHED_SELECTOR_BIT) != 0 && self.graphics_state.is_stretched {
+        if (selector & GLYPH_STRETCHED_SELECTOR_BIT) != 0 && self.graphics.is_stretched {
             const GLYPH_STRETCHED_RESULT_BIT: i32 = 1 << 9;
             result |= GLYPH_STRETCHED_RESULT_BIT;
         }
@@ -48,7 +48,7 @@ impl<'a> Engine<'a> {
             result |= FONT_VARIATIONS_RESULT_BIT;
         }
         // The following only apply for smooth hinting.
-        if self.graphics_state.mode.is_smooth() {
+        if self.graphics.mode.is_smooth() {
             // Subpixel hinting [cleartype enabled] (selector bit: 6, result bit: 13)
             // (always enabled)
             const SUBPIXEL_HINTING_SELECTOR_BIT: i32 = 1 << 6;
@@ -58,9 +58,7 @@ impl<'a> Engine<'a> {
             }
             // Vertical LCD subpixels? (selector bit: 8, result bit: 15)
             const VERTICAL_LCD_SELECTOR_BIT: i32 = 1 << 8;
-            if (selector & VERTICAL_LCD_SELECTOR_BIT) != 0
-                && self.graphics_state.mode.is_vertical_lcd()
-            {
+            if (selector & VERTICAL_LCD_SELECTOR_BIT) != 0 && self.graphics.mode.is_vertical_lcd() {
                 const VERTICAL_LCD_RESULT_BIT: i32 = 1 << 15;
                 result |= VERTICAL_LCD_RESULT_BIT;
             }
@@ -76,7 +74,7 @@ impl<'a> Engine<'a> {
             // preserve linear metrics flag is enabled.
             const SYMMETRICAL_SMOOTHING_SELECTOR_BIT: i32 = 1 << 11;
             if (selector & SYMMETRICAL_SMOOTHING_SELECTOR_BIT) != 0
-                && !self.graphics_state.mode.preserve_linear_metrics()
+                && !self.graphics.mode.preserve_linear_metrics()
             {
                 const SYMMETRICAL_SMOOTHING_RESULT_BIT: i32 = 1 << 18;
                 result |= SYMMETRICAL_SMOOTHING_RESULT_BIT;
@@ -84,7 +82,7 @@ impl<'a> Engine<'a> {
             // ClearType hinting and grayscale rendering (selector bit: 12, result bit: 19)
             const GRAYSCALE_CLEARTYPE_SELECTOR_BIT: i32 = 1 << 12;
             if (selector & GRAYSCALE_CLEARTYPE_SELECTOR_BIT) != 0
-                && self.graphics_state.mode.is_grayscale_cleartype()
+                && self.graphics.mode.is_grayscale_cleartype()
             {
                 const GRAYSCALE_CLEARTYPE_RESULT_BIT: i32 = 1 << 19;
                 result |= GRAYSCALE_CLEARTYPE_RESULT_BIT;

--- a/skrifa/src/outline/glyf/hint/engine/round.rs
+++ b/skrifa/src/outline/glyf/hint/engine/round.rs
@@ -24,7 +24,7 @@ impl<'a> Engine<'a> {
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L3143>
     pub(super) fn op_round(&mut self) -> OpResult {
         let n1 = self.value_stack.pop_f26dot6()?;
-        let n2 = self.graphics_state.round(n1);
+        let n2 = self.graphics.round(n1);
         self.value_stack.push(n2.to_bits())
     }
 }

--- a/skrifa/src/outline/glyf/hint/engine/storage.rs
+++ b/skrifa/src/outline/glyf/hint/engine/storage.rs
@@ -25,7 +25,7 @@ impl<'a> Engine<'a> {
     pub(super) fn op_rs(&mut self) -> OpResult {
         let location = self.value_stack.pop_usize()?;
         let maybe_value = self.storage.get(location);
-        let value = if self.graphics_state.is_pedantic {
+        let value = if self.graphics.is_pedantic {
             maybe_value?
         } else {
             maybe_value.unwrap_or(0)
@@ -52,7 +52,7 @@ impl<'a> Engine<'a> {
         let value = self.value_stack.pop()?;
         let location = self.value_stack.pop_usize()?;
         let result = self.storage.set(location, value);
-        if self.graphics_state.is_pedantic {
+        if self.graphics.is_pedantic {
             result
         } else {
             Ok(())
@@ -87,14 +87,14 @@ mod tests {
         let oob_index = 1000;
         // Disable pedantic mode: OOB writes are ignored, OOB reads
         // push 0
-        engine.graphics_state.is_pedantic = false;
+        engine.graphics.is_pedantic = false;
         engine.value_stack.push(oob_index).unwrap();
         engine.value_stack.push(0).unwrap();
         engine.op_ws().unwrap();
         engine.value_stack.push(oob_index).unwrap();
         engine.op_rs().unwrap();
         // Enable pedantic mode: OOB reads/writes error
-        engine.graphics_state.is_pedantic = true;
+        engine.graphics.is_pedantic = true;
         engine.value_stack.push(oob_index).unwrap();
         engine.value_stack.push(0).unwrap();
         assert_eq!(

--- a/skrifa/src/outline/glyf/hint/graphics.rs
+++ b/skrifa/src/outline/glyf/hint/graphics.rs
@@ -1,18 +1,11 @@
 //! Graphics state for the TrueType interpreter.
 
-mod projection;
-mod round;
-mod zone;
-
-use super::{F26Dot6, HintingMode, Point};
-use core::ops::{Deref, DerefMut};
-
-pub use {
-    round::{RoundMode, RoundState},
+use super::{
+    round::RoundState,
     zone::{Zone, ZonePointer},
+    F26Dot6, HintingMode, Point,
 };
-
-pub(crate) use zone::PointDisplacement;
+use core::ops::{Deref, DerefMut};
 
 /// Describes the axis to which a measurement or point movement operation
 /// applies.

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -6,9 +6,10 @@ use super::{
     definition::{Definition, DefinitionMap, DefinitionState},
     engine::Engine,
     error::HintError,
-    graphics_state::{RetainedGraphicsState, Zone},
+    graphics::RetainedGraphicsState,
     program::{Program, ProgramState},
     value_stack::ValueStack,
+    zone::Zone,
     HintOutline, HintingMode, PointFlags,
 };
 use raw::types::{F26Dot6, F2Dot14, Fixed, Point};
@@ -48,12 +49,7 @@ impl HintInstance {
         let glyph = Zone::default();
         let mut stack_buf = vec![0; self.max_stack];
         let value_stack = ValueStack::new(&mut stack_buf);
-        let graphics = RetainedGraphicsState {
-            scale,
-            ppem,
-            mode,
-            ..Default::default()
-        };
+        let graphics = RetainedGraphicsState::new(scale, ppem, mode);
         let mut engine = Engine::new(
             outlines,
             ProgramState::new(outlines.fpgm, outlines.prep, &[], Program::Font),

--- a/skrifa/src/outline/glyf/hint/mod.rs
+++ b/skrifa/src/outline/glyf/hint/mod.rs
@@ -6,12 +6,15 @@ mod cvt;
 mod definition;
 mod engine;
 mod error;
-mod graphics_state;
+mod graphics;
 mod instance;
 mod math;
 mod program;
+mod projection;
+mod round;
 mod storage;
 mod value_stack;
+mod zone;
 
 use super::super::{HintingMode, LcdLayout};
 

--- a/skrifa/src/outline/glyf/hint/projection.rs
+++ b/skrifa/src/outline/glyf/hint/projection.rs
@@ -1,8 +1,7 @@
 //! Point projection.
 
-use raw::types::F26Dot6;
-
-use super::{CoordAxis, GraphicsState, Point};
+use super::graphics::{CoordAxis, GraphicsState};
+use raw::types::{F26Dot6, Point};
 
 impl GraphicsState<'_> {
     /// Updates cached state that is derived from projection vectors.
@@ -127,7 +126,7 @@ fn dot14(ax: i32, ay: i32, bx: i32, by: i32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::math, CoordAxis, F26Dot6, GraphicsState, Point};
+    use super::{super::math, CoordAxis, F26Dot6, GraphicsState, Point};
 
     #[test]
     fn project_one_axis() {

--- a/skrifa/src/outline/glyf/hint/round.rs
+++ b/skrifa/src/outline/glyf/hint/round.rs
@@ -1,6 +1,6 @@
 //! Rounding state.
 
-use super::{super::F26Dot6, GraphicsState};
+use super::{super::F26Dot6, graphics::GraphicsState};
 
 /// Rounding strategies supported by the interpreter.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
@@ -71,7 +71,7 @@ impl Default for RoundState {
 
 impl RoundState {
     pub fn round(&self, distance: F26Dot6) -> F26Dot6 {
-        use super::super::math;
+        use super::math;
         use RoundMode::*;
         let distance = distance.to_bits();
         let result = match self.mode {

--- a/skrifa/src/outline/glyf/hint/value_stack.rs
+++ b/skrifa/src/outline/glyf/hint/value_stack.rs
@@ -29,10 +29,13 @@ impl<'a> ValueStack<'a> {
         self.top
     }
 
-    pub fn is_empty(&self) -> bool {
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
         self.top == 0
     }
 
+    // This is used in tests and also useful for tracing.
+    #[allow(dead_code)]
     pub fn values(&self) -> &[i32] {
         &self.values[..self.top]
     }
@@ -196,14 +199,6 @@ impl<'a> ValueStack<'a> {
         self.push(a)?;
         self.push(c)?;
         Ok(())
-    }
-
-    fn get(&mut self, index: usize) -> Option<i32> {
-        self.values.get(index).copied()
-    }
-
-    fn get_mut(&mut self, index: usize) -> Option<&mut i32> {
-        self.values.get_mut(index)
     }
 }
 

--- a/skrifa/src/outline/glyf/hint/zone.rs
+++ b/skrifa/src/outline/glyf/hint/zone.rs
@@ -6,8 +6,9 @@ use read_fonts::{
 };
 
 use super::{
-    super::{error::HintErrorKind, graphics_state::CoordAxis, math},
-    GraphicsState,
+    error::HintErrorKind,
+    graphics::{CoordAxis, GraphicsState},
+    math,
 };
 
 use HintErrorKind::{InvalidPointIndex, InvalidPointRange};
@@ -26,10 +27,6 @@ pub enum ZonePointer {
 impl ZonePointer {
     pub fn is_twilight(self) -> bool {
         self == Self::Twilight
-    }
-
-    pub fn is_glyph(self) -> bool {
-        self == Self::Glyph
     }
 }
 
@@ -334,12 +331,6 @@ impl<'a> Zone<'a> {
 }
 
 impl<'a> GraphicsState<'a> {
-    pub fn reset_zone_pointers(&mut self) {
-        self.zp0 = ZonePointer::default();
-        self.zp1 = ZonePointer::default();
-        self.zp2 = ZonePointer::default();
-    }
-
     /// Takes an array of (zone pointer, point index) pairs and returns true if
     /// all accesses would be valid.
     pub fn in_bounds<const N: usize>(&self, pairs: [(ZonePointer, usize); N]) -> bool {

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -1,8 +1,5 @@
 //! Scaling support for TrueType outlines.
 
-// Remove when hinting is implemented
-#![allow(dead_code)]
-
 mod deltas;
 mod hint;
 mod memory;


### PR DESCRIPTION
This is just a lot of shuffling I wanted to do but avoided while I had chained PRs pending. Makes module structure and naming more consistent.

Also removes the `#![allow(dead_code)]` attribute that was in place while things were incrementally landing.

No functional changes so JMM if you're brave.