### PR TITLE
[int-set] Add a second version of sparse bit set decode with max set size.

### DIFF
--- a/fuzz/fuzz_targets/fuzz_sparse_bit_set_decode.rs
+++ b/fuzz/fuzz_targets/fuzz_sparse_bit_set_decode.rs
@@ -5,5 +5,5 @@ use int_set::IntSet;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = IntSet::<u32>::from_sparse_bit_set(data);
+    let _ = IntSet::<u32>::from_sparse_bit_set_bounded(data, 10_000);
 });


### PR DESCRIPTION
It's very easy to construct a sparse bit set which contains all values in u32, which can be quite slow to decode. Add an alternate decoding method which can be given a maximum set size for callers who want to avoid long decoding times. Use the bounded version in the fuzzer.