### PR TITLE
Preserve format of value records after reading

### DIFF
--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -33,6 +33,9 @@ pub struct Cursor<'a> {
 }
 
 impl<'a> FontData<'a> {
+    /// Empty data, useful for some tests and examples
+    pub const EMPTY: FontData<'static> = FontData { bytes: &[] };
+
     /// Create a new `FontData` with these bytes.
     ///
     /// You generally don't need to do this? It is handled for you when loading


### PR DESCRIPTION
ValueRecords have an explicit format, which is generally stored once in their parent table. In the case of records with device or variation tables, we need to know the format in order to write them correctly, since it's possible for these fields to be legitimately null, and we cannot distinguish between a record which where a field is None because it is not included versus when it is intended to be null.

Previously, we would use the format when reading the table but would then discard it. This led to a bug where we would not know the correct format when we went to write the table back.

With this patch, we hold onto the format after reading, and pass it to write-fonts if we convert to write-fonts types. This ensures that we roundtrip tables correctly in this case.


closes #858 