### PR TITLE
[read-fonts] add helpers to hmtx/vmtx

### DIFF
--- a/read-fonts/src/tables/hmtx.rs
+++ b/read-fonts/src/tables/hmtx.rs
@@ -1,3 +1,74 @@
 //! The [hmtx (Horizontal Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx) table
 
 include!("../../generated/generated_hmtx.rs");
+
+impl<'a> Hmtx<'a> {
+    /// Returns the advance width for the given glyph identifier.
+    pub fn advance(&self, glyph_id: GlyphId) -> Option<u16> {
+        advance(self.h_metrics(), glyph_id)
+    }
+
+    /// Returns the left side bearing for the given glyph identifer.
+    pub fn side_bearing(&self, glyph_id: GlyphId) -> Option<i16> {
+        side_bearing(self.h_metrics(), self.left_side_bearings(), glyph_id)
+    }
+}
+
+pub(super) fn advance(metrics: &[LongMetric], glyph_id: GlyphId) -> Option<u16> {
+    metrics
+        .get(glyph_id.to_u16() as usize)
+        .or_else(|| metrics.last())
+        .map(|metric| metric.advance())
+}
+
+pub(super) fn side_bearing(
+    metrics: &[LongMetric],
+    side_bearings: &[BigEndian<i16>],
+    glyph_id: GlyphId,
+) -> Option<i16> {
+    let ix = glyph_id.to_u16() as usize;
+    metrics
+        .get(ix)
+        .map(|metric| metric.side_bearing())
+        .or_else(|| {
+            side_bearings
+                .get(ix.saturating_sub(metrics.len()))
+                .map(|sb| sb.get())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FontRef, TableProvider};
+
+    /// Test case where "long metric" array is short
+    #[test]
+    fn trimmed_advances() {
+        let font = FontRef::new(font_test_data::CBDT).unwrap();
+        let hmtx = font.hmtx().unwrap();
+        assert!(
+            !hmtx.left_side_bearings().is_empty(),
+            "if this fails then the test is no longer accurate"
+        );
+        let expected_lsbs = [100, 0, 100, 0];
+        for (i, lsb) in expected_lsbs.into_iter().enumerate() {
+            let gid = GlyphId::new(i as _);
+            // All glyphs have 800 advance width
+            assert_eq!(hmtx.advance(gid), Some(800));
+            assert_eq!(hmtx.side_bearing(gid), Some(lsb));
+        }
+    }
+
+    #[test]
+    fn metrics() {
+        let font = FontRef::new(font_test_data::VAZIRMATN_VAR).unwrap();
+        let hmtx = font.hmtx().unwrap();
+        let expected = [(908, 100), (1336, 29), (1336, 29), (633, 57)];
+        for (i, (advance, lsb)) in expected.into_iter().enumerate() {
+            let gid = GlyphId::new(i as _);
+            assert_eq!(hmtx.advance(gid), Some(advance));
+            assert_eq!(hmtx.side_bearing(gid), Some(lsb));
+        }
+    }
+}

--- a/read-fonts/src/tables/vmtx.rs
+++ b/read-fonts/src/tables/vmtx.rs
@@ -1,5 +1,18 @@
 //! The [vmtx (Vertical Metrics)](https://docs.microsoft.com/en-us/typography/opentype/spec/vmtx) table
 
+use super::hmtx;
 pub use super::hmtx::LongMetric;
 
 include!("../../generated/generated_vmtx.rs");
+
+impl<'a> Vmtx<'a> {
+    /// Returns the advance height for the given glyph identifier.
+    pub fn advance(&self, glyph_id: GlyphId) -> Option<u16> {
+        hmtx::advance(self.v_metrics(), glyph_id)
+    }
+
+    /// Returns the top side bearing for the given glyph identifer.
+    pub fn side_bearing(&self, glyph_id: GlyphId) -> Option<i16> {
+        hmtx::side_bearing(self.v_metrics(), self.top_side_bearings(), glyph_id)
+    }
+}

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -252,18 +252,7 @@ impl<'a> Outlines<'a> {
     }
 
     fn advance_width(&self, gid: GlyphId, coords: &'a [F2Dot14]) -> i32 {
-        let default_advance = self
-            .hmtx
-            .h_metrics()
-            .last()
-            .map(|metric| metric.advance())
-            .unwrap_or(0);
-        let mut advance = self
-            .hmtx
-            .h_metrics()
-            .get(gid.to_u16() as usize)
-            .map(|metric| metric.advance())
-            .unwrap_or(default_advance) as i32;
+        let mut advance = self.hmtx.advance(gid).unwrap_or_default() as i32;
         if let Some(hvar) = &self.hvar {
             advance += hvar
                 .advance_width_delta(gid, coords)
@@ -275,19 +264,7 @@ impl<'a> Outlines<'a> {
     }
 
     fn lsb(&self, gid: GlyphId, coords: &'a [F2Dot14]) -> i32 {
-        let gid_index = gid.to_u16() as usize;
-        let mut lsb = self
-            .hmtx
-            .h_metrics()
-            .get(gid_index)
-            .map(|metric| metric.side_bearing())
-            .unwrap_or_else(|| {
-                self.hmtx
-                    .left_side_bearings()
-                    .get(gid_index.saturating_sub(self.hmtx.h_metrics().len()))
-                    .map(|lsb| lsb.get())
-                    .unwrap_or(0)
-            }) as i32;
+        let mut lsb = self.hmtx.side_bearing(gid).unwrap_or_default() as i32;
         if let Some(hvar) = &self.hvar {
             lsb += hvar
                 .lsb_delta(gid, coords)


### PR DESCRIPTION
Adds `advance()` and `side_bearing()` methods to `Hmtx`/`Vmtx`.

Feels like I've hand written this code often enough that it's now time to put it in its proper place.

JMM