### PR TITLE
Update sparse bit set decode to avoid numerical overflows.

### DIFF
--- a/int-set/src/output_bit_stream.rs
+++ b/int-set/src/output_bit_stream.rs
@@ -9,7 +9,7 @@ pub(crate) struct OutputBitStream {
 }
 
 impl OutputBitStream {
-    pub(crate) const MAX_HEIGHT: u8 = 32;
+    pub(crate) const MAX_HEIGHT: u8 = 31;
 
     pub(crate) fn new(branch_factor: BranchFactor, height: u8) -> OutputBitStream {
         let mut out = OutputBitStream {
@@ -17,8 +17,8 @@ impl OutputBitStream {
             sub_index: 0,
             branch_factor,
         };
-        if height >= OutputBitStream::MAX_HEIGHT {
-            panic!("Height value exceeds 5 bits.");
+        if height > Self::MAX_HEIGHT {
+            panic!("Height value exceeds maximum for the branch factor.");
         }
         out.write_header(height);
         out


### PR DESCRIPTION
Given that we decode to a u32 int set, added two guards:
1. Enforce a maximum height per branch factor which will allow values up to u32 to be encoded, reject decoding sets with heights beyond this. Since the maximum value possible at each height in some cases still exceeds u32, the second guard is needed as well.
2. Do computations during decode using u64's and check for overflow before populating the output set. Reject decoding sets that exceed the u32 maximum.