### PR TITLE
[int-set] Add an IntSet fuzzer that checks for correctness.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ release = false
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 skrifa = { path="../skrifa" }
+int-set = { path = "../int-set" }
 
 [[bin]]
 name = "fuzz_skrifa_charmap"
@@ -42,5 +43,11 @@ doc = false
 [[bin]]
 name = "fuzz_skrifa_color"
 path = "fuzz_targets/fuzz_skrifa_color.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_int_set"
+path = "fuzz_targets/fuzz_int_set.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -8,35 +8,20 @@ use libfuzzer_sys::fuzz_target;
 // TODO allow inverted sets to be accessed.
 // TODO allow a limited domain set to be accessed.
 
-// TODO ops for most public api methods (have operations for iter() be what checks for
-//      iter() equality alongside the check at end):
-// - iter
-// - iter ranges
-// - extend / extend_unsorted
-// - remove_all
-// - union
-// - intersect
-// - first
-// - last
-// - contains
-// - is_empty
-// - len
-// - clear
-
 trait Operation {
     fn size(&self) -> u64;
     fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>);
 }
 
+/* ### Insert ### */
 struct InsertOp(u32);
 
 impl InsertOp {
     fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
-        if data.len() < 4 {
+        let (Some(val), data) = read_u32(data) else {
             return (None, data);
-        }
-
-        (Some(Box::new(InsertOp(read_u32(data)))), &data[4..])
+        };
+        (Some(Box::new(Self(val))), data)
     }
 }
 
@@ -51,31 +36,29 @@ impl Operation for InsertOp {
     }
 }
 
+/* ### Insert Range ### */
+
 struct InsertRangeOp(u32, u32);
 
 impl InsertRangeOp {
     fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
-        if data.len() < 8 {
+        let (Some(min), data) = read_u32(data) else {
             return (None, data);
-        }
+        };
+        let (Some(max), data) = read_u32(data) else {
+            return (None, data);
+        };
 
-        (
-            Some(Box::new(InsertRangeOp(
-                read_u32(data),
-                read_u32(&data[4..]),
-            ))),
-            &data[8..],
-        )
+        (Some(Box::new(Self(min, max))), data)
     }
 }
 
 impl Operation for InsertRangeOp {
     fn size(&self) -> u64 {
-        if self.1 > self.0 {
-            self.1 as u64 - self.0 as u64
-        } else {
-            1
+        if self.1 < self.0 {
+            return 1;
         }
+        (self.1 as u64 - self.0 as u64) + 1
     }
 
     fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
@@ -86,15 +69,16 @@ impl Operation for InsertRangeOp {
     }
 }
 
+/* ### Remove ### */
+
 struct RemoveOp(u32);
 
 impl RemoveOp {
     fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
-        if data.len() < 4 {
+        let (Some(val), data) = read_u32(data) else {
             return (None, data);
-        }
-
-        (Some(Box::new(RemoveOp(read_u32(data)))), &data[4..])
+        };
+        (Some(Box::new(Self(val))), data)
     }
 }
 
@@ -109,31 +93,29 @@ impl Operation for RemoveOp {
     }
 }
 
+/* ### Remove Range ### */
+
 struct RemoveRangeOp(u32, u32);
 
 impl RemoveRangeOp {
     fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
-        if data.len() < 8 {
+        let (Some(min), data) = read_u32(data) else {
             return (None, data);
-        }
+        };
+        let (Some(max), data) = read_u32(data) else {
+            return (None, data);
+        };
 
-        (
-            Some(Box::new(RemoveRangeOp(
-                read_u32(data),
-                read_u32(&data[4..]),
-            ))),
-            &data[8..],
-        )
+        (Some(Box::new(Self(min, max))), data)
     }
 }
 
 impl Operation for RemoveRangeOp {
     fn size(&self) -> u64 {
-        if self.1 > self.0 {
-            self.1 as u64 - self.0 as u64
-        } else {
-            1
+        if self.1 < self.0 {
+            return 1;
         }
+        (self.1 as u64 - self.0 as u64) + 1
     }
 
     fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
@@ -144,21 +126,212 @@ impl Operation for RemoveRangeOp {
     }
 }
 
-fn read_u32(data: &[u8]) -> u32 {
-    ((data[0] as u32) << 24) | ((data[1] as u32) << 16) | ((data[2] as u32) << 8) | (data[3] as u32)
+/* ### Length ### */
+struct LengthOp();
+
+impl LengthOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        (Some(Box::new(Self())), data)
+    }
+}
+
+impl Operation for LengthOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        assert_eq!(int_set.len(), btree_set.len());
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+/* ### Is Empty ### */
+
+struct IsEmptyOp();
+
+impl IsEmptyOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        (Some(Box::new(Self())), data)
+    }
+}
+
+impl Operation for IsEmptyOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        assert_eq!(int_set.is_empty(), btree_set.is_empty());
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+/* ### Contains ### */
+struct ContainsOp(u32);
+
+impl ContainsOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        let (Some(val), data) = read_u32(data) else {
+            return (None, data);
+        };
+        (Some(Box::new(Self(val))), data)
+    }
+}
+
+impl Operation for ContainsOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        assert_eq!(int_set.contains(self.0), btree_set.contains(&self.0));
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+/* ### Clear  ### */
+
+struct ClearOp();
+
+impl ClearOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        (Some(Box::new(Self())), data)
+    }
+}
+
+impl Operation for ClearOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        int_set.clear();
+        btree_set.clear();
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+/* ### Intersects Range ### */
+struct IntersectsRangeOp(u32, u32);
+
+impl IntersectsRangeOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        let (Some(min), data) = read_u32(data) else {
+            return (None, data);
+        };
+        let (Some(max), data) = read_u32(data) else {
+            return (None, data);
+        };
+        (Some(Box::new(Self(min, max))), data)
+    }
+}
+
+impl Operation for IntersectsRangeOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        let int_set_intersects = int_set.intersects_range(self.0..=self.1);
+
+        let mut btree_intersects = false;
+        for v in self.0..=self.1 {
+            if btree_set.contains(&v) {
+                btree_intersects = true;
+                break;
+            }
+        }
+
+        assert_eq!(int_set_intersects, btree_intersects);
+    }
+
+    fn size(&self) -> u64 {
+        if self.1 < self.0 {
+            return 1;
+        }
+        (self.1 as u64 - self.0 as u64) + 1
+    }
+}
+
+/* ### First  ### */
+
+struct FirstOp();
+
+impl FirstOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        (Some(Box::new(Self())), data)
+    }
+}
+
+impl Operation for FirstOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        assert_eq!(int_set.first(), btree_set.iter().next().copied());
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+/* ### First  ### */
+
+struct LastOp();
+
+impl LastOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        (Some(Box::new(Self())), data)
+    }
+}
+
+impl Operation for LastOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        assert_eq!(int_set.last(), btree_set.iter().next_back().copied());
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+/* ### End of Ops ### */
+
+fn read_u32(data: &[u8]) -> (Option<u32>, &[u8]) {
+    if data.len() < 4 {
+        return (None, data);
+    }
+    (
+        Some(
+            ((data[0] as u32) << 24)
+                | ((data[1] as u32) << 16)
+                | ((data[2] as u32) << 8)
+                | (data[3] as u32),
+        ),
+        &data[4..],
+    )
 }
 
 fn next_operation(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
-    let Some(next_byte) = data.get(0) else {
+    let Some(op_code) = data.get(0) else {
         return (None, &data[1..]);
     };
 
+    // TODO ops for most public api methods (have operations for iter() be what checks for
+    //      iter() equality alongside the check at end):
+    // - iter
+    // - iter ranges
+    // - iter after
+    // - extend / extend_unsorted
+    // - remove_all
+    // - union
+    // - intersect
+    // - first
+    // - last
     let data = &data[1..];
-    match next_byte {
+    match op_code {
         1 => InsertOp::new(data),
         2 => RemoveOp::new(data),
         3 => InsertRangeOp::new(data),
         4 => RemoveRangeOp::new(data),
+        5 => LengthOp::new(data),
+        6 => IsEmptyOp::new(data),
+        7 => ContainsOp::new(data),
+        8 => ClearOp::new(data),
+        9 => IntersectsRangeOp::new(data),
+        10 => FirstOp::new(data),
+        11 => LastOp::new(data),
         _ => (None, data),
     }
 }

--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -44,7 +44,7 @@ trait Operation {
 struct InsertOp(u32);
 
 impl InsertOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(val), data) = read_u32(data) else {
             return (None, data);
         };
@@ -68,7 +68,7 @@ impl Operation for InsertOp {
 struct InsertRangeOp(u32, u32);
 
 impl InsertRangeOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(min), data) = read_u32(data) else {
             return (None, data);
         };
@@ -101,7 +101,7 @@ impl Operation for InsertRangeOp {
 struct RemoveOp(u32);
 
 impl RemoveOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(val), data) = read_u32(data) else {
             return (None, data);
         };
@@ -125,7 +125,7 @@ impl Operation for RemoveOp {
 struct RemoveRangeOp(u32, u32);
 
 impl RemoveRangeOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(min), data) = read_u32(data) else {
             return (None, data);
         };
@@ -157,7 +157,7 @@ impl Operation for RemoveRangeOp {
 struct LengthOp();
 
 impl LengthOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -177,7 +177,7 @@ impl Operation for LengthOp {
 struct IsEmptyOp();
 
 impl IsEmptyOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -196,7 +196,7 @@ impl Operation for IsEmptyOp {
 struct ContainsOp(u32);
 
 impl ContainsOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(val), data) = read_u32(data) else {
             return (None, data);
         };
@@ -222,7 +222,7 @@ impl Operation for ContainsOp {
 struct ClearOp();
 
 impl ClearOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -243,7 +243,7 @@ impl Operation for ClearOp {
 struct IntersectsRangeOp(u32, u32);
 
 impl IntersectsRangeOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(min), data) = read_u32(data) else {
             return (None, data);
         };
@@ -282,7 +282,7 @@ impl Operation for IntersectsRangeOp {
 struct FirstOp();
 
 impl FirstOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -302,7 +302,7 @@ impl Operation for FirstOp {
 struct LastOp();
 
 impl LastOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -322,7 +322,7 @@ impl Operation for LastOp {
 struct IterOp();
 
 impl IterOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -333,7 +333,7 @@ impl Operation for IterOp {
     }
 
     fn size(&self, length: usize) -> usize {
-        return length as usize;
+        length
     }
 }
 
@@ -342,7 +342,7 @@ impl Operation for IterOp {
 struct IterRangesOp();
 
 impl IterRangesOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
@@ -372,7 +372,7 @@ impl Operation for IterRangesOp {
     }
 
     fn size(&self, length: usize) -> usize {
-        return length as usize;
+        length
     }
 }
 
@@ -381,7 +381,7 @@ impl Operation for IterRangesOp {
 struct IterAfterOp(u32);
 
 impl IterAfterOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(val), data) = read_u32(data) else {
             return (None, data);
         };
@@ -399,7 +399,7 @@ impl Operation for IterAfterOp {
     }
 
     fn size(&self, length: usize) -> usize {
-        return length as usize;
+        length
     }
 }
 
@@ -408,7 +408,7 @@ impl Operation for IterAfterOp {
 struct RemoveAllOp(Vec<u32>);
 
 impl RemoveAllOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(values), data) = read_u32_vec(data) else {
             return (None, data);
         };
@@ -420,12 +420,12 @@ impl Operation for RemoveAllOp {
     fn operate(&self, input: Input, _: Input) {
         input.int_set.remove_all(self.0.iter().copied());
         for v in self.0.iter() {
-            input.btree_set.remove(&v);
+            input.btree_set.remove(v);
         }
     }
 
     fn size(&self, length: usize) -> usize {
-        return (length.ilog2() as usize) * self.0.len();
+        (length.ilog2() as usize) * self.0.len()
     }
 }
 
@@ -434,7 +434,7 @@ impl Operation for RemoveAllOp {
 struct ExtendOp(Vec<u32>);
 
 impl ExtendOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(values), data) = read_u32_vec(data) else {
             return (None, data);
         };
@@ -449,7 +449,7 @@ impl Operation for ExtendOp {
     }
 
     fn size(&self, length: usize) -> usize {
-        return (length.ilog2() as usize) * self.0.len();
+        (length.ilog2() as usize) * self.0.len()
     }
 }
 
@@ -458,7 +458,7 @@ impl Operation for ExtendOp {
 struct ExtendUnsortedOp(Vec<u32>);
 
 impl ExtendUnsortedOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         let (Some(values), data) = read_u32_vec(data) else {
             return (None, data);
         };
@@ -473,7 +473,7 @@ impl Operation for ExtendUnsortedOp {
     }
 
     fn size(&self, length: usize) -> usize {
-        return (length.ilog2() as usize) * self.0.len();
+        (length.ilog2() as usize) * self.0.len()
     }
 }
 
@@ -482,14 +482,14 @@ impl Operation for ExtendUnsortedOp {
 struct UnionOp();
 
 impl UnionOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
 
 impl Operation for UnionOp {
     fn operate(&self, a: Input, b: Input) {
-        a.int_set.union(&b.int_set);
+        a.int_set.union(b.int_set);
         for v in b.btree_set.iter() {
             a.btree_set.insert(*v);
         }
@@ -497,7 +497,7 @@ impl Operation for UnionOp {
 
     fn size(&self, length: usize) -> usize {
         // TODO(garretrieger): should be length a + length b
-        return length;
+        length
     }
 }
 
@@ -506,29 +506,29 @@ impl Operation for UnionOp {
 struct IntersectOp();
 
 impl IntersectOp {
-    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    fn parse_args(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
         (Some(Box::new(Self())), data)
     }
 }
 
 impl Operation for IntersectOp {
     fn operate(&self, a: Input, b: Input) {
-        a.int_set.intersect(&b.int_set);
+        a.int_set.intersect(b.int_set);
         let mut intersected: BTreeSet<u32> =
-            a.btree_set.intersection(&b.btree_set).copied().collect();
+            a.btree_set.intersection(b.btree_set).copied().collect();
         std::mem::swap(a.btree_set, &mut intersected);
     }
 
     fn size(&self, length: usize) -> usize {
         // TODO(garretrieger): should be length a + length b
-        return length;
+        length
     }
 }
 
 /* ### End of Ops ### */
 
 fn read_u8(data: &[u8]) -> (Option<u8>, &[u8]) {
-    if data.len() < 1 {
+    if data.is_empty() {
         return (None, data);
     }
     (Some(data[0]), &data[1..])
@@ -574,9 +574,7 @@ struct NextOperation<'a> {
 }
 
 fn next_operation(data: &[u8]) -> Option<NextOperation> {
-    let Some(op_code) = data.get(0) else {
-        return None;
-    };
+    let op_code = data.first()?;
 
     // Check the msb of op code to see which set index to use.
     const INDEX_MASK: u8 = 0b10000000;
@@ -590,25 +588,25 @@ fn next_operation(data: &[u8]) -> Option<NextOperation> {
     // - is_inverted
     let data = &data[1..];
     let (op, data) = match op_code {
-        1 => InsertOp::new(data),
-        2 => RemoveOp::new(data),
-        3 => InsertRangeOp::new(data),
-        4 => RemoveRangeOp::new(data),
-        5 => LengthOp::new(data),
-        6 => IsEmptyOp::new(data),
-        7 => ContainsOp::new(data),
-        8 => ClearOp::new(data),
-        9 => IntersectsRangeOp::new(data),
-        10 => FirstOp::new(data),
-        11 => LastOp::new(data),
-        12 => IterOp::new(data),
-        13 => IterRangesOp::new(data),
-        14 => IterAfterOp::new(data),
-        15 => RemoveAllOp::new(data),
-        16 => ExtendOp::new(data),
-        17 => ExtendUnsortedOp::new(data),
-        18 => UnionOp::new(data),
-        19 => IntersectOp::new(data),
+        1 => InsertOp::parse_args(data),
+        2 => RemoveOp::parse_args(data),
+        3 => InsertRangeOp::parse_args(data),
+        4 => RemoveRangeOp::parse_args(data),
+        5 => LengthOp::parse_args(data),
+        6 => IsEmptyOp::parse_args(data),
+        7 => ContainsOp::parse_args(data),
+        8 => ClearOp::parse_args(data),
+        9 => IntersectsRangeOp::parse_args(data),
+        10 => FirstOp::parse_args(data),
+        11 => LastOp::parse_args(data),
+        12 => IterOp::parse_args(data),
+        13 => IterRangesOp::parse_args(data),
+        14 => IterAfterOp::parse_args(data),
+        15 => RemoveAllOp::parse_args(data),
+        16 => ExtendOp::parse_args(data),
+        17 => ExtendUnsortedOp::parse_args(data),
+        18 => UnionOp::parse_args(data),
+        19 => IntersectOp::parse_args(data),
         _ => (None, data),
     };
 

--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -1,0 +1,194 @@
+#![no_main]
+
+use std::{collections::BTreeSet, error::Error};
+
+use int_set::IntSet;
+use libfuzzer_sys::fuzz_target;
+
+// TODO allow inverted sets to be accessed.
+// TODO allow a limited domain set to be accessed.
+
+// TODO ops for most public api methods (have operations for iter() be what checks for
+//      iter() equality alongside the check at end):
+// - iter
+// - iter ranges
+// - extend / extend_unsorted
+// - remove_all
+// - union
+// - intersect
+// - first
+// - last
+// - contains
+// - is_empty
+// - len
+// - clear
+
+trait Operation {
+    fn size(&self) -> u64;
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>);
+}
+
+struct InsertOp(u32);
+
+impl InsertOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        if data.len() < 4 {
+            return (None, data);
+        }
+
+        (Some(Box::new(InsertOp(read_u32(data)))), &data[4..])
+    }
+}
+
+impl Operation for InsertOp {
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        int_set.insert(self.0);
+        btree_set.insert(self.0);
+    }
+
+    fn size(&self) -> u64 {
+        1
+    }
+}
+
+struct InsertRangeOp(u32, u32);
+
+impl InsertRangeOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        if data.len() < 8 {
+            return (None, data);
+        }
+
+        (
+            Some(Box::new(InsertRangeOp(
+                read_u32(data),
+                read_u32(&data[4..]),
+            ))),
+            &data[8..],
+        )
+    }
+}
+
+impl Operation for InsertRangeOp {
+    fn size(&self) -> u64 {
+        if self.1 > self.0 {
+            self.1 as u64 - self.0 as u64
+        } else {
+            1
+        }
+    }
+
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        int_set.insert_range(self.0..=self.1);
+        for v in self.0..=self.1 {
+            btree_set.insert(v);
+        }
+    }
+}
+
+struct RemoveOp(u32);
+
+impl RemoveOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        if data.len() < 4 {
+            return (None, data);
+        }
+
+        (Some(Box::new(RemoveOp(read_u32(data)))), &data[4..])
+    }
+}
+
+impl Operation for RemoveOp {
+    fn size(&self) -> u64 {
+        1
+    }
+
+    fn operate(&self, int_set: &mut IntSet<u32>, hash_set: &mut BTreeSet<u32>) {
+        int_set.remove(self.0);
+        hash_set.remove(&self.0);
+    }
+}
+
+struct RemoveRangeOp(u32, u32);
+
+impl RemoveRangeOp {
+    fn new(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+        if data.len() < 8 {
+            return (None, data);
+        }
+
+        (
+            Some(Box::new(RemoveRangeOp(
+                read_u32(data),
+                read_u32(&data[4..]),
+            ))),
+            &data[8..],
+        )
+    }
+}
+
+impl Operation for RemoveRangeOp {
+    fn size(&self) -> u64 {
+        if self.1 > self.0 {
+            self.1 as u64 - self.0 as u64
+        } else {
+            1
+        }
+    }
+
+    fn operate(&self, int_set: &mut IntSet<u32>, btree_set: &mut BTreeSet<u32>) {
+        int_set.remove_range(self.0..=self.1);
+        for v in self.0..=self.1 {
+            btree_set.remove(&v);
+        }
+    }
+}
+
+fn read_u32(data: &[u8]) -> u32 {
+    ((data[0] as u32) << 24) | ((data[1] as u32) << 16) | ((data[2] as u32) << 8) | (data[3] as u32)
+}
+
+fn next_operation(data: &[u8]) -> (Option<Box<dyn Operation>>, &[u8]) {
+    let Some(next_byte) = data.get(0) else {
+        return (None, &data[1..]);
+    };
+
+    let data = &data[1..];
+    match next_byte {
+        1 => InsertOp::new(data),
+        2 => RemoveOp::new(data),
+        3 => InsertRangeOp::new(data),
+        4 => RemoveRangeOp::new(data),
+        _ => (None, data),
+    }
+}
+
+fn do_int_set_things(data: &[u8]) -> Result<(), Box<dyn Error>> {
+    let mut int_set = IntSet::<u32>::empty();
+    let mut btree_set = BTreeSet::<u32>::new();
+
+    let mut ops = 0u64;
+    let mut data = data;
+    while !data.is_empty() {
+        let (op, new_data) = next_operation(data);
+        data = new_data;
+
+        let Some(op) = op else {
+            break;
+        };
+
+        ops = ops.saturating_add(op.size());
+        if ops > 1000 {
+            break;
+        }
+
+        op.operate(&mut int_set, &mut btree_set);
+    }
+
+    assert!(int_set.iter().eq(btree_set.into_iter()));
+    Ok(())
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = do_int_set_things(data);
+});

--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -17,6 +17,8 @@ use std::{collections::BTreeSet, error::Error};
 use int_set::IntSet;
 use libfuzzer_sys::fuzz_target;
 
+const OPERATION_COUNT: usize = 7_500;
+
 // TODO(garretrieger): allow inverted sets to be accessed.
 // TODO(garretrieger): allow a limited domain set to be accessed.
 
@@ -642,7 +644,7 @@ fn process_op_codes(data: &[u8]) -> Result<(), Box<dyn Error>> {
             };
             // when computing size use minimum length of 2 to ensure minimum value of log2(length) is 1.
             ops = ops.saturating_add(next_op.op.size(max(2, btree_set.len())));
-            if ops > 5000 {
+            if ops > OPERATION_COUNT {
                 // Operation count limit reached.
                 break;
             }


### PR DESCRIPTION
The fuzzer input is treated as a series of op codes which can invoke any of the int sets public api methods. The operations are performed on both and IntSet and BTreeSet in parallel and then method results and set contents are checked for equivalence.