### PR TITLE
Try to play nicer with the seed corpus

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,8 @@ release = false
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 skrifa = { path="../skrifa" }
+rand = "0.8"
+rand_chacha = "0.3"
 
 [[bin]]
 name = "fuzz_skrifa_charmap"

--- a/fuzz/fuzz_targets/fuzz_skrifa_outline.rs
+++ b/fuzz/fuzz_targets/fuzz_skrifa_outline.rs
@@ -1,10 +1,9 @@
 #![no_main]
 use std::{error::Error, fmt::Display};
 
-use libfuzzer_sys::{
-    arbitrary::{self, Arbitrary, Unstructured},
-    fuzz_target,
-};
+use libfuzzer_sys::fuzz_target;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 use skrifa::{
     instance::Size,
     outline::{DrawError, DrawSettings, HintingInstance, HintingMode, LcdLayout, OutlinePen},
@@ -37,50 +36,19 @@ impl OutlinePen for NopPen {
     }
 }
 
-/// Each entry represents a set of options for [HintingMode]
-///
-/// Exists to fulfill [Arbitrary]
-#[derive(Arbitrary, Debug)]
-enum FuzzerHintingMode {
-    Strong,
-    Smooth {
-        vertical_lcd: Option<bool>,
-        preserve_linear_metrics: bool,
-    },
-}
-
-impl From<FuzzerHintingMode> for HintingMode {
-    fn from(value: FuzzerHintingMode) -> Self {
-        match value {
-            FuzzerHintingMode::Strong => HintingMode::Strong,
-            FuzzerHintingMode::Smooth {
-                vertical_lcd,
-                preserve_linear_metrics,
-            } => HintingMode::Smooth {
-                lcd_subpixel: match vertical_lcd {
-                    None => None,
-                    Some(true) => Some(LcdLayout::Vertical),
-                    Some(false) => Some(LcdLayout::Horizontal),
-                },
-                preserve_linear_metrics,
-            },
-        }
-    }
-}
-
 /// Drawing glyph outlines is fun and flexible! Try to test lots of options.
 ///
 /// See
 /// * <https://rust-fuzz.github.io/book/cargo-fuzz/structure-aware-fuzzing.html>
 /// * <https://docs.rs/skrifa/latest/skrifa/outline/index.html>
-#[derive(Arbitrary, Debug)]
+#[derive(Default, Debug, Clone)]
 struct OutlineRequest {
     /// None => unscaled
     size: Option<f32>,
     axis_positions: Vec<f32>,
     hinted: bool,
     hinted_pedantic: bool,
-    hinting_mode: FuzzerHintingMode,
+    hinting_mode: HintingMode,
     with_memory: bool, // ~half tests should be with memory, half not
     memory_size: u16, // if we do test with_memory, how much of it? u16 to avoid asking for huge chunks.
     harfbuzz_pathstyle: bool,
@@ -119,13 +87,8 @@ fn do_glyf_things(outline_request: OutlineRequest, data: &[u8]) -> Result<(), Bo
     );
     let hinting_instance = if outline_request.hinted {
         Some(
-            HintingInstance::new(
-                &outlines,
-                size,
-                &location,
-                outline_request.hinting_mode.into(),
-            )
-            .map_err(DrawErrorWrapper)?,
+            HintingInstance::new(&outlines, size, &location, outline_request.hinting_mode)
+                .map_err(DrawErrorWrapper)?,
         )
     } else {
         None
@@ -154,11 +117,115 @@ fn do_glyf_things(outline_request: OutlineRequest, data: &[u8]) -> Result<(), Bo
     Ok(())
 }
 
+fn create_rng(data: &[u8]) -> ChaCha8Rng {
+    let mut seed = [0u8; 32];
+    for (i, entry) in seed.iter_mut().enumerate() {
+        *entry = data.get(i).copied().unwrap_or_default();
+    }
+    ChaCha8Rng::from_seed(seed)
+}
+
+fn hinting_modes(hinted: bool) -> Vec<HintingMode> {
+    if !hinted {
+        return vec![HintingMode::default()];
+    }
+    vec![
+        HintingMode::Strong,
+        HintingMode::Smooth {
+            lcd_subpixel: None,
+            preserve_linear_metrics: true,
+        },
+        HintingMode::Smooth {
+            lcd_subpixel: None,
+            preserve_linear_metrics: false,
+        },
+        HintingMode::Smooth {
+            lcd_subpixel: Some(LcdLayout::Horizontal),
+            preserve_linear_metrics: true,
+        },
+        HintingMode::Smooth {
+            lcd_subpixel: Some(LcdLayout::Horizontal),
+            preserve_linear_metrics: false,
+        },
+        HintingMode::Smooth {
+            lcd_subpixel: Some(LcdLayout::Vertical),
+            preserve_linear_metrics: true,
+        },
+        HintingMode::Smooth {
+            lcd_subpixel: Some(LcdLayout::Vertical),
+            preserve_linear_metrics: false,
+        },
+    ]
+}
+
 fuzz_target!(|data: &[u8]| {
-    let mut unstructured = Unstructured::new(data);
-    let Ok(outline_request) = unstructured.arbitrary() else {
-        return;
-    };
-    let data = unstructured.take_rest();
-    let _ = do_glyf_things(outline_request, data);
+    // data from corpus is likely to be a font. If we chope off the head to make an outline request
+    // it is likely data is no longer a font. So, take the cross product of likely values for various options
+    // If a lot of values are possible choose randomly with rng seeded from data to ensure reproducible results.
+    let mut rng = create_rng(data);
+    let random_position = (0..8)
+        .map(|_| rng.gen_range(-1000.0..1000.0))
+        .collect::<Vec<_>>();
+    let memory_sizes = vec![4096, 16384, rng.gen::<u16>(), rng.gen::<u16>()];
+
+    let mut requests = vec![OutlineRequest::default()];
+    requests = requests
+        .into_iter()
+        .flat_map(|r| {
+            [None, Some(64.0), Some(512.0)]
+                .into_iter()
+                .map(move |size| OutlineRequest { size, ..r.clone() })
+        })
+        .flat_map(|r| {
+            vec![
+                // default
+                (0..8).map(|_| 0.0).collect(),
+                // random
+                random_position.clone(),
+            ]
+            .into_iter()
+            .map(move |axis_positions| OutlineRequest {
+                axis_positions,
+                ..r.clone()
+            })
+        })
+        .flat_map(|r| {
+            [true, false].into_iter().map(move |hinted| OutlineRequest {
+                hinted,
+                ..r.clone()
+            })
+        })
+        .flat_map(|r| {
+            hinting_modes(r.hinted)
+                .into_iter()
+                .map(move |hinting_mode| OutlineRequest {
+                    hinting_mode,
+                    ..r.clone()
+                })
+        })
+        .flat_map(|r| {
+            [true, false]
+                .into_iter()
+                .map(move |with_memory| OutlineRequest {
+                    with_memory,
+                    ..r.clone()
+                })
+        })
+        .flat_map(|r| {
+            if r.with_memory {
+                memory_sizes.clone()
+            } else {
+                vec![0]
+            }
+            .into_iter()
+            .map(move |memory_size| OutlineRequest {
+                memory_size,
+                ..r.clone()
+            })
+        })
+        .collect();
+
+    for request in requests {
+        let _ = do_glyf_things(request, data);
+    }
 });

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -1,5 +1,6 @@
 //! raw font bytes
 
+#![deny(clippy::arithmetic_side_effects)]
 use std::ops::{Range, RangeBounds};
 
 use bytemuck::AnyBitPattern;
@@ -76,16 +77,22 @@ impl<'a> FontData<'a> {
 
     /// Read a scalar at the provided location in the data.
     pub fn read_at<T: Scalar>(&self, offset: usize) -> Result<T, ReadError> {
+        let end = offset
+            .checked_add(T::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         self.bytes
-            .get(offset..offset + T::RAW_BYTE_LEN)
+            .get(offset..end)
             .and_then(T::read)
             .ok_or(ReadError::OutOfBounds)
     }
 
     /// Read a big-endian value at the provided location in the data.
     pub fn read_be_at<T: Scalar>(&self, offset: usize) -> Result<BigEndian<T>, ReadError> {
+        let end = offset
+            .checked_add(T::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         self.bytes
-            .get(offset..offset + T::RAW_BYTE_LEN)
+            .get(offset..end)
             .and_then(BigEndian::from_slice)
             .ok_or(ReadError::OutOfBounds)
     }
@@ -123,8 +130,11 @@ impl<'a> FontData<'a> {
         &self,
         offset: usize,
     ) -> Result<&'a T, ReadError> {
+        let end = offset
+            .checked_add(T::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
         self.bytes
-            .get(offset..offset + T::RAW_BYTE_LEN)
+            .get(offset..end)
             .ok_or(ReadError::OutOfBounds)
             .map(bytemuck::from_bytes)
     }
@@ -151,7 +161,12 @@ impl<'a> FontData<'a> {
             .bytes
             .get(range.clone())
             .ok_or(ReadError::OutOfBounds)?;
-        if bytes.len() % std::mem::size_of::<T>() != 0 {
+        if bytes
+            .len()
+            .checked_rem(std::mem::size_of::<T>())
+            .unwrap_or(1) // definitely != 0
+            != 0
+        {
             return Err(ReadError::InvalidArrayLen);
         };
         Ok(bytemuck::cast_slice(bytes))
@@ -172,11 +187,11 @@ impl<'a> FontData<'a> {
 
 impl<'a> Cursor<'a> {
     pub(crate) fn advance<T: Scalar>(&mut self) {
-        self.pos += T::RAW_BYTE_LEN
+        self.pos = self.pos.saturating_add(T::RAW_BYTE_LEN);
     }
 
     pub(crate) fn advance_by(&mut self, n_bytes: usize) {
-        self.pos += n_bytes;
+        self.pos = self.pos.saturating_add(n_bytes);
     }
 
     /// Read a variable length u32 and advance the cursor
@@ -184,6 +199,7 @@ impl<'a> Cursor<'a> {
         let mut next = || self.read::<u8>().map(|v| v as u32);
         let b0 = next()?;
         // TODO this feels possible to simplify, e.g. compute length, loop taking one and shifting and or'ing
+        #[allow(clippy::arithmetic_side_effects)] // these are all checked
         let result = match b0 {
             _ if b0 < 0x80 => b0,
             _ if b0 < 0xC0 => (b0 - 0x80) << 8 | next()?,
@@ -201,14 +217,14 @@ impl<'a> Cursor<'a> {
     /// Read a scalar and advance the cursor.
     pub(crate) fn read<T: Scalar>(&mut self) -> Result<T, ReadError> {
         let temp = self.data.read_at(self.pos);
-        self.pos += T::RAW_BYTE_LEN;
+        self.advance::<T>();
         temp
     }
 
     /// Read a big-endian value and advance the cursor.
     pub(crate) fn read_be<T: Scalar>(&mut self) -> Result<BigEndian<T>, ReadError> {
         let temp = self.data.read_be_at(self.pos);
-        self.pos += T::RAW_BYTE_LEN;
+        self.advance::<T>();
         temp
     }
 
@@ -217,8 +233,9 @@ impl<'a> Cursor<'a> {
         T: FontReadWithArgs<'a> + ComputeSize,
     {
         let len = T::compute_size(args)?;
-        let temp = self.data.read_with_args(self.pos..self.pos + len, args);
-        self.pos += len;
+        let range_end = self.pos.checked_add(len).ok_or(ReadError::OutOfBounds)?;
+        let temp = self.data.read_with_args(self.pos..range_end, args);
+        self.advance_by(len);
         temp
     }
 
@@ -231,9 +248,12 @@ impl<'a> Cursor<'a> {
     where
         T: FontReadWithArgs<'a> + ComputeSize,
     {
-        let len = len * T::compute_size(args)?;
-        let temp = self.data.read_with_args(self.pos..self.pos + len, args);
-        self.pos += len;
+        let len = len
+            .checked_mul(T::compute_size(args)?)
+            .ok_or(ReadError::OutOfBounds)?;
+        let range_end = self.pos.checked_add(len).ok_or(ReadError::OutOfBounds)?;
+        let temp = self.data.read_with_args(self.pos..range_end, args);
+        self.advance_by(len);
         temp
     }
 
@@ -241,9 +261,12 @@ impl<'a> Cursor<'a> {
         &mut self,
         n_elem: usize,
     ) -> Result<&'a [T], ReadError> {
-        let len = n_elem * T::RAW_BYTE_LEN;
-        let temp = self.data.read_array(self.pos..self.pos + len);
-        self.pos += len;
+        let len = n_elem
+            .checked_mul(T::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        let end = self.pos.checked_add(len).ok_or(ReadError::OutOfBounds)?;
+        let temp = self.data.read_array(self.pos..end);
+        self.advance_by(len);
         temp
     }
 

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -1,5 +1,7 @@
 //! Traits for interpreting font data
 
+#![deny(clippy::arithmetic_side_effects)]
+
 use types::{FixedSize, Scalar, Tag};
 
 use crate::font_data::FontData;
@@ -90,7 +92,7 @@ pub trait VarSize {
     #[doc(hidden)]
     fn read_len_at(data: FontData, pos: usize) -> Option<usize> {
         let asu32 = data.read_at::<Self::Size>(pos).ok()?.into();
-        Some(asu32 as usize + Self::Size::RAW_BYTE_LEN)
+        (asu32 as usize).checked_add(Self::Size::RAW_BYTE_LEN)
     }
 }
 


### PR DESCRIPTION
The `data` provided to the fuzz target is likely to look like a font. If some fool cut the front off it would become unlikely to do so. I suspect this is why fuzzing outlines has near zero coverage:

![image](https://github.com/googlefonts/fontations/assets/6466432/4b756e55-e808-49e9-ab9e-9be9f30595cd)

https://storage.googleapis.com/oss-fuzz-coverage/fontations/reports/20240625/linux/src/fontations/skrifa/src/outline/report.html.

What if instead we try a crossproduct of likely and random options against the fuzzer provided data?

Contributes to #420.

JMM if happy