### PR TITLE
Use workspace inheritance for package properties.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ members = [
     "fuzz",
 ]
 
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/googlefonts/fontations"
+
 [workspace.dependencies]
 # note: bytemuck version must be available in all deployment environments, 
 # specifically the floor of the versions supported by google3 and Chrome

--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fauntlet"
 version = "0.1.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Testing tool for comparing Skrifa and FreeType."
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 skrifa = { version = "0.20.0", path = "../skrifa" }

--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "font-codegen"
 version = "0.0.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 autotests = false
 publish = false
 default-run = "codegen"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "codegen"

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "font-test-data"
 version = "0.1.5"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Test data for the fontations crates"
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["test data"]
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # It is useful to publish this so tools that pull from crates can see it
 #publish = false

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "font-types"
 version = "0.6.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Scalar types used in fonts."
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing"]
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 std = []

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,10 @@
 name = "fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [package.metadata]
 cargo-fuzz = true

--- a/klippa/Cargo.toml
+++ b/klippa/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "klippa"
 version = "0.1.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Subsetting a font file according to provided input."
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing"]
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "otexplorer"
 version = "0.1.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 publish = false
 
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 xflags = "0.3.0"

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "read-fonts"
 version = "0.20.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Reading OpenType font files."
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 std = ["font-types/std"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "skrifa"
 version = "0.20.0"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 default = ["traversal"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "write-fonts"
 version = "0.28.1"
-edition = "2021"
-license = "MIT/Apache-2.0"
 description = "Writing font files."
-repository = "https://github.com/googlefonts/fontations"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
This adds `[workspace.package]` to the root `Cargo.toml` with (initially) `edition`, `license`, and `repository` properties. It then inherits them into each package in the repository.

This gives `fuzz` a license that wasn't previously stated in the Cargo.toml and `font-codegen`, `fuzz`, and `otexplorer` get a `repository` property that they didn't have before.

The license in the `Cargo.toml` is now a valid SPDX license expression rather than using a form deprecated by cargo.