### PR TITLE
Bump for release

### DIFF
--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
-skrifa = { version = "0.19.1", path = "../skrifa" }
+skrifa = { version = "0.19.2", path = "../skrifa" }
 freetype-rs = "0.32.0"
 memmap2 = "0.5.10"
 rayon = "1.8.0"

--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.5.3", path = "../font-types" }
+font-types = { version = "0.5.4", path = "../font-types" }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Test data for the fontations crates"

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."

--- a/int-set/Cargo.toml
+++ b/int-set/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT/Apache-2.0"
 description = "A fast sparse and invertible bit set for u32's. Port of harfbuzz's hb_set_t."
 
 [dependencies]
-font-types = { version = "0.5.3", path = "../font-types"}
+font-types = { version = "0.5.4", path = "../font-types"}

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 xflags = "0.3.0"
 read-fonts = { path = "../read-fonts",version = "0.19.1" }
-font-types = { path = "../font-types",version = "0.5.3" }
+font-types = { path = "../font-types",version = "0.5.4" }
 ansi_term = "0.12.1"
 atty = "0.2"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -17,7 +17,7 @@ default = ["traversal"]
 serde = ["dep:serde", "font-types/serde"]
 
 [dependencies]
-font-types = { version = "0.5.3", path = "../font-types", features = ["bytemuck"] }
+font-types = { version = "0.5.4", path = "../font-types", features = ["bytemuck"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 bytemuck = { workspace = true }
 

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Writing font files."
@@ -14,7 +14,7 @@ read = []
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
-font-types = { version = "0.5.3", path = "../font-types" }
+font-types = { version = "0.5.4", path = "../font-types" }
 read-fonts = { version = "0.19.1", path = "../read-fonts" }
 log = "0.4"
 kurbo.workspace = true


### PR DESCRIPTION
* font-types as a useful GlyphId::new from u32
* Skrifa COLRv1 fix (#911)
* read-fonts cmap4 iterator fix (#899)
* write-fonts release while I am at it
* font-test-data for test for #911