### PR TITLE
[int-set] Expand Int Set Fuzzer Coverage

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ release = false
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 skrifa = { path="../skrifa" }
+font-types = { path= "../font-types" }
 int-set = { path = "../int-set" }
 
 [[bin]]

--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -6,6 +6,7 @@
 //!
 //! The fuzzer input data is interpreted as a series of op codes which map to the public api methods of IntSet.
 
+use font_types::{GlyphId, GlyphId16};
 use libfuzzer_sys::fuzz_target;
 mod int_set_op_processor;
 use int_set_op_processor::process_op_codes;
@@ -21,6 +22,7 @@ fuzz_target!(|data: &[u8]| {
     };
 
     match mode_byte {
+        // These variants provide the primary testing of functionality.
         1 => {
             let _ = process_op_codes::<u32>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
         }
@@ -34,6 +36,22 @@ fuzz_target!(|data: &[u8]| {
                 OPERATION_COUNT,
                 &data[1..],
             );
+        }
+
+        // And these provide coverage of remaining default supported domains
+        4 => {
+            let _ = process_op_codes::<u8>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+        }
+        5 => {
+            let _ = process_op_codes::<u16>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+        }
+        6 => {
+            let _ =
+                process_op_codes::<GlyphId>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+        }
+        7 => {
+            let _ =
+                process_op_codes::<GlyphId16>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
         }
         _ => return,
     };

--- a/fuzz/fuzz_targets/int_set_op_processor.rs
+++ b/fuzz/fuzz_targets/int_set_op_processor.rs
@@ -1,3 +1,4 @@
+use font_types::{GlyphId, GlyphId16};
 use std::fmt::Debug;
 use std::io::Cursor;
 use std::io::Read;
@@ -34,6 +35,63 @@ impl SetMember<u32> for u32 {
 
     fn increment(&mut self) {
         *self = self.saturating_add(1);
+    }
+}
+
+impl SetMember<u16> for u16 {
+    fn create(val: u32) -> Option<u16> {
+        val.try_into().ok()
+    }
+
+    fn can_be_inverted() -> bool {
+        false
+    }
+
+    fn increment(&mut self) {
+        *self = self.saturating_add(1);
+    }
+}
+
+impl SetMember<u8> for u8 {
+    fn create(val: u32) -> Option<u8> {
+        val.try_into().ok()
+    }
+
+    fn can_be_inverted() -> bool {
+        false
+    }
+
+    fn increment(&mut self) {
+        *self = self.saturating_add(1);
+    }
+}
+
+impl SetMember<GlyphId16> for GlyphId16 {
+    fn create(val: u32) -> Option<GlyphId16> {
+        let val: u16 = val.try_into().ok()?;
+        Some(GlyphId16::new(val))
+    }
+
+    fn can_be_inverted() -> bool {
+        false
+    }
+
+    fn increment(&mut self) {
+        *self = GlyphId16::new(self.to_u16().saturating_add(1));
+    }
+}
+
+impl SetMember<GlyphId> for GlyphId {
+    fn create(val: u32) -> Option<GlyphId> {
+        Some(GlyphId::new(val))
+    }
+
+    fn can_be_inverted() -> bool {
+        false
+    }
+
+    fn increment(&mut self) {
+        *self = GlyphId::new(self.to_u32().saturating_add(1));
     }
 }
 

--- a/int-set/src/bitset.rs
+++ b/int-set/src/bitset.rs
@@ -651,18 +651,6 @@ impl std::cmp::PartialEq for BitSet {
 
 impl std::cmp::Eq for BitSet {}
 
-impl std::cmp::Ord for PageInfo {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.major_value.cmp(&other.major_value)
-    }
-}
-
-impl std::cmp::PartialOrd for PageInfo {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 struct BitSetRangeIter<'a> {
     set: &'a BitSet,
     page_info_index: usize,


### PR DESCRIPTION
- Add hash and equals ops
- Add all of the int types which domains are provided for.