### PR TITLE
[read-fonts] Add test case for SBIX overflow

### DIFF
--- a/read-fonts/src/tables/sbix.rs
+++ b/read-fonts/src/tables/sbix.rs
@@ -22,3 +22,25 @@ impl<'a> Strike<'a> {
         Ok(Some(GlyphData::read(data)?))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tables::sbix::Sbix;
+    use crate::test_helpers::BeBuffer;
+
+    #[test]
+    fn sbix_strikes_count_overflow_table() {
+        // Contains an invalid `num_strikes` values which would move the cursor outside the able.
+        // See https://issues.chromium.org/issues/347835680 for the ClusterFuzz report.
+        // Failure only reproduces on 32-bit, for example, run with:
+        // cargo test --target=i686-unknown-linux-gnu "sbix_strikes_count_overflow_table"
+        let sbix = BeBuffer::new()
+            .push(1u16) // version
+            .push(0u16) // flags
+            .push(u32::MAX); // num_strikes
+
+        let table = Sbix::read(sbix.font_data(), 5);
+        // Must not panic with "attempt to multiply with overflow".
+        assert!(table.is_err());
+    }
+}


### PR DESCRIPTION
Add test case from crbug.com/347835680 which triggered overflows in font data reading, which are fixed after #966.

Test for #959. 

Test fails only on 32 bit, for example building and testing with: `--target=i686-unknown-linux-gnu`:
`cargo test --target=i686-unknown-linux-gnu "sbix_strikes_count_overflow"`
