### PR TITLE
Re-export both glyph ids

### DIFF
--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -56,7 +56,7 @@ pub mod prelude {
 }
 
 pub use read_fonts::{
-    types::{GlyphId, Tag},
+    types::{GlyphId, GlyphId16, Tag},
     FontRef,
 };
 


### PR DESCRIPTION
In trying to use gid16 in harfruzz I discovered we don't re-export it. Perhaps we should? 