### PR TITLE
Use explicit features for `serde`, `bytemuck`, `dot2`

### DIFF
--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -10,6 +10,8 @@ categories = ["text-processing"]
 
 [features]
 std = []
+bytemuck = ["dep:bytemuck"]
+serde = ["dep:serde"]
 
 [dependencies]
 # note: bytemuck version must be available in all deployment environments

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 default = []
 read = []
+dot2 = ["dep:dot2"]
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]


### PR DESCRIPTION
Provide explicit features for optional dependencies rather than implicit ones. This is slated to be required in Rust 2024 Edition.