### PR TITLE
[skrifa] color: add traversal depth limit

### DIFF
--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -74,6 +74,7 @@ pub enum PaintError {
     ParseError(ReadError),
     GlyphNotFound(GlyphId),
     PaintCycleDetected,
+    DepthLimitExceeded,
 }
 
 impl std::fmt::Display for PaintError {
@@ -86,6 +87,7 @@ impl std::fmt::Display for PaintError {
                 write!(f, "No COLRv1 glyph found for glyph id: {glyph_id}")
             }
             PaintError::PaintCycleDetected => write!(f, "Paint cycle detected in COLRv1 glyph."),
+            PaintError::DepthLimitExceeded => write!(f, "Depth limit exceeded in COLRv1 glyph."),
         }
     }
 }
@@ -353,6 +355,7 @@ impl<'a> ColorGlyph<'a> {
                     &instance,
                     painter,
                     &mut visited_set,
+                    0,
                 )?;
 
                 if clipbox.is_some() {


### PR DESCRIPTION
Adds a maximum recursion depth for COLRv1 paint graphs. The limit chosen is 64 which matches the one used in HarfBuzz.

This makes skrifa more robust to potential stack overflow attacks and will enable no_std support without taking a hashbrown dependency for the visited set.