### PR TITLE
[skrifa] autohint: public GlyphStyles type

### DIFF
--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -13,7 +13,7 @@ use raw::TableProvider;
 pub struct GlyphStyles(Arc<GlyphStyleMap>);
 
 impl GlyphStyles {
-    /// Precomputes the full set of glyph styles for the given font.
+    /// Precomputes the full set of glyph styles for the given outlines.
     pub fn new(outlines: &OutlineGlyphCollection) -> Self {
         if let Some(outlines) = outlines.common() {
             let glyph_count = outlines

--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -1,0 +1,32 @@
+//! Autohinting state for a font instance.
+
+use super::{super::OutlineGlyphCollection, style::GlyphStyleMap};
+use crate::MetadataProvider;
+use alloc::sync::Arc;
+use raw::TableProvider;
+
+/// Set of derived glyph styles that are used for automatic hinting.
+///
+/// These are invariant per font so can be precomputed and reused for multiple
+/// instances when requesting automatic hinting.
+#[derive(Clone, Debug)]
+pub struct GlyphStyles(Arc<GlyphStyleMap>);
+
+impl GlyphStyles {
+    /// Precomputes the full set of glyph styles for the given font.
+    pub fn new(outlines: &OutlineGlyphCollection) -> Self {
+        if let Some(outlines) = outlines.common() {
+            let glyph_count = outlines
+                .font
+                .maxp()
+                .map(|maxp| maxp.num_glyphs() as u32)
+                .unwrap_or_default();
+            Self(Arc::new(GlyphStyleMap::new(
+                glyph_count,
+                &outlines.font.charmap(),
+            )))
+        } else {
+            Self(Default::default())
+        }
+    }
+}

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -6,7 +6,10 @@
 mod axis;
 mod cycling;
 mod hint;
+mod instance;
 mod latin;
 mod metrics;
 mod outline;
 mod style;
+
+pub use instance::GlyphStyles;

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -188,6 +188,16 @@ impl GlyphStyleMap {
     }
 }
 
+impl Default for GlyphStyleMap {
+    fn default() -> Self {
+        Self {
+            styles: Default::default(),
+            metrics_map: [0xFF; MAX_STYLES],
+            metrics_count: 0,
+        }
+    }
+}
+
 /// Determines which algorithms the autohinter will use while generating
 /// metrics and processing a glyph outline.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -93,6 +93,8 @@ pub mod error;
 pub mod pen;
 
 use common::OutlinesCommon;
+
+pub use autohint::GlyphStyles;
 pub use hint::{HintingInstance, HintingMode, LcdLayout};
 use raw::FontRef;
 #[doc(inline)]
@@ -581,6 +583,14 @@ impl<'a> OutlineGlyphCollection<'a> {
             let glyph = copy.get(gid)?;
             Some((gid, glyph))
         })
+    }
+
+    pub(crate) fn common(&self) -> Option<&OutlinesCommon<'a>> {
+        match &self.kind {
+            OutlineCollectionKind::Glyf(glyf) => Some(&glyf.common),
+            OutlineCollectionKind::Cff(cff) => Some(&cff.common),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
Exposes the glyph style map as a public type and wrapped in an `Arc` to make it shareable among multiple autohinting instances.