### PR TITLE
Change IntSet::len() to return u64 instead of usize.

### DIFF
--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -14,7 +14,7 @@ use int_set_op_processor::OperationSet;
 use int_set_op_processor::SmallEvenInt;
 use int_set_op_processor::SmallInt;
 
-const OPERATION_COUNT: usize = 7_500;
+const OPERATION_COUNT: u64 = 7_500;
 
 fuzz_target!(|data: &[u8]| {
     let Some(mode_byte) = data.first() else {

--- a/fuzz/fuzz_targets/fuzz_sparse_bit_set_encode.rs
+++ b/fuzz/fuzz_targets/fuzz_sparse_bit_set_encode.rs
@@ -8,7 +8,7 @@ mod int_set_op_processor;
 use int_set_op_processor::process_op_codes;
 use int_set_op_processor::OperationSet;
 
-const OPERATION_COUNT: usize = 2000;
+const OPERATION_COUNT: u64 = 2000;
 
 fuzz_target!(|data: &[u8]| {
     let _ = process_op_codes::<u32>(OperationSet::SparseBitSetEncoding, OPERATION_COUNT, data);

--- a/fuzz/fuzz_targets/int_set_op_processor.rs
+++ b/fuzz/fuzz_targets/int_set_op_processor.rs
@@ -158,8 +158,8 @@ impl Domain for SmallInt {
         range.start().to_u32()..=range.end().to_u32()
     }
 
-    fn count() -> usize {
-        Self::MAX_VALUE as usize + 1
+    fn count() -> u64 {
+        Self::MAX_VALUE as u64 + 1
     }
 }
 
@@ -228,8 +228,8 @@ impl Domain for SmallEvenInt {
         ((range.start().to_u32() / 2)..=(range.end().to_u32() / 2)).map(|ord| ord * 2)
     }
 
-    fn count() -> usize {
-        ((Self::MAX_VALUE / 2) + 1) as usize
+    fn count() -> u64 {
+        ((Self::MAX_VALUE / 2) + 1) as u64
     }
 }
 
@@ -246,7 +246,7 @@ impl<T> Input<'_, T> {
 }
 
 trait Operation<T> {
-    fn size(&self, set_len: usize) -> usize;
+    fn size(&self, set_len: u64) -> u64;
     fn operate(&self, input: Input<T>, other: Input<T>);
 }
 
@@ -272,8 +272,8 @@ where
         input.btree_set.insert(self.0);
     }
 
-    fn size(&self, length: usize) -> usize {
-        length.ilog2() as usize
+    fn size(&self, length: u64) -> u64 {
+        length.ilog2() as u64
     }
 }
 
@@ -296,11 +296,11 @@ impl<T> Operation<T> for InsertRangeOp<T>
 where
     T: SetMember,
 {
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         if self.1 < self.0 {
             return 1;
         }
-        ((self.1.to_u32() as usize - self.0.to_u32() as usize) + 1) * (length.ilog2() as usize)
+        ((self.1.to_u32() as u64 - self.0.to_u32() as u64) + 1) * (length.ilog2() as u64)
     }
 
     fn operate(&self, input: Input<T>, _: Input<T>) {
@@ -331,8 +331,8 @@ impl<T> Operation<T> for RemoveOp<T>
 where
     T: SetMember,
 {
-    fn size(&self, length: usize) -> usize {
-        length.ilog2() as usize
+    fn size(&self, length: u64) -> u64 {
+        length.ilog2() as u64
     }
 
     fn operate(&self, input: Input<T>, _: Input<T>) {
@@ -360,11 +360,11 @@ impl<T> Operation<T> for RemoveRangeOp<T>
 where
     T: SetMember,
 {
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         if self.1 < self.0 {
             return 1;
         }
-        ((self.1.to_u32() as usize - self.0.to_u32() as usize) + 1) * (length.ilog2() as usize)
+        ((self.1.to_u32() as u64 - self.0.to_u32() as u64) + 1) * (length.ilog2() as u64)
     }
 
     fn operate(&self, input: Input<T>, _: Input<T>) {
@@ -394,10 +394,10 @@ where
     T: SetMember,
 {
     fn operate(&self, input: Input<T>, _: Input<T>) {
-        assert_eq!(input.int_set.len(), input.btree_set.len());
+        assert_eq!(input.int_set.len(), input.btree_set.len() as u64);
     }
 
-    fn size(&self, _: usize) -> usize {
+    fn size(&self, _: u64) -> u64 {
         1
     }
 }
@@ -423,7 +423,7 @@ where
         assert_eq!(input.int_set.is_empty(), input.btree_set.is_empty());
     }
 
-    fn size(&self, _: usize) -> usize {
+    fn size(&self, _: u64) -> u64 {
         1
     }
 }
@@ -453,8 +453,8 @@ where
         );
     }
 
-    fn size(&self, length: usize) -> usize {
-        length.ilog2() as usize
+    fn size(&self, length: u64) -> u64 {
+        length.ilog2() as u64
     }
 }
 
@@ -480,7 +480,7 @@ where
         input.btree_set.clear();
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -520,11 +520,11 @@ where
         assert_eq!(int_set_intersects, btree_intersects);
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         if self.1 < self.0 {
             return 1;
         }
-        ((self.1.to_u32() as usize - self.0.to_u32() as usize) + 1) * (length.ilog2() as usize)
+        ((self.1.to_u32() as u64 - self.0.to_u32() as u64) + 1) * (length.ilog2() as u64)
     }
 }
 
@@ -549,8 +549,8 @@ where
         assert_eq!(input.int_set.first(), input.btree_set.first().copied());
     }
 
-    fn size(&self, length: usize) -> usize {
-        length.ilog2() as usize
+    fn size(&self, length: u64) -> u64 {
+        length.ilog2() as u64
     }
 }
 
@@ -575,8 +575,8 @@ where
         assert_eq!(input.int_set.last(), input.btree_set.last().copied());
     }
 
-    fn size(&self, length: usize) -> usize {
-        length.ilog2() as usize
+    fn size(&self, length: u64) -> u64 {
+        length.ilog2() as u64
     }
 }
 
@@ -601,7 +601,7 @@ where
         assert!(input.int_set.iter().eq(input.btree_set.iter().copied()));
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -637,7 +637,7 @@ where
         };
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -684,7 +684,7 @@ where
         assert!(input.int_set.iter_ranges().eq(btree_ranges.iter().cloned()));
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -715,7 +715,7 @@ where
         assert!(it.eq(btree_it.copied()));
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -744,8 +744,8 @@ where
         }
     }
 
-    fn size(&self, length: usize) -> usize {
-        (length.ilog2() as usize) * self.0.len()
+    fn size(&self, length: u64) -> u64 {
+        (length.ilog2() as u64) * (self.0.len() as u64)
     }
 }
 
@@ -771,8 +771,8 @@ where
         input.btree_set.extend(self.0.iter().copied());
     }
 
-    fn size(&self, length: usize) -> usize {
-        (length.ilog2() as usize) * self.0.len()
+    fn size(&self, length: u64) -> u64 {
+        (length.ilog2() as u64) * (self.0.len() as u64)
     }
 }
 
@@ -798,8 +798,8 @@ where
         input.btree_set.extend(self.0.iter().copied());
     }
 
-    fn size(&self, length: usize) -> usize {
-        (length.ilog2() as usize) * self.0.len()
+    fn size(&self, length: u64) -> u64 {
+        (length.ilog2() as u64) * (self.0.len() as u64)
     }
 }
 
@@ -827,7 +827,7 @@ where
         }
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         // TODO(garretrieger): should be length a + length b
         length
     }
@@ -856,7 +856,7 @@ where
         std::mem::swap(a.btree_set, &mut intersected);
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         // TODO(garretrieger): should be length a + length b
         length
     }
@@ -893,7 +893,7 @@ where
         std::mem::swap(input.btree_set, &mut inverted);
     }
 
-    fn size(&self, _: usize) -> usize {
+    fn size(&self, _: u64) -> u64 {
         T::count()
     }
 }
@@ -919,7 +919,7 @@ where
         input.int_set.is_inverted();
     }
 
-    fn size(&self, _: usize) -> usize {
+    fn size(&self, _: u64) -> u64 {
         1
     }
 }
@@ -955,7 +955,7 @@ where
         }
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -981,7 +981,7 @@ where
         assert_eq!(a.int_set == b.int_set, a.btree_set == b.btree_set);
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -999,7 +999,7 @@ impl<T: SetMember> Operation<T> for CmpOp {
         assert_eq!(a.int_set.cmp(&b.int_set), a.btree_set.cmp(&b.btree_set));
     }
 
-    fn size(&self, length: usize) -> usize {
+    fn size(&self, length: u64) -> u64 {
         length
     }
 }
@@ -1101,7 +1101,7 @@ where
 
 pub fn process_op_codes<T: SetMember + 'static>(
     operation_set: OperationSet,
-    op_count_limit: usize,
+    op_count_limit: u64,
     data: &[u8],
 ) -> Result<(), Box<dyn Error>> {
     let mut int_set_0 = IntSet::<T>::empty();
@@ -1109,7 +1109,7 @@ pub fn process_op_codes<T: SetMember + 'static>(
     let mut btree_set_0 = BTreeSet::<T>::new();
     let mut btree_set_1 = BTreeSet::<T>::new();
 
-    let mut ops_counter = 0usize;
+    let mut ops_counter = 0u64;
     let mut data = Cursor::new(data);
     loop {
         let next_op = next_operation::<T>(operation_set, &mut data);
@@ -1124,7 +1124,8 @@ pub fn process_op_codes<T: SetMember + 'static>(
                 &btree_set_1
             };
             // when computing size use minimum length of 2 to ensure minimum value of log2(length) is 1.
-            ops_counter = ops_counter.saturating_add(next_op.op.size(2.max(btree_set.len())));
+            ops_counter =
+                ops_counter.saturating_add(next_op.op.size(2.max(btree_set.len() as u64)));
             if ops_counter > op_count_limit {
                 // Operation count limit reached.
                 break;

--- a/read-fonts/src/collections/int_set/bitpage.rs
+++ b/read-fonts/src/collections/int_set/bitpage.rs
@@ -35,13 +35,13 @@ impl BitPage {
     }
 
     /// Returns the number of members in this page.
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> u32 {
         if self.is_dirty() {
             // this means we're stale and should recompute
             let len = self.storage.iter().map(|val| val.count_ones()).sum();
             self.len.set(len);
         }
-        self.len.get() as usize
+        self.len.get()
     }
 
     /// Returns true if this page has no members.

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -18,7 +18,7 @@ pub(crate) struct BitSet {
     // TODO(garretrieger): consider a "small array" type instead of Vec.
     pages: Vec<BitPage>,
     page_map: Vec<PageInfo>,
-    len: Cell<usize>, // TODO(garretrieger): use an option instead of a sentinel.
+    len: Cell<u64>, // TODO(garretrieger): use an option instead of a sentinel.
 }
 
 impl BitSet {
@@ -166,12 +166,12 @@ impl BitSet {
     }
 
     /// Returns the number of members in this set.
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> u64 {
         // TODO(garretrieger): keep track of len on the fly, rather than computing it. Leave a computation method
         //                     for complex cases if needed.
         if self.is_dirty() {
             // this means we're stale and should recompute
-            let len = self.pages.iter().map(|val| val.len()).sum();
+            let len = self.pages.iter().map(|val| val.len() as u64).sum();
             self.len.set(len);
         }
         self.len.get()
@@ -471,11 +471,11 @@ impl BitSet {
     }
 
     fn mark_dirty(&mut self) {
-        self.len.set(usize::MAX);
+        self.len.set(u64::MAX);
     }
 
     fn is_dirty(&self) -> bool {
-        self.len.get() == usize::MAX
+        self.len.get() == u64::MAX
     }
 
     /// Return the major value (top 23 bits) of the page associated with value.
@@ -1156,7 +1156,7 @@ mod test {
             set.len();
             set.insert_range(range.0..=range.1);
             assert_eq!(set, set_for_range(range.0, range.1), "{range:?}");
-            assert_eq!(set.len(), (range.1 - range.0 + 1) as usize, "{range:?}");
+            assert_eq!(set.len(), (range.1 - range.0 + 1) as u64, "{range:?}");
         }
     }
 

--- a/read-fonts/src/collections/int_set/mod.rs
+++ b/read-fonts/src/collections/int_set/mod.rs
@@ -75,7 +75,7 @@ pub trait Domain: Sized {
     fn ordered_values_range(range: RangeInclusive<Self>) -> impl DoubleEndedIterator<Item = u32>;
 
     /// Returns the number of members in the domain.
-    fn count() -> usize;
+    fn count() -> u64;
 }
 
 /// Marks a mapped value as being in the domain of `T` for [`Domain`].
@@ -333,7 +333,7 @@ impl<T: Domain> IntSet<T> {
     }
 
     /// Returns the number of members in this set.
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         match &self.0 {
             Membership::Inclusive(s) => s.len(),
             Membership::Exclusive(s) => T::count() - s.len(),
@@ -851,8 +851,8 @@ impl Domain for u32 {
         range
     }
 
-    fn count() -> usize {
-        (u32::MAX as usize) - (u32::MIN as usize) + 1
+    fn count() -> u64 {
+        (u32::MAX as u64) - (u32::MIN as u64) + 1
     }
 }
 
@@ -877,8 +877,8 @@ impl Domain for u16 {
         (*range.start() as u32)..=(*range.end() as u32)
     }
 
-    fn count() -> usize {
-        (u16::MAX as usize) - (u16::MIN as usize) + 1
+    fn count() -> u64 {
+        (u16::MAX as u64) - (u16::MIN as u64) + 1
     }
 }
 
@@ -903,8 +903,8 @@ impl Domain for u8 {
         (*range.start() as u32)..=(*range.end() as u32)
     }
 
-    fn count() -> usize {
-        (u8::MAX as usize) - (u8::MIN as usize) + 1
+    fn count() -> u64 {
+        (u8::MAX as u64) - (u8::MIN as u64) + 1
     }
 }
 
@@ -931,8 +931,8 @@ impl Domain for GlyphId16 {
         range.start().to_u32()..=range.end().to_u32()
     }
 
-    fn count() -> usize {
-        (u16::MAX as usize) - (u16::MIN as usize) + 1
+    fn count() -> u64 {
+        (u16::MAX as u64) - (u16::MIN as u64) + 1
     }
 }
 
@@ -959,8 +959,8 @@ impl Domain for GlyphId {
         range.start().to_u32()..=range.end().to_u32()
     }
 
-    fn count() -> usize {
-        (u32::MAX as usize) - (u32::MIN as usize) + 1
+    fn count() -> u64 {
+        (u32::MAX as u64) - (u32::MIN as u64) + 1
     }
 }
 
@@ -1003,8 +1003,8 @@ mod test {
                 .filter(move |v| *v >= range.start().to_u32() && *v <= range.end().to_u32())
         }
 
-        fn count() -> usize {
-            ((u32::MAX as usize) - (u32::MIN as usize) + 1) / 2
+        fn count() -> u64 {
+            ((u32::MAX as u64) - (u32::MIN as u64) + 1) / 2
         }
     }
 
@@ -1035,7 +1035,7 @@ mod test {
                 .filter(move |v| *v >= range.start().to_u32() && *v <= range.end().to_u32())
         }
 
-        fn count() -> usize {
+        fn count() -> u64 {
             4 + 9
         }
     }
@@ -1069,7 +1069,7 @@ mod test {
                 .filter(move |v| *v >= range.start().to_u32() && *v <= range.end().to_u32())
         }
 
-        fn count() -> usize {
+        fn count() -> u64 {
             4
         }
     }
@@ -1866,7 +1866,7 @@ mod test {
         assert!(!set.is_inverted());
 
         set.invert();
-        assert_eq!(set.len(), u32::MAX as usize - 1);
+        assert_eq!(set.len(), u32::MAX as u64 - 1);
         assert!(!set.contains(13));
         assert!(set.contains(80));
         assert!(!set.contains(800));
@@ -2168,9 +2168,9 @@ mod test {
         assert_eq!(s.len(), 2);
 
         s.invert();
-        assert_eq!(s.len(), (u32::MAX - 1) as usize);
+        assert_eq!(s.len(), (u32::MAX - 1) as u64);
 
-        assert_eq!(IntSet::<u32>::all().len(), (u32::MAX as usize) + 1);
+        assert_eq!(IntSet::<u32>::all().len(), (u32::MAX as u64) + 1);
 
         let mut s = IntSet::<TwoParts>::all();
         assert_eq!(s.len(), 13);

--- a/read-fonts/src/collections/int_set/sparse_bit_set.rs
+++ b/read-fonts/src/collections/int_set/sparse_bit_set.rs
@@ -254,8 +254,8 @@ struct CreateLayerState<'a> {
     current_node: Option<Node>,
     current_node_filled_bits: u32,
     nodes: &'a mut Vec<Node>,
-    child_count: usize,
-    nodes_init_length: usize,
+    child_count: u64,
+    nodes_init_length: u64,
     branch_factor: BranchFactor,
 }
 
@@ -280,7 +280,9 @@ impl<'a> CreateLayerState<'a> {
                 let children_end_index = self.nodes_init_length;
                 // TODO(garretrieger): this scans all nodes of the previous layer to find those which are children,
                 //   but we can likely limit it to just the children of this node with some extra book keeping.
-                for child in &mut self.nodes[children_start_index..children_end_index] {
+                for child in
+                    &mut self.nodes[children_start_index as usize..children_end_index as usize]
+                {
                     if child.parent_index >= node.parent_index * self.branch_factor.value()
                         && child.parent_index < (node.parent_index + 1) * self.branch_factor.value()
                     {
@@ -314,7 +316,7 @@ fn create_layer(
         current_node: None,
         current_node_filled_bits: 0,
         child_count: values.len(),
-        nodes_init_length: nodes.len(),
+        nodes_init_length: nodes.len() as u64,
         nodes,
         branch_factor,
     };


### PR DESCRIPTION
A u32 containing intset can have up to u32::MAX + 1 elements in it which can overflow a usize when usize is a u32. Fixes #1057 