### PR TITLE
[read-fonts] limit iteration of cmap12

### DIFF
--- a/read-fonts/src/tables/cmap.rs
+++ b/read-fonts/src/tables/cmap.rs
@@ -200,8 +200,11 @@ impl<'a> Cmap12<'a> {
     fn group(&self, index: usize) -> Option<Cmap12Group> {
         let group = self.groups().get(index)?;
         let start_code = group.start_char_code();
+        // Limit to the valid range of Unicode characters
+        // per https://github.com/googlefonts/fontations/issues/952#issuecomment-2161510184
+        let end_code = group.end_char_code().min(char::MAX as u32);
         Some(Cmap12Group {
-            range: start_code..=group.end_char_code(),
+            range: start_code..=end_code,
             start_code,
             start_glyph_id: group.start_glyph_id(),
         })
@@ -255,7 +258,16 @@ impl<'a> Iterator for Cmap12Iter<'a> {
                 return Some((codepoint, glyph_id));
             } else {
                 self.cur_group_ix += 1;
-                self.cur_group = self.subtable.group(self.cur_group_ix);
+                let mut next_group = self.subtable.group(self.cur_group_ix)?;
+                // Groups should be in order and non-overlapping so make sure
+                // that the start code of next group is at least
+                // current_end + 1.
+                // This ensures we only ever generate a maximum of
+                // 0..=char::MAX results.
+                if next_group.range.start() <= group.range.end() {
+                    next_group.range = *group.range.end() + 1..=*next_group.range.end();
+                }
+                self.cur_group = Some(next_group);
             }
         }
     }
@@ -570,6 +582,74 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 10);
+    }
+
+    // oss-fuzz: detected integer addition overflow in Cmap12::group()
+    // ref: https://oss-fuzz.com/testcase-detail/5141969742397440
+    // and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69547
+    #[test]
+    fn cmap12_iter_avoid_overflow() {
+        let test_case = &[
+            79, 84, 84, 79, 0, 5, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
+            32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 10, 32, 32, 32, 32, 32, 32, 32,
+            99, 109, 97, 112, 32, 32, 32, 32, 0, 0, 0, 33, 0, 0, 0, 84, 32, 32, 32, 32, 32, 32, 0,
+            12, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 0, 0, 2, 32, 32, 32, 32, 32, 32, 32, 32,
+            32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32, 0,
+            0, 32, 32, 0, 0, 0, 33,
+        ];
+        let font = FontRef::new(test_case).unwrap();
+        let cmap = font.cmap().unwrap();
+        let cmap12 = find_cmap12(&cmap).unwrap();
+        let _ = cmap12.iter().count();
+    }
+
+    // oss-fuzz: timeout in Cmap12Iter
+    // ref: https://oss-fuzz.com/testcase-detail/4628971063934976
+    // and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69540
+    #[test]
+    fn cmap12_iter_avoid_timeout() {
+        let test_case = &[
+            0, 1, 0, 0, 0, 5, 0, 1, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 48, 0, 93, 0, 0, 3, 8, 0, 0,
+            151, 3, 0, 0, 0, 0, 0, 0, 0, 64, 255, 103, 5, 7, 221, 0, 99, 109, 97, 112, 0, 0, 3, 0,
+            0, 0, 0, 2, 0, 0, 0, 97, 97, 97, 159, 158, 158, 149, 0, 12, 255, 255, 249, 2, 0, 1, 0,
+            0, 0, 23, 0, 0, 0, 1, 0, 0, 0, 170, 79, 84, 84, 79, 0, 5, 5, 0, 1, 0, 0, 5, 5, 5, 5,
+            48, 5, 5, 5, 5, 0, 4, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 33, 0, 5,
+            3, 5, 5, 5, 5, 74, 5, 255, 255, 32, 1, 5, 44, 0, 0, 10, 116, 0, 33, 0, 0, 0, 102, 0, 0,
+            0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 0, 0, 0, 0, 0, 33, 0, 0, 87, 250, 181, 250, 250, 159,
+            0, 4, 0, 0, 0, 0, 0, 99, 109, 97, 112, 4, 64, 138, 0, 0, 0, 0, 33, 0, 0, 3, 0, 0, 0,
+            102, 0, 0, 0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 0, 255, 255, 96, 0, 0, 0, 12, 32, 0, 1, 0,
+            0, 5, 5, 97, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 149, 97, 0, 0, 4, 0, 0,
+            128, 5, 53, 37, 5, 5, 44, 5, 5, 0, 3, 5,
+        ];
+        let font = FontRef::new(test_case).unwrap();
+        let cmap = font.cmap().unwrap();
+        // ranges: [SequentialMapGroup { start_char_code: 170, end_char_code: 1330926671, start_glyph_id: 328960 }]
+        let cmap12 = find_cmap12(&cmap).unwrap();
+        assert!(cmap12.iter().count() <= char::MAX as usize);
+    }
+
+    #[test]
+    fn cmap12_iter_range_clamping() {
+        let test_case = &[
+            79, 84, 84, 79, 0, 5, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
+            32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 10, 32, 32, 32, 32, 32, 32, 32,
+            99, 109, 97, 112, 32, 32, 32, 32, 0, 0, 0, 33, 0, 0, 0, 84, 32, 32, 32, 32, 32, 32, 0,
+            12, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 0, 0, 2, 0, 0, 0, 0, 0, 255, 255, 255,
+            32, 32, 32, 32, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32, 0, 0,
+            32, 32, 0, 0, 0, 33,
+        ];
+        let font = FontRef::new(test_case).unwrap();
+        let cmap = font.cmap().unwrap();
+        let cmap12 = find_cmap12(&cmap).unwrap();
+        let ranges = cmap12
+            .groups()
+            .iter()
+            .map(|group| (group.start_char_code(), group.end_char_code()))
+            .collect::<Vec<_>>();
+        // These groups overlap and extend to the whole u32 range
+        assert_eq!(ranges, &[(0, 16777215), (255, u32::MAX)]);
+        // But we produce fewer than char::MAX results (some codepoints map to 0)
+        assert!(cmap12.iter().count() < char::MAX as usize);
     }
 
     #[test]

--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -499,28 +499,6 @@ mod tests {
         }
     }
 
-    // oss-fuzz detected integer addition overflow in Cmap12::group()
-    // ref: https://oss-fuzz.com/testcase-detail/5141969742397440
-    // and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69547
-    //
-    // test case slightly modified so that it runs in reasonable time
-    #[test]
-    fn fuzz_cmap12_mappings_overflow() {
-        let test_case = &[
-            79, 84, 84, 79, 0, 5, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32,
-            32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 10, 32, 32, 32, 32, 32, 32, 32,
-            99, 109, 97, 112, 32, 32, 32, 32, 0, 0, 0, 33, 0, 0, 0, 84, 32, 32, 32, 32, 32, 32, 0,
-            12, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 0, 0, 0, 2, 32, 32, 32, 32, 32, 32, 32, 32,
-            // original data for following row:
-            // 32, 32, 32, 32, 32, 32, 32, 32, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32,
-            32, 32, 32, 32, 254, 255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 32, 32, 32, 32,
-            0, 0, 32, 32, 0, 0, 0, 33,
-        ];
-        let font = FontRef::new(test_case).unwrap();
-        let charmap = font.charmap();
-        for _ in charmap.mappings() {}
-    }
-
     #[test]
     fn variant_mappings() {
         let font = FontRef::new(font_test_data::CMAP14_FONT1).unwrap();


### PR DESCRIPTION
Limits iteration to the range of valid Unicode characters. Also ensures that we don't waste time iterating over the overlapping portions of subsequent ranges. This guarantees that we'll only ever loop a maximum of `char::MAX` times.

Addresses fuzzer timeout in https://oss-fuzz.com/testcase-detail/4628971063934976 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69540