### PR TITLE
Box write-fonts offset markers

### DIFF
--- a/write-fonts/src/validate.rs
+++ b/write-fonts/src/validate.rs
@@ -203,7 +203,9 @@ impl<const N: usize, T: Validate> Validate for OffsetMarker<T, N> {
 
 impl<const N: usize, T: Validate> Validate for NullableOffsetMarker<T, N> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
-        self.deref().validate_impl(ctx)
+        if let Some(b) = self.as_ref() {
+            b.validate_impl(ctx);
+        }
     }
 }
 


### PR DESCRIPTION
lest recursive data structures like COLR Paint (not yet generating a write-fonts impl) or Conditions in #930 get upset about infinite recursion to get size.

```
// This is OK, presumably because we don't generate compile (write-fonts) for colr
format u8 Paint {
   Glyph(PaintGlyph),
}
table PaintGlyph {
   paint_offset: Offset24<Paint>,
}

// This is NOT OK; reading is fine but writing fails
// error[E0072]: recursive types `tables::layout::Condition` and `ConditionFormat5` have infinite size
format u16 Condition {
    Format5Negate(ConditionFormat5),
}
table ConditionFormat5 {
    condition_offset: Offset24<Condition>,
}
```

Fix suggested by @dfrg , errors all by me. 

Meant to unblock https://github.com/googlefonts/fontations/pull/930.