### PR TITLE
Make `font-types` an optional dependenct in `int-set`

### DIFF
--- a/int-set/Cargo.toml
+++ b/int-set/Cargo.toml
@@ -6,7 +6,11 @@ license = "MIT/Apache-2.0"
 description = "A fast sparse and invertible bit set for u32's. Port of harfbuzz's hb_set_t."
 
 [dependencies]
-font-types = { version = "0.5.5", path = "../font-types"}
+font-types = { version = "0.5.5", path = "../font-types", optional = true}
+
+[features]
+default = ["font_types"]
+font_types = ["dep:font-types"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/int-set/src/lib.rs
+++ b/int-set/src/lib.rs
@@ -24,6 +24,7 @@ mod output_bit_stream;
 pub mod sparse_bit_set;
 
 use bitset::BitSet;
+#[cfg(feature = "font_types")]
 use font_types::{GlyphId, GlyphId16};
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -700,6 +701,7 @@ impl Domain<u8> for u8 {
     }
 }
 
+#[cfg(feature = "font_types")]
 impl Domain<GlyphId16> for GlyphId16 {
     fn to_u32(&self) -> u32 {
         self.to_u16() as u32
@@ -724,6 +726,7 @@ impl Domain<GlyphId16> for GlyphId16 {
     }
 }
 
+#[cfg(feature = "font_types")]
 impl Domain<GlyphId> for GlyphId {
     fn to_u32(&self) -> u32 {
         GlyphId::to_u32(*self)


### PR DESCRIPTION
So that it can be used without pulling in a whole new dependency. I think in theory it would be nicer if the default were to not include it, but since many of the tests rely on it I've made it opt out instead. Perhaps it would be nice to also check it in CI.