### PR TITLE
Use workspace dependencies for libs in this repo.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,17 @@ kurbo = "0.11.0"
 
 core_maths = "0.1"
 
+# These allow using the workspace library crates without having to
+# update the versions in each crate that uses the libraries or
+# having to use the correct path.
+# `read-fonts` disables default-features so that it can be used without
+# default-features enabled by `skrifa`. Other crates using `read-fonts`
+# that want default features will have to enable them directly.
+font-test-data = { path = "font-test-data" }
+font-types = { version = "0.6.0", path = "font-types" }
+read-fonts = { version = "0.20.0", path = "read-fonts", default-features = false }
+skrifa = { version = "0.20.0", path = "skrifa" }
+write-fonts = { version = "0.28.1", path = "write-fonts" }
+
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-skrifa = { version = "0.20.0", path = "../skrifa" }
+skrifa = { workspace = true }
 freetype-rs = "0.32.0"
 memmap2 = "0.5.10"
 rayon = "1.8.0"

--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -14,7 +14,7 @@ name = "codegen"
 path = "src/main.rs"
 
 [dependencies]
-font-types = { version = "0.6.0", path = "../font-types" }
+font-types = { workspace = true }
 rustfmt-wrapper = "0.2"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,9 +16,9 @@ release = false
 
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
-skrifa = { path="../skrifa" }
-font-types = { path= "../font-types" }
-read-fonts = { path = "../read-fonts" }
+font-types = { workspace = true }
+read-fonts = { workspace = true, default-features = true }
+skrifa = { workspace = true }
 
 [[bin]]
 name = "fuzz_skrifa_charmap"

--- a/klippa/Cargo.toml
+++ b/klippa/Cargo.toml
@@ -14,12 +14,12 @@ repository.workspace = true
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
 regex = "1.10.4"
-skrifa = { version = "0.20.0", path = "../skrifa" }
+skrifa = { workspace = true }
 thiserror = "1.0.58"
-write-fonts = { path = "../write-fonts", features = ["read"] }
+write-fonts = { workspace = true, features = ["read"] }
 
 
 [dev-dependencies]
 diff = "0.1.13"
 tempdir = "0.3.7"
-font-test-data = { path = "../font-test-data" }
+font-test-data = { workspace = true }

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,11 +8,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-xflags = "0.3.0"
-read-fonts = { path = "../read-fonts",version = "0.20.0" }
-font-types = { path = "../font-types",version = "0.6.0" }
 ansi_term = "0.12.1"
 atty = "0.2"
+font-types = { workspace = true }
+read-fonts = { workspace = true, default-features = true }
+xflags = "0.3.0"
 
 # cargo-release settings
 [package.metadata.release]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -19,13 +19,13 @@ serde = ["dep:serde", "font-types/serde"]
 libm = ["dep:core_maths"]
 
 [dependencies]
-font-types = { version = "0.6.0", path = "../font-types", features = ["bytemuck"] }
+font-types = { workspace = true, features = ["bytemuck"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 core_maths = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 
 [dev-dependencies]
-font-test-data = { path = "../font-test-data" }
+font-test-data = { workspace = true }
 criterion = "0.5.1"
 rand = "0.8.5"
 

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -16,18 +16,18 @@ traversal = ["std", "read-fonts/traversal"]
 libm = ["dep:core_maths", "read-fonts/libm"]
 
 [dependencies]
-read-fonts = { version = "0.20.0", path = "../read-fonts", default-features = false }
+read-fonts = { workspace = true, default-features = false }
 core_maths = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 
 [dev-dependencies]
-font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.20.0", path = "../read-fonts", features = [
+font-test-data = { workspace = true }
+read-fonts = { workspace = true, features = [
     "scaler_test",
     "serde",
 ] }
 serde = "1.0"
 serde_json = "1.0"
 pretty_assertions = "1.3.0"
-write-fonts = { path = "../write-fonts" }
+write-fonts = { workspace = true }
 kurbo.workspace = true

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -16,8 +16,8 @@ dot2 = ["dep:dot2"]
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 
 [dependencies]
-font-types = { version = "0.6.0", path = "../font-types" }
-read-fonts = { version = "0.20.0", path = "../read-fonts" }
+font-types = { workspace = true }
+read-fonts = { workspace = true, default-features = true }
 log = "0.4"
 kurbo.workspace = true
 dot2 = { version = "1.0", optional = true }
@@ -27,8 +27,8 @@ indexmap = "2.0"
 [dev-dependencies]
 diff = "0.1.12"
 ansi_term = "0.12.1"
-font-test-data = { path = "../font-test-data" }
-read-fonts = { version = "0.20.0", path = "../read-fonts", features = [
+font-test-data = { workspace = true }
+read-fonts = { workspace = true, features = [
   "codegen_test",
 ] }
 rstest = "0.18.0"


### PR DESCRIPTION
This eliminates having to specify the version for the library crates in each thing that depends upon them.