### PR TITLE
[int-set] Add a iter_ranges() method to int set

### DIFF
--- a/int-set/src/bitpage.rs
+++ b/int-set/src/bitpage.rs
@@ -65,7 +65,7 @@ impl BitPage {
     }
 
     /// Iterator over the ranges in this page.
-    pub(crate) fn iter_ranges(&self) -> impl Iterator<Item = RangeInclusive<u32>> + '_ {
+    pub(crate) fn iter_ranges(&self) -> RangeIter<'_> {
         return RangeIter {
             page: self,
             next_value_to_check: 0,
@@ -245,7 +245,7 @@ impl DoubleEndedIterator for Iter {
     }
 }
 
-struct RangeIter<'a> {
+pub(crate) struct RangeIter<'a> {
     page: &'a BitPage,
     next_value_to_check: u32,
 }

--- a/int-set/src/bitpage.rs
+++ b/int-set/src/bitpage.rs
@@ -1,6 +1,6 @@
 //! Stores a page of bits, used inside of bitset's.
 
-use std::{cell::Cell, hash::Hash};
+use std::{cell::Cell, hash::Hash, ops::RangeInclusive};
 
 // the integer type underlying our bit set
 type Element = u64;
@@ -62,6 +62,14 @@ impl BitPage {
                 let base = i as u32 * ELEM_BITS;
                 Iter::new(*elem).map(move |idx| base + idx)
             })
+    }
+
+    /// Iterator over the ranges in this page.
+    pub(crate) fn iter_ranges(&self) -> impl Iterator<Item = RangeInclusive<u32>> + '_ {
+        return RangeIter {
+            page: self,
+            next_value_to_check: 0,
+        };
     }
 
     /// Marks (val % page width) a member of this set and returns true if it is newly added.
@@ -234,6 +242,71 @@ impl DoubleEndedIterator for Iter {
         }
         self.backward_index = next_index - 1;
         Some(next_index as u32)
+    }
+}
+
+struct RangeIter<'a> {
+    page: &'a BitPage,
+    next_value_to_check: u32,
+}
+
+impl<'a> RangeIter<'a> {
+    fn next_range_in_element(&self) -> Option<RangeInclusive<u32>> {
+        if self.next_value_to_check >= PAGE_BITS {
+            return None;
+        }
+
+        let element = self.page.element(self.next_value_to_check);
+        let element_bit = (self.next_value_to_check & ELEM_MASK) as u64;
+        let major = self.next_value_to_check & !ELEM_MASK;
+
+        let mask = !((1 << element_bit) - 1);
+        let range_start = (element & mask).trailing_zeros();
+        if range_start == ELEM_BITS {
+            // There's no remaining values in this element.
+            return None;
+        }
+
+        let mask = (1 << range_start) - 1;
+        let range_end = (element | mask).trailing_ones() - 1;
+
+        Some((major + range_start)..=(major + range_end))
+    }
+}
+
+impl<'a> Iterator for RangeIter<'a> {
+    type Item = RangeInclusive<u32>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut current_range = self.next_range_in_element();
+        loop {
+            let element_end = (self.next_value_to_check & !ELEM_MASK) + ELEM_BITS - 1;
+            let Some(range) = current_range.clone() else {
+                // No more ranges in the current element, move to the next one.
+                self.next_value_to_check = element_end + 1;
+                if self.next_value_to_check < PAGE_BITS {
+                    current_range = self.next_range_in_element();
+                    continue;
+                } else {
+                    return None;
+                }
+            };
+
+            self.next_value_to_check = range.end() + 1;
+            if *range.end() == element_end {
+                let continuation = self.next_range_in_element();
+                if let Some(continuation) = continuation {
+                    if *continuation.start() == element_end + 1 {
+                        current_range = Some(*range.start()..=*continuation.end());
+                        continue;
+                    }
+                }
+            }
+
+            break;
+        }
+
+        return current_range;
     }
 }
 
@@ -493,6 +566,41 @@ mod test {
 
         let items: Vec<_> = page.iter().collect();
         assert_eq!(items, vec![0, 12, 13, 23, 63, 64, 78, 400, 511,])
+    }
+
+    fn check_iter_ranges(ranges: Vec<RangeInclusive<u32>>) {
+        let mut page = BitPage::new_zeroes();
+        for range in ranges.iter() {
+            page.insert_range(*range.start(), *range.end());
+        }
+        let items: Vec<_> = page.iter_ranges().collect();
+        assert_eq!(items, ranges);
+    }
+
+    #[test]
+    fn iter_ranges() {
+        // basic
+        check_iter_ranges(vec![]);
+        check_iter_ranges(vec![0..=5]);
+        check_iter_ranges(vec![0..=0, 5..=5, 10..=10]);
+        check_iter_ranges(vec![0..=5, 12..=31]);
+        check_iter_ranges(vec![12..=31]);
+        check_iter_ranges(vec![71..=84]);
+        check_iter_ranges(vec![273..=284]);
+        check_iter_ranges(vec![0..=511]);
+
+        // end of boundary
+        check_iter_ranges(vec![511..=511]);
+        check_iter_ranges(vec![500..=511]);
+        check_iter_ranges(vec![400..=511]);
+        check_iter_ranges(vec![0..=511]);
+
+        // continutation ranges
+        check_iter_ranges(vec![64..=127]);
+        check_iter_ranges(vec![64..=127, 129..=135]);
+        check_iter_ranges(vec![64..=135]);
+        check_iter_ranges(vec![71..=135]);
+        check_iter_ranges(vec![71..=435]);
     }
 
     #[test]

--- a/int-set/src/bitpage.rs
+++ b/int-set/src/bitpage.rs
@@ -66,10 +66,10 @@ impl BitPage {
 
     /// Iterator over the ranges in this page.
     pub(crate) fn iter_ranges(&self) -> RangeIter<'_> {
-        return RangeIter {
+        RangeIter {
             page: self,
             next_value_to_check: 0,
-        };
+        }
     }
 
     /// Marks (val % page width) a member of this set and returns true if it is newly added.
@@ -306,7 +306,7 @@ impl<'a> Iterator for RangeIter<'a> {
             break;
         }
 
-        return current_range;
+        current_range
     }
 }
 

--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -610,9 +610,7 @@ impl<'a> Iterator for BitSetRangeIter<'a> {
     type Item = RangeInclusive<u32>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.page_iter.is_none() {
-            return None;
-        }
+        self.page_iter.as_ref()?;
 
         let mut current_range = self.next_range();
         loop {

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -1105,11 +1105,25 @@ mod test {
     #[test]
     fn iter_ranges_inclusive() {
         let mut set = IntSet::<u32>::empty();
+        let items: Vec<_> = set.iter_ranges().collect();
+        assert_eq!(items, vec![]);
+
         set.insert_range(200..=700);
         set.insert(5);
-
         let items: Vec<_> = set.iter_ranges().collect();
         assert_eq!(items, vec![5..=5, 200..=700]);
+
+        let mut set = IntSet::<u32>::empty();
+        set.insert_range(0..=0);
+        set.insert_range(u32::MAX..=u32::MAX);
+        let items: Vec<_> = set.iter_ranges().collect();
+        assert_eq!(items, vec![0..=0, u32::MAX..=u32::MAX]);
+
+        let mut set = IntSet::<u32>::empty();
+        set.insert_range(0..=5);
+        set.insert_range(u32::MAX - 5..=u32::MAX);
+        let items: Vec<_> = set.iter_ranges().collect();
+        assert_eq!(items, vec![0..=5, u32::MAX - 5..=u32::MAX]);
     }
 
     #[test]
@@ -1144,6 +1158,10 @@ mod test {
         set.remove_range(1..=u16::MAX);
         let items: Vec<_> = set.iter_ranges().collect();
         assert_eq!(items, vec![0..=0]);
+
+        let set = IntSet::<u32>::all();
+        let items: Vec<_> = set.iter_ranges().collect();
+        assert_eq!(items, vec![0..=u32::MAX]);
     }
 
     #[test]

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -109,7 +109,7 @@ impl<T: Domain<T>> IntSet<T> {
     // - Intersects range and intersects iter.
     // - min()/max()
 
-    /// Returns an iterator over all members of the set.
+    /// Returns an iterator over all members of the set in sorted ascending order.
     ///
     /// Note: iteration of inverted sets can be extremely slow due to the very large number of members in the set
     /// care should be taken when using .iter() in combination with an inverted set.
@@ -121,6 +121,7 @@ impl<T: Domain<T>> IntSet<T> {
         u32_iter.map(|v| T::from_u32(InDomain(v)))
     }
 
+    /// Returns an iterator over all disjoint ranges of values within the set in sorted ascending order.
     pub fn iter_ranges(&self) -> impl Iterator<Item = RangeInclusive<T>> + '_ {
         let u32_iter = match &self.0 {
             Membership::Inclusive(s) => RangeIter::Inclusive {


### PR DESCRIPTION
Provides an iterator which iterates over ranges present in the set. Uses a specialized implementation where possible to quickly locate ranges in the underlying bit sets.