### PR TITLE
Add back 'std' feature for font-types

### DIFF
--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing"]
 
+[features]
+std = []
+
 [dependencies]
 # note: bytemuck version must be available in all deployment environments
 bytemuck = { workspace = true,  features = ["derive", "min_const_generics"], optional = true }

--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -3,9 +3,13 @@
 //! [data types]: https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types
 
 #![deny(rustdoc::broken_intra_doc_links)]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(test))]
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate core as std;
 

--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -157,6 +157,9 @@ impl crate::raw::Scalar for Tag {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidTag {}
+
 impl Borrow<[u8; 4]> for Tag {
     fn borrow(&self) -> &[u8; 4] {
         &self.0
@@ -323,6 +326,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn display() {
         let bad_tag = Tag::new(&[0x19, b'z', b'@', 0x7F]);
         assert_eq!(bad_tag.to_string(), "{0x19}z@{0x7F}");

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 
 [features]
-std = []
+std = ["font-types/std"]
 codegen_test = []
 scaler_test = []
 traversal = ["std"]


### PR DESCRIPTION
This is not enabled by default, but is turned on by read-fonts when read-fonts' 'std' feature is enabled.

The main thing that enabling 'std' does now is provide an impl of std::error::Error for the InvalidTag error type.