### PR TITLE
Fix fuzzer bug with cmap4

### DIFF
--- a/font-test-data/src/cmap.rs
+++ b/font-test-data/src/cmap.rs
@@ -1,0 +1,36 @@
+//! cmap test data for scenarios not readily produced with ttx
+
+use read_fonts::{be_buffer, be_buffer_add, test_helpers::BeBuffer};
+
+/// Contains two codepoint ranges, both [6, 64]. Surely you don't duplicate them?
+pub fn repetitive_cmap4() -> BeBuffer {
+    // <https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values>
+    be_buffer! {
+      4_u16,                      // uint16	format
+      0_u16,                      // uint16	length, unused
+      0_u16,                      // uint16	language, unused
+      4_u16,                      // uint16	segCountX2, 2 * 2 segments
+      0_u16,                      // uint16	searchRange, unused
+      0_u16,                      // uint16	entrySelector, unused
+      0_u16,                      // uint16	rangeShift, unused
+      // segCount endCode entries
+      64_u16,                    // uint16	endCode[0]
+      64_u16,                    // uint16	endCode[1]
+
+      0_u16,                      // uint16	reservedPad, unused
+
+      // segCount startCode entries
+      6_u16,                      // uint16	startCode[0]
+      6_u16,                      // uint16	startCode[1]
+
+      // segCount idDelta entries
+      0_u16,                      // uint16	idDelta[0]
+      0_u16,                      // uint16	idDelta[1]
+
+      // segCount idRangeOffset entries
+      0_u16,                      // uint16	idRangeOffset[0]
+      0_u16                       // uint16	idRangeOffset[1]
+
+      // no glyphIdArray entries
+    }
+}

--- a/font-test-data/src/lib.rs
+++ b/font-test-data/src/lib.rs
@@ -1,5 +1,6 @@
 //! test data shared between various fontations crates.
 
+pub mod cmap;
 pub mod gdef;
 pub mod gpos;
 pub mod gsub;


### PR DESCRIPTION
#954 (the same for cmap12) has raw bytes which are presumably the minimized test repro (?)

The fuzzer repro for this is 137K so we use hand-crafted data to demonstrate the Cmap4Iter used to be happy to reprocess codepoints.

IMHO the floor for the next range should be `cur_range.end + 1` but this somehow breaks a klippa integrate test so I deferred that to https://github.com/googlefonts/fontations/issues/1166.

Fixes #1100