### PR TITLE
[skrifa] autohint outline cleanup

### DIFF
--- a/skrifa/src/outline/autohint/cycling.rs
+++ b/skrifa/src/outline/autohint/cycling.rs
@@ -1,38 +1,6 @@
 //! Various helpers for dealing with iteration of a slice
 //! that represents a loop. Specifically, outline contours.
 
-#[derive(Copy, Clone, Debug)]
-pub(super) struct IndexCycler {
-    last: usize,
-}
-
-impl IndexCycler {
-    /// Creates a new index cycler for a collection of the given length.
-    ///
-    /// Returns `None` if the length is 0.
-    pub fn new(len: usize) -> Option<Self> {
-        Some(Self {
-            last: len.checked_sub(1)?,
-        })
-    }
-
-    pub fn next(self, ix: usize) -> usize {
-        if ix >= self.last {
-            0
-        } else {
-            ix + 1
-        }
-    }
-
-    pub fn prev(self, ix: usize) -> usize {
-        if ix == 0 {
-            self.last
-        } else {
-            ix - 1
-        }
-    }
-}
-
 /// Iterator that begins at `start + 1` and cycles through all items
 /// of the slice in forward order, ending with `start`.
 pub(super) fn cycle_forward<T>(items: &[T], start: usize) -> impl Iterator<Item = (usize, &T)> {
@@ -56,20 +24,6 @@ pub(super) fn cycle_backward<T>(items: &[T], start: usize) -> impl Iterator<Item
 
 #[cfg(test)]
 mod tests {
-    use super::IndexCycler;
-
-    #[test]
-    fn cycler() {
-        let cycler = IndexCycler::new(4).unwrap();
-        // basic ops
-        assert_eq!(cycler.next(0), 1);
-        assert_eq!(cycler.prev(2), 1);
-        // cycling ops
-        assert_eq!(cycler.next(3), 0);
-        assert_eq!(cycler.prev(0), 3);
-        assert!(IndexCycler::new(0).is_none());
-    }
-
     #[test]
     fn cycle_iter_forward() {
         let items = [0, 1, 2, 3, 4, 5, 6, 7];


### PR DESCRIPTION
* Rework `IndexCycler` into just a `Contour` type that is now used in `Outline`.
* Add next/prev indices to `Point`.