### PR TITLE
ci: Add a check for common typos.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,3 +123,11 @@ jobs:
       - name: cargo check wasm target
         run: cargo check --manifest-path=write-fonts/Cargo.toml --target wasm32-unknown-unknown
 
+  # If this fails, consider changing your text or adding something to .typos.toml
+  typos:
+    name: Check for typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: check typos
+        uses: crate-ci/typos@v1.23.2

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,37 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+extend-exclude = [
+    '*.ttx',
+    # /.git isn't in .gitignore, because git never tracks it.
+    # Typos doesn't know that, though.
+    '/.git',
+]
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+ba = "ba"
+BA = "BA"
+BENG = "BENG"
+fd_select_datas = "fd_select_datas"
+fo = "fo"
+FO = "FO"
+nd = "nd"
+ot = "ot"
+ot_round = "ot_round"
+OtRound = "OtRound"
+pn = "pn"
+Vai = "Vai"
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+loca = "loca"
+wdth = "wdth"


### PR DESCRIPTION
False positives can be addressed by adding them into `.typos.toml`.