### PR TITLE
Read the fields of the multitem variation store

### DIFF
--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -1174,7 +1174,7 @@ fn resolve_ident<'a>(
     } else {
         Err(logged_syn_error(
             field_type.span(),
-            "Error: undeclared type",
+            "Error: undeclared type. Missing a record, table, extern table, or extern record?",
         ))
     }
 }

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -168,33 +168,121 @@ impl<'a> std::fmt::Debug for Varc<'a> {
     }
 }
 
+impl Format<u16> for MultiItemVariationStoreMarker {
+    const FORMAT: u16 = 1;
+}
+
+/// * <https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3451-L3457>
+/// * <https://github.com/harfbuzz/harfbuzz/blob/7be12b33e3f07067c159d8f516eb31df58c75876/src/hb-ot-layout-common.hh#L3517-L3520C3>
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MultiItemVariationStoreMarker {}
+pub struct MultiItemVariationStoreMarker {
+    variation_data_offsets_byte_len: usize,
+}
 
-impl MultiItemVariationStoreMarker {}
-
-impl<'a> FontRead<'a> for MultiItemVariationStore<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let cursor = data.cursor();
-        cursor.finish(MultiItemVariationStoreMarker {})
+impl MultiItemVariationStoreMarker {
+    fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn region_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+    fn variation_data_count_byte_range(&self) -> Range<usize> {
+        let start = self.region_list_offset_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn variation_data_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.variation_data_count_byte_range().end;
+        start..start + self.variation_data_offsets_byte_len
     }
 }
 
+impl<'a> FontRead<'a> for MultiItemVariationStore<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset32>();
+        let variation_data_count: u16 = cursor.read()?;
+        let variation_data_offsets_byte_len =
+            variation_data_count as usize * Offset32::RAW_BYTE_LEN;
+        cursor.advance_by(variation_data_offsets_byte_len);
+        cursor.finish(MultiItemVariationStoreMarker {
+            variation_data_offsets_byte_len,
+        })
+    }
+}
+
+/// * <https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3451-L3457>
+/// * <https://github.com/harfbuzz/harfbuzz/blob/7be12b33e3f07067c159d8f516eb31df58c75876/src/hb-ot-layout-common.hh#L3517-L3520C3>
 pub type MultiItemVariationStore<'a> = TableRef<'a, MultiItemVariationStoreMarker>;
 
-impl<'a> MultiItemVariationStore<'a> {}
+impl<'a> MultiItemVariationStore<'a> {
+    pub fn format(&self) -> u16 {
+        let range = self.shape.format_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn region_list_offset(&self) -> Offset32 {
+        let range = self.shape.region_list_offset_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    /// Attempt to resolve [`region_list_offset`][Self::region_list_offset].
+    pub fn region_list(&self) -> Result<SparseVariationRegionList<'a>, ReadError> {
+        let data = self.data;
+        self.region_list_offset().resolve(data)
+    }
+
+    pub fn variation_data_count(&self) -> u16 {
+        let range = self.shape.variation_data_count_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn variation_data_offsets(&self) -> &'a [BigEndian<Offset32>] {
+        let range = self.shape.variation_data_offsets_byte_range();
+        self.data.read_array(range).unwrap()
+    }
+
+    /// A dynamically resolving wrapper for [`variation_data_offsets`][Self::variation_data_offsets].
+    pub fn variation_data(&self) -> ArrayOfOffsets<'a, MultiItemVariationData<'a>, Offset32> {
+        let data = self.data;
+        let offsets = self.variation_data_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
+    }
+}
 
 #[cfg(feature = "traversal")]
 impl<'a> SomeTable<'a> for MultiItemVariationStore<'a> {
     fn type_name(&self) -> &str {
         "MultiItemVariationStore"
     }
-
-    #[allow(unused_variables)]
-    #[allow(clippy::match_single_binding)]
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
+            0usize => Some(Field::new("format", self.format())),
+            1usize => Some(Field::new(
+                "region_list_offset",
+                FieldType::offset(self.region_list_offset(), self.region_list()),
+            )),
+            2usize => Some(Field::new(
+                "variation_data_count",
+                self.variation_data_count(),
+            )),
+            3usize => Some({
+                let data = self.data;
+                Field::new(
+                    "variation_data_offsets",
+                    FieldType::array_of_offsets(
+                        better_type_name::<MultiItemVariationData>(),
+                        self.variation_data_offsets(),
+                        move |off| {
+                            let target = off.get().resolve::<MultiItemVariationData>(data);
+                            FieldType::offset(off.get(), target)
+                        },
+                    ),
+                )
+            }),
             _ => None,
         }
     }
@@ -202,6 +290,349 @@ impl<'a> SomeTable<'a> for MultiItemVariationStore<'a> {
 
 #[cfg(feature = "traversal")]
 impl<'a> std::fmt::Debug for MultiItemVariationStore<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct SparseVariationRegionListMarker {
+    region_offsets_byte_len: usize,
+}
+
+impl SparseVariationRegionListMarker {
+    fn region_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn region_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.region_count_byte_range().end;
+        start..start + self.region_offsets_byte_len
+    }
+}
+
+impl<'a> FontRead<'a> for SparseVariationRegionList<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let region_count: u16 = cursor.read()?;
+        let region_offsets_byte_len = region_count as usize * Offset32::RAW_BYTE_LEN;
+        cursor.advance_by(region_offsets_byte_len);
+        cursor.finish(SparseVariationRegionListMarker {
+            region_offsets_byte_len,
+        })
+    }
+}
+
+pub type SparseVariationRegionList<'a> = TableRef<'a, SparseVariationRegionListMarker>;
+
+impl<'a> SparseVariationRegionList<'a> {
+    pub fn region_count(&self) -> u16 {
+        let range = self.shape.region_count_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn region_offsets(&self) -> &'a [BigEndian<Offset32>] {
+        let range = self.shape.region_offsets_byte_range();
+        self.data.read_array(range).unwrap()
+    }
+
+    /// A dynamically resolving wrapper for [`region_offsets`][Self::region_offsets].
+    pub fn regions(&self) -> ArrayOfOffsets<'a, SparseVariationRegion<'a>, Offset32> {
+        let data = self.data;
+        let offsets = self.region_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> SomeTable<'a> for SparseVariationRegionList<'a> {
+    fn type_name(&self) -> &str {
+        "SparseVariationRegionList"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("region_count", self.region_count())),
+            1usize => Some({
+                let data = self.data;
+                Field::new(
+                    "region_offsets",
+                    FieldType::array_of_offsets(
+                        better_type_name::<SparseVariationRegion>(),
+                        self.region_offsets(),
+                        move |off| {
+                            let target = off.get().resolve::<SparseVariationRegion>(data);
+                            FieldType::offset(off.get(), target)
+                        },
+                    ),
+                )
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> std::fmt::Debug for SparseVariationRegionList<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct SparseVariationRegionMarker {
+    region_axis_offsets_byte_len: usize,
+}
+
+impl SparseVariationRegionMarker {
+    fn region_axis_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn region_axis_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.region_axis_count_byte_range().end;
+        start..start + self.region_axis_offsets_byte_len
+    }
+}
+
+impl<'a> FontRead<'a> for SparseVariationRegion<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let region_axis_count: u16 = cursor.read()?;
+        let region_axis_offsets_byte_len = region_axis_count as usize * Offset32::RAW_BYTE_LEN;
+        cursor.advance_by(region_axis_offsets_byte_len);
+        cursor.finish(SparseVariationRegionMarker {
+            region_axis_offsets_byte_len,
+        })
+    }
+}
+
+pub type SparseVariationRegion<'a> = TableRef<'a, SparseVariationRegionMarker>;
+
+impl<'a> SparseVariationRegion<'a> {
+    pub fn region_axis_count(&self) -> u16 {
+        let range = self.shape.region_axis_count_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn region_axis_offsets(&self) -> &'a [BigEndian<Offset32>] {
+        let range = self.shape.region_axis_offsets_byte_range();
+        self.data.read_array(range).unwrap()
+    }
+
+    /// A dynamically resolving wrapper for [`region_axis_offsets`][Self::region_axis_offsets].
+    pub fn region_axiss(&self) -> ArrayOfOffsets<'a, SparseRegionAxisCoordinates<'a>, Offset32> {
+        let data = self.data;
+        let offsets = self.region_axis_offsets();
+        ArrayOfOffsets::new(offsets, data, ())
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> SomeTable<'a> for SparseVariationRegion<'a> {
+    fn type_name(&self) -> &str {
+        "SparseVariationRegion"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("region_axis_count", self.region_axis_count())),
+            1usize => Some({
+                let data = self.data;
+                Field::new(
+                    "region_axis_offsets",
+                    FieldType::array_of_offsets(
+                        better_type_name::<SparseRegionAxisCoordinates>(),
+                        self.region_axis_offsets(),
+                        move |off| {
+                            let target = off.get().resolve::<SparseRegionAxisCoordinates>(data);
+                            FieldType::offset(off.get(), target)
+                        },
+                    ),
+                )
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> std::fmt::Debug for SparseVariationRegion<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct SparseRegionAxisCoordinatesMarker {}
+
+impl SparseRegionAxisCoordinatesMarker {
+    fn axis_index_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn start_byte_range(&self) -> Range<usize> {
+        let start = self.axis_index_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+    fn peak_byte_range(&self) -> Range<usize> {
+        let start = self.start_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+    fn end_byte_range(&self) -> Range<usize> {
+        let start = self.peak_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+}
+
+impl<'a> FontRead<'a> for SparseRegionAxisCoordinates<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.finish(SparseRegionAxisCoordinatesMarker {})
+    }
+}
+
+pub type SparseRegionAxisCoordinates<'a> = TableRef<'a, SparseRegionAxisCoordinatesMarker>;
+
+impl<'a> SparseRegionAxisCoordinates<'a> {
+    pub fn axis_index(&self) -> u16 {
+        let range = self.shape.axis_index_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn start(&self) -> F2Dot14 {
+        let range = self.shape.start_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn peak(&self) -> F2Dot14 {
+        let range = self.shape.peak_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn end(&self) -> F2Dot14 {
+        let range = self.shape.end_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> SomeTable<'a> for SparseRegionAxisCoordinates<'a> {
+    fn type_name(&self) -> &str {
+        "SparseRegionAxisCoordinates"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("axis_index", self.axis_index())),
+            1usize => Some(Field::new("start", self.start())),
+            2usize => Some(Field::new("peak", self.peak())),
+            3usize => Some(Field::new("end", self.end())),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> std::fmt::Debug for SparseRegionAxisCoordinates<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl Format<u8> for MultiItemVariationDataMarker {
+    const FORMAT: u8 = 1;
+}
+
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct MultiItemVariationDataMarker {
+    region_indices_byte_len: usize,
+    raw_delta_sets_byte_len: usize,
+}
+
+impl MultiItemVariationDataMarker {
+    fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+    fn region_index_count_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+    fn region_indices_byte_range(&self) -> Range<usize> {
+        let start = self.region_index_count_byte_range().end;
+        start..start + self.region_indices_byte_len
+    }
+    fn raw_delta_sets_byte_range(&self) -> Range<usize> {
+        let start = self.region_indices_byte_range().end;
+        start..start + self.raw_delta_sets_byte_len
+    }
+}
+
+impl<'a> FontRead<'a> for MultiItemVariationData<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        let region_index_count: u16 = cursor.read()?;
+        let region_indices_byte_len = region_index_count as usize * u16::RAW_BYTE_LEN;
+        cursor.advance_by(region_indices_byte_len);
+        let raw_delta_sets_byte_len =
+            cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(raw_delta_sets_byte_len);
+        cursor.finish(MultiItemVariationDataMarker {
+            region_indices_byte_len,
+            raw_delta_sets_byte_len,
+        })
+    }
+}
+
+pub type MultiItemVariationData<'a> = TableRef<'a, MultiItemVariationDataMarker>;
+
+impl<'a> MultiItemVariationData<'a> {
+    pub fn format(&self) -> u8 {
+        let range = self.shape.format_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn region_index_count(&self) -> u16 {
+        let range = self.shape.region_index_count_byte_range();
+        self.data.read_at(range.start).unwrap()
+    }
+
+    pub fn region_indices(&self) -> &'a [BigEndian<u16>] {
+        let range = self.shape.region_indices_byte_range();
+        self.data.read_array(range).unwrap()
+    }
+
+    pub fn raw_delta_sets(&self) -> &'a [u8] {
+        let range = self.shape.raw_delta_sets_byte_range();
+        self.data.read_array(range).unwrap()
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> SomeTable<'a> for MultiItemVariationData<'a> {
+    fn type_name(&self) -> &str {
+        "MultiItemVariationData"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("format", self.format())),
+            1usize => Some(Field::new("region_index_count", self.region_index_count())),
+            2usize => Some(Field::new("region_indices", self.region_indices())),
+            3usize => Some(Field::new("raw_delta_sets", self.raw_delta_sets())),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "traversal")]
+impl<'a> std::fmt::Debug for MultiItemVariationData<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }

--- a/read-fonts/src/tables/varc.rs
+++ b/read-fonts/src/tables/varc.rs
@@ -637,17 +637,49 @@ mod tests {
     }
 
     #[test]
-    fn read_multivar_store_fields() {
+    fn read_multivar_store_region_list() {
         let font = FontRef::new(font_test_data::varc::CJK_6868).unwrap();
         let table = font.varc().unwrap();
         let varstore = table.multi_var_store().unwrap().unwrap();
+        let regions = varstore.region_list().unwrap().regions();
+
+        let sparse_regions = regions
+            .iter()
+            .map(|r| {
+                r.unwrap()
+                    .region_axis_offsets()
+                    .iter()
+                    .map(|a| {
+                        (
+                            a.axis_index(),
+                            a.start().to_f32(),
+                            a.peak().to_f32(),
+                            a.end().to_f32(),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        // Check a sampling of the regions
         assert_eq!(
-            (39, 4),
-            (
-                varstore.region_list().unwrap().region_count(),
-                varstore.variation_data_count()
-            )
+            vec![
+                vec![(0, 0.0, 1.0, 1.0),],
+                vec![(0, 0.0, 1.0, 1.0), (1, 0.0, 1.0, 1.0),],
+                vec![(6, -1.0, -1.0, 0.0),],
+            ],
+            [0, 2, 38]
+                .into_iter()
+                .map(|i| sparse_regions[i].clone())
+                .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn read_multivar_store_delta_sets() {
+        let font = FontRef::new(font_test_data::varc::CJK_6868).unwrap();
+        let table = font.varc().unwrap();
+        let varstore = table.multi_var_store().unwrap().unwrap();
         assert_eq!(
             vec![(3, 6), (33, 6), (10, 5), (25, 8),],
             varstore

--- a/resources/codegen_inputs/varc.rs
+++ b/resources/codegen_inputs/varc.rs
@@ -42,10 +42,10 @@ table SparseVariationRegionList {
 table SparseVariationRegion {
     region_axis_count: u16,
     #[count($region_axis_count)]
-    region_axis_offsets: [Offset32<SparseRegionAxisCoordinates>],
+    region_axis_offsets: [SparseRegionAxisCoordinates],
 }
 
-table SparseRegionAxisCoordinates
+record SparseRegionAxisCoordinates
 {
   axis_index: u16,
   start: F2Dot14,

--- a/resources/codegen_inputs/varc.rs
+++ b/resources/codegen_inputs/varc.rs
@@ -1,5 +1,7 @@
 #![parse_module(read_fonts::tables::varc)]
 
+extern record Index2;
+
 /// [VARC](https://github.com/harfbuzz/boring-expansion-spec/blob/main/VARC.md) (Variable Composites / Components Table)
 /// 
 /// [FontTools VARC](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3459-L3476)
@@ -20,8 +22,45 @@ table Varc {
     var_composite_glyphs_offset: Offset32<Index2>,
 }
 
+/// * <https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3451-L3457>
+/// * <https://github.com/harfbuzz/harfbuzz/blob/7be12b33e3f07067c159d8f516eb31df58c75876/src/hb-ot-layout-common.hh#L3517-L3520C3>
 table MultiItemVariationStore {
-    // TODO(rsheeter) Doing VARC incrementally, haven't got here yet.
+    #[format = 1]
+    format: u16,
+    region_list_offset: Offset32<SparseVariationRegionList>,
+    variation_data_count: u16,
+    #[count($variation_data_count)]
+    variation_data_offsets: [Offset32<MultiItemVariationData>],
+}
+
+table SparseVariationRegionList {
+  region_count: u16,
+  #[count($region_count)]
+  region_offsets: [Offset32<SparseVariationRegion>],
+}
+
+table SparseVariationRegion {
+    region_axis_count: u16,
+    #[count($region_axis_count)]
+    region_axis_offsets: [Offset32<SparseRegionAxisCoordinates>],
+}
+
+table SparseRegionAxisCoordinates
+{
+  axis_index: u16,
+  start: F2Dot14,
+  peak: F2Dot14,
+  end: F2Dot14,
+}
+
+table MultiItemVariationData {
+    #[format = 1]
+    format: u8,
+    region_index_count: u16,
+    #[count($region_index_count)]
+    region_indices: [u16],
+    #[count(..)]
+    raw_delta_sets: [u8],    
 }
 
 table ConditionList {


### PR DESCRIPTION
Read the fields of the MultiItemVarStore. This gives us raw and fairly unfriendly access to VARC and hopefully positions us to start thinking providing friendlier access, such as by loading paths in Skrifa.