### PR TITLE
[int-set] Optimize set building time during sparse set decoding.

### DIFF
--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -489,22 +489,45 @@ impl BitSet {
 
 impl Extend<u32> for BitSet {
     fn extend<U: IntoIterator<Item = u32>>(&mut self, iter: U) {
+        let mut builder = BitSetBuilder::start(self);
+        for val in iter {
+            builder.insert(val);
+        }
+        builder.finish();
+    }
+}
+
+pub(crate) struct BitSetBuilder<'a> {
+    pub(crate) set: &'a mut BitSet,
+    last_page_index: usize,
+    last_major_value: u32,
+}
+
+impl<'a> BitSetBuilder<'a> {
+    pub(crate) fn start(set: &'a mut BitSet) -> BitSetBuilder {
+        BitSetBuilder {
+            set,
+            last_page_index: usize::MAX,
+            last_major_value: u32::MAX,
+        }
+    }
+
+    pub(crate) fn insert(&mut self, val: u32) {
         // TODO(garretrieger): additional optimization ideas:
         // - Assuming data is sorted accumulate a single element mask and only commit it to the element
         //   once the next value passes the end of the element.
-        let mut last_page_index = usize::MAX;
-        let mut last_major_value = u32::MAX;
-        for val in iter {
-            let major_value = self.get_major_value(val);
-            if major_value != last_major_value {
-                last_page_index = self.ensure_page_index_for_major(major_value);
-                last_major_value = major_value;
-            };
-            if let Some(page) = self.pages.get_mut(last_page_index) {
-                page.insert_no_return(val);
-            }
+        let major_value = self.set.get_major_value(val);
+        if major_value != self.last_major_value {
+            self.last_page_index = self.set.ensure_page_index_for_major(major_value);
+            self.last_major_value = major_value;
+        };
+        if let Some(page) = self.set.pages.get_mut(self.last_page_index) {
+            page.insert_no_return(val);
         }
-        self.mark_dirty();
+    }
+
+    pub(crate) fn finish(&mut self) {
+        self.set.mark_dirty();
     }
 }
 

--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -497,6 +497,10 @@ impl Extend<u32> for BitSet {
     }
 }
 
+/// This helper is used to construct BitSet's from a stream of possibly sorted values.
+/// It remembers the last page index to reduce the amount of page lookups needed when inserting
+/// sorted data. If given unsorted values it will still work correctly, but may be slower then just
+/// repeatedly calling insert() on the bitset.
 pub(crate) struct BitSetBuilder<'a> {
     pub(crate) set: &'a mut BitSet,
     last_page_index: usize,

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -239,6 +239,12 @@ impl<T: Domain<T>> IntSet<T> {
     }
 }
 
+impl IntSet<u32> {
+    pub(crate) fn from_bitset(set: BitSet) -> IntSet<u32> {
+        IntSet(Membership::Inclusive(set), PhantomData::<u32>)
+    }
+}
+
 impl<T> IntSet<T> {
     /// Create a new empty set (inclusive).
     pub fn empty() -> IntSet<T> {

--- a/int-set/src/sparse_bit_set.rs
+++ b/int-set/src/sparse_bit_set.rs
@@ -54,7 +54,7 @@ impl IntSet<u32> {
             BranchFactor::ThirtyTwo => Self::decode_sparse_bit_set_nodes::<32>(data, height),
         };
 
-        result.map(|set| IntSet::<u32>::from_bitset(set))
+        result.map(IntSet::<u32>::from_bitset)
     }
 
     fn decode_sparse_bit_set_nodes<const BF: u8>(


### PR DESCRIPTION
- Make specialized sorted insert available and use it during the decoding operation.
- Results in speedups up to 60% for the decoding of large sets (32k elements).