### PR TITLE
[skrifa] autohint: axis types

### DIFF
--- a/skrifa/src/outline/autohint/axis.rs
+++ b/skrifa/src/outline/autohint/axis.rs
@@ -1,0 +1,101 @@
+//! Segments and edges for one dimension of an outline.
+
+use super::outline::{Direction, Point};
+use crate::collections::SmallVec;
+
+/// Maximum number of segments and edges stored inline.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L306>
+const MAX_INLINE_SEGMENTS: usize = 18;
+const MAX_INLINE_EDGES: usize = 12;
+
+/// Segments and edges for one dimension of an outline.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L309>
+#[derive(Clone, Default, Debug)]
+pub struct Axis {
+    /// Either horizontal or vertical.
+    pub dim: Dimension,
+    /// Depends on dimension and outline orientation.
+    pub major_dir: Direction,
+    /// Collection of segments for the axis.
+    pub segments: SmallVec<Segment, MAX_INLINE_SEGMENTS>,
+}
+
+/// Either horizontal or vertical.
+///
+/// A type alias because it's used as an index.
+pub type Dimension = usize;
+
+impl Axis {
+    /// X coordinates, i.e. vertical segments and edges.
+    pub const HORIZONTAL: Dimension = 0;
+    /// Y coordinates, i.e. horizontal segments and edges.
+    pub const VERTICAL: Dimension = 1;
+}
+
+/// Sequence of points with a single dominant direction.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L262>
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub struct Segment {
+    /// Flags describing the properties of the segment.
+    pub flags: u8,
+    /// Dominant direction of the segment.
+    pub dir: Direction,
+    /// Position of the segment.
+    pub pos: i16,
+    /// Deviation from segment position.
+    pub delta: i16,
+    /// Minimum coordinate of the segment.
+    pub min_coord: i16,
+    /// Maximum coordinate of the segment.
+    pub max_coord: i16,
+    /// Hinted segment height.
+    pub height: i16,
+    /// Used during stem matching.
+    pub score: i32,
+    /// Index of first point in the outline.
+    pub first_ix: u16,
+    /// Index of last point in the outline.
+    pub last_ix: u16,
+}
+
+/// Segment flags.
+///
+/// Note: these are the same as edge flags.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L227>
+impl Segment {
+    pub const NORMAL: u8 = 0;
+    pub const ROUND: u8 = 1;
+    pub const SERIF: u8 = 2;
+    pub const DONE: u8 = 4;
+    pub const NEUTRAL: u8 = 8;
+}
+
+impl Segment {
+    pub fn first(&self) -> usize {
+        self.first_ix as usize
+    }
+
+    pub fn first_point<'a>(&self, points: &'a [Point]) -> &'a Point {
+        &points[self.first()]
+    }
+
+    pub fn first_point_mut<'a>(&self, points: &'a mut [Point]) -> &'a mut Point {
+        &mut points[self.first()]
+    }
+
+    pub fn last(&self) -> usize {
+        self.last_ix as usize
+    }
+
+    pub fn last_point<'a>(&self, points: &'a [Point]) -> &'a Point {
+        &points[self.last()]
+    }
+
+    pub fn last_point_mut<'a>(&self, points: &'a mut [Point]) -> &'a mut Point {
+        &mut points[self.last()]
+    }
+}

--- a/skrifa/src/outline/autohint/latin/blues.rs
+++ b/skrifa/src/outline/autohint/latin/blues.rs
@@ -1,6 +1,6 @@
-//! Latin specific autohinting support.
+//! Latin blue values.
 
-use super::{
+use super::super::{
     super::unscaled::UnscaledOutlineBuf,
     cycling::{cycle_backward, cycle_forward},
     metrics::{UnscaledBlue, UnscaledBlues, MAX_BLUES},
@@ -421,13 +421,13 @@ impl UnscaledBlues {
 
 #[cfg(test)]
 mod tests {
-    use super::{blue_flags, UnscaledBlue};
+    use super::{super::super::script, blue_flags, UnscaledBlue};
     use raw::FontRef;
 
     #[test]
     fn latin_blues() {
         let font = FontRef::new(font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS).unwrap();
-        let script = &super::super::script::SCRIPT_CLASSES[super::ScriptClass::LATN];
+        let script = &script::SCRIPT_CLASSES[super::ScriptClass::LATN];
         let blues = super::UnscaledBlues::new_latin(&font, &[], script);
         let values = blues.as_slice();
         let expected = [
@@ -481,7 +481,7 @@ mod tests {
     fn latin_long_blues() {
         let font = FontRef::new(font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS).unwrap();
         // Hebrew triggers "long" blue code path
-        let script = &super::super::script::SCRIPT_CLASSES[super::ScriptClass::HEBR];
+        let script = &script::SCRIPT_CLASSES[super::ScriptClass::HEBR];
         let blues = super::UnscaledBlues::new_latin(&font, &[], script);
         let values = blues.as_slice();
         assert_eq!(values.len(), 3);

--- a/skrifa/src/outline/autohint/latin/mod.rs
+++ b/skrifa/src/outline/autohint/latin/mod.rs
@@ -1,0 +1,3 @@
+//! Latin writing system.
+
+mod blues;

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -3,6 +3,7 @@
 // Remove when the work is complete.
 #![allow(dead_code)]
 
+mod axis;
 mod cycling;
 mod latin;
 mod metrics;


### PR DESCRIPTION
Adds some new types to describe hints along a single axis.

Also does some shuffling of modules to make room for more Latin specific code.