### PR TITLE
Unlock bytemuck version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
 ]
 
 [workspace.dependencies]
+# note: bytemuck version must be available in all deployment environments
+bytemuck = "1.13.1"
 # dev dependencies
 env_logger = "0.11"
 pretty_assertions = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ members = [
 ]
 
 [workspace.dependencies]
-# note: bytemuck version must be available in all deployment environments
+# note: bytemuck version must be available in all deployment environments, 
+# specifically the floor of the versions supported by google3 and Chrome
 bytemuck = "1.13.1"
 # dev dependencies
 env_logger = "0.11"

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["text-processing"]
 
 [dependencies]
 # note: bytemuck version must be available in all deployment environments
-bytemuck = {version = "=1.13.1", features = ["derive", "min_const_generics"], optional = true }
+bytemuck = { workspace = true,  features = ["derive", "min_const_generics"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -19,8 +19,7 @@ serde = ["dep:serde", "font-types/serde"]
 [dependencies]
 font-types = { version = "0.5.1", path = "../font-types", features = ["bytemuck"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-# note: bytemuck version must be available in all deployment environments
-bytemuck = "=1.13.1"
+bytemuck = { workspace = true }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -17,8 +17,7 @@ libm = ["dep:core_maths"]
 [dependencies]
 read-fonts = { version = "0.18.0", path = "../read-fonts", default-features = false }
 core_maths = { version = "0.1", optional = true }
-# note: bytemuck version must be available in all deployment environments
-bytemuck = "=1.13.1"
+bytemuck = { workspace = true }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }


### PR DESCRIPTION
Switch bytemuck version from `=1.31.1` to `1.31.1`. Also moves bytemuck to a workspace dependency to make it easier to update the version in the future.