### PR TITLE
Tweak typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,13 +21,9 @@ extend-exclude = [
 ba = "ba"
 BA = "BA"
 BENG = "BENG"
-fd_select_datas = "fd_select_datas"
 fo = "fo"
 FO = "FO"
 nd = "nd"
-ot = "ot"
-ot_round = "ot_round"
-OtRound = "OtRound"
 pn = "pn"
 Vai = "Vai"
 
@@ -35,3 +31,4 @@ Vai = "Vai"
 [default.extend-words]
 loca = "loca"
 wdth = "wdth"
+ot = "ot"

--- a/read-fonts/src/tables/postscript/fd_select.rs
+++ b/read-fonts/src/tables/postscript/fd_select.rs
@@ -53,8 +53,7 @@ mod tests {
             (34..128, 12),
             (128..1024, 2),
         ];
-        let fd_select_datas = make_fd_selects(map);
-        for data in fd_select_datas {
+        for data in make_fd_selects(map) {
             let fd_select = FdSelect::read(data.font_data()).unwrap();
             for (range, font_index) in map {
                 for gid in range.clone() {


### PR DESCRIPTION
Followon to #1030, fix use of "datas" and promot "ot" to word status because it is a very common abbreviation of OpenType

JMM