### PR TITLE
[read/codegen] Use checked ops in length calculations

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1132,7 +1132,9 @@ impl Field {
                         // Prevent identity-op clippy error with `1 * size`
                         size_expr
                     }
-                    _ => quote!(  #count_expr * #size_expr ),
+                    _ => {
+                        quote!(  (#count_expr).checked_mul(#size_expr).ok_or(ReadError::OutOfBounds)? )
+                    }
                 }
             }
             None => quote!(compile_error!("missing count attribute?")),

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -47,7 +47,9 @@ impl<'a> FontRead<'a> for TableDirectory<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let table_records_byte_len = num_tables as usize * TableRecord::RAW_BYTE_LEN;
+        let table_records_byte_len = (num_tables as usize)
+            .checked_mul(TableRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(table_records_byte_len);
         cursor.finish(TableDirectoryMarker {
             table_records_byte_len,
@@ -231,7 +233,9 @@ impl<'a> FontRead<'a> for TTCHeader<'a> {
         cursor.advance::<Tag>();
         let version: MajorMinor = cursor.read()?;
         let num_fonts: u32 = cursor.read()?;
-        let table_directory_offsets_byte_len = num_fonts as usize * u32::RAW_BYTE_LEN;
+        let table_directory_offsets_byte_len = (num_fonts as usize)
+            .checked_mul(u32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(table_directory_offsets_byte_len);
         let dsig_tag_byte_start = version
             .compatible((2u16, 0u16))

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -242,7 +242,9 @@ impl<'a> FontRead<'a> for BaseTagList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let base_tag_count: u16 = cursor.read()?;
-        let baseline_tags_byte_len = base_tag_count as usize * Tag::RAW_BYTE_LEN;
+        let baseline_tags_byte_len = (base_tag_count as usize)
+            .checked_mul(Tag::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(baseline_tags_byte_len);
         cursor.finish(BaseTagListMarker {
             baseline_tags_byte_len,
@@ -312,8 +314,9 @@ impl<'a> FontRead<'a> for BaseScriptList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let base_script_count: u16 = cursor.read()?;
-        let base_script_records_byte_len =
-            base_script_count as usize * BaseScriptRecord::RAW_BYTE_LEN;
+        let base_script_records_byte_len = (base_script_count as usize)
+            .checked_mul(BaseScriptRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_script_records_byte_len);
         cursor.finish(BaseScriptListMarker {
             base_script_records_byte_len,
@@ -452,8 +455,9 @@ impl<'a> FontRead<'a> for BaseScript<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let base_lang_sys_count: u16 = cursor.read()?;
-        let base_lang_sys_records_byte_len =
-            base_lang_sys_count as usize * BaseLangSysRecord::RAW_BYTE_LEN;
+        let base_lang_sys_records_byte_len = (base_lang_sys_count as usize)
+            .checked_mul(BaseLangSysRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_lang_sys_records_byte_len);
         cursor.finish(BaseScriptMarker {
             base_lang_sys_records_byte_len,
@@ -622,7 +626,9 @@ impl<'a> FontRead<'a> for BaseValues<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let base_coord_count: u16 = cursor.read()?;
-        let base_coord_offsets_byte_len = base_coord_count as usize * Offset16::RAW_BYTE_LEN;
+        let base_coord_offsets_byte_len = (base_coord_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_coord_offsets_byte_len);
         cursor.finish(BaseValuesMarker {
             base_coord_offsets_byte_len,
@@ -735,8 +741,9 @@ impl<'a> FontRead<'a> for MinMax<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let feat_min_max_count: u16 = cursor.read()?;
-        let feat_min_max_records_byte_len =
-            feat_min_max_count as usize * FeatMinMaxRecord::RAW_BYTE_LEN;
+        let feat_min_max_records_byte_len = (feat_min_max_count as usize)
+            .checked_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(feat_min_max_records_byte_len);
         cursor.finish(MinMaxMarker {
             feat_min_max_records_byte_len,

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -1251,8 +1251,9 @@ impl<'a> FontRead<'a> for IndexSubtable4<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u32>();
         let num_glyphs: u32 = cursor.read()?;
-        let glyph_array_byte_len =
-            transforms::add(num_glyphs, 1_usize) * GlyphIdOffsetPair::RAW_BYTE_LEN;
+        let glyph_array_byte_len = (transforms::add(num_glyphs, 1_usize))
+            .checked_mul(GlyphIdOffsetPair::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_array_byte_len);
         cursor.finish(IndexSubtable4Marker {
             glyph_array_byte_len,
@@ -1421,7 +1422,9 @@ impl<'a> FontRead<'a> for IndexSubtable5<'a> {
         let big_metrics_byte_len = BigGlyphMetrics::RAW_BYTE_LEN;
         cursor.advance_by(big_metrics_byte_len);
         let num_glyphs: u32 = cursor.read()?;
-        let glyph_array_byte_len = num_glyphs as usize * GlyphId::RAW_BYTE_LEN;
+        let glyph_array_byte_len = (num_glyphs as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_array_byte_len);
         cursor.finish(IndexSubtable5Marker {
             big_metrics_byte_len,

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -42,7 +42,9 @@ impl<'a> FontRead<'a> for Cblc<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         let num_sizes: u32 = cursor.read()?;
-        let bitmap_sizes_byte_len = num_sizes as usize * BitmapSize::RAW_BYTE_LEN;
+        let bitmap_sizes_byte_len = (num_sizes as usize)
+            .checked_mul(BitmapSize::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(bitmap_sizes_byte_len);
         cursor.finish(CblcMarker {
             bitmap_sizes_byte_len,

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -47,7 +47,9 @@ impl<'a> FontRead<'a> for CffHeader<'a> {
         cursor.advance::<u8>();
         let hdr_size: u8 = cursor.read()?;
         cursor.advance::<u8>();
-        let _padding_byte_len = transforms::subtract(hdr_size, 4_usize) * u8::RAW_BYTE_LEN;
+        let _padding_byte_len = (transforms::subtract(hdr_size, 4_usize))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(_padding_byte_len);
         let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(trailing_data_byte_len);

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -52,9 +52,13 @@ impl<'a> FontRead<'a> for Cff2Header<'a> {
         cursor.advance::<u8>();
         let header_size: u8 = cursor.read()?;
         let top_dict_length: u16 = cursor.read()?;
-        let _padding_byte_len = transforms::subtract(header_size, 5_usize) * u8::RAW_BYTE_LEN;
+        let _padding_byte_len = (transforms::subtract(header_size, 5_usize))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(_padding_byte_len);
-        let top_dict_data_byte_len = top_dict_length as usize * u8::RAW_BYTE_LEN;
+        let top_dict_data_byte_len = (top_dict_length as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(top_dict_data_byte_len);
         let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(trailing_data_byte_len);

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -37,7 +37,9 @@ impl<'a> FontRead<'a> for Cmap<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let num_tables: u16 = cursor.read()?;
-        let encoding_records_byte_len = num_tables as usize * EncodingRecord::RAW_BYTE_LEN;
+        let encoding_records_byte_len = (num_tables as usize)
+            .checked_mul(EncodingRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(encoding_records_byte_len);
         cursor.finish(CmapMarker {
             encoding_records_byte_len,
@@ -331,7 +333,9 @@ impl<'a> FontRead<'a> for Cmap0<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let glyph_id_array_byte_len = 256_usize * u8::RAW_BYTE_LEN;
+        let glyph_id_array_byte_len = (256_usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_id_array_byte_len);
         cursor.finish(Cmap0Marker {
             glyph_id_array_byte_len,
@@ -428,7 +432,9 @@ impl<'a> FontRead<'a> for Cmap2<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let sub_header_keys_byte_len = 256_usize * u16::RAW_BYTE_LEN;
+        let sub_header_keys_byte_len = (256_usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(sub_header_keys_byte_len);
         cursor.finish(Cmap2Marker {
             sub_header_keys_byte_len,
@@ -629,14 +635,22 @@ impl<'a> FontRead<'a> for Cmap4<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let end_code_byte_len = transforms::half(seg_count_x2) * u16::RAW_BYTE_LEN;
+        let end_code_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(end_code_byte_len);
         cursor.advance::<u16>();
-        let start_code_byte_len = transforms::half(seg_count_x2) * u16::RAW_BYTE_LEN;
+        let start_code_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(start_code_byte_len);
-        let id_delta_byte_len = transforms::half(seg_count_x2) * i16::RAW_BYTE_LEN;
+        let id_delta_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(i16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(id_delta_byte_len);
-        let id_range_offsets_byte_len = transforms::half(seg_count_x2) * u16::RAW_BYTE_LEN;
+        let id_range_offsets_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(id_range_offsets_byte_len);
         let glyph_id_array_byte_len =
             cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
@@ -810,7 +824,9 @@ impl<'a> FontRead<'a> for Cmap6<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         let entry_count: u16 = cursor.read()?;
-        let glyph_id_array_byte_len = entry_count as usize * u16::RAW_BYTE_LEN;
+        let glyph_id_array_byte_len = (entry_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_id_array_byte_len);
         cursor.finish(Cmap6Marker {
             glyph_id_array_byte_len,
@@ -935,10 +951,14 @@ impl<'a> FontRead<'a> for Cmap8<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u32>();
         cursor.advance::<u32>();
-        let is32_byte_len = 8192_usize * u8::RAW_BYTE_LEN;
+        let is32_byte_len = (8192_usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(is32_byte_len);
         let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = num_groups as usize * SequentialMapGroup::RAW_BYTE_LEN;
+        let groups_byte_len = (num_groups as usize)
+            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(groups_byte_len);
         cursor.finish(Cmap8Marker {
             is32_byte_len,
@@ -1254,7 +1274,9 @@ impl<'a> FontRead<'a> for Cmap12<'a> {
         cursor.advance::<u32>();
         cursor.advance::<u32>();
         let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = num_groups as usize * SequentialMapGroup::RAW_BYTE_LEN;
+        let groups_byte_len = (num_groups as usize)
+            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(groups_byte_len);
         cursor.finish(Cmap12Marker { groups_byte_len })
     }
@@ -1373,7 +1395,9 @@ impl<'a> FontRead<'a> for Cmap13<'a> {
         cursor.advance::<u32>();
         cursor.advance::<u32>();
         let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = num_groups as usize * ConstantMapGroup::RAW_BYTE_LEN;
+        let groups_byte_len = (num_groups as usize)
+            .checked_mul(ConstantMapGroup::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(groups_byte_len);
         cursor.finish(Cmap13Marker { groups_byte_len })
     }
@@ -1534,8 +1558,9 @@ impl<'a> FontRead<'a> for Cmap14<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u32>();
         let num_var_selector_records: u32 = cursor.read()?;
-        let var_selector_byte_len =
-            num_var_selector_records as usize * VariationSelector::RAW_BYTE_LEN;
+        let var_selector_byte_len = (num_var_selector_records as usize)
+            .checked_mul(VariationSelector::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(var_selector_byte_len);
         cursor.finish(Cmap14Marker {
             var_selector_byte_len,
@@ -1709,7 +1734,9 @@ impl<'a> FontRead<'a> for DefaultUvs<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let num_unicode_value_ranges: u32 = cursor.read()?;
-        let ranges_byte_len = num_unicode_value_ranges as usize * UnicodeRange::RAW_BYTE_LEN;
+        let ranges_byte_len = (num_unicode_value_ranges as usize)
+            .checked_mul(UnicodeRange::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ranges_byte_len);
         cursor.finish(DefaultUvsMarker { ranges_byte_len })
     }
@@ -1785,7 +1812,9 @@ impl<'a> FontRead<'a> for NonDefaultUvs<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let num_uvs_mappings: u32 = cursor.read()?;
-        let uvs_mapping_byte_len = num_uvs_mappings as usize * UvsMapping::RAW_BYTE_LEN;
+        let uvs_mapping_byte_len = (num_uvs_mappings as usize)
+            .checked_mul(UvsMapping::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(uvs_mapping_byte_len);
         cursor.finish(NonDefaultUvsMarker {
             uvs_mapping_byte_len,

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -418,8 +418,9 @@ impl<'a> FontRead<'a> for BaseGlyphList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let num_base_glyph_paint_records: u32 = cursor.read()?;
-        let base_glyph_paint_records_byte_len =
-            num_base_glyph_paint_records as usize * BaseGlyphPaint::RAW_BYTE_LEN;
+        let base_glyph_paint_records_byte_len = (num_base_glyph_paint_records as usize)
+            .checked_mul(BaseGlyphPaint::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_glyph_paint_records_byte_len);
         cursor.finish(BaseGlyphListMarker {
             base_glyph_paint_records_byte_len,
@@ -548,7 +549,9 @@ impl<'a> FontRead<'a> for LayerList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let num_layers: u32 = cursor.read()?;
-        let paint_offsets_byte_len = num_layers as usize * Offset32::RAW_BYTE_LEN;
+        let paint_offsets_byte_len = (num_layers as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(paint_offsets_byte_len);
         cursor.finish(LayerListMarker {
             paint_offsets_byte_len,
@@ -640,7 +643,9 @@ impl<'a> FontRead<'a> for ClipList<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u8>();
         let num_clips: u32 = cursor.read()?;
-        let clips_byte_len = num_clips as usize * Clip::RAW_BYTE_LEN;
+        let clips_byte_len = (num_clips as usize)
+            .checked_mul(Clip::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(clips_byte_len);
         cursor.finish(ClipListMarker { clips_byte_len })
     }
@@ -1293,7 +1298,9 @@ impl<'a> FontRead<'a> for ColorLine<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<Extend>();
         let num_stops: u16 = cursor.read()?;
-        let color_stops_byte_len = num_stops as usize * ColorStop::RAW_BYTE_LEN;
+        let color_stops_byte_len = (num_stops as usize)
+            .checked_mul(ColorStop::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(color_stops_byte_len);
         cursor.finish(ColorLineMarker {
             color_stops_byte_len,
@@ -1379,7 +1386,9 @@ impl<'a> FontRead<'a> for VarColorLine<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<Extend>();
         let num_stops: u16 = cursor.read()?;
-        let color_stops_byte_len = num_stops as usize * VarColorStop::RAW_BYTE_LEN;
+        let color_stops_byte_len = (num_stops as usize)
+            .checked_mul(VarColorStop::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(color_stops_byte_len);
         cursor.finish(VarColorLineMarker {
             color_stops_byte_len,

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -67,7 +67,9 @@ impl<'a> FontRead<'a> for Cpal<'a> {
         let num_palettes: u16 = cursor.read()?;
         cursor.advance::<u16>();
         cursor.advance::<Offset32>();
-        let color_record_indices_byte_len = num_palettes as usize * u16::RAW_BYTE_LEN;
+        let color_record_indices_byte_len = (num_palettes as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(color_record_indices_byte_len);
         let palette_types_array_offset_byte_start = version
             .compatible(1u16)

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -42,7 +42,9 @@ impl<'a> FontRead<'a> for Eblc<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         let num_sizes: u32 = cursor.read()?;
-        let bitmap_sizes_byte_len = num_sizes as usize * BitmapSize::RAW_BYTE_LEN;
+        let bitmap_sizes_byte_len = (num_sizes as usize)
+            .checked_mul(BitmapSize::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(bitmap_sizes_byte_len);
         cursor.finish(EblcMarker {
             bitmap_sizes_byte_len,

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -175,10 +175,16 @@ impl<'a> FontReadWithArgs<'a> for AxisInstanceArrays<'a> {
     fn read_with_args(data: FontData<'a>, args: &(u16, u16, u16)) -> Result<Self, ReadError> {
         let (axis_count, instance_count, instance_size) = *args;
         let mut cursor = data.cursor();
-        let axes_byte_len = axis_count as usize * VariationAxisRecord::RAW_BYTE_LEN;
+        let axes_byte_len = (axis_count as usize)
+            .checked_mul(VariationAxisRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(axes_byte_len);
-        let instances_byte_len = instance_count as usize
-            * <InstanceRecord as ComputeSize>::compute_size(&(axis_count, instance_size))?;
+        let instances_byte_len = (instance_count as usize)
+            .checked_mul(<InstanceRecord as ComputeSize>::compute_size(&(
+                axis_count,
+                instance_size,
+            ))?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(instances_byte_len);
         cursor.finish(AxisInstanceArraysMarker {
             axis_count,

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -32,7 +32,9 @@ impl<'a> FontRead<'a> for Gasp<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let num_ranges: u16 = cursor.read()?;
-        let gasp_ranges_byte_len = num_ranges as usize * GaspRange::RAW_BYTE_LEN;
+        let gasp_ranges_byte_len = (num_ranges as usize)
+            .checked_mul(GaspRange::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(gasp_ranges_byte_len);
         cursor.finish(GaspMarker {
             gasp_ranges_byte_len,

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -297,7 +297,9 @@ impl<'a> FontRead<'a> for AttachList<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let glyph_count: u16 = cursor.read()?;
-        let attach_point_offsets_byte_len = glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let attach_point_offsets_byte_len = (glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(attach_point_offsets_byte_len);
         cursor.finish(AttachListMarker {
             attach_point_offsets_byte_len,
@@ -402,7 +404,9 @@ impl<'a> FontRead<'a> for AttachPoint<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let point_count: u16 = cursor.read()?;
-        let point_indices_byte_len = point_count as usize * u16::RAW_BYTE_LEN;
+        let point_indices_byte_len = (point_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(point_indices_byte_len);
         cursor.finish(AttachPointMarker {
             point_indices_byte_len,
@@ -475,7 +479,9 @@ impl<'a> FontRead<'a> for LigCaretList<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let lig_glyph_count: u16 = cursor.read()?;
-        let lig_glyph_offsets_byte_len = lig_glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let lig_glyph_offsets_byte_len = (lig_glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lig_glyph_offsets_byte_len);
         cursor.finish(LigCaretListMarker {
             lig_glyph_offsets_byte_len,
@@ -580,7 +586,9 @@ impl<'a> FontRead<'a> for LigGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let caret_count: u16 = cursor.read()?;
-        let caret_value_offsets_byte_len = caret_count as usize * Offset16::RAW_BYTE_LEN;
+        let caret_value_offsets_byte_len = (caret_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(caret_value_offsets_byte_len);
         cursor.finish(LigGlyphMarker {
             caret_value_offsets_byte_len,
@@ -964,7 +972,9 @@ impl<'a> FontRead<'a> for MarkGlyphSets<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let mark_glyph_set_count: u16 = cursor.read()?;
-        let coverage_offsets_byte_len = mark_glyph_set_count as usize * Offset32::RAW_BYTE_LEN;
+        let coverage_offsets_byte_len = (mark_glyph_set_count as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(coverage_offsets_byte_len);
         cursor.finish(MarkGlyphSetsMarker {
             coverage_offsets_byte_len,

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -107,10 +107,14 @@ impl<'a> FontRead<'a> for SimpleGlyph<'a> {
         cursor.advance::<i16>();
         cursor.advance::<i16>();
         cursor.advance::<i16>();
-        let end_pts_of_contours_byte_len = number_of_contours as usize * u16::RAW_BYTE_LEN;
+        let end_pts_of_contours_byte_len = (number_of_contours as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(end_pts_of_contours_byte_len);
         let instruction_length: u16 = cursor.read()?;
-        let instructions_byte_len = instruction_length as usize * u8::RAW_BYTE_LEN;
+        let instructions_byte_len = (instruction_length as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(instructions_byte_len);
         let glyph_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(glyph_data_byte_len);

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -983,7 +983,9 @@ impl<'a> FontRead<'a> for MarkArray<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let mark_count: u16 = cursor.read()?;
-        let mark_records_byte_len = mark_count as usize * MarkRecord::RAW_BYTE_LEN;
+        let mark_records_byte_len = (mark_count as usize)
+            .checked_mul(MarkRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(mark_records_byte_len);
         cursor.finish(MarkArrayMarker {
             mark_records_byte_len,
@@ -1313,8 +1315,9 @@ impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
         cursor.advance::<Offset16>();
         let value_format: ValueFormat = cursor.read()?;
         let value_count: u16 = cursor.read()?;
-        let value_records_byte_len =
-            value_count as usize * <ValueRecord as ComputeSize>::compute_size(&value_format)?;
+        let value_records_byte_len = (value_count as usize)
+            .checked_mul(<ValueRecord as ComputeSize>::compute_size(&value_format)?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(value_records_byte_len);
         cursor.finish(SinglePosFormat2Marker {
             value_records_byte_len,
@@ -1527,7 +1530,9 @@ impl<'a> FontRead<'a> for PairPosFormat1<'a> {
         cursor.advance::<ValueFormat>();
         cursor.advance::<ValueFormat>();
         let pair_set_count: u16 = cursor.read()?;
-        let pair_set_offsets_byte_len = pair_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let pair_set_offsets_byte_len = (pair_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(pair_set_offsets_byte_len);
         cursor.finish(PairPosFormat1Marker {
             pair_set_offsets_byte_len,
@@ -1667,8 +1672,12 @@ impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
         let (value_format1, value_format2) = *args;
         let mut cursor = data.cursor();
         let pair_value_count: u16 = cursor.read()?;
-        let pair_value_records_byte_len = pair_value_count as usize
-            * <PairValueRecord as ComputeSize>::compute_size(&(value_format1, value_format2))?;
+        let pair_value_records_byte_len = (pair_value_count as usize)
+            .checked_mul(<PairValueRecord as ComputeSize>::compute_size(&(
+                value_format1,
+                value_format2,
+            ))?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(pair_value_records_byte_len);
         cursor.finish(PairSetMarker {
             value_format1,
@@ -1784,11 +1793,20 @@ impl ReadArgs for PairValueRecord {
 }
 
 impl ComputeSize for PairValueRecord {
+    #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &(ValueFormat, ValueFormat)) -> Result<usize, ReadError> {
         let (value_format1, value_format2) = *args;
-        Ok(GlyphId::RAW_BYTE_LEN
-            + <ValueRecord as ComputeSize>::compute_size(&value_format1)?
-            + <ValueRecord as ComputeSize>::compute_size(&value_format2)?)
+        let mut result = 0usize;
+        result = result
+            .checked_add(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        result = result
+            .checked_add(<ValueRecord as ComputeSize>::compute_size(&value_format1)?)
+            .ok_or(ReadError::OutOfBounds)?;
+        result = result
+            .checked_add(<ValueRecord as ComputeSize>::compute_size(&value_format2)?)
+            .ok_or(ReadError::OutOfBounds)?;
+        Ok(result)
     }
 }
 
@@ -1905,12 +1923,13 @@ impl<'a> FontRead<'a> for PairPosFormat2<'a> {
         cursor.advance::<Offset16>();
         let class1_count: u16 = cursor.read()?;
         let class2_count: u16 = cursor.read()?;
-        let class1_records_byte_len = class1_count as usize
-            * <Class1Record as ComputeSize>::compute_size(&(
+        let class1_records_byte_len = (class1_count as usize)
+            .checked_mul(<Class1Record as ComputeSize>::compute_size(&(
                 class2_count,
                 value_format1,
                 value_format2,
-            ))?;
+            ))?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class1_records_byte_len);
         cursor.finish(PairPosFormat2Marker {
             class1_records_byte_len,
@@ -2071,10 +2090,15 @@ impl ReadArgs for Class1Record<'_> {
 }
 
 impl ComputeSize for Class1Record<'_> {
+    #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &(u16, ValueFormat, ValueFormat)) -> Result<usize, ReadError> {
         let (class2_count, value_format1, value_format2) = *args;
-        Ok(class2_count as usize
-            * <Class2Record as ComputeSize>::compute_size(&(value_format1, value_format2))?)
+        Ok((class2_count as usize)
+            .checked_mul(<Class2Record as ComputeSize>::compute_size(&(
+                value_format1,
+                value_format2,
+            ))?)
+            .ok_or(ReadError::OutOfBounds)?)
     }
 }
 
@@ -2155,10 +2179,17 @@ impl ReadArgs for Class2Record {
 }
 
 impl ComputeSize for Class2Record {
+    #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &(ValueFormat, ValueFormat)) -> Result<usize, ReadError> {
         let (value_format1, value_format2) = *args;
-        Ok(<ValueRecord as ComputeSize>::compute_size(&value_format1)?
-            + <ValueRecord as ComputeSize>::compute_size(&value_format2)?)
+        let mut result = 0usize;
+        result = result
+            .checked_add(<ValueRecord as ComputeSize>::compute_size(&value_format1)?)
+            .ok_or(ReadError::OutOfBounds)?;
+        result = result
+            .checked_add(<ValueRecord as ComputeSize>::compute_size(&value_format2)?)
+            .ok_or(ReadError::OutOfBounds)?;
+        Ok(result)
     }
 }
 
@@ -2248,7 +2279,9 @@ impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let entry_exit_count: u16 = cursor.read()?;
-        let entry_exit_record_byte_len = entry_exit_count as usize * EntryExitRecord::RAW_BYTE_LEN;
+        let entry_exit_record_byte_len = (entry_exit_count as usize)
+            .checked_mul(EntryExitRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(entry_exit_record_byte_len);
         cursor.finish(CursivePosFormat1Marker {
             entry_exit_record_byte_len,
@@ -2584,8 +2617,11 @@ impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let base_count: u16 = cursor.read()?;
-        let base_records_byte_len =
-            base_count as usize * <BaseRecord as ComputeSize>::compute_size(&mark_class_count)?;
+        let base_records_byte_len = (base_count as usize)
+            .checked_mul(<BaseRecord as ComputeSize>::compute_size(
+                &mark_class_count,
+            )?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_records_byte_len);
         cursor.finish(BaseArrayMarker {
             mark_class_count,
@@ -2693,9 +2729,12 @@ impl ReadArgs for BaseRecord<'_> {
 }
 
 impl ComputeSize for BaseRecord<'_> {
+    #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok(mark_class_count as usize * Offset16::RAW_BYTE_LEN)
+        Ok((mark_class_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?)
     }
 }
 
@@ -2930,7 +2969,9 @@ impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let ligature_count: u16 = cursor.read()?;
-        let ligature_attach_offsets_byte_len = ligature_count as usize * Offset16::RAW_BYTE_LEN;
+        let ligature_attach_offsets_byte_len = (ligature_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ligature_attach_offsets_byte_len);
         cursor.finish(LigatureArrayMarker {
             mark_class_count,
@@ -3044,8 +3085,11 @@ impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let component_count: u16 = cursor.read()?;
-        let component_records_byte_len = component_count as usize
-            * <ComponentRecord as ComputeSize>::compute_size(&mark_class_count)?;
+        let component_records_byte_len = (component_count as usize)
+            .checked_mul(<ComponentRecord as ComputeSize>::compute_size(
+                &mark_class_count,
+            )?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(component_records_byte_len);
         cursor.finish(LigatureAttachMarker {
             mark_class_count,
@@ -3153,9 +3197,12 @@ impl ReadArgs for ComponentRecord<'_> {
 }
 
 impl ComputeSize for ComponentRecord<'_> {
+    #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok(mark_class_count as usize * Offset16::RAW_BYTE_LEN)
+        Ok((mark_class_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?)
     }
 }
 
@@ -3390,8 +3437,11 @@ impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
         let mark2_count: u16 = cursor.read()?;
-        let mark2_records_byte_len =
-            mark2_count as usize * <Mark2Record as ComputeSize>::compute_size(&mark_class_count)?;
+        let mark2_records_byte_len = (mark2_count as usize)
+            .checked_mul(<Mark2Record as ComputeSize>::compute_size(
+                &mark_class_count,
+            )?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(mark2_records_byte_len);
         cursor.finish(Mark2ArrayMarker {
             mark_class_count,
@@ -3499,9 +3549,12 @@ impl ReadArgs for Mark2Record<'_> {
 }
 
 impl ComputeSize for Mark2Record<'_> {
+    #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok(mark_class_count as usize * Offset16::RAW_BYTE_LEN)
+        Ok((mark_class_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?)
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -430,7 +430,9 @@ impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let substitute_glyph_ids_byte_len = (glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitute_glyph_ids_byte_len);
         cursor.finish(SingleSubstFormat2Marker {
             substitute_glyph_ids_byte_len,
@@ -539,7 +541,9 @@ impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let sequence_count: u16 = cursor.read()?;
-        let sequence_offsets_byte_len = sequence_count as usize * Offset16::RAW_BYTE_LEN;
+        let sequence_offsets_byte_len = (sequence_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(sequence_offsets_byte_len);
         cursor.finish(MultipleSubstFormat1Marker {
             sequence_offsets_byte_len,
@@ -652,7 +656,9 @@ impl<'a> FontRead<'a> for Sequence<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let substitute_glyph_ids_byte_len = (glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitute_glyph_ids_byte_len);
         cursor.finish(SequenceMarker {
             substitute_glyph_ids_byte_len,
@@ -738,7 +744,9 @@ impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let alternate_set_count: u16 = cursor.read()?;
-        let alternate_set_offsets_byte_len = alternate_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let alternate_set_offsets_byte_len = (alternate_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(alternate_set_offsets_byte_len);
         cursor.finish(AlternateSubstFormat1Marker {
             alternate_set_offsets_byte_len,
@@ -854,7 +862,9 @@ impl<'a> FontRead<'a> for AlternateSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
-        let alternate_glyph_ids_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let alternate_glyph_ids_byte_len = (glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(alternate_glyph_ids_byte_len);
         cursor.finish(AlternateSetMarker {
             alternate_glyph_ids_byte_len,
@@ -939,7 +949,9 @@ impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let ligature_set_count: u16 = cursor.read()?;
-        let ligature_set_offsets_byte_len = ligature_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let ligature_set_offsets_byte_len = (ligature_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ligature_set_offsets_byte_len);
         cursor.finish(LigatureSubstFormat1Marker {
             ligature_set_offsets_byte_len,
@@ -1052,7 +1064,9 @@ impl<'a> FontRead<'a> for LigatureSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let ligature_count: u16 = cursor.read()?;
-        let ligature_offsets_byte_len = ligature_count as usize * Offset16::RAW_BYTE_LEN;
+        let ligature_offsets_byte_len = (ligature_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ligature_offsets_byte_len);
         cursor.finish(LigatureSetMarker {
             ligature_offsets_byte_len,
@@ -1146,8 +1160,9 @@ impl<'a> FontRead<'a> for Ligature<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<GlyphId>();
         let component_count: u16 = cursor.read()?;
-        let component_glyph_ids_byte_len =
-            transforms::subtract(component_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
+        let component_glyph_ids_byte_len = (transforms::subtract(component_count, 1_usize))
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(component_glyph_ids_byte_len);
         cursor.finish(LigatureMarker {
             component_glyph_ids_byte_len,
@@ -1471,15 +1486,19 @@ impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_coverage_offsets_byte_len =
-            backtrack_glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let backtrack_coverage_offsets_byte_len = (backtrack_glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(backtrack_coverage_offsets_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_coverage_offsets_byte_len =
-            lookahead_glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let lookahead_coverage_offsets_byte_len = (lookahead_glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookahead_coverage_offsets_byte_len);
         let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let substitute_glyph_ids_byte_len = (glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitute_glyph_ids_byte_len);
         cursor.finish(ReverseChainSingleSubstFormat1Marker {
             backtrack_coverage_offsets_byte_len,

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -62,8 +62,9 @@ impl<'a> FontRead<'a> for Gvar<'a> {
         let glyph_count: u16 = cursor.read()?;
         let flags: GvarFlags = cursor.read()?;
         cursor.advance::<u32>();
-        let glyph_variation_data_offsets_byte_len =
-            transforms::add(glyph_count, 1_usize) * <U16Or32 as ComputeSize>::compute_size(&flags)?;
+        let glyph_variation_data_offsets_byte_len = (transforms::add(glyph_count, 1_usize))
+            .checked_mul(<U16Or32 as ComputeSize>::compute_size(&flags)?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_variation_data_offsets_byte_len);
         cursor.finish(GvarMarker {
             glyph_variation_data_offsets_byte_len,
@@ -500,8 +501,9 @@ impl<'a> FontReadWithArgs<'a> for SharedTuples<'a> {
     fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
         let (shared_tuple_count, axis_count) = *args;
         let mut cursor = data.cursor();
-        let tuples_byte_len =
-            shared_tuple_count as usize * <Tuple as ComputeSize>::compute_size(&axis_count)?;
+        let tuples_byte_len = (shared_tuple_count as usize)
+            .checked_mul(<Tuple as ComputeSize>::compute_size(&axis_count)?)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(tuples_byte_len);
         cursor.finish(SharedTuplesMarker {
             axis_count,

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -37,10 +37,13 @@ impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
     fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
         let (number_of_h_metrics, num_glyphs) = *args;
         let mut cursor = data.cursor();
-        let h_metrics_byte_len = number_of_h_metrics as usize * LongMetric::RAW_BYTE_LEN;
+        let h_metrics_byte_len = (number_of_h_metrics as usize)
+            .checked_mul(LongMetric::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(h_metrics_byte_len);
-        let left_side_bearings_byte_len =
-            transforms::subtract(num_glyphs, number_of_h_metrics) * i16::RAW_BYTE_LEN;
+        let left_side_bearings_byte_len = (transforms::subtract(num_glyphs, number_of_h_metrics))
+            .checked_mul(i16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(left_side_bearings_byte_len);
         cursor.finish(HmtxMarker {
             h_metrics_byte_len,

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -27,7 +27,9 @@ impl<'a> FontRead<'a> for ScriptList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let script_count: u16 = cursor.read()?;
-        let script_records_byte_len = script_count as usize * ScriptRecord::RAW_BYTE_LEN;
+        let script_records_byte_len = (script_count as usize)
+            .checked_mul(ScriptRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(script_records_byte_len);
         cursor.finish(ScriptListMarker {
             script_records_byte_len,
@@ -160,7 +162,9 @@ impl<'a> FontRead<'a> for Script<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let lang_sys_count: u16 = cursor.read()?;
-        let lang_sys_records_byte_len = lang_sys_count as usize * LangSysRecord::RAW_BYTE_LEN;
+        let lang_sys_records_byte_len = (lang_sys_count as usize)
+            .checked_mul(LangSysRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lang_sys_records_byte_len);
         cursor.finish(ScriptMarker {
             lang_sys_records_byte_len,
@@ -315,7 +319,9 @@ impl<'a> FontRead<'a> for LangSys<'a> {
         cursor.advance::<u16>();
         cursor.advance::<u16>();
         let feature_index_count: u16 = cursor.read()?;
-        let feature_indices_byte_len = feature_index_count as usize * u16::RAW_BYTE_LEN;
+        let feature_indices_byte_len = (feature_index_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(feature_indices_byte_len);
         cursor.finish(LangSysMarker {
             feature_indices_byte_len,
@@ -398,7 +404,9 @@ impl<'a> FontRead<'a> for FeatureList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let feature_count: u16 = cursor.read()?;
-        let feature_records_byte_len = feature_count as usize * FeatureRecord::RAW_BYTE_LEN;
+        let feature_records_byte_len = (feature_count as usize)
+            .checked_mul(FeatureRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(feature_records_byte_len);
         cursor.finish(FeatureListMarker {
             feature_records_byte_len,
@@ -539,7 +547,9 @@ impl<'a> FontReadWithArgs<'a> for Feature<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<Offset16>();
         let lookup_index_count: u16 = cursor.read()?;
-        let lookup_list_indices_byte_len = lookup_index_count as usize * u16::RAW_BYTE_LEN;
+        let lookup_list_indices_byte_len = (lookup_index_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookup_list_indices_byte_len);
         cursor.finish(FeatureMarker {
             feature_tag,
@@ -653,7 +663,9 @@ impl<'a, T> FontRead<'a> for LookupList<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let lookup_count: u16 = cursor.read()?;
-        let lookup_offsets_byte_len = lookup_count as usize * Offset16::RAW_BYTE_LEN;
+        let lookup_offsets_byte_len = (lookup_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookup_offsets_byte_len);
         cursor.finish(LookupListMarker {
             lookup_offsets_byte_len,
@@ -798,7 +810,9 @@ impl<'a, T> FontRead<'a> for Lookup<'a, T> {
         cursor.advance::<u16>();
         cursor.advance::<LookupFlag>();
         let sub_table_count: u16 = cursor.read()?;
-        let subtable_offsets_byte_len = sub_table_count as usize * Offset16::RAW_BYTE_LEN;
+        let subtable_offsets_byte_len = (sub_table_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(subtable_offsets_byte_len);
         cursor.advance::<u16>();
         cursor.finish(LookupMarker {
@@ -953,7 +967,9 @@ impl<'a> FontRead<'a> for CoverageFormat1<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let glyph_count: u16 = cursor.read()?;
-        let glyph_array_byte_len = glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let glyph_array_byte_len = (glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_array_byte_len);
         cursor.finish(CoverageFormat1Marker {
             glyph_array_byte_len,
@@ -1037,7 +1053,9 @@ impl<'a> FontRead<'a> for CoverageFormat2<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let range_count: u16 = cursor.read()?;
-        let range_records_byte_len = range_count as usize * RangeRecord::RAW_BYTE_LEN;
+        let range_records_byte_len = (range_count as usize)
+            .checked_mul(RangeRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(range_records_byte_len);
         cursor.finish(CoverageFormat2Marker {
             range_records_byte_len,
@@ -1241,7 +1259,9 @@ impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<GlyphId>();
         let glyph_count: u16 = cursor.read()?;
-        let class_value_array_byte_len = glyph_count as usize * u16::RAW_BYTE_LEN;
+        let class_value_array_byte_len = (glyph_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_value_array_byte_len);
         cursor.finish(ClassDefFormat1Marker {
             class_value_array_byte_len,
@@ -1332,8 +1352,9 @@ impl<'a> FontRead<'a> for ClassDefFormat2<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let class_range_count: u16 = cursor.read()?;
-        let class_range_records_byte_len =
-            class_range_count as usize * ClassRangeRecord::RAW_BYTE_LEN;
+        let class_range_records_byte_len = (class_range_count as usize)
+            .checked_mul(ClassRangeRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_range_records_byte_len);
         cursor.finish(ClassDefFormat2Marker {
             class_range_records_byte_len,
@@ -1576,7 +1597,9 @@ impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let seq_rule_set_count: u16 = cursor.read()?;
-        let seq_rule_set_offsets_byte_len = seq_rule_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let seq_rule_set_offsets_byte_len = (seq_rule_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_rule_set_offsets_byte_len);
         cursor.finish(SequenceContextFormat1Marker {
             seq_rule_set_offsets_byte_len,
@@ -1689,7 +1712,9 @@ impl<'a> FontRead<'a> for SequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let seq_rule_count: u16 = cursor.read()?;
-        let seq_rule_offsets_byte_len = seq_rule_count as usize * Offset16::RAW_BYTE_LEN;
+        let seq_rule_offsets_byte_len = (seq_rule_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_rule_offsets_byte_len);
         cursor.finish(SequenceRuleSetMarker {
             seq_rule_offsets_byte_len,
@@ -1788,11 +1813,13 @@ impl<'a> FontRead<'a> for SequenceRule<'a> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
-        let input_sequence_byte_len =
-            transforms::subtract(glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
+        let input_sequence_byte_len = (transforms::subtract(glyph_count, 1_usize))
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(input_sequence_byte_len);
-        let seq_lookup_records_byte_len =
-            seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
         cursor.finish(SequenceRuleMarker {
             input_sequence_byte_len,
@@ -1901,8 +1928,9 @@ impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let class_seq_rule_set_count: u16 = cursor.read()?;
-        let class_seq_rule_set_offsets_byte_len =
-            class_seq_rule_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let class_seq_rule_set_offsets_byte_len = (class_seq_rule_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_seq_rule_set_offsets_byte_len);
         cursor.finish(SequenceContextFormat2Marker {
             class_seq_rule_set_offsets_byte_len,
@@ -2037,8 +2065,9 @@ impl<'a> FontRead<'a> for ClassSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let class_seq_rule_count: u16 = cursor.read()?;
-        let class_seq_rule_offsets_byte_len =
-            class_seq_rule_count as usize * Offset16::RAW_BYTE_LEN;
+        let class_seq_rule_offsets_byte_len = (class_seq_rule_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_seq_rule_offsets_byte_len);
         cursor.finish(ClassSequenceRuleSetMarker {
             class_seq_rule_offsets_byte_len,
@@ -2140,11 +2169,13 @@ impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
         let mut cursor = data.cursor();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
-        let input_sequence_byte_len =
-            transforms::subtract(glyph_count, 1_usize) * u16::RAW_BYTE_LEN;
+        let input_sequence_byte_len = (transforms::subtract(glyph_count, 1_usize))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(input_sequence_byte_len);
-        let seq_lookup_records_byte_len =
-            seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
         cursor.finish(ClassSequenceRuleMarker {
             input_sequence_byte_len,
@@ -2254,10 +2285,13 @@ impl<'a> FontRead<'a> for SequenceContextFormat3<'a> {
         cursor.advance::<u16>();
         let glyph_count: u16 = cursor.read()?;
         let seq_lookup_count: u16 = cursor.read()?;
-        let coverage_offsets_byte_len = glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let coverage_offsets_byte_len = (glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(coverage_offsets_byte_len);
-        let seq_lookup_records_byte_len =
-            seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
         cursor.finish(SequenceContextFormat3Marker {
             coverage_offsets_byte_len,
@@ -2447,8 +2481,9 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset16>();
         let chained_seq_rule_set_count: u16 = cursor.read()?;
-        let chained_seq_rule_set_offsets_byte_len =
-            chained_seq_rule_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let chained_seq_rule_set_offsets_byte_len = (chained_seq_rule_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(chained_seq_rule_set_offsets_byte_len);
         cursor.finish(ChainedSequenceContextFormat1Marker {
             chained_seq_rule_set_offsets_byte_len,
@@ -2566,8 +2601,9 @@ impl<'a> FontRead<'a> for ChainedSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let chained_seq_rule_count: u16 = cursor.read()?;
-        let chained_seq_rule_offsets_byte_len =
-            chained_seq_rule_count as usize * Offset16::RAW_BYTE_LEN;
+        let chained_seq_rule_offsets_byte_len = (chained_seq_rule_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(chained_seq_rule_offsets_byte_len);
         cursor.finish(ChainedSequenceRuleSetMarker {
             chained_seq_rule_offsets_byte_len,
@@ -2686,18 +2722,24 @@ impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_sequence_byte_len = backtrack_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let backtrack_sequence_byte_len = (backtrack_glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(backtrack_sequence_byte_len);
         let input_glyph_count: u16 = cursor.read()?;
-        let input_sequence_byte_len =
-            transforms::subtract(input_glyph_count, 1_usize) * GlyphId::RAW_BYTE_LEN;
+        let input_sequence_byte_len = (transforms::subtract(input_glyph_count, 1_usize))
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(input_sequence_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_sequence_byte_len = lookahead_glyph_count as usize * GlyphId::RAW_BYTE_LEN;
+        let lookahead_sequence_byte_len = (lookahead_glyph_count as usize)
+            .checked_mul(GlyphId::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookahead_sequence_byte_len);
         let seq_lookup_count: u16 = cursor.read()?;
-        let seq_lookup_records_byte_len =
-            seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
         cursor.finish(ChainedSequenceRuleMarker {
             backtrack_sequence_byte_len,
@@ -2852,8 +2894,10 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
         cursor.advance::<Offset16>();
         cursor.advance::<Offset16>();
         let chained_class_seq_rule_set_count: u16 = cursor.read()?;
-        let chained_class_seq_rule_set_offsets_byte_len =
-            chained_class_seq_rule_set_count as usize * Offset16::RAW_BYTE_LEN;
+        let chained_class_seq_rule_set_offsets_byte_len = (chained_class_seq_rule_set_count
+            as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(chained_class_seq_rule_set_offsets_byte_len);
         cursor.finish(ChainedSequenceContextFormat2Marker {
             chained_class_seq_rule_set_offsets_byte_len,
@@ -3028,8 +3072,9 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let chained_class_seq_rule_count: u16 = cursor.read()?;
-        let chained_class_seq_rule_offsets_byte_len =
-            chained_class_seq_rule_count as usize * Offset16::RAW_BYTE_LEN;
+        let chained_class_seq_rule_offsets_byte_len = (chained_class_seq_rule_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(chained_class_seq_rule_offsets_byte_len);
         cursor.finish(ChainedClassSequenceRuleSetMarker {
             chained_class_seq_rule_offsets_byte_len,
@@ -3150,18 +3195,24 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_sequence_byte_len = backtrack_glyph_count as usize * u16::RAW_BYTE_LEN;
+        let backtrack_sequence_byte_len = (backtrack_glyph_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(backtrack_sequence_byte_len);
         let input_glyph_count: u16 = cursor.read()?;
-        let input_sequence_byte_len =
-            transforms::subtract(input_glyph_count, 1_usize) * u16::RAW_BYTE_LEN;
+        let input_sequence_byte_len = (transforms::subtract(input_glyph_count, 1_usize))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(input_sequence_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_sequence_byte_len = lookahead_glyph_count as usize * u16::RAW_BYTE_LEN;
+        let lookahead_sequence_byte_len = (lookahead_glyph_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookahead_sequence_byte_len);
         let seq_lookup_count: u16 = cursor.read()?;
-        let seq_lookup_records_byte_len =
-            seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
         cursor.finish(ChainedClassSequenceRuleMarker {
             backtrack_sequence_byte_len,
@@ -3324,19 +3375,24 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat3<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_coverage_offsets_byte_len =
-            backtrack_glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let backtrack_coverage_offsets_byte_len = (backtrack_glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(backtrack_coverage_offsets_byte_len);
         let input_glyph_count: u16 = cursor.read()?;
-        let input_coverage_offsets_byte_len = input_glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let input_coverage_offsets_byte_len = (input_glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(input_coverage_offsets_byte_len);
         let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_coverage_offsets_byte_len =
-            lookahead_glyph_count as usize * Offset16::RAW_BYTE_LEN;
+        let lookahead_coverage_offsets_byte_len = (lookahead_glyph_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookahead_coverage_offsets_byte_len);
         let seq_lookup_count: u16 = cursor.read()?;
-        let seq_lookup_records_byte_len =
-            seq_lookup_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
         cursor.finish(ChainedSequenceContextFormat3Marker {
             backtrack_coverage_offsets_byte_len,
@@ -3651,8 +3707,9 @@ impl<'a> FontRead<'a> for Device<'a> {
         let start_size: u16 = cursor.read()?;
         let end_size: u16 = cursor.read()?;
         let delta_format: DeltaFormat = cursor.read()?;
-        let delta_value_byte_len =
-            DeltaFormat::value_count(delta_format, start_size, end_size) * u16::RAW_BYTE_LEN;
+        let delta_value_byte_len = (DeltaFormat::value_count(delta_format, start_size, end_size))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(delta_value_byte_len);
         cursor.finish(DeviceMarker {
             delta_value_byte_len,
@@ -3873,8 +3930,9 @@ impl<'a> FontRead<'a> for FeatureVariations<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<MajorMinor>();
         let feature_variation_record_count: u32 = cursor.read()?;
-        let feature_variation_records_byte_len =
-            feature_variation_record_count as usize * FeatureVariationRecord::RAW_BYTE_LEN;
+        let feature_variation_records_byte_len = (feature_variation_record_count as usize)
+            .checked_mul(FeatureVariationRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(feature_variation_records_byte_len);
         cursor.finish(FeatureVariationsMarker {
             feature_variation_records_byte_len,
@@ -4037,7 +4095,9 @@ impl<'a> FontRead<'a> for ConditionSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let condition_count: u16 = cursor.read()?;
-        let condition_offsets_byte_len = condition_count as usize * Offset32::RAW_BYTE_LEN;
+        let condition_offsets_byte_len = (condition_count as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
         cursor.finish(ConditionSetMarker {
             condition_offsets_byte_len,
@@ -4384,7 +4444,9 @@ impl<'a> FontRead<'a> for ConditionFormat3<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let condition_count: u8 = cursor.read()?;
-        let condition_offsets_byte_len = condition_count as usize * Offset24::RAW_BYTE_LEN;
+        let condition_offsets_byte_len = (condition_count as usize)
+            .checked_mul(Offset24::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
         cursor.finish(ConditionFormat3Marker {
             condition_offsets_byte_len,
@@ -4488,7 +4550,9 @@ impl<'a> FontRead<'a> for ConditionFormat4<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let condition_count: u8 = cursor.read()?;
-        let condition_offsets_byte_len = condition_count as usize * Offset24::RAW_BYTE_LEN;
+        let condition_offsets_byte_len = (condition_count as usize)
+            .checked_mul(Offset24::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
         cursor.finish(ConditionFormat4Marker {
             condition_offsets_byte_len,
@@ -4664,8 +4728,9 @@ impl<'a> FontRead<'a> for FeatureTableSubstitution<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<MajorMinor>();
         let substitution_count: u16 = cursor.read()?;
-        let substitutions_byte_len =
-            substitution_count as usize * FeatureTableSubstitutionRecord::RAW_BYTE_LEN;
+        let substitutions_byte_len = (substitution_count as usize)
+            .checked_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitutions_byte_len);
         cursor.finish(FeatureTableSubstitutionMarker {
             substitutions_byte_len,
@@ -5016,7 +5081,9 @@ impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
         cursor.advance::<u16>();
         cursor.advance::<NameId>();
         let char_count: u16 = cursor.read()?;
-        let character_byte_len = char_count as usize * Uint24::RAW_BYTE_LEN;
+        let character_byte_len = (char_count as usize)
+            .checked_mul(Uint24::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(character_byte_len);
         cursor.finish(CharacterVariantParamsMarker { character_byte_len })
     }

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -52,7 +52,9 @@ impl<'a> FontRead<'a> for Mvar<'a> {
         cursor.advance::<u16>();
         let value_record_count: u16 = cursor.read()?;
         cursor.advance::<Offset16>();
-        let value_records_byte_len = value_record_count as usize * ValueRecord::RAW_BYTE_LEN;
+        let value_records_byte_len = (value_record_count as usize)
+            .checked_mul(ValueRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(value_records_byte_len);
         cursor.finish(MvarMarker {
             value_records_byte_len,

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -557,7 +557,9 @@ impl<'a> FontRead<'a> for Os2<'a> {
         cursor.advance::<i16>();
         cursor.advance::<i16>();
         cursor.advance::<i16>();
-        let panose_10_byte_len = 10_usize * u8::RAW_BYTE_LEN;
+        let panose_10_byte_len = (10_usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(panose_10_byte_len);
         cursor.advance::<u32>();
         cursor.advance::<u32>();

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -97,9 +97,11 @@ impl<'a> FontRead<'a> for Post<'a> {
             .compatible((2u16, 0u16))
             .then(|| cursor.position())
             .transpose()?;
-        let glyph_name_index_byte_len = version
-            .compatible((2u16, 0u16))
-            .then_some(num_glyphs as usize * u16::RAW_BYTE_LEN);
+        let glyph_name_index_byte_len = version.compatible((2u16, 0u16)).then_some(
+            (num_glyphs as usize)
+                .checked_mul(u16::RAW_BYTE_LEN)
+                .ok_or(ReadError::OutOfBounds)?,
+        );
         if let Some(value) = glyph_name_index_byte_len {
             cursor.advance_by(value);
         }

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -37,8 +37,9 @@ impl<'a> FontRead<'a> for Index1<'a> {
         let mut cursor = data.cursor();
         let count: u16 = cursor.read()?;
         let off_size: u8 = cursor.read()?;
-        let offsets_byte_len =
-            transforms::add_multiply(count, 1_usize, off_size) * u8::RAW_BYTE_LEN;
+        let offsets_byte_len = (transforms::add_multiply(count, 1_usize, off_size))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(offsets_byte_len);
         let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
@@ -133,8 +134,9 @@ impl<'a> FontRead<'a> for Index2<'a> {
         let mut cursor = data.cursor();
         let count: u32 = cursor.read()?;
         let off_size: u8 = cursor.read()?;
-        let offsets_byte_len =
-            transforms::add_multiply(count, 1_usize, off_size) * u8::RAW_BYTE_LEN;
+        let offsets_byte_len = (transforms::add_multiply(count, 1_usize, off_size))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(offsets_byte_len);
         let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
@@ -361,7 +363,9 @@ impl<'a> FontRead<'a> for FdSelectFormat3<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u8>();
         let n_ranges: u16 = cursor.read()?;
-        let ranges_byte_len = n_ranges as usize * FdSelectRange3::RAW_BYTE_LEN;
+        let ranges_byte_len = (n_ranges as usize)
+            .checked_mul(FdSelectRange3::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ranges_byte_len);
         cursor.advance::<u16>();
         cursor.finish(FdSelectFormat3Marker { ranges_byte_len })
@@ -504,7 +508,9 @@ impl<'a> FontRead<'a> for FdSelectFormat4<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u8>();
         let n_ranges: u32 = cursor.read()?;
-        let ranges_byte_len = n_ranges as usize * FdSelectRange4::RAW_BYTE_LEN;
+        let ranges_byte_len = (n_ranges as usize)
+            .checked_mul(FdSelectRange4::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ranges_byte_len);
         cursor.advance::<u32>();
         cursor.finish(FdSelectFormat4Marker { ranges_byte_len })

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -356,7 +356,9 @@ impl<'a> FontReadWithArgs<'a> for Sbix<'a> {
         cursor.advance::<u16>();
         cursor.advance::<HeaderFlags>();
         let num_strikes: u32 = cursor.read()?;
-        let strike_offsets_byte_len = num_strikes as usize * Offset32::RAW_BYTE_LEN;
+        let strike_offsets_byte_len = (num_strikes as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(strike_offsets_byte_len);
         cursor.finish(SbixMarker {
             num_glyphs,
@@ -488,7 +490,9 @@ impl<'a> FontReadWithArgs<'a> for Strike<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        let glyph_data_offsets_byte_len = transforms::add(num_glyphs, 1_usize) * u32::RAW_BYTE_LEN;
+        let glyph_data_offsets_byte_len = (transforms::add(num_glyphs, 1_usize))
+            .checked_mul(u32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_data_offsets_byte_len);
         cursor.finish(StrikeMarker {
             glyph_data_offsets_byte_len,

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -265,7 +265,9 @@ impl<'a> FontReadWithArgs<'a> for AxisValueArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let axis_value_count = *args;
         let mut cursor = data.cursor();
-        let axis_value_offsets_byte_len = axis_value_count as usize * Offset16::RAW_BYTE_LEN;
+        let axis_value_offsets_byte_len = (axis_value_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(axis_value_offsets_byte_len);
         cursor.finish(AxisValueArrayMarker {
             axis_value_offsets_byte_len,
@@ -817,7 +819,9 @@ impl<'a> FontRead<'a> for AxisValueFormat4<'a> {
         let axis_count: u16 = cursor.read()?;
         cursor.advance::<AxisValueTableFlags>();
         cursor.advance::<NameId>();
-        let axis_values_byte_len = axis_count as usize * AxisValueRecord::RAW_BYTE_LEN;
+        let axis_values_byte_len = (axis_count as usize)
+            .checked_mul(AxisValueRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(axis_values_byte_len);
         cursor.finish(AxisValueFormat4Marker {
             axis_values_byte_len,

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -109,7 +109,9 @@ impl<'a> FontRead<'a> for Table2<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u16>();
         let value_count: u16 = cursor.read()?;
-        let values_byte_len = value_count as usize * u16::RAW_BYTE_LEN;
+        let values_byte_len = (value_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(values_byte_len);
         cursor.finish(Table2Marker { values_byte_len })
     }

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -305,17 +305,23 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets<'a> {
         let mut cursor = data.cursor();
         let version: MajorMinor = cursor.read()?;
         let count: u16 = cursor.read()?;
-        let nonnullable_offsets_byte_len = count as usize * Offset16::RAW_BYTE_LEN;
+        let nonnullable_offsets_byte_len = (count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(nonnullable_offsets_byte_len);
-        let nullable_offsets_byte_len = count as usize * Offset16::RAW_BYTE_LEN;
+        let nullable_offsets_byte_len = (count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(nullable_offsets_byte_len);
         let versioned_nonnullable_offsets_byte_start = version
             .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
-        let versioned_nonnullable_offsets_byte_len = version
-            .compatible((1u16, 1u16))
-            .then_some(count as usize * Offset16::RAW_BYTE_LEN);
+        let versioned_nonnullable_offsets_byte_len = version.compatible((1u16, 1u16)).then_some(
+            (count as usize)
+                .checked_mul(Offset16::RAW_BYTE_LEN)
+                .ok_or(ReadError::OutOfBounds)?,
+        );
         if let Some(value) = versioned_nonnullable_offsets_byte_len {
             cursor.advance_by(value);
         }
@@ -323,9 +329,11 @@ impl<'a> FontRead<'a> for KindsOfArraysOfOffsets<'a> {
             .compatible((1u16, 1u16))
             .then(|| cursor.position())
             .transpose()?;
-        let versioned_nullable_offsets_byte_len = version
-            .compatible((1u16, 1u16))
-            .then_some(count as usize * Offset16::RAW_BYTE_LEN);
+        let versioned_nullable_offsets_byte_len = version.compatible((1u16, 1u16)).then_some(
+            (count as usize)
+                .checked_mul(Offset16::RAW_BYTE_LEN)
+                .ok_or(ReadError::OutOfBounds)?,
+        );
         if let Some(value) = versioned_nullable_offsets_byte_len {
             cursor.advance_by(value);
         }
@@ -529,17 +537,23 @@ impl<'a> FontRead<'a> for KindsOfArrays<'a> {
         let mut cursor = data.cursor();
         let version: u16 = cursor.read()?;
         let count: u16 = cursor.read()?;
-        let scalars_byte_len = count as usize * u16::RAW_BYTE_LEN;
+        let scalars_byte_len = (count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(scalars_byte_len);
-        let records_byte_len = count as usize * Shmecord::RAW_BYTE_LEN;
+        let records_byte_len = (count as usize)
+            .checked_mul(Shmecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(records_byte_len);
         let versioned_scalars_byte_start = version
             .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        let versioned_scalars_byte_len = version
-            .compatible(1u16)
-            .then_some(count as usize * u16::RAW_BYTE_LEN);
+        let versioned_scalars_byte_len = version.compatible(1u16).then_some(
+            (count as usize)
+                .checked_mul(u16::RAW_BYTE_LEN)
+                .ok_or(ReadError::OutOfBounds)?,
+        );
         if let Some(value) = versioned_scalars_byte_len {
             cursor.advance_by(value);
         }
@@ -547,9 +561,11 @@ impl<'a> FontRead<'a> for KindsOfArrays<'a> {
             .compatible(1u16)
             .then(|| cursor.position())
             .transpose()?;
-        let versioned_records_byte_len = version
-            .compatible(1u16)
-            .then_some(count as usize * Shmecord::RAW_BYTE_LEN);
+        let versioned_records_byte_len = version.compatible(1u16).then_some(
+            (count as usize)
+                .checked_mul(Shmecord::RAW_BYTE_LEN)
+                .ok_or(ReadError::OutOfBounds)?,
+        );
         if let Some(value) = versioned_records_byte_len {
             cursor.advance_by(value);
         }

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -205,8 +205,9 @@ impl<'a> FontRead<'a> for MultiItemVariationStore<'a> {
         cursor.advance::<u16>();
         cursor.advance::<Offset32>();
         let variation_data_count: u16 = cursor.read()?;
-        let variation_data_offsets_byte_len =
-            variation_data_count as usize * Offset32::RAW_BYTE_LEN;
+        let variation_data_offsets_byte_len = (variation_data_count as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(variation_data_offsets_byte_len);
         cursor.finish(MultiItemVariationStoreMarker {
             variation_data_offsets_byte_len,
@@ -316,7 +317,9 @@ impl<'a> FontRead<'a> for SparseVariationRegionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let region_count: u16 = cursor.read()?;
-        let region_offsets_byte_len = region_count as usize * Offset32::RAW_BYTE_LEN;
+        let region_offsets_byte_len = (region_count as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(region_offsets_byte_len);
         cursor.finish(SparseVariationRegionListMarker {
             region_offsets_byte_len,
@@ -400,8 +403,9 @@ impl<'a> FontRead<'a> for SparseVariationRegion<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let region_axis_count: u16 = cursor.read()?;
-        let region_axis_offsets_byte_len =
-            region_axis_count as usize * SparseRegionAxisCoordinates::RAW_BYTE_LEN;
+        let region_axis_offsets_byte_len = (region_axis_count as usize)
+            .checked_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(region_axis_offsets_byte_len);
         cursor.finish(SparseVariationRegionMarker {
             region_axis_offsets_byte_len,
@@ -536,7 +540,9 @@ impl<'a> FontRead<'a> for MultiItemVariationData<'a> {
         let mut cursor = data.cursor();
         cursor.advance::<u8>();
         let region_index_count: u16 = cursor.read()?;
-        let region_indices_byte_len = region_index_count as usize * u16::RAW_BYTE_LEN;
+        let region_indices_byte_len = (region_index_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(region_indices_byte_len);
         let raw_delta_sets_byte_len =
             cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
@@ -616,7 +622,9 @@ impl<'a> FontRead<'a> for ConditionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let condition_count: u32 = cursor.read()?;
-        let condition_offsets_byte_len = condition_count as usize * Offset32::RAW_BYTE_LEN;
+        let condition_offsets_byte_len = (condition_count as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
         cursor.finish(ConditionListMarker {
             condition_offsets_byte_len,

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -37,10 +37,14 @@ impl<'a> FontReadWithArgs<'a> for Vmtx<'a> {
     fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
         let (number_of_long_ver_metrics, num_glyphs) = *args;
         let mut cursor = data.cursor();
-        let v_metrics_byte_len = number_of_long_ver_metrics as usize * LongMetric::RAW_BYTE_LEN;
+        let v_metrics_byte_len = (number_of_long_ver_metrics as usize)
+            .checked_mul(LongMetric::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(v_metrics_byte_len);
         let top_side_bearings_byte_len =
-            transforms::subtract(num_glyphs, number_of_long_ver_metrics) * i16::RAW_BYTE_LEN;
+            (transforms::subtract(num_glyphs, number_of_long_ver_metrics))
+                .checked_mul(i16::RAW_BYTE_LEN)
+                .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(top_side_bearings_byte_len);
         cursor.finish(VmtxMarker {
             v_metrics_byte_len,


### PR DESCRIPTION
following on from #966, this updates all of the codegen'd length calculations to use checked math.

So to the best of my understanding these overflows would only be possible on 32-bit architectures, so I'm not sure how best to test this? @drott added a test case in #969, but that test passes everywhere we run it. If we wanted to test this in CI we would need to either use a custom build machine, or _maybe_ we could have `wasm32` as a target? 
