### PR TITLE
Outline of a Skrifa fuzzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "fauntlet",
     "klippa",
     "int-set",
+    "fuzz",
 ]
 
 [workspace.dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
+# cargo-release settings
+[package.metadata.release]
+release = false
+
 [dependencies]
 libfuzzer-sys = "0.4"
 skrifa = { path="../skrifa" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+skrifa = { path="../skrifa" }
+
+[[bin]]
+name = "fuzz_skrifa"
+path = "fuzz_targets/fuzz_skrifa.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,15 @@
+# Fuzz
+
+Fuzzing is generally run by https://github.com/google/oss-fuzz.
+
+To run fuzzing locally:
+
+```shell
+# Make sure you have cargo-fuzz and the nightly toolchain
+$ cargo install cargo-fuzz
+$ rustup install nightly
+
+# Build the fuzzer
+$ cargo +nightly  fuzz build -O --debug-assertions
+$ target/x86_64-unknown-linux-gnu/release/fuzz_skrifa
+```

--- a/fuzz/fuzz_targets/fuzz_skrifa.rs
+++ b/fuzz/fuzz_targets/fuzz_skrifa.rs
@@ -1,0 +1,15 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use skrifa::FontRef;
+
+fn do_skrifa_things(data: &[u8]) -> Result<(), String> {
+    let _font = FontRef::new(data).map_err(|e| format!("{e}"))?;
+
+    // TODO: put skrifa through it's paces
+
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = do_skrifa_things(data);
+});


### PR DESCRIPTION
First step toward #420. Fuzzer is currently nop. Meant to enable oss-fuzz setup and establish a pattern we can use to add additional fuzzers for subsetting, etc.

For context, first swing at oss-fuzz rigging in https://github.com/google/oss-fuzz/pull/12011.

JMM