### PR TITLE
Fix integer overflow in Cmap12::group()

### DIFF
--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -501,6 +501,8 @@ mod tests {
 
     // oss-fuzz detected integer addition overflow in Cmap12::group()
     // ref: https://oss-fuzz.com/testcase-detail/5141969742397440
+    //
+    // test case slightly modified so that it runs in reasonable time
     #[test]
     fn fuzz_cmap12_mappings_overflow() {
         let test_case = &[
@@ -508,8 +510,10 @@ mod tests {
             32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 10, 32, 32, 32, 32, 32, 32, 32,
             99, 109, 97, 112, 32, 32, 32, 32, 0, 0, 0, 33, 0, 0, 0, 84, 32, 32, 32, 32, 32, 32, 0,
             12, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 0, 0, 2, 32, 32, 32, 32, 32, 32, 32, 32,
-            32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32, 0,
-            0, 32, 32, 0, 0, 0, 33,
+            // original data for following row:
+            // 32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32, 0,
+            32, 32, 32, 32, 254, 255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32,
+            0, 0, 32, 32, 0, 0, 0, 33,
         ];
         let font = FontRef::new(test_case).unwrap();
         let charmap = font.charmap();

--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -501,6 +501,7 @@ mod tests {
 
     // oss-fuzz detected integer addition overflow in Cmap12::group()
     // ref: https://oss-fuzz.com/testcase-detail/5141969742397440
+    // and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69547
     //
     // test case slightly modified so that it runs in reasonable time
     #[test]
@@ -511,7 +512,7 @@ mod tests {
             99, 109, 97, 112, 32, 32, 32, 32, 0, 0, 0, 33, 0, 0, 0, 84, 32, 32, 32, 32, 32, 32, 0,
             12, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 0, 0, 2, 32, 32, 32, 32, 32, 32, 32, 32,
             // original data for following row:
-            // 32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32, 0,
+            // 32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32,
             32, 32, 32, 32, 254, 255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32,
             0, 0, 32, 32, 0, 0, 0, 33,
         ];

--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -499,6 +499,23 @@ mod tests {
         }
     }
 
+    // oss-fuzz detected integer addition overflow in Cmap12::group()
+    // ref: https://oss-fuzz.com/testcase-detail/5141969742397440
+    #[test]
+    fn fuzz_cmap12_mappings_overflow() {
+        let test_case = &[
+            79, 84, 84, 79, 0, 5, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
+            32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 10, 32, 32, 32, 32, 32, 32, 32,
+            99, 109, 97, 112, 32, 32, 32, 32, 0, 0, 0, 33, 0, 0, 0, 84, 32, 32, 32, 32, 32, 32, 0,
+            12, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 0, 0, 2, 32, 32, 32, 32, 32, 32, 32, 32,
+            32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32, 0,
+            0, 32, 32, 0, 0, 0, 33,
+        ];
+        let font = FontRef::new(test_case).unwrap();
+        let charmap = font.charmap();
+        for _ in charmap.mappings() {}
+    }
+
     #[test]
     fn variant_mappings() {
         let font = FontRef::new(font_test_data::CMAP14_FONT1).unwrap();


### PR DESCRIPTION
As discovered by fuzzing.
ref https://oss-fuzz.com/testcase-detail/5141969742397440 and  https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69547

First commit contains the failing test.