### PR TITLE
Fix font-types docs, and bump patch version

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.5.0", path = "../font-types" }
+font-types = { version = "0.5.1", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/font-types/README.md
+++ b/font-types/README.md
@@ -10,7 +10,3 @@ projects that work with font data.
 
 [opentype]: https://docs.microsoft.com/en-us/typography/opentype/
 
-## Safety
-
-Unsafe code is forbidden by a `#![forbid(unsafe_code)]` attribute in the root
-of the library.

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 xflags = "0.3.0"
 read-fonts = { path = "../read-fonts",version = "0.18.0" }
-font-types = { path = "../font-types",version = "0.5.0" }
+font-types = { path = "../font-types",version = "0.5.1" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -17,7 +17,7 @@ default = ["traversal"]
 serde = ["dep:serde", "font-types/serde"]
 
 [dependencies]
-font-types = { version = "0.5.0", path = "../font-types", features = ["bytemuck"] }
+font-types = { version = "0.5.1", path = "../font-types", features = ["bytemuck"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 # note: bytemuck version must be available in all deployment environments
 bytemuck = "=1.13.1"

--- a/read-fonts/README.md
+++ b/read-fonts/README.md
@@ -4,6 +4,11 @@ This crate handles parsing and reading of OpenType fonts. It is intended to be a
 high performance implementation suitable for tasks such as [shaping][], while
 still providing a convenient, high-level API.
 
+## Safety
+
+Unsafe code is forbidden by a `#![forbid(unsafe_code)]` attribute in the root
+of the library.
+
 ## codegen
 
 Much of the code in this crate is generated automatically. This generated code

--- a/skrifa/README.md
+++ b/skrifa/README.md
@@ -60,3 +60,8 @@ corrupted/malicious font files. Please file an issue if this occurs.
 
 Following along with our theme, *skrifa* is Old Norse for "write" or "it is
 written." And so it is named.
+
+## Safety
+
+Unsafe code is forbidden by a `#![forbid(unsafe_code)]` attribute in the root
+of the library.

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -14,7 +14,7 @@ read = []
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
-font-types = { version = "0.5.0", path = "../font-types" }
+font-types = { version = "0.5.1", path = "../font-types" }
 read-fonts = { version = "0.18.0", path = "../read-fonts" }
 log = "0.4"
 kurbo = "0.11.0"


### PR DESCRIPTION
There is now some unsafe in font-types, which lets us remove unsafe in crates with more churn.