### PR TITLE
[int-set] Add iter_after() and intersects(range) to IntSet

### DIFF
--- a/int-set/src/bitpage.rs
+++ b/int-set/src/bitpage.rs
@@ -64,6 +64,26 @@ impl BitPage {
             })
     }
 
+    /// Iterator over the members of this page that come after 'value'.
+    pub(crate) fn iter_after(&self, value: u32) -> impl DoubleEndedIterator<Item = u32> + '_ {
+        let start_index = self.element_index(value);
+        self.storage[start_index..]
+            .iter()
+            .enumerate()
+            .filter(|(_, elem)| **elem != 0)
+            .flat_map(move |(i, elem)| {
+                let i = i + start_index;
+                let base = i as u32 * ELEM_BITS;
+                let index_in_elem = value & ELEM_MASK;
+                let it = if start_index == i {
+                    Iter::from(*elem, index_in_elem + 1)
+                } else {
+                    Iter::new(*elem)
+                };
+                it.map(move |idx| base + idx)
+            })
+    }
+
     /// Iterator over the ranges in this page.
     pub(crate) fn iter_ranges(&self) -> RangeIter<'_> {
         RangeIter {
@@ -176,13 +196,15 @@ impl BitPage {
     }
 
     fn element(&self, value: u32) -> &Element {
-        let idx = (value & PAGE_MASK) / ELEM_BITS;
-        &self.storage[idx as usize]
+        &self.storage[self.element_index(value) as usize]
     }
 
     fn element_mut(&mut self, value: u32) -> &mut Element {
-        let idx = (value & PAGE_MASK) / ELEM_BITS;
-        &mut self.storage[idx as usize]
+        &mut self.storage[self.element_index(value) as usize]
+    }
+
+    fn element_index(&self, value: u32) -> usize {
+        (value as usize & PAGE_MASK as usize) / (ELEM_BITS as usize)
     }
 }
 
@@ -202,6 +224,17 @@ impl Iter {
         Iter {
             val: elem,
             forward_index: 0,
+            backward_index: ELEM_BITS as i32 - 1,
+        }
+    }
+
+    /// Construct an iterator that starts at 'index'
+    ///
+    /// Specifically if 'index' bit is set it will be returned on the first call to next().
+    fn from(elem: Element, index: u32) -> Iter {
+        Iter {
+            val: elem,
+            forward_index: index,
             backward_index: ELEM_BITS as i32 - 1,
         }
     }
@@ -566,6 +599,94 @@ mod test {
 
         let items: Vec<_> = page.iter().collect();
         assert_eq!(items, vec![0, 12, 13, 23, 63, 64, 78, 400, 511,])
+    }
+
+    #[test]
+    fn page_iter_after() {
+        let mut page = BitPage::new_zeroes();
+        let items: Vec<_> = page.iter_after(0).collect();
+        assert_eq!(items, vec![]);
+        let items: Vec<_> = page.iter_after(256).collect();
+        assert_eq!(items, vec![]);
+
+        page.insert(1);
+        page.insert(12);
+        page.insert(13);
+        page.insert(63);
+        page.insert(64);
+        page.insert(511);
+        page.insert(23);
+        page.insert(400);
+        page.insert(78);
+
+        let items: Vec<_> = page.iter_after(0).collect();
+        assert_eq!(items, vec![1, 12, 13, 23, 63, 64, 78, 400, 511,]);
+
+        page.insert(0);
+        let items: Vec<_> = page.iter_after(0).collect();
+        assert_eq!(items, vec![1, 12, 13, 23, 63, 64, 78, 400, 511,]);
+
+        let items: Vec<_> = page.iter_after(1).collect();
+        assert_eq!(items, vec![12, 13, 23, 63, 64, 78, 400, 511,]);
+
+        let items: Vec<_> = page.iter_after(63).collect();
+        assert_eq!(items, vec![64, 78, 400, 511,]);
+
+        let items: Vec<_> = page.iter_after(256).collect();
+        assert_eq!(items, vec![400, 511]);
+
+        let items: Vec<_> = page.iter_after(511).collect();
+        assert_eq!(items, vec![]);
+
+        let items: Vec<_> = page.iter_after(390).collect();
+        assert_eq!(items, vec![400, 511]);
+
+        let items: Vec<_> = page.iter_after(400).collect();
+        assert_eq!(items, vec![511]);
+    }
+
+    #[test]
+    fn page_iter_after_rev() {
+        let mut page = BitPage::new_zeroes();
+        let items: Vec<_> = page.iter_after(0).collect();
+        assert_eq!(items, vec![]);
+        let items: Vec<_> = page.iter_after(256).collect();
+        assert_eq!(items, vec![]);
+
+        page.insert(1);
+        page.insert(12);
+        page.insert(13);
+        page.insert(63);
+        page.insert(64);
+        page.insert(511);
+        page.insert(23);
+        page.insert(400);
+        page.insert(78);
+
+        let items: Vec<_> = page.iter_after(0).rev().collect();
+        assert_eq!(items, vec![511, 400, 78, 64, 63, 23, 13, 12, 1]);
+
+        page.insert(0);
+        let items: Vec<_> = page.iter_after(0).rev().collect();
+        assert_eq!(items, vec![511, 400, 78, 64, 63, 23, 13, 12, 1]);
+
+        let items: Vec<_> = page.iter_after(1).rev().collect();
+        assert_eq!(items, vec![511, 400, 78, 64, 63, 23, 13, 12,]);
+
+        let items: Vec<_> = page.iter_after(63).rev().collect();
+        assert_eq!(items, vec![511, 400, 78, 64,]);
+
+        let items: Vec<_> = page.iter_after(256).rev().collect();
+        assert_eq!(items, vec![511, 400]);
+
+        let items: Vec<_> = page.iter_after(511).rev().collect();
+        assert_eq!(items, vec![]);
+
+        let items: Vec<_> = page.iter_after(390).rev().collect();
+        assert_eq!(items, vec![511, 400]);
+
+        let items: Vec<_> = page.iter_after(400).rev().collect();
+        assert_eq!(items, vec![511]);
     }
 
     fn check_iter_ranges(ranges: Vec<RangeInclusive<u32>>) {

--- a/int-set/src/bitpage.rs
+++ b/int-set/src/bitpage.rs
@@ -196,11 +196,11 @@ impl BitPage {
     }
 
     fn element(&self, value: u32) -> &Element {
-        &self.storage[self.element_index(value) as usize]
+        &self.storage[self.element_index(value)]
     }
 
     fn element_mut(&mut self, value: u32) -> &mut Element {
-        &mut self.storage[self.element_index(value) as usize]
+        &mut self.storage[self.element_index(value)]
     }
 
     fn element_index(&self, value: u32) -> usize {

--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -167,8 +167,19 @@ impl BitSet {
     }
 
     pub(crate) fn intersects(&mut self, range: RangeInclusive<u32>) -> bool {
-        // TODO: use iter_after and check for existence of a value in 'range'.
-        todo!()
+        let start = range.start().checked_sub(1);
+        let next = if let Some(start) = start {
+            self.iter_after(start).next()
+        } else {
+            self.iter().next()
+        };
+
+        let Some(next) = next else {
+            return false;
+        };
+
+        // If next is <= end then there is at least one value in the input range.
+        return next <= *range.end();
     }
 
     /// Sets the members of this set to self - other.
@@ -1047,6 +1058,28 @@ mod test {
         check_process([1, 1000, 2000], [1000], [1000], |a, b| a.intersect(b));
         check_process([1000], [1, 1000, 2000], [1000], |a, b| a.intersect(b));
         check_process([1, 1000, 2000], [1000, 5000], [1000], |a, b| a.intersect(b));
+    }
+
+    #[test]
+    fn intersects_range() {
+        let mut bitset = BitSet::empty();
+        assert!(!bitset.intersects(0..=0));
+        assert!(!bitset.intersects(0..=100));
+        assert!(!bitset.intersects(0..=u32::MAX));
+        assert!(!bitset.intersects(u32::MAX..=u32::MAX));
+
+        bitset.insert(1234);
+        assert!(!bitset.intersects(0..=1233));
+        assert!(!bitset.intersects(1235..=1240));
+
+        assert!(bitset.intersects(1234..=1234));
+        assert!(bitset.intersects(1230..=1240));
+        assert!(bitset.intersects(0..=1234));
+        assert!(bitset.intersects(1234..=u32::MAX));
+
+        bitset.insert(0);
+        assert!(bitset.intersects(0..=0));
+        assert!(!bitset.intersects(1..=1));
     }
 
     #[test]

--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -886,6 +886,13 @@ mod test {
             bitset.iter_after(u32::MAX - 1).collect::<Vec<u32>>(),
             vec![u32::MAX]
         );
+
+        let mut bitset = BitSet::empty();
+        bitset.extend([510, 511, 512]);
+
+        assert_eq!(bitset.iter_after(510).collect::<Vec<u32>>(), vec![511, 512]);
+        assert_eq!(bitset.iter_after(511).collect::<Vec<u32>>(), vec![512]);
+        assert_eq!(bitset.iter_after(512).collect::<Vec<u32>>(), vec![]);
     }
 
     #[test]

--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -166,22 +166,6 @@ impl BitSet {
         self.process(BitPage::intersect, other);
     }
 
-    pub(crate) fn intersects(&mut self, range: RangeInclusive<u32>) -> bool {
-        let start = range.start().checked_sub(1);
-        let next = if let Some(start) = start {
-            self.iter_after(start).next()
-        } else {
-            self.iter().next()
-        };
-
-        let Some(next) = next else {
-            return false;
-        };
-
-        // If next is <= end then there is at least one value in the input range.
-        return next <= *range.end();
-    }
-
     /// Sets the members of this set to self - other.
     pub(crate) fn subtract(&mut self, other: &BitSet) {
         self.process(BitPage::subtract, other);
@@ -1058,28 +1042,6 @@ mod test {
         check_process([1, 1000, 2000], [1000], [1000], |a, b| a.intersect(b));
         check_process([1000], [1, 1000, 2000], [1000], |a, b| a.intersect(b));
         check_process([1, 1000, 2000], [1000, 5000], [1000], |a, b| a.intersect(b));
-    }
-
-    #[test]
-    fn intersects_range() {
-        let mut bitset = BitSet::empty();
-        assert!(!bitset.intersects(0..=0));
-        assert!(!bitset.intersects(0..=100));
-        assert!(!bitset.intersects(0..=u32::MAX));
-        assert!(!bitset.intersects(u32::MAX..=u32::MAX));
-
-        bitset.insert(1234);
-        assert!(!bitset.intersects(0..=1233));
-        assert!(!bitset.intersects(1235..=1240));
-
-        assert!(bitset.intersects(1234..=1234));
-        assert!(bitset.intersects(1230..=1240));
-        assert!(bitset.intersects(0..=1234));
-        assert!(bitset.intersects(1234..=u32::MAX));
-
-        bitset.insert(0);
-        assert!(bitset.intersects(0..=0));
-        assert!(!bitset.intersects(1..=1));
     }
 
     #[test]

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -114,11 +114,11 @@ impl<T: Domain<T>> IntSet<T> {
         u32_iter.map(|v| T::from_u32(InDomain(v)))
     }
 
-    /// Returns and iterator over the members of this set that come after 'value' in ascending order.
+    /// Returns an iterator over the members of this set that come after 'value' in ascending order.
     ///
     /// Note: iteration of inverted sets can be extremely slow due to the very large number of members in the set
     /// care should be taken when using .iter() in combination with an inverted set.
-    pub(crate) fn iter_after(&self, value: T) -> impl Iterator<Item = T> + '_ {
+    pub fn iter_after(&self, value: T) -> impl Iterator<Item = T> + '_ {
         let u32_iter = match &self.0 {
             Membership::Inclusive(s) => IterAfter::new(s.iter_after(value.to_u32()), None),
             Membership::Exclusive(s) => {
@@ -273,7 +273,7 @@ impl<T: Domain<T>> IntSet<T> {
     }
 
     /// Returns true if this set contains at least one element in 'range'.
-    pub fn intersects(&mut self, range: RangeInclusive<T>) -> bool {
+    pub fn intersects_range(&mut self, range: RangeInclusive<T>) -> bool {
         let domain_min = T::ordered_values()
             .next()
             .map(|v_u32| T::from_u32(InDomain(v_u32)));
@@ -1900,100 +1900,100 @@ mod test {
     #[test]
     fn intersects_range() {
         let mut set = IntSet::<u32>::empty();
-        assert!(!set.intersects(0..=0));
-        assert!(!set.intersects(0..=100));
-        assert!(!set.intersects(0..=u32::MAX));
-        assert!(!set.intersects(u32::MAX..=u32::MAX));
+        assert!(!set.intersects_range(0..=0));
+        assert!(!set.intersects_range(0..=100));
+        assert!(!set.intersects_range(0..=u32::MAX));
+        assert!(!set.intersects_range(u32::MAX..=u32::MAX));
 
         set.insert(1234);
-        assert!(!set.intersects(0..=1233));
-        assert!(!set.intersects(1235..=1240));
+        assert!(!set.intersects_range(0..=1233));
+        assert!(!set.intersects_range(1235..=1240));
 
-        assert!(set.intersects(1234..=1234));
-        assert!(set.intersects(1230..=1240));
-        assert!(set.intersects(0..=1234));
-        assert!(set.intersects(1234..=u32::MAX));
+        assert!(set.intersects_range(1234..=1234));
+        assert!(set.intersects_range(1230..=1240));
+        assert!(set.intersects_range(0..=1234));
+        assert!(set.intersects_range(1234..=u32::MAX));
 
         set.insert(0);
-        assert!(set.intersects(0..=0));
-        assert!(!set.intersects(1..=1));
+        assert!(set.intersects_range(0..=0));
+        assert!(!set.intersects_range(1..=1));
     }
 
     #[test]
     fn intersects_range_discontinous() {
         let mut set = IntSet::<EvenInts>::empty();
-        assert!(!set.intersects(EvenInts(0)..=EvenInts(0)));
-        assert!(!set.intersects(EvenInts(0)..=EvenInts(100)));
-        assert!(!set.intersects(EvenInts(0)..=EvenInts(u16::MAX - 1)));
-        assert!(!set.intersects(EvenInts(u16::MAX - 1)..=EvenInts(u16::MAX - 1)));
+        assert!(!set.intersects_range(EvenInts(0)..=EvenInts(0)));
+        assert!(!set.intersects_range(EvenInts(0)..=EvenInts(100)));
+        assert!(!set.intersects_range(EvenInts(0)..=EvenInts(u16::MAX - 1)));
+        assert!(!set.intersects_range(EvenInts(u16::MAX - 1)..=EvenInts(u16::MAX - 1)));
 
         set.insert(EvenInts(1234));
-        assert!(!set.intersects(EvenInts(0)..=EvenInts(1232)));
-        assert!(!set.intersects(EvenInts(1236)..=EvenInts(1240)));
+        assert!(!set.intersects_range(EvenInts(0)..=EvenInts(1232)));
+        assert!(!set.intersects_range(EvenInts(1236)..=EvenInts(1240)));
 
-        assert!(set.intersects(EvenInts(1234)..=EvenInts(1234)));
-        assert!(set.intersects(EvenInts(1230)..=EvenInts(1240)));
-        assert!(set.intersects(EvenInts(0)..=EvenInts(1234)));
-        assert!(set.intersects(EvenInts(1234)..=EvenInts(u16::MAX - 1)));
+        assert!(set.intersects_range(EvenInts(1234)..=EvenInts(1234)));
+        assert!(set.intersects_range(EvenInts(1230)..=EvenInts(1240)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(1234)));
+        assert!(set.intersects_range(EvenInts(1234)..=EvenInts(u16::MAX - 1)));
 
         set.insert(EvenInts(0));
-        assert!(set.intersects(EvenInts(0)..=EvenInts(0)));
-        assert!(!set.intersects(EvenInts(2)..=EvenInts(2)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(0)));
+        assert!(!set.intersects_range(EvenInts(2)..=EvenInts(2)));
     }
 
     #[test]
     fn intersects_range_exclusive() {
         let mut set = IntSet::<u32>::all();
-        assert!(set.intersects(0..=0));
-        assert!(set.intersects(0..=100));
-        assert!(set.intersects(0..=u32::MAX));
-        assert!(set.intersects(u32::MAX..=u32::MAX));
+        assert!(set.intersects_range(0..=0));
+        assert!(set.intersects_range(0..=100));
+        assert!(set.intersects_range(0..=u32::MAX));
+        assert!(set.intersects_range(u32::MAX..=u32::MAX));
 
         set.remove(1234);
-        assert!(set.intersects(0..=1233));
-        assert!(set.intersects(1235..=1240));
+        assert!(set.intersects_range(0..=1233));
+        assert!(set.intersects_range(1235..=1240));
 
-        assert!(!set.intersects(1234..=1234));
-        assert!(set.intersects(1230..=1240));
-        assert!(set.intersects(0..=1234));
-        assert!(set.intersects(1234..=u32::MAX));
+        assert!(!set.intersects_range(1234..=1234));
+        assert!(set.intersects_range(1230..=1240));
+        assert!(set.intersects_range(0..=1234));
+        assert!(set.intersects_range(1234..=u32::MAX));
 
         set.remove(0);
-        assert!(!set.intersects(0..=0));
-        assert!(set.intersects(1..=1));
+        assert!(!set.intersects_range(0..=0));
+        assert!(set.intersects_range(1..=1));
 
         set.remove_range(5000..=5200);
-        assert!(!set.intersects(5000..=5200));
-        assert!(!set.intersects(5100..=5150));
-        assert!(set.intersects(4999..=5200));
-        assert!(set.intersects(5000..=5201));
+        assert!(!set.intersects_range(5000..=5200));
+        assert!(!set.intersects_range(5100..=5150));
+        assert!(set.intersects_range(4999..=5200));
+        assert!(set.intersects_range(5000..=5201));
     }
 
     #[test]
     fn intersects_range_exclusive_discontinous() {
         let mut set = IntSet::<EvenInts>::all();
-        assert!(set.intersects(EvenInts(0)..=EvenInts(0)));
-        assert!(set.intersects(EvenInts(0)..=EvenInts(100)));
-        assert!(set.intersects(EvenInts(0)..=EvenInts(u16::MAX - 1)));
-        assert!(set.intersects(EvenInts(u16::MAX - 1)..=EvenInts(u16::MAX - 1)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(0)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(100)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(u16::MAX - 1)));
+        assert!(set.intersects_range(EvenInts(u16::MAX - 1)..=EvenInts(u16::MAX - 1)));
 
         set.remove(EvenInts(1234));
-        assert!(set.intersects(EvenInts(0)..=EvenInts(1232)));
-        assert!(set.intersects(EvenInts(1236)..=EvenInts(1240)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(1232)));
+        assert!(set.intersects_range(EvenInts(1236)..=EvenInts(1240)));
 
-        assert!(!set.intersects(EvenInts(1234)..=EvenInts(1234)));
-        assert!(set.intersects(EvenInts(1230)..=EvenInts(1240)));
-        assert!(set.intersects(EvenInts(0)..=EvenInts(1234)));
-        assert!(set.intersects(EvenInts(1234)..=EvenInts(u16::MAX - 1)));
+        assert!(!set.intersects_range(EvenInts(1234)..=EvenInts(1234)));
+        assert!(set.intersects_range(EvenInts(1230)..=EvenInts(1240)));
+        assert!(set.intersects_range(EvenInts(0)..=EvenInts(1234)));
+        assert!(set.intersects_range(EvenInts(1234)..=EvenInts(u16::MAX - 1)));
 
         set.remove(EvenInts(0));
-        assert!(!set.intersects(EvenInts(0)..=EvenInts(0)));
-        assert!(set.intersects(EvenInts(2)..=EvenInts(2)));
+        assert!(!set.intersects_range(EvenInts(0)..=EvenInts(0)));
+        assert!(set.intersects_range(EvenInts(2)..=EvenInts(2)));
 
         set.remove_range(EvenInts(5000)..=EvenInts(5200));
-        assert!(!set.intersects(EvenInts(5000)..=EvenInts(5200)));
-        assert!(!set.intersects(EvenInts(5100)..=EvenInts(5150)));
-        assert!(set.intersects(EvenInts(4998)..=EvenInts(5200)));
-        assert!(set.intersects(EvenInts(5000)..=EvenInts(5202)));
+        assert!(!set.intersects_range(EvenInts(5000)..=EvenInts(5200)));
+        assert!(!set.intersects_range(EvenInts(5100)..=EvenInts(5150)));
+        assert!(set.intersects_range(EvenInts(4998)..=EvenInts(5200)));
+        assert!(set.intersects_range(EvenInts(5000)..=EvenInts(5202)));
     }
 }

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -272,6 +272,34 @@ impl<T: Domain<T>> IntSet<T> {
         }
     }
 
+    /// Returns true if this set contains at least one element in 'range'.
+    pub fn intersects(&mut self, range: RangeInclusive<T>) -> bool {
+        let domain_min = T::ordered_values()
+            .next()
+            .map(|v_u32| T::from_u32(InDomain(v_u32)));
+        let Some(domain_min) = domain_min else {
+            return false;
+        };
+
+        let start_u32 = range.start().to_u32();
+        let mut it = T::ordered_values_range(domain_min..=T::from_u32(InDomain(start_u32)));
+        it.next_back();
+        let before_start = it.next_back();
+
+        let next = if let Some(before_start) = before_start {
+            self.iter_after(T::from_u32(InDomain(before_start))).next()
+        } else {
+            self.iter().next()
+        };
+
+        let Some(next) = next else {
+            return false;
+        };
+
+        // If next is <= end then there is at least one value in the input range.
+        return next.to_u32() <= range.end().to_u32();
+    }
+
     /// Returns first element in the set, if any. This element is always the minimum of all elements in the set.
     pub fn first(&self) -> Option<T> {
         return self.iter().next();
@@ -1867,5 +1895,105 @@ mod test {
         assert_eq!(it.next(), Some(GlyphId::new(3)));
         assert_eq!(it.next(), Some(GlyphId::new(4)));
         assert_eq!(it.next(), Some(GlyphId::new(6)));
+    }
+
+    #[test]
+    fn intersects_range() {
+        let mut set = IntSet::<u32>::empty();
+        assert!(!set.intersects(0..=0));
+        assert!(!set.intersects(0..=100));
+        assert!(!set.intersects(0..=u32::MAX));
+        assert!(!set.intersects(u32::MAX..=u32::MAX));
+
+        set.insert(1234);
+        assert!(!set.intersects(0..=1233));
+        assert!(!set.intersects(1235..=1240));
+
+        assert!(set.intersects(1234..=1234));
+        assert!(set.intersects(1230..=1240));
+        assert!(set.intersects(0..=1234));
+        assert!(set.intersects(1234..=u32::MAX));
+
+        set.insert(0);
+        assert!(set.intersects(0..=0));
+        assert!(!set.intersects(1..=1));
+    }
+
+    #[test]
+    fn intersects_range_discontinous() {
+        let mut set = IntSet::<EvenInts>::empty();
+        assert!(!set.intersects(EvenInts(0)..=EvenInts(0)));
+        assert!(!set.intersects(EvenInts(0)..=EvenInts(100)));
+        assert!(!set.intersects(EvenInts(0)..=EvenInts(u16::MAX - 1)));
+        assert!(!set.intersects(EvenInts(u16::MAX - 1)..=EvenInts(u16::MAX - 1)));
+
+        set.insert(EvenInts(1234));
+        assert!(!set.intersects(EvenInts(0)..=EvenInts(1232)));
+        assert!(!set.intersects(EvenInts(1236)..=EvenInts(1240)));
+
+        assert!(set.intersects(EvenInts(1234)..=EvenInts(1234)));
+        assert!(set.intersects(EvenInts(1230)..=EvenInts(1240)));
+        assert!(set.intersects(EvenInts(0)..=EvenInts(1234)));
+        assert!(set.intersects(EvenInts(1234)..=EvenInts(u16::MAX - 1)));
+
+        set.insert(EvenInts(0));
+        assert!(set.intersects(EvenInts(0)..=EvenInts(0)));
+        assert!(!set.intersects(EvenInts(2)..=EvenInts(2)));
+    }
+
+    #[test]
+    fn intersects_range_exclusive() {
+        let mut set = IntSet::<u32>::all();
+        assert!(set.intersects(0..=0));
+        assert!(set.intersects(0..=100));
+        assert!(set.intersects(0..=u32::MAX));
+        assert!(set.intersects(u32::MAX..=u32::MAX));
+
+        set.remove(1234);
+        assert!(set.intersects(0..=1233));
+        assert!(set.intersects(1235..=1240));
+
+        assert!(!set.intersects(1234..=1234));
+        assert!(set.intersects(1230..=1240));
+        assert!(set.intersects(0..=1234));
+        assert!(set.intersects(1234..=u32::MAX));
+
+        set.remove(0);
+        assert!(!set.intersects(0..=0));
+        assert!(set.intersects(1..=1));
+
+        set.remove_range(5000..=5200);
+        assert!(!set.intersects(5000..=5200));
+        assert!(!set.intersects(5100..=5150));
+        assert!(set.intersects(4999..=5200));
+        assert!(set.intersects(5000..=5201));
+    }
+
+    #[test]
+    fn intersects_range_exclusive_discontinous() {
+        let mut set = IntSet::<EvenInts>::all();
+        assert!(set.intersects(EvenInts(0)..=EvenInts(0)));
+        assert!(set.intersects(EvenInts(0)..=EvenInts(100)));
+        assert!(set.intersects(EvenInts(0)..=EvenInts(u16::MAX - 1)));
+        assert!(set.intersects(EvenInts(u16::MAX - 1)..=EvenInts(u16::MAX - 1)));
+
+        set.remove(EvenInts(1234));
+        assert!(set.intersects(EvenInts(0)..=EvenInts(1232)));
+        assert!(set.intersects(EvenInts(1236)..=EvenInts(1240)));
+
+        assert!(!set.intersects(EvenInts(1234)..=EvenInts(1234)));
+        assert!(set.intersects(EvenInts(1230)..=EvenInts(1240)));
+        assert!(set.intersects(EvenInts(0)..=EvenInts(1234)));
+        assert!(set.intersects(EvenInts(1234)..=EvenInts(u16::MAX - 1)));
+
+        set.remove(EvenInts(0));
+        assert!(!set.intersects(EvenInts(0)..=EvenInts(0)));
+        assert!(set.intersects(EvenInts(2)..=EvenInts(2)));
+
+        set.remove_range(EvenInts(5000)..=EvenInts(5200));
+        assert!(!set.intersects(EvenInts(5000)..=EvenInts(5200)));
+        assert!(!set.intersects(EvenInts(5100)..=EvenInts(5150)));
+        assert!(set.intersects(EvenInts(4998)..=EvenInts(5200)));
+        assert!(set.intersects(EvenInts(5000)..=EvenInts(5202)));
     }
 }


### PR DESCRIPTION
iter_after() creates an iterator of values in the set that come after a given value.
intersects(range) checks if any values in the set intersect a range.