### PR TITLE
[read-fonts] gvar: phantom point deltas

### DIFF
--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -100,7 +100,6 @@ impl<'a> Gvar<'a> {
         // count), so that we know where the deltas for phantom points start
         // in the variation data.
         let (glyph_id, point_count) = find_glyph_and_point_count(glyf, loca, glyph_id, 0)?;
-        // [left_extent_delta, right_extent_delta]
         let mut phantom_deltas = [Fixed::ZERO; 4];
         let phantom_range = point_count..point_count + 4;
         let var_data = self.glyph_variation_data(glyph_id).ok()?;

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -189,7 +189,7 @@ impl TupleDelta for GlyphDelta {
 /// For simple glyphs, that is simply the requested glyph. For composites, it
 /// depends on the USE_MY_METRICS flag.
 ///
-/// Returns the resulting glyph identifer and the number of points (or
+/// Returns the resulting glyph identifier and the number of points (or
 /// components) in that glyph. This count represents the start of the phantom
 /// points.
 fn find_glyph_and_point_count(

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -369,10 +369,11 @@ impl<'a> GlyphMetrics<'a> {
 impl<'a> GlyphMetrics<'a> {
     fn metric_deltas_from_gvar(&self, glyph_id: GlyphId) -> Option<[i32; 2]> {
         let (loca, glyf) = self.loca_glyf.as_ref()?;
-        let mut deltas =
-            self.gvar
-                .as_ref()?
-                .phantom_point_deltas(glyf, loca, self.coords, glyph_id)?;
+        let mut deltas = self
+            .gvar
+            .as_ref()?
+            .phantom_point_deltas(glyf, loca, self.coords, glyph_id)
+            .ok()?;
         deltas[1] -= deltas[0];
         Some([deltas[0], deltas[1]].map(|delta| delta.to_i32()))
     }


### PR DESCRIPTION
Basically just moves our gvar phantom point delta computation from skrifa to read-fonts since we'll need this for glyph metrics in harfruzz.