### PR TITLE
bump types/read/skrifa for release

### DIFF
--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-skrifa = { version = "0.18.0", path = "../skrifa" }
+skrifa = { version = "0.19.0", path = "../skrifa" }
 freetype-rs = "0.32.0"
 memmap2 = "0.5.10"
 rayon = "1.8.0"

--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.5.1", path = "../font-types" }
+font-types = { version = "0.5.2", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 xflags = "0.3.0"
-read-fonts = { path = "../read-fonts",version = "0.18.0" }
-font-types = { path = "../font-types",version = "0.5.1" }
+read-fonts = { path = "../read-fonts",version = "0.19.0" }
+font-types = { path = "../font-types",version = "0.5.2" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."
@@ -17,7 +17,7 @@ default = ["traversal"]
 serde = ["dep:serde", "font-types/serde"]
 
 [dependencies]
-font-types = { version = "0.5.1", path = "../font-types", features = ["bytemuck"] }
+font-types = { version = "0.5.2", path = "../font-types", features = ["bytemuck"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 bytemuck = { workspace = true }
 

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
@@ -15,13 +15,13 @@ traversal = ["std", "read-fonts/traversal"]
 libm = ["dep:core_maths"]
 
 [dependencies]
-read-fonts = { version = "0.18.0", path = "../read-fonts", default-features = false }
+read-fonts = { version = "0.19.0", path = "../read-fonts", default-features = false }
 core_maths = { version = "0.1", optional = true }
 bytemuck = { workspace = true }
 
 [dev-dependencies]
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.18.0", path = "../read-fonts", features = [
+read-fonts = { version = "0.19.0", path = "../read-fonts", features = [
     "scaler_test",
     "serde",
 ] }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -14,8 +14,8 @@ read = []
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
-font-types = { version = "0.5.1", path = "../font-types" }
-read-fonts = { version = "0.18.0", path = "../read-fonts" }
+font-types = { version = "0.5.2", path = "../font-types" }
+read-fonts = { version = "0.19.0", path = "../read-fonts" }
 log = "0.4"
 kurbo = "0.11.0"
 dot2 = { version = "1.0", optional = true }
@@ -26,7 +26,7 @@ indexmap = "2.0"
 diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.18.0", path = "../read-fonts", features = [
+read-fonts = { version = "0.19.0", path = "../read-fonts", features = [
   "codegen_test",
 ] }
 rstest = "0.18.0"


### PR DESCRIPTION
* patch update for font-types just to capture changed bytemuck dependency version
* minor for read-fonts and skrifa due to breaking change in CBLC fix