### PR TITLE
[skrifa] reduce pedantry

### DIFF
--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -1,12 +1,9 @@
 use ::skrifa::{
+    outline::{DrawError, DrawSettings, EmbeddedHintingInstance},
     prelude::{LocationRef, Size},
-    raw::{types::Pen, FontRef, TableProvider},
-    GlyphId, MetadataProvider,
-};
-use skrifa::{
-    outline::{DrawError, EmbeddedHintingInstance},
     raw::types::F2Dot14,
-    OutlineGlyphCollection,
+    raw::{types::Pen, FontRef, TableProvider},
+    GlyphId, MetadataProvider, OutlineGlyphCollection,
 };
 
 use super::{InstanceOptions, SharedFontData};
@@ -36,7 +33,7 @@ impl<'a> SkrifaInstance<'a> {
                     options.coords,
                     options.hinting.unwrap(),
                 )
-                .unwrap(),
+                .ok()?,
             )
         } else {
             None
@@ -69,7 +66,7 @@ impl<'a> SkrifaInstance<'a> {
             .get(glyph_id)
             .ok_or(DrawError::GlyphNotFound(glyph_id))?;
         if let Some(hinter) = self.hinter.as_ref() {
-            outline.draw(hinter, pen)?;
+            outline.draw(DrawSettings::hinted(hinter, false), pen)?;
         } else {
             outline.draw((self.size, self.coords.as_slice()), pen)?;
         }

--- a/skrifa/src/outline/embedded_hinting.rs
+++ b/skrifa/src/outline/embedded_hinting.rs
@@ -202,7 +202,7 @@ impl EmbeddedHintingInstance {
                         outline,
                         ppem,
                         coords,
-                        |mut hint_outline| instance.hint(glyf, &mut hint_outline),
+                        |mut hint_outline| instance.hint(glyf, &mut hint_outline, is_pedantic),
                         is_pedantic,
                     )?;
                     scaled_outline.to_path(path_style, pen)?;

--- a/skrifa/src/outline/glyf/hint/cow_slice.rs
+++ b/skrifa/src/outline/glyf/hint/cow_slice.rs
@@ -88,6 +88,14 @@ impl<'a> CowSlice<'a> {
         *self.data_mut.get_mut(index)? = value;
         Some(())
     }
+
+    pub fn len(&self) -> usize {
+        if self.use_mut {
+            self.data_mut.len()
+        } else {
+            self.data.len()
+        }
+    }
 }
 
 /// Error returned when the sizes of the immutable and mutable buffers

--- a/skrifa/src/outline/glyf/hint/cvt.rs
+++ b/skrifa/src/outline/glyf/hint/cvt.rs
@@ -21,6 +21,10 @@ impl<'a> Cvt<'a> {
             .set(index, value.to_bits())
             .ok_or(HintErrorKind::InvalidCvtIndex(index))
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl<'a> From<CowSlice<'a>> for Cvt<'a> {

--- a/skrifa/src/outline/glyf/hint/engine/data.rs
+++ b/skrifa/src/outline/glyf/hint/engine/data.rs
@@ -28,6 +28,10 @@ impl<'a> Engine<'a> {
     pub(super) fn op_gc(&mut self, opcode: u8) -> OpResult {
         let p = self.value_stack.pop_usize()?;
         let gs = &mut self.graphics;
+        if !gs.is_pedantic && !gs.in_bounds([(gs.zp2, p)]) {
+            self.value_stack.push(0)?;
+            return Ok(());
+        }
         let value = if (opcode & 1) != 0 {
             gs.dual_project(gs.zp2().original(p)?, Default::default())
         } else {
@@ -86,6 +90,10 @@ impl<'a> Engine<'a> {
         let p1 = self.value_stack.pop_usize()?;
         let p2 = self.value_stack.pop_usize()?;
         let gs = &self.graphics;
+        if !gs.is_pedantic && !gs.in_bounds([(gs.zp0, p2), (gs.zp1, p1)]) {
+            self.value_stack.push(0)?;
+            return Ok(());
+        }
         let distance = if (opcode & 1) != 0 {
             // measure in grid fitted outline
             gs.project(gs.zp0().point(p2)?, gs.zp1().point(p1)?)

--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -11,16 +11,17 @@ const MAX_RUN_INSTRUCTIONS: usize = 1_000_000;
 
 impl<'a> Engine<'a> {
     /// Resets state for the specified program and executes all instructions.
-    pub fn run_program(&mut self, program: Program) -> Result<(), HintError> {
-        self.reset(program);
+    pub fn run_program(&mut self, program: Program, is_pedantic: bool) -> Result<(), HintError> {
+        self.reset(program, is_pedantic);
         self.run()
     }
 
     /// Set internal state for running the specified program.
-    pub fn reset(&mut self, program: Program) {
+    pub fn reset(&mut self, program: Program, is_pedantic: bool) {
         self.program.reset(program);
         // Reset overall graphics state, keeping the retained bits.
         self.graphics.reset();
+        self.graphics.is_pedantic = is_pedantic;
         self.loop_budget.reset();
         // Program specific setup.
         match program {
@@ -62,6 +63,7 @@ impl<'a> Engine<'a> {
                     program: self.program.current,
                     glyph_id: None,
                     pc: ins.pc,
+                    opcode: Some(ins.opcode),
                     kind: HintErrorKind::ExceededExecutionBudget,
                 });
             }
@@ -76,6 +78,7 @@ impl<'a> Engine<'a> {
             program: self.program.current,
             glyph_id: None,
             pc: self.program.decoder.pc,
+            opcode: None,
             kind: HintErrorKind::UnexpectedEndOfBytecode,
         }))
     }
@@ -87,6 +90,7 @@ impl<'a> Engine<'a> {
             program: current_program,
             glyph_id: None,
             pc: ins.pc,
+            opcode: Some(ins.opcode),
             kind,
         })
     }

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -230,7 +230,7 @@ mod mock {
                 graphics: graphics_state,
                 cvt: CowSlice::new_mut(cvt).into(),
                 storage: CowSlice::new_mut(storage).into(),
-                value_stack: ValueStack::new(&mut self.value_stack),
+                value_stack: ValueStack::new(&mut self.value_stack, false),
                 program: ProgramState::new(font_code, cv_code, glyph_code, Program::Font),
                 loop_budget: LoopBudget {
                     limit: 10,

--- a/skrifa/src/outline/glyf/hint/error.rs
+++ b/skrifa/src/outline/glyf/hint/error.rs
@@ -97,6 +97,7 @@ pub struct HintError {
     pub program: Program,
     pub glyph_id: Option<GlyphId>,
     pub pc: usize,
+    pub opcode: Option<Opcode>,
     pub kind: HintErrorKind,
 }
 
@@ -105,16 +106,15 @@ impl core::fmt::Display for HintError {
         match self.program {
             Program::ControlValue => write!(f, "prep")?,
             Program::Font => write!(f, "fpgm")?,
-            Program::Glyph => {
-                write!(f, "glyf[")?;
-                if let Some(glyph_id) = self.glyph_id {
-                    write!(f, "{}", glyph_id.to_u16())?;
-                } else {
-                    write!(f, "?")?;
-                }
-                write!(f, "]")?
-            }
+            Program::Glyph => write!(f, "glyf")?,
         }
-        write!(f, "+{}: {}", self.pc, self.kind)
+        if let Some(glyph_id) = self.glyph_id {
+            write!(f, "[{}]", glyph_id.to_u16())?;
+        }
+        let (opcode, colon) = match self.opcode {
+            Some(opcode) => (opcode.name(), ":"),
+            _ => ("", ""),
+        };
+        write!(f, "@{}:{opcode}{colon} {}", self.pc, self.kind)
     }
 }


### PR DESCRIPTION
Propagate the `is_pedantic` flag to a few places and reduce the strictness in various parts of the hinter based on that flag.

With these changes we match FT hinting for all of Google Fonts and Noto.