### PR TITLE
Support 'true' SFNT version

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -49,5 +49,7 @@ pub const TTC_HEADER_TAG: Tag = Tag::new(b"ttcf");
 
 /// The SFNT version for fonts containing TrueType outlines.
 pub const TT_SFNT_VERSION: u32 = 0x00010000;
+/// The SFNT version for legacy Apple fonts containing TrueType outlines.
+pub const TRUE_SFNT_VERSION: u32 = 0x74727565;
 /// The SFNT version for fonts containing CFF outlines.
 pub const CFF_SFTN_VERSION: u32 = 0x4F54544F;

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -306,7 +306,9 @@ impl<'a> FontRef<'a> {
         data: FontData<'a>,
         table_directory: TableDirectory<'a>,
     ) -> Result<Self, ReadError> {
-        if [TT_SFNT_VERSION, CFF_SFTN_VERSION].contains(&table_directory.sfnt_version()) {
+        if [TT_SFNT_VERSION, CFF_SFTN_VERSION, TRUE_SFNT_VERSION]
+            .contains(&table_directory.sfnt_version())
+        {
             Ok(FontRef {
                 data,
                 table_directory,


### PR DESCRIPTION
The `Zycon.ttf` test font at https://github.com/unicode-org/text-rendering-tests/tree/main/fonts uses this.

JMM