### PR TITLE
[int-set] Impl From<[T; N]> for IntSet<T>

### DIFF
--- a/read-fonts/src/collections/int_set/mod.rs
+++ b/read-fonts/src/collections/int_set/mod.rs
@@ -470,6 +470,12 @@ impl<T: Domain> Hash for IntSet<T> {
 
 impl<T: Domain> Eq for IntSet<T> {}
 
+impl<T: Domain, const N: usize> From<[T; N]> for IntSet<T> {
+    fn from(value: [T; N]) -> Self {
+        value.into_iter().collect()
+    }
+}
+
 struct Iter<SetIter, AllValuesIter> {
     set_values: SetIter,
     all_values: Option<AllValuesIter>,


### PR DESCRIPTION
This is a common way to initialize construct sets (particularly for testing), and is implemented for both HashSet and BTreeSet; having it here will make it easier to use IntSet as a drop-in replacement for those types.