### PR TITLE
[skrifa] tthint: rounding phantom points

### DIFF
--- a/skrifa/src/outline/embedded_hinting.rs
+++ b/skrifa/src/outline/embedded_hinting.rs
@@ -197,14 +197,8 @@ impl EmbeddedHintingInstance {
                     let mem = outline
                         .memory_from_buffer(buf, Hinting::Embedded)
                         .ok_or(DrawError::InsufficientMemory)?;
-                    let scaled_outline = glyf.draw_hinted(
-                        mem,
-                        outline,
-                        ppem,
-                        coords,
-                        |mut hint_outline| instance.hint(glyf, &mut hint_outline, is_pedantic),
-                        is_pedantic,
-                    )?;
+                    let scaled_outline =
+                        glyf.draw_hinted(mem, outline, ppem, coords, instance, is_pedantic)?;
                     scaled_outline.to_path(path_style, pen)?;
                     Ok(AdjustedMetrics {
                         has_overlaps: outline.has_overlaps,

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -85,6 +85,19 @@ impl HintInstance {
         self.graphics.instruct_control & 1 == 0
     }
 
+    /// Returns true if backward compatibility mode has been activated
+    /// by the hinter settings or the `prep` table.
+    pub fn backward_compatibility(&self) -> bool {
+        // Set backward compatibility mode
+        if self.graphics.mode.preserve_linear_metrics() {
+            true
+        } else if self.graphics.mode.is_smooth() {
+            (self.graphics.instruct_control & 0x4) == 0
+        } else {
+            false
+        }
+    }
+
     pub fn hint(
         &self,
         outlines: &Outlines,


### PR DESCRIPTION
This fixes a weird edge case where the user requests a strong hinting mode (FT_LOAD_TARGET_MONO) but no instructions are present in a simple glyph. FreeType still rounds the phantom points in this case but we weren't doing so causing some glyphs to be offset a tiny bit in the x direction.

With this fix we now have 100% matching fauntlet runs for all of Google Fonts and Noto with all four hinting modes.