### PR TITLE
Add #[if_cond(always_true())] to codegen.

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -173,9 +173,12 @@ The following annotations are supported on top-level objects:
 - `#[if_flag($field, Flags::SOME_FLAG)]`: indicates that a given field is only
   present if a particular flag is set on the named field. The field is expected
   to be a bitset with a `contains` method.
-- `#[if_cond($field, Flags::SOME_FLAG_A, Flags::SOME_FLAG_B, ...)]`: indicates that a
-  given field is only present if at least one of the listed flags is set on the named
-  field. The field is expected to be a bitset with a `contains` method.
+- `#[if_cond(any_flag($field, Flags::SOME_FLAG_A, Flags::SOME_FLAG_B, ...))]`:
+  indicates that a given field is only present if at least one of the listed flags
+  is set on the named field. The field is expected to be a bitset with a `contains` method.
+- `#[if_cond(always_true())]`:
+  indicates that a given field is always present. This is useful to sidestep the restriction
+  that non-conditional fields cannot follow a conditional field.
 - `#[skip_getter]`: if present, we will not generate a getter for this field.
   Used on things like padding fields.
 - `#[offset_getter(method name)]`: only allowed on offsets or arrays of offsets.

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -230,6 +230,13 @@ impl Fields {
                                     }
                                 }
                             }
+                            IfTransform::True() => {
+                                quote!(
+                                    if self.#name.is_none() {
+                                        ctx.report("'{name}' should always be present.");
+                                    }
+                                )
+                            }
                         },
                     }
                 });
@@ -311,6 +318,9 @@ fn if_expression(xform: &IfTransform, add_self: bool) -> TokenStream {
             } else {
                 quote!(#field.intersects(#(#flags)|*))
             }
+        }
+        IfTransform::True() => {
+            quote!(true)
         }
     }
 }

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -256,6 +256,11 @@ pub(crate) enum IfTransform {
     ///
     /// Evaluates to true if field has at least one of the input flags set.
     AnyFlag(syn::Ident, Vec<syn::Path>),
+
+    /// true():
+    ///
+    /// Always evaluates to true.
+    True(),
 }
 
 enum IfArg {
@@ -1844,6 +1849,7 @@ impl IfTransform {
     fn from_args(s: &str, args: Vec<IfArg>) -> Result<Self, String> {
         match s {
             "any_flag" => Self::any_flag(args),
+            "always_true" => Ok(IfTransform::True()),
             _ => Err(format!("invalid if_cond transform function: {}", s)),
         }
     }
@@ -1870,6 +1876,7 @@ impl IfTransform {
     pub(crate) fn input_field(&self) -> Vec<syn::Ident> {
         match self {
             IfTransform::AnyFlag(field, _) => vec![field.clone()],
+            IfTransform::True() => vec![],
         }
     }
 }

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -156,6 +156,7 @@ pub mod conditions {
         if flags.contains(GotFlags::FOO) || flags.contains(GotFlags::BAZ) {
             buf = buf.push(0xba2_u16);
         }
+        buf = buf.push(0xff_u16);
         buf
     }
 
@@ -165,6 +166,7 @@ pub mod conditions {
         let table = FlagDay::read(data.font_data()).unwrap();
         assert!(table.foo().is_none());
         assert!(table.bar().is_none());
+        assert_eq!(table.always_present(), Some(0xff));
     }
 
     #[test]
@@ -174,6 +176,7 @@ pub mod conditions {
         assert_eq!(table.foo(), Some(0xf00));
         assert!(table.bar().is_none());
         assert_eq!(table.baz(), Some(0xba2));
+        assert_eq!(table.always_present(), Some(0xff));
     }
 
     #[test]
@@ -183,6 +186,7 @@ pub mod conditions {
         assert!(table.foo().is_none());
         assert_eq!(table.bar(), Some(0xba4));
         assert!(table.baz().is_none());
+        assert_eq!(table.always_present(), Some(0xff));
     }
 
     #[test]
@@ -192,6 +196,7 @@ pub mod conditions {
         assert!(table.foo().is_none());
         assert!(table.bar().is_none());
         assert_eq!(table.baz(), Some(0xba2));
+        assert_eq!(table.always_present(), Some(0xff));
     }
 
     #[test]
@@ -201,5 +206,6 @@ pub mod conditions {
         assert_eq!(table.foo(), Some(0xf00));
         assert_eq!(table.bar(), Some(0xba4));
         assert_eq!(table.baz(), Some(0xba2));
+        assert_eq!(table.always_present(), Some(0xff));
     }
 }

--- a/resources/codegen_inputs/test_conditions.rs
+++ b/resources/codegen_inputs/test_conditions.rs
@@ -28,4 +28,6 @@ table FlagDay {
     bar: u16,
     #[if_cond(any_flag($flags, GotFlags::BAZ, GotFlags::FOO))]
     baz: u16,
+    #[if_cond(always_true())]
+    always_present: u16,
 }

--- a/write-fonts/generated/generated_test_conditions.rs
+++ b/write-fonts/generated/generated_test_conditions.rs
@@ -110,6 +110,7 @@ pub struct FlagDay {
     pub foo: Option<u16>,
     pub bar: Option<u16>,
     pub baz: Option<u16>,
+    pub always_present: Option<u16>,
 }
 
 impl FlagDay {
@@ -147,6 +148,12 @@ impl FontWrite for FlagDay {
                     .expect("missing conditional field should have failed validation")
                     .write_into(writer)
             });
+        true.then(|| {
+            self.always_present
+                .as_ref()
+                .expect("missing conditional field should have failed validation")
+                .write_into(writer)
+        });
     }
     fn table_type(&self) -> TableType {
         TableType::Named("FlagDay")
@@ -181,6 +188,11 @@ impl Validate for FlagDay {
                     ctx.report("if_cond is satisfied by 'baz' is not present.");
                 }
             });
+            ctx.in_field("always_present", |ctx| {
+                if self.always_present.is_none() {
+                    ctx.report("'{name}' should always be present.");
+                }
+            });
         })
     }
 }
@@ -193,6 +205,7 @@ impl<'a> FromObjRef<read_fonts::codegen_test::conditions::FlagDay<'a>> for FlagD
             foo: obj.foo(),
             bar: obj.bar(),
             baz: obj.baz(),
+            always_present: obj.always_present(),
         }
     }
 }


### PR DESCRIPTION
Used to allow the inclusion of a non-conditional field following a conditional field.