### PR TITLE
[skrifa] FontRef instead of TableProvider

### DIFF
--- a/skrifa/src/outline/base.rs
+++ b/skrifa/src/outline/base.rs
@@ -1,0 +1,58 @@
+//! Common functionality for glyf, cff and autohinting scalers.
+
+use raw::{
+    tables::{hmtx::Hmtx, hvar::Hvar},
+    types::{BigEndian, F2Dot14, GlyphId, Tag},
+    FontRef, TableProvider,
+};
+
+/// Common functionality for glyf, cff and autohinting scalers.
+#[derive(Clone)]
+pub(crate) struct BaseScaler<'a> {
+    pub font: FontRef<'a>,
+    pub hmtx: Hmtx<'a>,
+    pub hvar: Option<Hvar<'a>>,
+}
+
+impl<'a> BaseScaler<'a> {
+    pub fn new(font: &FontRef<'a>) -> Option<Self> {
+        let hmtx = font.hmtx().ok()?;
+        let hvar = font.hvar().ok();
+        Some(Self {
+            font: font.clone(),
+            hmtx,
+            hvar,
+        })
+    }
+
+    pub fn advance_width(&self, gid: GlyphId, coords: &'a [F2Dot14]) -> i32 {
+        let mut advance = self.hmtx.advance(gid).unwrap_or_default() as i32;
+        if let Some(hvar) = &self.hvar {
+            advance += hvar
+                .advance_width_delta(gid, coords)
+                // FreeType truncates metric deltas...
+                .map(|delta| delta.to_f64() as i32)
+                .unwrap_or(0);
+        }
+        advance
+    }
+
+    pub fn lsb(&self, gid: GlyphId, coords: &'a [F2Dot14]) -> i32 {
+        let mut lsb = self.hmtx.side_bearing(gid).unwrap_or_default() as i32;
+        if let Some(hvar) = &self.hvar {
+            lsb += hvar
+                .lsb_delta(gid, coords)
+                // FreeType truncates metric deltas...
+                .map(|delta| delta.to_f64() as i32)
+                .unwrap_or(0);
+        }
+        lsb
+    }
+
+    pub fn cvt(&self) -> &[BigEndian<i16>] {
+        self.font
+            .data_for_tag(Tag::new(b"cvt "))
+            .and_then(|d| d.read_array(0..d.len()).ok())
+            .unwrap_or_default()
+    }
+}

--- a/skrifa/src/outline/base.rs
+++ b/skrifa/src/outline/base.rs
@@ -8,13 +8,13 @@ use raw::{
 
 /// Common functionality for glyf, cff and autohinting scalers.
 #[derive(Clone)]
-pub(crate) struct BaseScaler<'a> {
+pub(crate) struct BaseOutlines<'a> {
     pub font: FontRef<'a>,
     pub hmtx: Hmtx<'a>,
     pub hvar: Option<Hvar<'a>>,
 }
 
-impl<'a> BaseScaler<'a> {
+impl<'a> BaseOutlines<'a> {
     pub fn new(font: &FontRef<'a>) -> Option<Self> {
         let hmtx = font.hmtx().ok()?;
         let hvar = font.hvar().ok();

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -1105,7 +1105,7 @@ mod tests {
     use read_fonts::{tables::postscript::charstring::CommandSink, types::F2Dot14, FontRef};
 
     use super::{
-        super::BaseOutlines, BlueZone, Blues, Fixed, Hint, HintMap, HintMask, HintParams,
+        super::OutlinesCommon, BlueZone, Blues, Fixed, Hint, HintMap, HintMask, HintParams,
         HintState, HintingSink, StemHint, GHOST_BOTTOM, GHOST_TOP, HINT_MASK_SIZE, LOCKED,
         PAIR_BOTTOM, PAIR_TOP,
     };
@@ -1303,7 +1303,7 @@ mod tests {
     #[test]
     fn hint_mapping() {
         let font = FontRef::new(font_test_data::CANTARELL_VF_TRIMMED).unwrap();
-        let base = BaseOutlines::new(&font).unwrap();
+        let base = OutlinesCommon::new(&font).unwrap();
         let cff_font = super::super::Outlines::new(&base).unwrap();
         let state = cff_font
             .subfont(0, Some(8.0), &[F2Dot14::from_f32(-1.0); 2])

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -1105,8 +1105,9 @@ mod tests {
     use read_fonts::{tables::postscript::charstring::CommandSink, types::F2Dot14, FontRef};
 
     use super::{
-        BlueZone, Blues, Fixed, Hint, HintMap, HintMask, HintParams, HintState, HintingSink,
-        StemHint, GHOST_BOTTOM, GHOST_TOP, HINT_MASK_SIZE, LOCKED, PAIR_BOTTOM, PAIR_TOP,
+        super::BaseScaler, BlueZone, Blues, Fixed, Hint, HintMap, HintMask, HintParams, HintState,
+        HintingSink, StemHint, GHOST_BOTTOM, GHOST_TOP, HINT_MASK_SIZE, LOCKED, PAIR_BOTTOM,
+        PAIR_TOP,
     };
 
     fn make_hint_state() -> HintState {
@@ -1302,7 +1303,8 @@ mod tests {
     #[test]
     fn hint_mapping() {
         let font = FontRef::new(font_test_data::CANTARELL_VF_TRIMMED).unwrap();
-        let cff_font = super::super::Outlines::new(&font).unwrap();
+        let base = BaseScaler::new(&font).unwrap();
+        let cff_font = super::super::CffScaler::new(&base).unwrap();
         let state = cff_font
             .subfont(0, Some(8.0), &[F2Dot14::from_f32(-1.0); 2])
             .unwrap()

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -1105,9 +1105,9 @@ mod tests {
     use read_fonts::{tables::postscript::charstring::CommandSink, types::F2Dot14, FontRef};
 
     use super::{
-        super::BaseScaler, BlueZone, Blues, Fixed, Hint, HintMap, HintMask, HintParams, HintState,
-        HintingSink, StemHint, GHOST_BOTTOM, GHOST_TOP, HINT_MASK_SIZE, LOCKED, PAIR_BOTTOM,
-        PAIR_TOP,
+        super::BaseOutlines, BlueZone, Blues, Fixed, Hint, HintMap, HintMask, HintParams,
+        HintState, HintingSink, StemHint, GHOST_BOTTOM, GHOST_TOP, HINT_MASK_SIZE, LOCKED,
+        PAIR_BOTTOM, PAIR_TOP,
     };
 
     fn make_hint_state() -> HintState {
@@ -1303,8 +1303,8 @@ mod tests {
     #[test]
     fn hint_mapping() {
         let font = FontRef::new(font_test_data::CANTARELL_VF_TRIMMED).unwrap();
-        let base = BaseScaler::new(&font).unwrap();
-        let cff_font = super::super::CffScaler::new(&base).unwrap();
+        let base = BaseOutlines::new(&font).unwrap();
+        let cff_font = super::super::Outlines::new(&base).unwrap();
         let state = cff_font
             .subfont(0, Some(8.0), &[F2Dot14::from_f32(-1.0); 2])
             .unwrap()

--- a/skrifa/src/outline/common.rs
+++ b/skrifa/src/outline/common.rs
@@ -1,4 +1,7 @@
 //! Common functionality for glyf, cff and autohinting scalers.
+//!
+//! Currently this includes the font reference as well as horizontal glyph
+//! metrics and access to the control value table.
 
 use raw::{
     tables::{hmtx::Hmtx, hvar::Hvar},

--- a/skrifa/src/outline/common.rs
+++ b/skrifa/src/outline/common.rs
@@ -16,6 +16,7 @@ pub(crate) struct OutlinesCommon<'a> {
 
 impl<'a> OutlinesCommon<'a> {
     pub fn new(font: &FontRef<'a>) -> Option<Self> {
+        // Note: hmtx is required and HVAR is optional
         let hmtx = font.hmtx().ok()?;
         let hvar = font.hvar().ok();
         Some(Self {

--- a/skrifa/src/outline/common.rs
+++ b/skrifa/src/outline/common.rs
@@ -8,13 +8,13 @@ use raw::{
 
 /// Common functionality for glyf, cff and autohinting scalers.
 #[derive(Clone)]
-pub(crate) struct BaseOutlines<'a> {
+pub(crate) struct OutlinesCommon<'a> {
     pub font: FontRef<'a>,
     pub hmtx: Hmtx<'a>,
     pub hvar: Option<Hvar<'a>>,
 }
 
-impl<'a> BaseOutlines<'a> {
+impl<'a> OutlinesCommon<'a> {
     pub fn new(font: &FontRef<'a>) -> Option<Self> {
         let hmtx = font.hmtx().ok()?;
         let hvar = font.hvar().ok();
@@ -25,30 +25,36 @@ impl<'a> BaseOutlines<'a> {
         })
     }
 
+    /// Returns the advance width (in font units) for the given glyph and
+    /// the location in variation space represented by the set of normalized
+    /// coordinates in 2.14 fixed point.
     pub fn advance_width(&self, gid: GlyphId, coords: &'a [F2Dot14]) -> i32 {
         let mut advance = self.hmtx.advance(gid).unwrap_or_default() as i32;
         if let Some(hvar) = &self.hvar {
             advance += hvar
                 .advance_width_delta(gid, coords)
-                // FreeType truncates metric deltas...
-                .map(|delta| delta.to_f64() as i32)
+                .map(|delta| delta.to_i32())
                 .unwrap_or(0);
         }
         advance
     }
 
+    /// Returns the left side bearing (in font units) for the given glyph and
+    /// the location in variation space represented by the set of normalized
+    /// coordinates in 2.14 fixed point.    
     pub fn lsb(&self, gid: GlyphId, coords: &'a [F2Dot14]) -> i32 {
         let mut lsb = self.hmtx.side_bearing(gid).unwrap_or_default() as i32;
         if let Some(hvar) = &self.hvar {
             lsb += hvar
                 .lsb_delta(gid, coords)
-                // FreeType truncates metric deltas...
-                .map(|delta| delta.to_f64() as i32)
+                .map(|delta| delta.to_i32())
                 .unwrap_or(0);
         }
         lsb
     }
 
+    /// Returns the array of entries for the control value table which is used
+    /// for TrueType hinting.
     pub fn cvt(&self) -> &[BigEndian<i16>] {
         self.font
             .data_for_tag(Tag::new(b"cvt "))

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -21,7 +21,7 @@ use read_fonts::{
 };
 
 use super::{
-    super::Outlines,
+    super::GlyfScaler,
     cvt::Cvt,
     definition::DefinitionState,
     error::{HintError, HintErrorKind},
@@ -51,7 +51,7 @@ pub struct Engine<'a> {
 impl<'a> Engine<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        outlines: &Outlines,
+        outlines: &GlyfScaler,
         program: ProgramState<'a>,
         graphics: RetainedGraphicsState,
         definitions: DefinitionState<'a>,
@@ -109,13 +109,14 @@ struct LoopBudget {
 }
 
 impl LoopBudget {
-    fn new(outlines: &Outlines, point_count: Option<usize>) -> Self {
+    fn new(outlines: &GlyfScaler, point_count: Option<usize>) -> Self {
+        let cvt_len = outlines.cvt_len as usize;
         // Compute limits for loop calls and backward jumps.
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L6955>
         let limit = if let Some(point_count) = point_count {
-            (point_count * 10).max(50) + (outlines.cvt.len() / 10).max(50)
+            (point_count * 10).max(50) + (cvt_len / 10).max(50)
         } else {
-            300 + 22 * outlines.cvt.len()
+            300 + 22 * cvt_len
         };
         // FreeType has two variables for neg_jump_counter_max and
         // loopcall_counter_max but sets them to the same value so

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -21,7 +21,7 @@ use read_fonts::{
 };
 
 use super::{
-    super::GlyfScaler,
+    super::Outlines,
     cvt::Cvt,
     definition::DefinitionState,
     error::{HintError, HintErrorKind},
@@ -51,7 +51,7 @@ pub struct Engine<'a> {
 impl<'a> Engine<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        outlines: &GlyfScaler,
+        outlines: &Outlines,
         program: ProgramState<'a>,
         graphics: RetainedGraphicsState,
         definitions: DefinitionState<'a>,
@@ -109,7 +109,7 @@ struct LoopBudget {
 }
 
 impl LoopBudget {
-    fn new(outlines: &GlyfScaler, point_count: Option<usize>) -> Self {
+    fn new(outlines: &Outlines, point_count: Option<usize>) -> Self {
         let cvt_len = outlines.cvt_len as usize;
         // Compute limits for loop calls and backward jumps.
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L6955>

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -1,7 +1,7 @@
 //! Instance state for TrueType hinting.
 
 use super::{
-    super::Outlines,
+    super::GlyfScaler,
     cow_slice::CowSlice,
     definition::{Definition, DefinitionMap, DefinitionState},
     engine::Engine,
@@ -13,7 +13,10 @@ use super::{
     HintOutline, HintingMode, PointFlags,
 };
 use alloc::vec::Vec;
-use raw::types::{F26Dot6, F2Dot14, Fixed, Point};
+use raw::{
+    types::{F26Dot6, F2Dot14, Fixed, Point},
+    TableProvider,
+};
 
 #[derive(Clone, Default)]
 pub struct HintInstance {
@@ -32,7 +35,7 @@ pub struct HintInstance {
 impl HintInstance {
     pub fn reconfigure(
         &mut self,
-        outlines: &Outlines,
+        outlines: &GlyfScaler,
         scale: i32,
         ppem: i32,
         mode: HintingMode,
@@ -100,7 +103,7 @@ impl HintInstance {
 
     pub fn hint(
         &self,
-        outlines: &Outlines,
+        outlines: &GlyfScaler,
         outline: &mut HintOutline,
         is_pedantic: bool,
     ) -> Result<(), HintError> {
@@ -174,7 +177,7 @@ impl HintInstance {
     }
 
     /// Captures limits, resizes buffers and scales the CVT.
-    fn setup(&mut self, outlines: &Outlines, scale: i32, coords: &[F2Dot14]) {
+    fn setup(&mut self, outlines: &GlyfScaler, scale: i32, coords: &[F2Dot14]) {
         let axis_count = outlines
             .gvar
             .as_ref()
@@ -188,12 +191,13 @@ impl HintInstance {
             Definition::default(),
         );
         self.cvt.clear();
-        if let Some(cvar) = outlines.cvar.as_ref() {
+        let cvt = outlines.base.cvt();
+        if let Ok(cvar) = outlines.base.font.cvar() {
             // First accumulate all the deltas in 16.16
-            self.cvt.resize(outlines.cvt.len(), 0);
+            self.cvt.resize(cvt.len(), 0);
             let _ = cvar.deltas(axis_count, coords, &mut self.cvt);
             // Now add the base CVT values
-            for (value, base_value) in self.cvt.iter_mut().zip(outlines.cvt.iter()) {
+            for (value, base_value) in self.cvt.iter_mut().zip(cvt.iter()) {
                 // Deltas are converted from 16.16 to 26.6
                 // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttgxvar.c#L3822>
                 let delta = Fixed::from_bits(*value).to_f26dot6().to_bits();
@@ -204,7 +208,7 @@ impl HintInstance {
             // CVT values are converted to 26.6 on load
             // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttpload.c#L350>
             self.cvt
-                .extend(outlines.cvt.iter().map(|value| (value.get() as i32) * 64));
+                .extend(cvt.iter().map(|value| (value.get() as i32) * 64));
         }
         // More weird scaling. This is due to the fact that CVT values are
         // already in 26.6
@@ -233,13 +237,17 @@ impl HintInstance {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::Outlines, HintInstance};
+    use super::{
+        super::super::{BaseScaler, GlyfScaler},
+        HintInstance,
+    };
     use read_fonts::{types::F2Dot14, FontRef};
 
     #[test]
     fn scaled_cvar_cvt() {
         let font = FontRef::new(font_test_data::CVAR).unwrap();
-        let outlines = Outlines::new(&font).unwrap();
+        let base = BaseScaler::new(&font).unwrap();
+        let outlines = GlyfScaler::new(&base).unwrap();
         let mut instance = HintInstance::default();
         let coords = [0.5, -0.5].map(F2Dot14::from_f32);
         let ppem = 16;

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -1,7 +1,7 @@
 //! Instance state for TrueType hinting.
 
 use super::{
-    super::GlyfScaler,
+    super::Outlines,
     cow_slice::CowSlice,
     definition::{Definition, DefinitionMap, DefinitionState},
     engine::Engine,
@@ -35,7 +35,7 @@ pub struct HintInstance {
 impl HintInstance {
     pub fn reconfigure(
         &mut self,
-        outlines: &GlyfScaler,
+        outlines: &Outlines,
         scale: i32,
         ppem: i32,
         mode: HintingMode,
@@ -103,7 +103,7 @@ impl HintInstance {
 
     pub fn hint(
         &self,
-        outlines: &GlyfScaler,
+        outlines: &Outlines,
         outline: &mut HintOutline,
         is_pedantic: bool,
     ) -> Result<(), HintError> {
@@ -177,7 +177,7 @@ impl HintInstance {
     }
 
     /// Captures limits, resizes buffers and scales the CVT.
-    fn setup(&mut self, outlines: &GlyfScaler, scale: i32, coords: &[F2Dot14]) {
+    fn setup(&mut self, outlines: &Outlines, scale: i32, coords: &[F2Dot14]) {
         let axis_count = outlines
             .gvar
             .as_ref()
@@ -238,7 +238,7 @@ impl HintInstance {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::super::{BaseScaler, GlyfScaler},
+        super::super::{BaseOutlines, Outlines},
         HintInstance,
     };
     use read_fonts::{types::F2Dot14, FontRef};
@@ -246,8 +246,8 @@ mod tests {
     #[test]
     fn scaled_cvar_cvt() {
         let font = FontRef::new(font_test_data::CVAR).unwrap();
-        let base = BaseScaler::new(&font).unwrap();
-        let outlines = GlyfScaler::new(&base).unwrap();
+        let base = BaseOutlines::new(&font).unwrap();
+        let outlines = Outlines::new(&base).unwrap();
         let mut instance = HintInstance::default();
         let coords = [0.5, -0.5].map(F2Dot14::from_f32);
         let ppem = 16;

--- a/skrifa/src/outline/glyf/hint/instance.rs
+++ b/skrifa/src/outline/glyf/hint/instance.rs
@@ -191,8 +191,8 @@ impl HintInstance {
             Definition::default(),
         );
         self.cvt.clear();
-        let cvt = outlines.base.cvt();
-        if let Ok(cvar) = outlines.base.font.cvar() {
+        let cvt = outlines.common.cvt();
+        if let Ok(cvar) = outlines.common.font.cvar() {
             // First accumulate all the deltas in 16.16
             self.cvt.resize(cvt.len(), 0);
             let _ = cvar.deltas(axis_count, coords, &mut self.cvt);
@@ -238,7 +238,7 @@ impl HintInstance {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::super::{BaseOutlines, Outlines},
+        super::super::{Outlines, OutlinesCommon},
         HintInstance,
     };
     use read_fonts::{types::F2Dot14, FontRef};
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn scaled_cvar_cvt() {
         let font = FontRef::new(font_test_data::CVAR).unwrap();
-        let base = BaseOutlines::new(&font).unwrap();
+        let base = OutlinesCommon::new(&font).unwrap();
         let outlines = Outlines::new(&base).unwrap();
         let mut instance = HintInstance::default();
         let coords = [0.5, -0.5].map(F2Dot14::from_f32);

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -6,7 +6,7 @@
 //! # Drawing a glyph
 //!
 //! Generating SVG [path commands](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#path_commands)
-//! for a character (this assumes a local variable `font` of type [`FontRef`](crate::FontRef)):
+//! for a character (this assumes a local variable `font` of type [`FontRef`]):
 //!
 //! ```rust
 //! use skrifa::{

--- a/skrifa/src/patchmap.rs
+++ b/skrifa/src/patchmap.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 
 use crate::GlyphId;
 use crate::Tag;
-use raw::FontData;
+use raw::{FontData, FontRef};
 use read_fonts::{
     tables::ift::{EntryMapRecord, Ift, PatchMapFormat1},
     ReadError, TableProvider,
@@ -18,8 +18,8 @@ use read_fonts::collections::IntSet;
 use crate::charmap::Charmap;
 
 /// Find the set of patches which intersect the specified subset definition.
-pub fn intersecting_patches<'a>(
-    font: &impl TableProvider<'a>,
+pub fn intersecting_patches(
+    font: &FontRef,
     codepoints: &IntSet<u32>,
     features: &BTreeSet<Tag>,
 ) -> Result<Vec<PatchUri>, ReadError> {
@@ -36,8 +36,8 @@ pub fn intersecting_patches<'a>(
     Ok(result)
 }
 
-fn add_intersecting_patches<'a>(
-    font: &impl TableProvider<'a>,
+fn add_intersecting_patches(
+    font: &FontRef,
     ift: &Ift,
     codepoints: &IntSet<u32>,
     features: &BTreeSet<Tag>,
@@ -51,8 +51,8 @@ fn add_intersecting_patches<'a>(
     }
 }
 
-fn add_intersecting_format1_patches<'a>(
-    font: &impl TableProvider<'a>,
+fn add_intersecting_format1_patches(
+    font: &FontRef,
     map: &PatchMapFormat1,
     codepoints: &IntSet<u32>,
     features: &BTreeSet<Tag>,
@@ -105,8 +105,8 @@ fn add_intersecting_format1_patches<'a>(
     Ok(())
 }
 
-fn intersect_format1_glyph_map<'a>(
-    font: &impl TableProvider<'a>,
+fn intersect_format1_glyph_map(
+    font: &FontRef,
     map: &PatchMapFormat1,
     codepoints: &IntSet<u32>,
     entries: &mut IntSet<u16>,

--- a/skrifa/src/provider.rs
+++ b/skrifa/src/provider.rs
@@ -7,10 +7,48 @@ use super::{
     outline::OutlineGlyphCollection,
     string::{LocalizedStrings, StringId},
     variation::{AxisCollection, NamedInstanceCollection},
+    FontRef,
 };
 
 /// Interface for types that can provide font metadata.
-pub trait MetadataProvider<'a>: raw::TableProvider<'a> + Sized {
+pub trait MetadataProvider<'a>: Sized {
+    /// Returns the primary attributes for font classification-- stretch,
+    /// style and weight.
+    fn attributes(&self) -> Attributes;
+
+    /// Returns the collection of variation axes.
+    fn axes(&self) -> AxisCollection<'a>;
+
+    /// Returns the collection of named variation instances.
+    fn named_instances(&self) -> NamedInstanceCollection<'a>;
+
+    /// Returns an iterator over the collection of localized strings for the
+    /// given informational string identifier.
+    fn localized_strings(&self, id: StringId) -> LocalizedStrings<'a>;
+
+    /// Returns the global font metrics for the specified size and location in
+    /// normalized variation space.
+    fn metrics(&self, size: Size, location: impl Into<LocationRef<'a>>) -> Metrics;
+
+    /// Returns the glyph specific metrics for the specified size and location
+    /// in normalized variation space.
+    fn glyph_metrics(&self, size: Size, location: impl Into<LocationRef<'a>>) -> GlyphMetrics<'a>;
+
+    /// Returns the character to nominal glyph identifier mapping.
+    fn charmap(&self) -> Charmap<'a>;
+
+    /// Returns the collection of scalable glyph outlines.
+    ///
+    /// If the font contains multiple outline sources, this method prioritizes
+    /// `glyf`, `CFF2` and `CFF` in that order. To select a specific outline
+    /// source, use the [`OutlineGlyphCollection::with_format`] method.
+    fn outline_glyphs(&self) -> OutlineGlyphCollection<'a>;
+
+    // Returns a collection of paintable color glyphs.
+    fn color_glyphs(&self) -> ColorGlyphCollection<'a>;
+}
+
+impl<'a> MetadataProvider<'a> for FontRef<'a> {
     /// Returns the primary attributes for font classification-- stretch,
     /// style and weight.
     fn attributes(&self) -> Attributes {
@@ -64,7 +102,3 @@ pub trait MetadataProvider<'a>: raw::TableProvider<'a> + Sized {
         ColorGlyphCollection::new(self)
     }
 }
-
-/// Blanket implementation of `MetadataProvider` for any type that implements
-/// `TableProvider`.
-impl<'a, T> MetadataProvider<'a> for T where T: raw::TableProvider<'a> {}


### PR DESCRIPTION
Per IM, changes skrifa to use `FontRef` directly rather than `TableProvider`.

Extracts some shared functionality into a `BaseOutlines` type for outlines in preparation for more autohinting work but no real functional changes.