### PR TITLE
[codegen] Use dot instead of comma in version spec

### DIFF
--- a/docs/codegen-tour.md
+++ b/docs/codegen-tour.md
@@ -732,7 +732,7 @@ the size and contents of the array:
   table Post {
       // some fields omited
       #[count(..)]
-      #[since_version(2,0)]
+      #[since_version(2.0)]
       string_data: VarLenArray<PString<'a>>,
   }
   ```

--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -169,8 +169,7 @@ The following annotations are supported on top-level objects:
   as well as validation and compilation code.
 - `#[since_version(version)]`: indicates that a field only exists in a given version
   of the table. The `version` may be either a single integer literal
-  (`#[since_version(1)]`), or a comma-separated pair of integer literals
-  (`#[since_version(1,1)]`).
+  (`#[since_version(1)]`), or a major.minor pair (`#[since_version(1.1)]`).
 - `#[skip_getter]`: if present, we will not generate a getter for this field.
   Used on things like padding fields.
 - `#[offset_getter(method name)]`: only allowed on offsets or arrays of offsets.

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -234,20 +234,26 @@ impl<'a> FontRead<'a> for TTCHeader<'a> {
         let table_directory_offsets_byte_len = num_fonts as usize * u32::RAW_BYTE_LEN;
         cursor.advance_by(table_directory_offsets_byte_len);
         let dsig_tag_byte_start = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((2, 0)).then(|| cursor.advance::<u32>());
+        version
+            .compatible((2u16, 0u16))
+            .then(|| cursor.advance::<u32>());
         let dsig_length_byte_start = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((2, 0)).then(|| cursor.advance::<u32>());
+        version
+            .compatible((2u16, 0u16))
+            .then(|| cursor.advance::<u32>());
         let dsig_offset_byte_start = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((2, 0)).then(|| cursor.advance::<u32>());
+        version
+            .compatible((2u16, 0u16))
+            .then(|| cursor.advance::<u32>());
         cursor.finish(TTCHeaderMarker {
             table_directory_offsets_byte_len,
             dsig_tag_byte_start,
@@ -319,13 +325,13 @@ impl<'a> SomeTable<'a> for TTCHeader<'a> {
                 "table_directory_offsets",
                 self.table_directory_offsets(),
             )),
-            4usize if version.compatible((2, 0)) => {
+            4usize if version.compatible((2u16, 0u16)) => {
                 Some(Field::new("dsig_tag", self.dsig_tag().unwrap()))
             }
-            5usize if version.compatible((2, 0)) => {
+            5usize if version.compatible((2u16, 0u16)) => {
                 Some(Field::new("dsig_length", self.dsig_length().unwrap()))
             }
-            6usize if version.compatible((2, 0)) => {
+            6usize if version.compatible((2u16, 0u16)) => {
                 Some(Field::new("dsig_offset", self.dsig_offset().unwrap()))
             }
             _ => None,

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -43,11 +43,11 @@ impl<'a> FontRead<'a> for Base<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let item_var_store_offset_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(BaseMarker {
             item_var_store_offset_byte_start,
@@ -119,7 +119,7 @@ impl<'a> SomeTable<'a> for Base<'a> {
                 "vert_axis_offset",
                 FieldType::offset(self.vert_axis_offset(), self.vert_axis()),
             )),
-            3usize if version.compatible((1, 1)) => Some(Field::new(
+            3usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "item_var_store_offset",
                 FieldType::offset(
                     self.item_var_store_offset().unwrap(),

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -73,30 +73,40 @@ impl<'a> FontRead<'a> for Colr<'a> {
         cursor.advance::<Offset32>();
         cursor.advance::<u16>();
         let base_glyph_list_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         let layer_list_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         let clip_list_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         let var_index_map_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         let item_variation_store_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         cursor.finish(ColrMarker {
             base_glyph_list_offset_byte_start,
             layer_list_offset_byte_start,
@@ -250,32 +260,32 @@ impl<'a> SomeTable<'a> for Colr<'a> {
                 ),
             )),
             4usize => Some(Field::new("num_layer_records", self.num_layer_records())),
-            5usize if version.compatible(1) => Some(Field::new(
+            5usize if version.compatible(1u16) => Some(Field::new(
                 "base_glyph_list_offset",
                 FieldType::offset(
                     self.base_glyph_list_offset().unwrap(),
                     self.base_glyph_list().unwrap(),
                 ),
             )),
-            6usize if version.compatible(1) => Some(Field::new(
+            6usize if version.compatible(1u16) => Some(Field::new(
                 "layer_list_offset",
                 FieldType::offset(
                     self.layer_list_offset().unwrap(),
                     self.layer_list().unwrap(),
                 ),
             )),
-            7usize if version.compatible(1) => Some(Field::new(
+            7usize if version.compatible(1u16) => Some(Field::new(
                 "clip_list_offset",
                 FieldType::offset(self.clip_list_offset().unwrap(), self.clip_list().unwrap()),
             )),
-            8usize if version.compatible(1) => Some(Field::new(
+            8usize if version.compatible(1u16) => Some(Field::new(
                 "var_index_map_offset",
                 FieldType::offset(
                     self.var_index_map_offset().unwrap(),
                     self.var_index_map().unwrap(),
                 ),
             )),
-            9usize if version.compatible(1) => Some(Field::new(
+            9usize if version.compatible(1u16) => Some(Field::new(
                 "item_variation_store_offset",
                 FieldType::offset(
                     self.item_variation_store_offset().unwrap(),

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -70,20 +70,26 @@ impl<'a> FontRead<'a> for Cpal<'a> {
         let color_record_indices_byte_len = num_palettes as usize * u16::RAW_BYTE_LEN;
         cursor.advance_by(color_record_indices_byte_len);
         let palette_types_array_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         let palette_labels_array_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         let palette_entry_labels_array_offset_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<Offset32>());
+        version
+            .compatible(1u16)
+            .then(|| cursor.advance::<Offset32>());
         cursor.finish(CpalMarker {
             color_record_indices_byte_len,
             palette_types_array_offset_byte_start,
@@ -232,21 +238,21 @@ impl<'a> SomeTable<'a> for Cpal<'a> {
                 "color_record_indices",
                 self.color_record_indices(),
             )),
-            6usize if version.compatible(1) => Some(Field::new(
+            6usize if version.compatible(1u16) => Some(Field::new(
                 "palette_types_array_offset",
                 FieldType::offset_to_array_of_scalars(
                     self.palette_types_array_offset().unwrap(),
                     self.palette_types_array().unwrap(),
                 ),
             )),
-            7usize if version.compatible(1) => Some(Field::new(
+            7usize if version.compatible(1u16) => Some(Field::new(
                 "palette_labels_array_offset",
                 FieldType::offset_to_array_of_scalars(
                     self.palette_labels_array_offset().unwrap(),
                     self.palette_labels_array().unwrap(),
                 ),
             )),
-            8usize if version.compatible(1) => Some(Field::new(
+            8usize if version.compatible(1u16) => Some(Field::new(
                 "palette_entry_labels_array_offset",
                 FieldType::offset_to_array_of_scalars(
                     self.palette_entry_labels_array_offset().unwrap(),

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -58,18 +58,18 @@ impl<'a> FontRead<'a> for Gdef<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let mark_glyph_sets_def_offset_byte_start = version
-            .compatible((1, 2))
+            .compatible((1u16, 2u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 2))
+            .compatible((1u16, 2u16))
             .then(|| cursor.advance::<Offset16>());
         let item_var_store_offset_byte_start = version
-            .compatible((1, 3))
+            .compatible((1u16, 3u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 3))
+            .compatible((1u16, 3u16))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(GdefMarker {
             mark_glyph_sets_def_offset_byte_start,
@@ -195,14 +195,14 @@ impl<'a> SomeTable<'a> for Gdef<'a> {
                     self.mark_attach_class_def(),
                 ),
             )),
-            5usize if version.compatible((1, 2)) => Some(Field::new(
+            5usize if version.compatible((1u16, 2u16)) => Some(Field::new(
                 "mark_glyph_sets_def_offset",
                 FieldType::offset(
                     self.mark_glyph_sets_def_offset().unwrap(),
                     self.mark_glyph_sets_def().unwrap(),
                 ),
             )),
-            6usize if version.compatible((1, 3)) => Some(Field::new(
+            6usize if version.compatible((1u16, 3u16)) => Some(Field::new(
                 "item_var_store_offset",
                 FieldType::offset(
                     self.item_var_store_offset().unwrap(),

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -49,11 +49,11 @@ impl<'a> FontRead<'a> for Gpos<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let feature_variations_offset_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(GposMarker {
             feature_variations_offset_byte_start,
@@ -141,7 +141,7 @@ impl<'a> SomeTable<'a> for Gpos<'a> {
                 "lookup_list_offset",
                 FieldType::offset(self.lookup_list_offset(), self.lookup_list()),
             )),
-            4usize if version.compatible((1, 1)) => Some(Field::new(
+            4usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "feature_variations_offset",
                 FieldType::offset(
                     self.feature_variations_offset().unwrap(),

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -48,11 +48,11 @@ impl<'a> FontRead<'a> for Gsub<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let feature_variations_offset_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(GsubMarker {
             feature_variations_offset_byte_start,
@@ -141,7 +141,7 @@ impl<'a> SomeTable<'a> for Gsub<'a> {
                 "lookup_list_offset",
                 FieldType::offset(self.lookup_list_offset(), self.lookup_list()),
             )),
-            4usize if version.compatible((1, 1)) => Some(Field::new(
+            4usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "feature_variations_offset",
                 FieldType::offset(
                     self.feature_variations_offset().unwrap(),

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -98,70 +98,96 @@ impl<'a> FontRead<'a> for Maxp<'a> {
         let version: Version16Dot16 = cursor.read()?;
         cursor.advance::<u16>();
         let max_points_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_contours_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_composite_points_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_composite_contours_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_zones_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_twilight_points_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_storage_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_function_defs_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_instruction_defs_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_stack_elements_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_size_of_instructions_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_component_elements_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         let max_component_depth_byte_start = version
-            .compatible((1, 0))
+            .compatible((1u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible((1, 0)).then(|| cursor.advance::<u16>());
+        version
+            .compatible((1u16, 0u16))
+            .then(|| cursor.advance::<u16>());
         cursor.finish(MaxpMarker {
             max_points_byte_start,
             max_contours_byte_start,
@@ -289,51 +315,51 @@ impl<'a> SomeTable<'a> for Maxp<'a> {
         match idx {
             0usize => Some(Field::new("version", self.version())),
             1usize => Some(Field::new("num_glyphs", self.num_glyphs())),
-            2usize if version.compatible((1, 0)) => {
+            2usize if version.compatible((1u16, 0u16)) => {
                 Some(Field::new("max_points", self.max_points().unwrap()))
             }
-            3usize if version.compatible((1, 0)) => {
+            3usize if version.compatible((1u16, 0u16)) => {
                 Some(Field::new("max_contours", self.max_contours().unwrap()))
             }
-            4usize if version.compatible((1, 0)) => Some(Field::new(
+            4usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_composite_points",
                 self.max_composite_points().unwrap(),
             )),
-            5usize if version.compatible((1, 0)) => Some(Field::new(
+            5usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_composite_contours",
                 self.max_composite_contours().unwrap(),
             )),
-            6usize if version.compatible((1, 0)) => {
+            6usize if version.compatible((1u16, 0u16)) => {
                 Some(Field::new("max_zones", self.max_zones().unwrap()))
             }
-            7usize if version.compatible((1, 0)) => Some(Field::new(
+            7usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_twilight_points",
                 self.max_twilight_points().unwrap(),
             )),
-            8usize if version.compatible((1, 0)) => {
+            8usize if version.compatible((1u16, 0u16)) => {
                 Some(Field::new("max_storage", self.max_storage().unwrap()))
             }
-            9usize if version.compatible((1, 0)) => Some(Field::new(
+            9usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_function_defs",
                 self.max_function_defs().unwrap(),
             )),
-            10usize if version.compatible((1, 0)) => Some(Field::new(
+            10usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_instruction_defs",
                 self.max_instruction_defs().unwrap(),
             )),
-            11usize if version.compatible((1, 0)) => Some(Field::new(
+            11usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_stack_elements",
                 self.max_stack_elements().unwrap(),
             )),
-            12usize if version.compatible((1, 0)) => Some(Field::new(
+            12usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_size_of_instructions",
                 self.max_size_of_instructions().unwrap(),
             )),
-            13usize if version.compatible((1, 0)) => Some(Field::new(
+            13usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_component_elements",
                 self.max_component_elements().unwrap(),
             )),
-            14usize if version.compatible((1, 0)) => Some(Field::new(
+            14usize if version.compatible((1u16, 0u16)) => Some(Field::new(
                 "max_component_depth",
                 self.max_component_depth().unwrap(),
             )),

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -56,20 +56,20 @@ impl<'a> FontRead<'a> for Name<'a> {
         let name_record_byte_len = count as usize * NameRecord::RAW_BYTE_LEN;
         cursor.advance_by(name_record_byte_len);
         let lang_tag_count_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
         let lang_tag_count = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.read::<u16>())
             .transpose()?
             .unwrap_or(0);
         let lang_tag_record_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
         let lang_tag_record_byte_len = version
-            .compatible(1)
+            .compatible(1u16)
             .then_some(lang_tag_count as usize * LangTagRecord::RAW_BYTE_LEN);
         if let Some(value) = lang_tag_record_byte_len {
             cursor.advance_by(value);
@@ -143,10 +143,10 @@ impl<'a> SomeTable<'a> for Name<'a> {
                     self.string_data(),
                 ),
             )),
-            4usize if version.compatible(1) => {
+            4usize if version.compatible(1u16) => {
                 Some(Field::new("lang_tag_count", self.lang_tag_count().unwrap()))
             }
-            5usize if version.compatible(1) => Some(Field::new(
+            5usize if version.compatible(1u16) => Some(Field::new(
                 "lang_tag_record",
                 traversal::FieldType::array_of_records(
                     stringify!(LangTagRecord),

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -573,50 +573,50 @@ impl<'a> FontRead<'a> for Os2<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         let ul_code_page_range_1_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<u32>());
+        version.compatible(1u16).then(|| cursor.advance::<u32>());
         let ul_code_page_range_2_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(1).then(|| cursor.advance::<u32>());
+        version.compatible(1u16).then(|| cursor.advance::<u32>());
         let sx_height_byte_start = version
-            .compatible(2)
+            .compatible(2u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(2).then(|| cursor.advance::<i16>());
+        version.compatible(2u16).then(|| cursor.advance::<i16>());
         let s_cap_height_byte_start = version
-            .compatible(2)
+            .compatible(2u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(2).then(|| cursor.advance::<i16>());
+        version.compatible(2u16).then(|| cursor.advance::<i16>());
         let us_default_char_byte_start = version
-            .compatible(2)
+            .compatible(2u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(2).then(|| cursor.advance::<u16>());
+        version.compatible(2u16).then(|| cursor.advance::<u16>());
         let us_break_char_byte_start = version
-            .compatible(2)
+            .compatible(2u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(2).then(|| cursor.advance::<u16>());
+        version.compatible(2u16).then(|| cursor.advance::<u16>());
         let us_max_context_byte_start = version
-            .compatible(2)
+            .compatible(2u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(2).then(|| cursor.advance::<u16>());
+        version.compatible(2u16).then(|| cursor.advance::<u16>());
         let us_lower_optical_point_size_byte_start = version
-            .compatible(5)
+            .compatible(5u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(5).then(|| cursor.advance::<u16>());
+        version.compatible(5u16).then(|| cursor.advance::<u16>());
         let us_upper_optical_point_size_byte_start = version
-            .compatible(5)
+            .compatible(5u16)
             .then(|| cursor.position())
             .transpose()?;
-        version.compatible(5).then(|| cursor.advance::<u16>());
+        version.compatible(5u16).then(|| cursor.advance::<u16>());
         cursor.finish(Os2Marker {
             panose_10_byte_len,
             ul_code_page_range_1_byte_start,
@@ -973,35 +973,35 @@ impl<'a> SomeTable<'a> for Os2<'a> {
             27usize => Some(Field::new("s_typo_line_gap", self.s_typo_line_gap())),
             28usize => Some(Field::new("us_win_ascent", self.us_win_ascent())),
             29usize => Some(Field::new("us_win_descent", self.us_win_descent())),
-            30usize if version.compatible(1) => Some(Field::new(
+            30usize if version.compatible(1u16) => Some(Field::new(
                 "ul_code_page_range_1",
                 self.ul_code_page_range_1().unwrap(),
             )),
-            31usize if version.compatible(1) => Some(Field::new(
+            31usize if version.compatible(1u16) => Some(Field::new(
                 "ul_code_page_range_2",
                 self.ul_code_page_range_2().unwrap(),
             )),
-            32usize if version.compatible(2) => {
+            32usize if version.compatible(2u16) => {
                 Some(Field::new("sx_height", self.sx_height().unwrap()))
             }
-            33usize if version.compatible(2) => {
+            33usize if version.compatible(2u16) => {
                 Some(Field::new("s_cap_height", self.s_cap_height().unwrap()))
             }
-            34usize if version.compatible(2) => Some(Field::new(
+            34usize if version.compatible(2u16) => Some(Field::new(
                 "us_default_char",
                 self.us_default_char().unwrap(),
             )),
-            35usize if version.compatible(2) => {
+            35usize if version.compatible(2u16) => {
                 Some(Field::new("us_break_char", self.us_break_char().unwrap()))
             }
-            36usize if version.compatible(2) => {
+            36usize if version.compatible(2u16) => {
                 Some(Field::new("us_max_context", self.us_max_context().unwrap()))
             }
-            37usize if version.compatible(5) => Some(Field::new(
+            37usize if version.compatible(5u16) => Some(Field::new(
                 "us_lower_optical_point_size",
                 self.us_lower_optical_point_size().unwrap(),
             )),
-            38usize if version.compatible(5) => Some(Field::new(
+            38usize if version.compatible(5u16) => Some(Field::new(
                 "us_upper_optical_point_size",
                 self.us_upper_optical_point_size().unwrap(),
             )),

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -85,30 +85,30 @@ impl<'a> FontRead<'a> for Post<'a> {
         cursor.advance::<u32>();
         cursor.advance::<u32>();
         let num_glyphs_byte_start = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
         let num_glyphs = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.read::<u16>())
             .transpose()?
             .unwrap_or(0);
         let glyph_name_index_byte_start = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
         let glyph_name_index_byte_len = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then_some(num_glyphs as usize * u16::RAW_BYTE_LEN);
         if let Some(value) = glyph_name_index_byte_len {
             cursor.advance_by(value);
         }
         let string_data_byte_start = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
         let string_data_byte_len = version
-            .compatible((2, 0))
+            .compatible((2u16, 0u16))
             .then_some(cursor.remaining_bytes());
         if let Some(value) = string_data_byte_len {
             cursor.advance_by(value);
@@ -237,14 +237,14 @@ impl<'a> SomeTable<'a> for Post<'a> {
             6usize => Some(Field::new("max_mem_type42", self.max_mem_type42())),
             7usize => Some(Field::new("min_mem_type1", self.min_mem_type1())),
             8usize => Some(Field::new("max_mem_type1", self.max_mem_type1())),
-            9usize if version.compatible((2, 0)) => {
+            9usize if version.compatible((2u16, 0u16)) => {
                 Some(Field::new("num_glyphs", self.num_glyphs().unwrap()))
             }
-            10usize if version.compatible((2, 0)) => Some(Field::new(
+            10usize if version.compatible((2u16, 0u16)) => Some(Field::new(
                 "glyph_name_index",
                 self.glyph_name_index().unwrap(),
             )),
-            11usize if version.compatible((2, 0)) => {
+            11usize if version.compatible((2u16, 0u16)) => {
                 Some(Field::new("string_data", self.traverse_string_data()))
             }
             _ => None,

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -58,11 +58,11 @@ impl<'a> FontRead<'a> for Stat<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset32>();
         let elided_fallback_name_id_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<NameId>());
         cursor.finish(StatMarker {
             elided_fallback_name_id_byte_start,
@@ -171,7 +171,7 @@ impl<'a> SomeTable<'a> for Stat<'a> {
                     self.offset_to_axis_values(),
                 ),
             )),
-            6usize if version.compatible((1, 1)) => Some(Field::new(
+            6usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "elided_fallback_name_id",
                 self.elided_fallback_name_id().unwrap(),
             )),

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -62,25 +62,25 @@ impl<'a> FontRead<'a> for KindsOfOffsets<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let versioned_nullable_record_array_offset_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset16>());
         let versioned_nonnullable_offset_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset16>());
         let versioned_nullable_offset_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset32>());
         cursor.finish(KindsOfOffsetsMarker {
             versioned_nullable_record_array_offset_byte_start,
@@ -227,7 +227,7 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
                     self.offset_data(),
                 ),
             )),
-            6usize if version.compatible((1, 1)) => Some(Field::new(
+            6usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nullable_record_array_offset",
                 traversal::FieldType::offset_to_array_of_records(
                     self.versioned_nullable_record_array_offset().unwrap(),
@@ -236,14 +236,14 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
                     self.offset_data(),
                 ),
             )),
-            7usize if version.compatible((1, 1)) => Some(Field::new(
+            7usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nonnullable_offset",
                 FieldType::offset(
                     self.versioned_nonnullable_offset().unwrap(),
                     self.versioned_nonnullable().unwrap(),
                 ),
             )),
-            8usize if version.compatible((1, 1)) => Some(Field::new(
+            8usize if version.compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nullable_offset",
                 FieldType::offset(
                     self.versioned_nullable_offset().unwrap(),
@@ -310,21 +310,21 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets<'a> {
         let nullable_offsets_byte_len = count as usize * Offset16::RAW_BYTE_LEN;
         cursor.advance_by(nullable_offsets_byte_len);
         let versioned_nonnullable_offsets_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         let versioned_nonnullable_offsets_byte_len = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then_some(count as usize * Offset16::RAW_BYTE_LEN);
         if let Some(value) = versioned_nonnullable_offsets_byte_len {
             cursor.advance_by(value);
         }
         let versioned_nullable_offsets_byte_start = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
         let versioned_nullable_offsets_byte_len = version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then_some(count as usize * Offset16::RAW_BYTE_LEN);
         if let Some(value) = versioned_nullable_offsets_byte_len {
             cursor.advance_by(value);
@@ -446,7 +446,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                     ),
                 )
             }),
-            4usize if version.compatible((1, 1)) => Some({
+            4usize if version.compatible((1u16, 1u16)) => Some({
                 let data = self.data;
                 Field::new(
                     "versioned_nonnullable_offsets",
@@ -460,7 +460,7 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
                     ),
                 )
             }),
-            5usize if version.compatible((1, 1)) => Some({
+            5usize if version.compatible((1u16, 1u16)) => Some({
                 let data = self.data;
                 Field::new(
                     "versioned_nullable_offsets",
@@ -534,21 +534,21 @@ impl<'a> FontRead<'a> for KindsOfArrays<'a> {
         let records_byte_len = count as usize * Shmecord::RAW_BYTE_LEN;
         cursor.advance_by(records_byte_len);
         let versioned_scalars_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
         let versioned_scalars_byte_len = version
-            .compatible(1)
+            .compatible(1u16)
             .then_some(count as usize * u16::RAW_BYTE_LEN);
         if let Some(value) = versioned_scalars_byte_len {
             cursor.advance_by(value);
         }
         let versioned_records_byte_start = version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
         let versioned_records_byte_len = version
-            .compatible(1)
+            .compatible(1u16)
             .then_some(count as usize * Shmecord::RAW_BYTE_LEN);
         if let Some(value) = versioned_records_byte_len {
             cursor.advance_by(value);
@@ -622,11 +622,11 @@ impl<'a> SomeTable<'a> for KindsOfArrays<'a> {
                     self.offset_data(),
                 ),
             )),
-            4usize if version.compatible(1) => Some(Field::new(
+            4usize if version.compatible(1u16) => Some(Field::new(
                 "versioned_scalars",
                 self.versioned_scalars().unwrap(),
             )),
-            5usize if version.compatible(1) => Some(Field::new(
+            5usize if version.compatible(1u16) => Some(Field::new(
                 "versioned_records",
                 traversal::FieldType::array_of_records(
                     stringify!(Shmecord),

--- a/resources/codegen_inputs/base.rs
+++ b/resources/codegen_inputs/base.rs
@@ -14,7 +14,7 @@ table Base {
     #[nullable]
     vert_axis_offset: Offset16<Axis>,
     /// Offset to Item Variation Store table, from beginning of BASE table (may be null)
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     #[nullable]
     item_var_store_offset: Offset32<ItemVariationStore>,
 }

--- a/resources/codegen_inputs/font.rs
+++ b/resources/codegen_inputs/font.rs
@@ -48,12 +48,12 @@ table TTCHeader {
     table_directory_offsets: [u32],
 
     /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
-    #[since_version(2,0)]
+    #[since_version(2.0)]
     dsig_tag: u32,
     /// The length (in bytes) of the DSIG table (null if no signature)
-    #[since_version(2,0)]
+    #[since_version(2.0)]
     dsig_length: u32,
     /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
-    #[since_version(2,0)]
+    #[since_version(2.0)]
     dsig_offset: u32,
 }

--- a/resources/codegen_inputs/gdef.rs
+++ b/resources/codegen_inputs/gdef.rs
@@ -25,12 +25,12 @@ table Gdef {
     mark_attach_class_def_offset: Offset16<ClassDef>,
     /// Offset to the table of mark glyph set definitions, from
     /// beginning of GDEF header (may be NULL)
-    #[since_version(1,2)]
+    #[since_version(1.2)]
     #[nullable]
     mark_glyph_sets_def_offset: Offset16<MarkGlyphSets>,
     /// Offset to the Item Variation Store table, from beginning of
     /// GDEF header (may be NULL)
-    #[since_version(1,3)]
+    #[since_version(1.3)]
     #[nullable]
     item_var_store_offset: Offset32<ItemVariationStore>,
 }

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -17,7 +17,7 @@ table Gpos {
     feature_list_offset: Offset16<FeatureList>,
     /// Offset to LookupList table, from beginning of GPOS table
     lookup_list_offset: Offset16<PositionLookupList>,
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     #[nullable]
     feature_variations_offset: Offset32<FeatureVariations>,
 }

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -16,7 +16,7 @@ table Gsub {
     lookup_list_offset: Offset16<SubstitutionLookupList>,
     /// Offset to FeatureVariations table, from beginning of the GSUB
     /// table (may be NULL)
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     #[nullable]
     feature_variations_offset: Offset32<FeatureVariations>,
 }

--- a/resources/codegen_inputs/maxp.rs
+++ b/resources/codegen_inputs/maxp.rs
@@ -10,46 +10,46 @@ table Maxp {
     /// The number of glyphs in the font.
     num_glyphs: u16,
     /// Maximum points in a non-composite glyph.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_points: u16,
     /// Maximum contours in a non-composite glyph.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_contours: u16,
     /// Maximum points in a composite glyph.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_composite_points: u16,
     /// Maximum contours in a composite glyph.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_composite_contours: u16,
     /// 1 if instructions do not use the twilight zone (Z0), or 2 if
     /// instructions do use Z0; should be set to 2 in most cases.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_zones: u16,
     /// Maximum points used in Z0.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_twilight_points: u16,
     /// Number of Storage Area locations.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_storage: u16,
     /// Number of FDEFs, equal to the highest function number + 1.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_function_defs: u16,
     /// Number of IDEFs.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_instruction_defs: u16,
     /// Maximum stack depth across Font Program ('fpgm' table), CVT
     /// Program ('prep' table) and all glyph instructions (in the
     /// 'glyf' table).
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_stack_elements: u16,
     /// Maximum byte count for glyph instructions.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_size_of_instructions: u16,
     /// Maximum number of components referenced at “top level” for
     /// any composite glyph.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_component_elements: u16,
     /// Maximum levels of recursion; 1 for simple components.
-    #[since_version(1,0)]
+    #[since_version(1.0)]
     max_component_depth: u16,
 }

--- a/resources/codegen_inputs/post.rs
+++ b/resources/codegen_inputs/post.rs
@@ -43,16 +43,16 @@ table Post {
     max_mem_type1: u32,
     /// Number of glyphs (this should be the same as numGlyphs in
     /// 'maxp' table).
-    #[since_version(2,0)]
+    #[since_version(2.0)]
     num_glyphs: u16,
     /// Array of indices into the string data. See below for details.
     #[count($num_glyphs)]
-    #[since_version(2,0)]
+    #[since_version(2.0)]
     glyph_name_index: [u16],
     /// Storage for the string data.
     #[count(..)]
     #[validate(skip)]
-    #[since_version(2,0)]
+    #[since_version(2.0)]
     #[traverse_with(traverse_string_data)]
     string_data: VarLenArray<PString<'a>>,
 }

--- a/resources/codegen_inputs/stat.rs
+++ b/resources/codegen_inputs/stat.rs
@@ -38,7 +38,7 @@ table Stat {
     /// Name ID used as fallback when projection of names into a
     /// particular font model produces a subfamily name containing only
     /// elidable elements.
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     elided_fallback_name_id: NameId,
 }
 

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -29,13 +29,13 @@ table KindsOfOffsets {
     /// A nullable, versioned offset to an array of records
     #[read_offset_with($array_offset_count)]
     #[nullable]
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     versioned_nullable_record_array_offset: Offset16<[Shmecord]>,
     /// A normal offset that is versioned
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     versioned_nonnullable_offset: Offset16<Dummy>,
     /// An offset that is nullable and versioned
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     #[nullable]
     versioned_nullable_offset: Offset32<Dummy>,
 }
@@ -57,11 +57,11 @@ table KindsOfArraysOfOffsets {
     #[count($count)]
     nullable_offsets: [Offset16<Dummy>],
     /// A normal offset that is versioned
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     #[count($count)]
     versioned_nonnullable_offsets: [Offset16<Dummy>],
     /// An offset that is nullable and versioned
-    #[since_version(1,1)]
+    #[since_version(1.1)]
     #[nullable]
     #[count($count)]
     versioned_nullable_offsets: [Offset16<Dummy>],

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -36,7 +36,7 @@ impl FontWrite for Base {
         self.horiz_axis.write_into(writer);
         self.vert_axis.write_into(writer);
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| self.item_var_store.write_into(writer));
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -80,13 +80,13 @@ impl FontWrite for Cpal {
         self.color_records_array.write_into(writer);
         self.color_record_indices.write_into(writer);
         version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| self.palette_types_array.write_into(writer));
         version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| self.palette_labels_array.write_into(writer));
         version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| self.palette_entry_labels_array.write_into(writer));
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -135,17 +135,17 @@ impl Validate for TTCHeader {
                 }
             });
             ctx.in_field("dsig_tag", |ctx| {
-                if version.compatible((2, 0)) && self.dsig_tag.is_none() {
+                if version.compatible((2u16, 0u16)) && self.dsig_tag.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("dsig_length", |ctx| {
-                if version.compatible((2, 0)) && self.dsig_length.is_none() {
+                if version.compatible((2u16, 0u16)) && self.dsig_length.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("dsig_offset", |ctx| {
-                if version.compatible((2, 0)) && self.dsig_offset.is_none() {
+                if version.compatible((2u16, 0u16)) && self.dsig_offset.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -59,10 +59,10 @@ impl FontWrite for Gdef {
         self.lig_caret_list.write_into(writer);
         self.mark_attach_class_def.write_into(writer);
         version
-            .compatible((1, 2))
+            .compatible((1u16, 2u16))
             .then(|| self.mark_glyph_sets_def.write_into(writer));
         version
-            .compatible((1, 3))
+            .compatible((1u16, 3u16))
             .then(|| self.item_var_store.write_into(writer));
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -46,7 +46,7 @@ impl FontWrite for Gpos {
         self.feature_list.write_into(writer);
         self.lookup_list.write_into(writer);
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| self.feature_variations.write_into(writer));
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -45,7 +45,7 @@ impl FontWrite for Gsub {
         self.feature_list.write_into(writer);
         self.lookup_list.write_into(writer);
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| self.feature_variations.write_into(writer));
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_maxp.rs
+++ b/write-fonts/generated/generated_maxp.rs
@@ -59,79 +59,79 @@ impl FontWrite for Maxp {
         let version = self.compute_version() as Version16Dot16;
         version.write_into(writer);
         self.num_glyphs.write_into(writer);
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_points
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_contours
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_composite_points
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_composite_contours
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_zones
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_twilight_points
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_storage
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_function_defs
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_instruction_defs
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_stack_elements
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_size_of_instructions
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_component_elements
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 0)).then(|| {
+        version.compatible((1u16, 0u16)).then(|| {
             self.max_component_depth
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -148,67 +148,67 @@ impl Validate for Maxp {
         ctx.in_table("Maxp", |ctx| {
             let version: Version16Dot16 = self.compute_version();
             ctx.in_field("max_points", |ctx| {
-                if version.compatible((1, 0)) && self.max_points.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_points.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_contours", |ctx| {
-                if version.compatible((1, 0)) && self.max_contours.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_contours.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_composite_points", |ctx| {
-                if version.compatible((1, 0)) && self.max_composite_points.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_composite_points.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_composite_contours", |ctx| {
-                if version.compatible((1, 0)) && self.max_composite_contours.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_composite_contours.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_zones", |ctx| {
-                if version.compatible((1, 0)) && self.max_zones.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_zones.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_twilight_points", |ctx| {
-                if version.compatible((1, 0)) && self.max_twilight_points.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_twilight_points.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_storage", |ctx| {
-                if version.compatible((1, 0)) && self.max_storage.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_storage.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_function_defs", |ctx| {
-                if version.compatible((1, 0)) && self.max_function_defs.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_function_defs.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_instruction_defs", |ctx| {
-                if version.compatible((1, 0)) && self.max_instruction_defs.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_instruction_defs.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_stack_elements", |ctx| {
-                if version.compatible((1, 0)) && self.max_stack_elements.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_stack_elements.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_size_of_instructions", |ctx| {
-                if version.compatible((1, 0)) && self.max_size_of_instructions.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_size_of_instructions.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_component_elements", |ctx| {
-                if version.compatible((1, 0)) && self.max_component_elements.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_component_elements.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("max_component_depth", |ctx| {
-                if version.compatible((1, 0)) && self.max_component_depth.is_none() {
+                if version.compatible((1u16, 0u16)) && self.max_component_depth.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -37,10 +37,10 @@ impl FontWrite for Name {
             self.name_record.write_into(writer);
         });
         version
-            .compatible(1)
+            .compatible(1u16)
             .then(|| (array_len(&self.lang_tag_record).unwrap() as u16).write_into(writer));
         writer.adjust_offsets(self.compute_storage_offset() as u32, |writer| {
-            version.compatible(1).then(|| {
+            version.compatible(1u16).then(|| {
                 self.lang_tag_record
                     .as_ref()
                     .expect("missing versioned field should have failed validation")
@@ -64,7 +64,7 @@ impl Validate for Name {
                 self.name_record.validate_impl(ctx);
             });
             ctx.in_field("lang_tag_record", |ctx| {
-                if version.compatible(1) && self.lang_tag_record.is_none() {
+                if version.compatible(1u16) && self.lang_tag_record.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.lang_tag_record.is_some()

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -215,55 +215,55 @@ impl FontWrite for Os2 {
         self.s_typo_line_gap.write_into(writer);
         self.us_win_ascent.write_into(writer);
         self.us_win_descent.write_into(writer);
-        version.compatible(1).then(|| {
+        version.compatible(1u16).then(|| {
             self.ul_code_page_range_1
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(1).then(|| {
+        version.compatible(1u16).then(|| {
             self.ul_code_page_range_2
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(2).then(|| {
+        version.compatible(2u16).then(|| {
             self.sx_height
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(2).then(|| {
+        version.compatible(2u16).then(|| {
             self.s_cap_height
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(2).then(|| {
+        version.compatible(2u16).then(|| {
             self.us_default_char
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(2).then(|| {
+        version.compatible(2u16).then(|| {
             self.us_break_char
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(2).then(|| {
+        version.compatible(2u16).then(|| {
             self.us_max_context
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(5).then(|| {
+        version.compatible(5u16).then(|| {
             self.us_lower_optical_point_size
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(5).then(|| {
+        version.compatible(5u16).then(|| {
             self.us_upper_optical_point_size
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -280,47 +280,47 @@ impl Validate for Os2 {
         ctx.in_table("Os2", |ctx| {
             let version: u16 = self.compute_version();
             ctx.in_field("ul_code_page_range_1", |ctx| {
-                if version.compatible(1) && self.ul_code_page_range_1.is_none() {
+                if version.compatible(1u16) && self.ul_code_page_range_1.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("ul_code_page_range_2", |ctx| {
-                if version.compatible(1) && self.ul_code_page_range_2.is_none() {
+                if version.compatible(1u16) && self.ul_code_page_range_2.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("sx_height", |ctx| {
-                if version.compatible(2) && self.sx_height.is_none() {
+                if version.compatible(2u16) && self.sx_height.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("s_cap_height", |ctx| {
-                if version.compatible(2) && self.s_cap_height.is_none() {
+                if version.compatible(2u16) && self.s_cap_height.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("us_default_char", |ctx| {
-                if version.compatible(2) && self.us_default_char.is_none() {
+                if version.compatible(2u16) && self.us_default_char.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("us_break_char", |ctx| {
-                if version.compatible(2) && self.us_break_char.is_none() {
+                if version.compatible(2u16) && self.us_break_char.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("us_max_context", |ctx| {
-                if version.compatible(2) && self.us_max_context.is_none() {
+                if version.compatible(2u16) && self.us_max_context.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("us_lower_optical_point_size", |ctx| {
-                if version.compatible(5) && self.us_lower_optical_point_size.is_none() {
+                if version.compatible(5u16) && self.us_lower_optical_point_size.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("us_upper_optical_point_size", |ctx| {
-                if version.compatible(5) && self.us_upper_optical_point_size.is_none() {
+                if version.compatible(5u16) && self.us_upper_optical_point_size.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -110,19 +110,19 @@ impl FontWrite for Post {
         self.max_mem_type42.write_into(writer);
         self.min_mem_type1.write_into(writer);
         self.max_mem_type1.write_into(writer);
-        version.compatible((2, 0)).then(|| {
+        version.compatible((2u16, 0u16)).then(|| {
             self.num_glyphs
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((2, 0)).then(|| {
+        version.compatible((2u16, 0u16)).then(|| {
             self.glyph_name_index
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((2, 0)).then(|| {
+        version.compatible((2u16, 0u16)).then(|| {
             self.string_data
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -139,12 +139,12 @@ impl Validate for Post {
         ctx.in_table("Post", |ctx| {
             let version = self.version;
             ctx.in_field("num_glyphs", |ctx| {
-                if version.compatible((2, 0)) && self.num_glyphs.is_none() {
+                if version.compatible((2u16, 0u16)) && self.num_glyphs.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });
             ctx.in_field("glyph_name_index", |ctx| {
-                if version.compatible((2, 0)) && self.glyph_name_index.is_none() {
+                if version.compatible((2u16, 0u16)) && self.glyph_name_index.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.glyph_name_index.is_some()

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -37,7 +37,7 @@ impl FontWrite for Stat {
         self.design_axes.write_into(writer);
         (array_len(&self.offset_to_axis_values).unwrap() as u16).write_into(writer);
         self.offset_to_axis_values.write_into(writer);
-        version.compatible((1, 1)).then(|| {
+        version.compatible((1u16, 1u16)).then(|| {
             self.elided_fallback_name_id
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -60,7 +60,7 @@ impl Validate for Stat {
                 self.offset_to_axis_values.validate_impl(ctx);
             });
             ctx.in_field("elided_fallback_name_id", |ctx| {
-                if version.compatible((1, 1)) && self.elided_fallback_name_id.is_none() {
+                if version.compatible((1u16, 1u16)) && self.elided_fallback_name_id.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
             });

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -52,16 +52,16 @@ impl FontWrite for KindsOfOffsets {
         self.array.write_into(writer);
         self.record_array.write_into(writer);
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| self.versioned_nullable_record_array.write_into(writer));
-        version.compatible((1, 1)).then(|| {
+        version.compatible((1u16, 1u16)).then(|| {
             self.versioned_nonnullable
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
         version
-            .compatible((1, 1))
+            .compatible((1u16, 1u16))
             .then(|| self.versioned_nullable.write_into(writer));
     }
     fn table_type(&self) -> TableType {
@@ -86,7 +86,7 @@ impl Validate for KindsOfOffsets {
                 self.versioned_nullable_record_array.validate_impl(ctx);
             });
             ctx.in_field("versioned_nonnullable", |ctx| {
-                if version.compatible((1, 1)) && self.versioned_nonnullable.is_none() {
+                if version.compatible((1u16, 1u16)) && self.versioned_nonnullable.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 self.versioned_nonnullable.validate_impl(ctx);
@@ -154,13 +154,13 @@ impl FontWrite for KindsOfArraysOfOffsets {
         (array_len(&self.nonnullables).unwrap() as u16).write_into(writer);
         self.nonnullables.write_into(writer);
         self.nullables.write_into(writer);
-        version.compatible((1, 1)).then(|| {
+        version.compatible((1u16, 1u16)).then(|| {
             self.versioned_nonnullables
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible((1, 1)).then(|| {
+        version.compatible((1u16, 1u16)).then(|| {
             self.versioned_nullables
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -189,7 +189,7 @@ impl Validate for KindsOfArraysOfOffsets {
                 self.nullables.validate_impl(ctx);
             });
             ctx.in_field("versioned_nonnullables", |ctx| {
-                if version.compatible((1, 1)) && self.versioned_nonnullables.is_none() {
+                if version.compatible((1u16, 1u16)) && self.versioned_nonnullables.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_nonnullables.is_some()
@@ -200,7 +200,7 @@ impl Validate for KindsOfArraysOfOffsets {
                 self.versioned_nonnullables.validate_impl(ctx);
             });
             ctx.in_field("versioned_nullables", |ctx| {
-                if version.compatible((1, 1)) && self.versioned_nullables.is_none() {
+                if version.compatible((1u16, 1u16)) && self.versioned_nullables.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_nullables.is_some()
@@ -276,13 +276,13 @@ impl FontWrite for KindsOfArrays {
         (array_len(&self.scalars).unwrap() as u16).write_into(writer);
         self.scalars.write_into(writer);
         self.records.write_into(writer);
-        version.compatible(1).then(|| {
+        version.compatible(1u16).then(|| {
             self.versioned_scalars
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
                 .write_into(writer)
         });
-        version.compatible(1).then(|| {
+        version.compatible(1u16).then(|| {
             self.versioned_records
                 .as_ref()
                 .expect("missing versioned field should have failed validation")
@@ -310,7 +310,7 @@ impl Validate for KindsOfArrays {
                 self.records.validate_impl(ctx);
             });
             ctx.in_field("versioned_scalars", |ctx| {
-                if version.compatible(1) && self.versioned_scalars.is_none() {
+                if version.compatible(1u16) && self.versioned_scalars.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_scalars.is_some()
@@ -320,7 +320,7 @@ impl Validate for KindsOfArrays {
                 }
             });
             ctx.in_field("versioned_records", |ctx| {
-                if version.compatible(1) && self.versioned_records.is_none() {
+                if version.compatible(1u16) && self.versioned_records.is_none() {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_records.is_some()


### PR DESCRIPTION
This tweaks how we represent versions in codegen; previously we would do `#[since_version(2,0)]` and this changes the `2,0` to `2.0`. This is in anticipation of using versions in more places in codegen, and potentially wanting to to be able to have a comma-separated list of them, which would be hard to parse with the current syntax.