### PR TITLE
Add nullable annotations on VARC

### DIFF
--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -80,35 +80,35 @@ impl<'a> Varc<'a> {
         self.coverage_offset().resolve(data)
     }
 
-    pub fn multi_var_store_offset(&self) -> Offset32 {
+    pub fn multi_var_store_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.multi_var_store_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`multi_var_store_offset`][Self::multi_var_store_offset].
-    pub fn multi_var_store(&self) -> Result<MultiItemVariationStore<'a>, ReadError> {
+    pub fn multi_var_store(&self) -> Option<Result<MultiItemVariationStore<'a>, ReadError>> {
         let data = self.data;
         self.multi_var_store_offset().resolve(data)
     }
 
-    pub fn condition_list_offset(&self) -> Offset32 {
+    pub fn condition_list_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.condition_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`condition_list_offset`][Self::condition_list_offset].
-    pub fn condition_list(&self) -> Result<ConditionList<'a>, ReadError> {
+    pub fn condition_list(&self) -> Option<Result<ConditionList<'a>, ReadError>> {
         let data = self.data;
         self.condition_list_offset().resolve(data)
     }
 
-    pub fn axis_indices_list_offset(&self) -> Offset32 {
+    pub fn axis_indices_list_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.axis_indices_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`axis_indices_list_offset`][Self::axis_indices_list_offset].
-    pub fn axis_indices_list(&self) -> Result<AxisIndicesList<'a>, ReadError> {
+    pub fn axis_indices_list(&self) -> Option<Result<AxisIndicesList<'a>, ReadError>> {
         let data = self.data;
         self.axis_indices_list_offset().resolve(data)
     }

--- a/read-fonts/src/tables/varc.rs
+++ b/read-fonts/src/tables/varc.rs
@@ -13,7 +13,8 @@ mod tests {
     impl Varc<'_> {
         fn conditions(&self) -> impl Iterator<Item = Condition<'_>> {
             self.condition_list()
-                .expect("A condition list")
+                .expect("A condition list is present")
+                .expect("We could read the condition list")
                 .conditions()
                 .iter()
                 .enumerate()

--- a/resources/codegen_inputs/varc.rs
+++ b/resources/codegen_inputs/varc.rs
@@ -11,8 +11,11 @@ table Varc {
     version: MajorMinor,
 
     coverage_offset: Offset32<CoverageTable>,
+    #[nullable]
     multi_var_store_offset: Offset32<MultiItemVariationStore>,
+    #[nullable]
     condition_list_offset: Offset32<ConditionList>,
+    #[nullable]
     axis_indices_list_offset: Offset32<AxisIndicesList>,
     var_composite_glyphs_offset: Offset32<VarCompositeGlyphs>,
 }


### PR DESCRIPTION
https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3471-L3473 says these can be NULL. JMM.