### PR TITLE
[read] Make ComputeSize fallible

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1023,7 +1023,7 @@ impl Field {
             .map(FieldReadArgs::to_tokens_for_validation);
 
         if let FieldType::Struct { typ } = &self.typ {
-            return Some(quote!( <#typ as ComputeSize>::compute_size(&#read_args)));
+            return Some(quote!( <#typ as ComputeSize>::compute_size(&#read_args)? ));
         }
         if let FieldType::PendingResolution { .. } = &self.typ {
             panic!("Should have resolved {self:?}")
@@ -1050,7 +1050,7 @@ impl Field {
                     }
                     FieldType::ComputedArray(array) => {
                         let inner = array.raw_inner_type();
-                        quote!( <#inner as ComputeSize>::compute_size(&#read_args) )
+                        quote!( <#inner as ComputeSize>::compute_size(&#read_args)? )
                     }
                     _ => unreachable!("count not valid here"),
                 };

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -90,9 +90,9 @@ fn generate_read_with_args(item: &Record) -> TokenStream {
         }
 
         impl ComputeSize for #name #anon_lifetime {
-            fn compute_size(args: &#args_type) -> usize {
+            fn compute_size(args: &#args_type) -> Result<usize, ReadError> {
                 let #destructure_pattern = *args;
-                #( #field_size_expr )+*
+               Ok( #( #field_size_expr )+* )
             }
         }
 

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -178,7 +178,7 @@ impl<'a> FontReadWithArgs<'a> for AxisInstanceArrays<'a> {
         let axes_byte_len = axis_count as usize * VariationAxisRecord::RAW_BYTE_LEN;
         cursor.advance_by(axes_byte_len);
         let instances_byte_len = instance_count as usize
-            * <InstanceRecord as ComputeSize>::compute_size(&(axis_count, instance_size));
+            * <InstanceRecord as ComputeSize>::compute_size(&(axis_count, instance_size))?;
         cursor.advance_by(instances_byte_len);
         cursor.finish(AxisInstanceArraysMarker {
             axis_count,

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -63,7 +63,7 @@ impl<'a> FontRead<'a> for Gvar<'a> {
         let flags: GvarFlags = cursor.read()?;
         cursor.advance::<u32>();
         let glyph_variation_data_offsets_byte_len =
-            transforms::add(glyph_count, 1_usize) * <U16Or32 as ComputeSize>::compute_size(&flags);
+            transforms::add(glyph_count, 1_usize) * <U16Or32 as ComputeSize>::compute_size(&flags)?;
         cursor.advance_by(glyph_variation_data_offsets_byte_len);
         cursor.finish(GvarMarker {
             glyph_variation_data_offsets_byte_len,
@@ -501,7 +501,7 @@ impl<'a> FontReadWithArgs<'a> for SharedTuples<'a> {
         let (shared_tuple_count, axis_count) = *args;
         let mut cursor = data.cursor();
         let tuples_byte_len =
-            shared_tuple_count as usize * <Tuple as ComputeSize>::compute_size(&axis_count);
+            shared_tuple_count as usize * <Tuple as ComputeSize>::compute_size(&axis_count)?;
         cursor.advance_by(tuples_byte_len);
         cursor.finish(SharedTuplesMarker {
             axis_count,

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -44,7 +44,7 @@ impl<'a> FontRead<'a> for BasicTable<'a> {
         let arrays_inner_count: u16 = cursor.read()?;
         let array_records_count: u32 = cursor.read()?;
         let array_records_byte_len = array_records_count as usize
-            * <ContainsArrays as ComputeSize>::compute_size(&arrays_inner_count);
+            * <ContainsArrays as ComputeSize>::compute_size(&arrays_inner_count)?;
         cursor.advance_by(array_records_byte_len);
         cursor.finish(BasicTableMarker {
             simple_records_byte_len,
@@ -183,9 +183,12 @@ impl ReadArgs for ContainsArrays<'_> {
 }
 
 impl ComputeSize for ContainsArrays<'_> {
-    fn compute_size(args: &u16) -> usize {
+    fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let array_len = *args;
-        array_len as usize * u16::RAW_BYTE_LEN + array_len as usize * SimpleRecord::RAW_BYTE_LEN
+        Ok(
+            array_len as usize * u16::RAW_BYTE_LEN
+                + array_len as usize * SimpleRecord::RAW_BYTE_LEN,
+        )
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -147,9 +147,9 @@ impl ReadArgs for Tuple<'_> {
 }
 
 impl ComputeSize for Tuple<'_> {
-    fn compute_size(args: &u16) -> usize {
+    fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let axis_count = *args;
-        axis_count as usize * F2Dot14::RAW_BYTE_LEN
+        Ok(axis_count as usize * F2Dot14::RAW_BYTE_LEN)
     }
 }
 
@@ -789,7 +789,7 @@ impl<'a> FontRead<'a> for VariationRegionList<'a> {
         let axis_count: u16 = cursor.read()?;
         let region_count: u16 = cursor.read()?;
         let variation_regions_byte_len =
-            region_count as usize * <VariationRegion as ComputeSize>::compute_size(&axis_count);
+            region_count as usize * <VariationRegion as ComputeSize>::compute_size(&axis_count)?;
         cursor.advance_by(variation_regions_byte_len);
         cursor.finish(VariationRegionListMarker {
             variation_regions_byte_len,
@@ -872,9 +872,9 @@ impl ReadArgs for VariationRegion<'_> {
 }
 
 impl ComputeSize for VariationRegion<'_> {
-    fn compute_size(args: &u16) -> usize {
+    fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let axis_count = *args;
-        axis_count as usize * RegionAxisCoordinates::RAW_BYTE_LEN
+        Ok(axis_count as usize * RegionAxisCoordinates::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -24,15 +24,15 @@ pub struct ComputedArray<'a, T: ReadArgs> {
 }
 
 impl<'a, T: ComputeSize> ComputedArray<'a, T> {
-    pub fn new(data: FontData<'a>, args: T::Args) -> Self {
-        let item_len = T::compute_size(&args);
+    pub fn new(data: FontData<'a>, args: T::Args) -> Result<Self, ReadError> {
+        let item_len = T::compute_size(&args)?;
         let len = data.len().checked_div(item_len).unwrap_or(0);
-        ComputedArray {
+        Ok(ComputedArray {
             item_len,
             len,
             data,
             args,
-        }
+        })
     }
 
     /// The number of items in the array
@@ -55,7 +55,7 @@ where
     T::Args: Copy,
 {
     fn read_with_args(data: FontData<'a>, args: &Self::Args) -> Result<Self, ReadError> {
-        Ok(Self::new(data, *args))
+        Self::new(data, *args)
     }
 }
 

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -216,7 +216,7 @@ impl<'a> Cursor<'a> {
     where
         T: FontReadWithArgs<'a> + ComputeSize,
     {
-        let len = T::compute_size(args);
+        let len = T::compute_size(args)?;
         let temp = self.data.read_with_args(self.pos..self.pos + len, args);
         self.pos += len;
         temp
@@ -231,7 +231,7 @@ impl<'a> Cursor<'a> {
     where
         T: FontReadWithArgs<'a> + ComputeSize,
     {
-        let len = len * T::compute_size(args);
+        let len = len * T::compute_size(args)?;
         let temp = self.data.read_with_args(self.pos..self.pos + len, args);
         self.pos += len;
         temp

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -71,7 +71,7 @@ pub trait Format<T> {
 /// for types which store their size inline, see [`VarSize`].
 pub trait ComputeSize: ReadArgs {
     /// Compute the number of bytes required to represent this type.
-    fn compute_size(args: &Self::Args) -> usize;
+    fn compute_size(args: &Self::Args) -> Result<usize, ReadError>;
 }
 
 /// A trait for types that have variable length.

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -22,12 +22,12 @@ impl ReadArgs for U16Or32 {
 }
 
 impl ComputeSize for U16Or32 {
-    fn compute_size(args: &GvarFlags) -> usize {
-        if args.contains(GvarFlags::LONG_OFFSETS) {
+    fn compute_size(args: &GvarFlags) -> Result<usize, ReadError> {
+        Ok(if args.contains(GvarFlags::LONG_OFFSETS) {
             4
         } else {
             2
-        }
+        })
     }
 }
 

--- a/read-fonts/src/tables/instance_record.rs
+++ b/read-fonts/src/tables/instance_record.rs
@@ -64,8 +64,8 @@ impl<'a> FontReadWithArgs<'a> for InstanceRecord<'a> {
 
 impl ComputeSize for InstanceRecord<'_> {
     #[inline]
-    fn compute_size(args: &(u16, u16)) -> usize {
-        args.1 as usize
+    fn compute_size(args: &(u16, u16)) -> Result<usize, ReadError> {
+        Ok(args.1 as usize)
     }
 }
 

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -172,8 +172,8 @@ impl std::fmt::Debug for ValueRecord {
 
 impl ComputeSize for ValueRecord {
     #[inline]
-    fn compute_size(args: &ValueFormat) -> usize {
-        args.record_byte_len()
+    fn compute_size(args: &ValueFormat) -> Result<usize, ReadError> {
+        Ok(args.record_byte_len())
     }
 }
 


### PR DESCRIPTION
This will ensure we do not panic on overflow when handling pathological inputs.