### PR TITLE
Fix `clippy::doc_lazy_continuation` lints

### DIFF
--- a/fauntlet/src/pen.rs
+++ b/fauntlet/src/pen.rs
@@ -5,20 +5,20 @@ use skrifa::raw::types::{Pen, PenCommand};
 /// This covers three primary cases:
 ///
 /// 1. All contours in FT are implicitly closed while Skrifa emits an
-/// explicit close element. This simply drops close elements and replaces
-/// them with a line if the current point does not match the most recent
-/// start point.
+///    explicit close element. This simply drops close elements and replaces
+///    them with a line if the current point does not match the most recent
+///    start point.
 ///
 /// 2. The FT CFF loader elminates some, but not all degenerate move/line
-/// elements (due to a final scaling step that may introduce new ones).
-/// Skrifa applies this pass *after* scaling so is more aggressive about
-/// removing degenerates. This drops unused moves and lines that end at the
-/// current point.
+///    elements (due to a final scaling step that may introduce new ones).
+///    Skrifa applies this pass *after* scaling so is more aggressive about
+///    removing degenerates. This drops unused moves and lines that end at the
+///    current point.
 ///
 /// 3. The FT TrueType loader in unscaled mode always produces integers. This
-/// leads to truncated results when midpoints are computed for implied
-/// oncurve points. Skrifa retains the more accurate representation so
-/// points are truncated here (in the unscaled case) for comparison.
+///    leads to truncated results when midpoints are computed for implied
+///    oncurve points. Skrifa retains the more accurate representation so
+///    points are truncated here (in the unscaled case) for comparison.
 pub struct RegularizingPen<'a, P> {
     inner: &'a mut P,
     is_scaled: bool,

--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -41,14 +41,14 @@ pub use read_fonts::tables::cmap::MapVariant;
 /// coverage:
 ///
 /// * Unicode characters: a symbol mapping subtable is selected if available. Otherwise, subtables supporting
-/// the Unicode full repertoire or Basic Multilingual Plane (BMP) are preferred, in that order. Formats
-/// [4](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values)
-/// and [12](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage) are
-/// supported.
+///   the Unicode full repertoire or Basic Multilingual Plane (BMP) are preferred, in that order. Formats
+///   [4](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values)
+///   and [12](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage) are
+///   supported.
 ///
 /// * Unicode variation sequences: these are provided by a format
-/// [14](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
-/// subtable.
+///   [14](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences)
+///   subtable.
 ///
 #[derive(Clone, Default)]
 pub struct Charmap<'a> {

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -146,8 +146,8 @@ pub enum Brush<'a> {
         color_stops: &'a [ColorStop],
         extend: Extend,
     },
-    /// A radial gradient, with color stops normalized to the range of 0 to
-    /// 1. Caution: This normalization can mean that negative radii occur. It is
+    /// A radial gradient, with color stops normalized to the range of 0 to 1.
+    /// Caution: This normalization can mean that negative radii occur. It is
     /// the client's responsibility to truncate the color line at the 0
     /// position, interpolating between `r0` and `r1` and compute an
     /// interpolated color at that position.

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -4,22 +4,22 @@
 //! characteristics for a font. They come in two flavors:
 //!
 //! * Global metrics: these are applicable to all glyphs in a font and generally
-//! define values that are used for the layout of a collection of glyphs. For example,
-//! the ascent, descent and leading values determine the position of the baseline where
-//! a glyph should be rendered as well as the suggested spacing above and below it.
+//!   define values that are used for the layout of a collection of glyphs. For example,
+//!   the ascent, descent and leading values determine the position of the baseline where
+//!   a glyph should be rendered as well as the suggested spacing above and below it.
 //!
 //! * Glyph metrics: these apply to single glyphs. For example, the advance
-//! width value describes the distance between two consecutive glyphs on a line.
+//!   width value describes the distance between two consecutive glyphs on a line.
 //!
 //! ### Selecting an "instance"
 //! Both global and glyph specific metrics accept two additional pieces of information
 //! to select the desired instance of a font:
 //! * Size: represented by the [Size] type, this determines the scaling factor that is
-//! applied to all metrics.
+//!   applied to all metrics.
 //! * Normalized variation coordinates: represented by the [LocationRef] type,
-//! these define the position in design space for a variable font. For a non-variable
-//! font, these coordinates are ignored and you can pass [LocationRef::default()]
-//! as an argument for this parameter.
+//!   these define the position in design space for a variable font. For a non-variable
+//!   font, these coordinates are ignored and you can pass [LocationRef::default()]
+//!   as an argument for this parameter.
 //!
 
 use read_fonts::{
@@ -61,10 +61,10 @@ pub struct Decoration {
 /// * [maxp](https://learn.microsoft.com/en-us/typography/opentype/spec/maxp): `glyph_count`
 /// * [post](https://learn.microsoft.com/en-us/typography/opentype/spec/post): `is_monospace`, `italic_angle`, `underline`
 /// * [OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2): `average_width`, `cap_height`,
-/// `x_height`, `strikeout`, as well as the line metrics: `ascent`, `descent`, `leading` if the `USE_TYPOGRAPHIC_METRICS`
-/// flag is set or the `hhea` line metrics are zero (the Windows metrics are used as a last resort).
+///   `x_height`, `strikeout`, as well as the line metrics: `ascent`, `descent`, `leading` if the `USE_TYPOGRAPHIC_METRICS`
+///   flag is set or the `hhea` line metrics are zero (the Windows metrics are used as a last resort).
 /// * [hhea](https://learn.microsoft.com/en-us/typography/opentype/spec/hhea): `max_width`, as well as the line metrics:
-/// `ascent`, `descent`, `leading` if they are non-zero and the `USE_TYPOGRAHIC_METRICS` flag is not set in the OS/2 table
+///   `ascent`, `descent`, `leading` if they are non-zero and the `USE_TYPOGRAHIC_METRICS` flag is not set in the OS/2 table
 ///
 /// For variable fonts, deltas are computed using the  [MVAR](https://learn.microsoft.com/en-us/typography/opentype/spec/MVAR)
 /// table.

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -4,8 +4,8 @@
 //! with a few minor differences:
 //!
 //! - we don't use a context/interface for the tables, instead using a generic
-//! 'split_subtables' method similar to 'actuate_subtable_split' and passing
-//! it a method for each lookup type
+//!   'split_subtables' method similar to 'actuate_subtable_split' and passing
+//!   it a method for each lookup type
 //! - harfbuzz splits off new subtables but retains the original subtable,
 //!   shrinking it to fit. We skip this step, and generate all new subtables.
 


### PR DESCRIPTION
This improves readability and is a new lint coming next week in Rust 1.80.