### PR TITLE
[int-set] Optimize the sparse set decoding operation.

### DIFF
--- a/int-set/src/input_bit_stream.rs
+++ b/int-set/src/input_bit_stream.rs
@@ -46,7 +46,7 @@ impl<'a, const BF: u8> InputBitStream<'a, BF> {
     ///
     /// See: <https://w3c.github.io/IFT/Overview.html#sparse-bit-set-decoding>
     /// Returns None if the stream does not have enough remaining bits.
-    #[allow(clippy::unusual_byte_groupings)]
+    #[allow(clippy::unusual_byte_groupings)] // Used to separate bit values into units used in the set encoding.
     pub(crate) fn decode_header(data: &'a [u8]) -> Option<(BranchFactor, u8)> {
         let first_byte = data.first()?;
         let bf_bits = 0b0_00000_11 & first_byte;

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -883,7 +883,7 @@ mod test {
 
     #[test]
     fn from_iterator() {
-        let s: IntSet<u32> = [3, 8, 12, 589].iter().copied().collect();
+        let s: IntSet<u32> = [3, 8, 12, 589].into_iter().collect();
         let mut expected = IntSet::<u32>::empty();
         expected.insert(3);
         expected.insert(8);
@@ -895,7 +895,7 @@ mod test {
 
     #[test]
     fn from_int_set_iterator() {
-        let s1: IntSet<u32> = [3, 8, 12, 589].iter().copied().collect();
+        let s1: IntSet<u32> = [3, 8, 12, 589].into_iter().collect();
         let s2: IntSet<u32> = s1.iter().collect();
         assert_eq!(s1, s2);
     }
@@ -903,8 +903,8 @@ mod test {
     #[test]
     fn extend() {
         let mut s = IntSet::<u32>::empty();
-        s.extend([3, 12].iter().copied());
-        s.extend([8, 10, 589].iter().copied());
+        s.extend([3, 12]);
+        s.extend([8, 10, 589]);
 
         let mut expected = IntSet::<u32>::empty();
         expected.insert(3);
@@ -923,7 +923,7 @@ mod test {
             s.remove(i);
         }
 
-        s.extend([12, 17, 18].iter().copied());
+        s.extend([12, 17, 18]);
 
         assert!(!s.contains(11));
         assert!(s.contains(12));

--- a/int-set/src/sparse_bit_set.rs
+++ b/int-set/src/sparse_bit_set.rs
@@ -68,9 +68,7 @@ impl IntSet<u32> {
         queue.push_back(NextNode { start: 0, depth: 1 });
 
         while let Some(next) = queue.pop_front() {
-            let Some(mut bits) = bits.next() else {
-                return Err(DecodingError);
-            };
+            let mut bits = bits.next().ok_or(DecodingError)?;
 
             if bits == 0 {
                 // all bits were zeroes which is a special command to completely fill in


### PR DESCRIPTION
- Switch to reading and processing a node at a time instead of bit by bit.
- Using count trailing zeroes to find the '1' bits instead of checking all bits.
- Make branch factor during decode a compile time constant to allow the compiler to generate specialized versions for each of the four branch factors.

Yields a ~45% speedup versus the previous implementation.

