### PR TITLE
[font-types] float to fixed point rounding

### DIFF
--- a/read-fonts/src/tables/avar.rs
+++ b/read-fonts/src/tables/avar.rs
@@ -82,9 +82,9 @@ mod tests {
             value_map(-0.6667, -0.5),
             value_map(-0.3333, -0.25),
             value_map(0.0, 0.0),
-            value_map(0.2000122, 0.3674),
-            value_map(0.4000244, 0.52246094),
-            value_map(0.6, 0.67755127),
+            value_map(0.2, 0.3674),
+            value_map(0.4, 0.52246),
+            value_map(0.6, 0.67755),
             value_map(0.8, 0.83875),
             value_map(1.0, 1.0),
         ]];

--- a/read-fonts/src/tables/postscript/dict.rs
+++ b/read-fonts/src/tables/postscript/dict.rs
@@ -655,7 +655,7 @@ mod tests {
                 -20.0, 0.0, 473.0, 491.0, 525.0, 540.0, 644.0, 659.0, 669.0, 689.0, 729.0, 749.0,
             ])),
             FamilyOtherBlues(make_blues(&[-249.0, -239.0])),
-            BlueScale(Fixed::from_f64(0.0374908447265625)),
+            BlueScale(Fixed::from_f64(0.037506103515625)),
             BlueFuzz(Fixed::ZERO),
             StdHw(Fixed::from_f64(55.0)),
             StdVw(Fixed::from_f64(80.0)),

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -1136,7 +1136,7 @@ mod tests {
         let state = make_hint_state();
         assert!(!state.do_em_box_hints);
         assert_eq!(state.zone_count, 6);
-        assert_eq!(state.boost, Fixed::from_f64(0.412445068359375));
+        assert_eq!(state.boost, Fixed::from_bits(27035));
         assert!(state.supress_overshoot);
         // FreeType generates the following zones:
         let expected_zones = &[


### PR DESCRIPTION
We had two implementations for float to fixed conversion based on whether std was available and the no_std implementation had a very subtle rounding bug (adding -0.5 for negative values but 0.0 for positive ones) causing some tests to fail.

This fixes the bug, restores the original tests and adds a new one to check rounding behavior in font-types.