### PR TITLE
[codegen] non-conditional fields after conditionals

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -891,9 +891,10 @@ impl Table {
 
             // versioned fields have a different signature
             if field.attrs.conditional.is_some() {
-                prev_field_end_expr = quote!(compile_error!(
-                    "non-version dependent field cannot follow version-dependent field"
-                ));
+                prev_field_end_expr = quote! {
+                    self.#fn_name().map(|range| range.end)
+                        .unwrap_or_else(|| #prev_field_end_expr)
+                };
                 let start_field_name = field.shape_byte_start_field_name();
                 return Some(quote! {
                     fn #fn_name(&self) -> Option<Range<usize>> {

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -202,4 +202,55 @@ pub mod conditions {
         assert_eq!(table.bar(), Some(0xba4));
         assert_eq!(table.baz(), Some(0xba2));
     }
+
+    #[test]
+    fn fields_after_conditions_all_none() {
+        let data = crate::test_helpers::BeBuffer::new()
+            .push(GotFlags::empty())
+            .extend([1u16, 2, 3]);
+
+        let table = FieldsAfterConditionals::read(data.font_data()).unwrap();
+        assert_eq!(table.always_here(), 1);
+        assert_eq!(table.also_always_here(), 2);
+        assert_eq!(table.and_me_too(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "OutOfBounds")]
+    fn fields_after_conditions_wrong_len() {
+        let data = crate::test_helpers::BeBuffer::new()
+            .push(GotFlags::FOO)
+            .extend([1u16, 2, 3]);
+
+        let _table = FieldsAfterConditionals::read(data.font_data()).unwrap();
+    }
+
+    #[test]
+    fn fields_after_conditionals_one_present() {
+        let data = crate::test_helpers::BeBuffer::new()
+            .push(GotFlags::BAR)
+            .extend([1u16, 0xba4, 2, 3]);
+
+        let table = FieldsAfterConditionals::read(data.font_data()).unwrap();
+        assert_eq!(table.always_here(), 1);
+        assert_eq!(table.bar(), Some(0xba4));
+        assert_eq!(table.also_always_here(), 2);
+        assert!(table.foo().is_none() && table.baz().is_none());
+        assert_eq!(table.and_me_too(), 3);
+    }
+
+    #[test]
+    fn fields_after_conditions_all_present() {
+        let data = crate::test_helpers::BeBuffer::new()
+            .push(GotFlags::FOO | GotFlags::BAR | GotFlags::BAZ)
+            .extend([0xf00u16, 1, 0xba4, 0xba2, 2, 3]);
+
+        let table = FieldsAfterConditionals::read(data.font_data()).unwrap();
+        assert_eq!(table.foo(), Some(0xf00));
+        assert_eq!(table.always_here(), 1);
+        assert_eq!(table.bar(), Some(0xba4));
+        assert_eq!(table.baz(), Some(0xba2));
+        assert_eq!(table.also_always_here(), 2);
+        assert_eq!(table.and_me_too(), 3);
+    }
 }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -84,9 +84,10 @@ pub mod traversal;
 #[cfg(any(test, feature = "codegen_test"))]
 pub mod codegen_test;
 
-#[cfg(test)]
 #[path = "tests/test_helpers.rs"]
-mod test_helpers;
+#[doc(hidden)]
+#[cfg(feature = "std")]
+pub mod test_helpers;
 
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};

--- a/read-fonts/src/tests/test_helpers.rs
+++ b/read-fonts/src/tests/test_helpers.rs
@@ -11,6 +11,11 @@ impl BeBuffer {
         Default::default()
     }
 
+    /// Return a reference to the contents of the buffer
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
     /// Write any scalar to this buffer.
     pub fn push(mut self, item: impl Scalar) -> Self {
         self.0.extend(item.to_raw().as_ref());

--- a/resources/codegen_inputs/test_conditions.rs
+++ b/resources/codegen_inputs/test_conditions.rs
@@ -29,3 +29,16 @@ table FlagDay {
     #[if_cond(any_flag($flags, GotFlags::BAZ, GotFlags::FOO))]
     baz: u16,
 }
+
+table FieldsAfterConditionals {
+    flags: GotFlags,
+    #[if_flag($flags, GotFlags::FOO)]
+    foo: u16,
+    always_here: u16,
+    #[if_flag($flags, GotFlags::BAR)]
+    bar: u16,
+    #[if_flag($flags, GotFlags::BAZ)]
+    baz: u16,
+    also_always_here: u16,
+    and_me_too: u16,
+}

--- a/write-fonts/generated/generated_test_conditions.rs
+++ b/write-fonts/generated/generated_test_conditions.rs
@@ -205,3 +205,121 @@ impl<'a> FontRead<'a> for FlagDay {
             .map(|x| x.to_owned_table())
     }
 }
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FieldsAfterConditionals {
+    pub flags: GotFlags,
+    pub foo: Option<u16>,
+    pub always_here: u16,
+    pub bar: Option<u16>,
+    pub baz: Option<u16>,
+    pub also_always_here: u16,
+    pub and_me_too: u16,
+}
+
+impl FieldsAfterConditionals {
+    /// Construct a new `FieldsAfterConditionals`
+    pub fn new(flags: GotFlags, always_here: u16, also_always_here: u16, and_me_too: u16) -> Self {
+        Self {
+            flags,
+            always_here,
+            also_always_here,
+            and_me_too,
+            ..Default::default()
+        }
+    }
+}
+
+impl FontWrite for FieldsAfterConditionals {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.flags.write_into(writer);
+        self.flags.contains(GotFlags::FOO).then(|| {
+            self.foo
+                .as_ref()
+                .expect("missing conditional field should have failed validation")
+                .write_into(writer)
+        });
+        self.always_here.write_into(writer);
+        self.flags.contains(GotFlags::BAR).then(|| {
+            self.bar
+                .as_ref()
+                .expect("missing conditional field should have failed validation")
+                .write_into(writer)
+        });
+        self.flags.contains(GotFlags::BAZ).then(|| {
+            self.baz
+                .as_ref()
+                .expect("missing conditional field should have failed validation")
+                .write_into(writer)
+        });
+        self.also_always_here.write_into(writer);
+        self.and_me_too.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("FieldsAfterConditionals")
+    }
+}
+
+impl Validate for FieldsAfterConditionals {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("FieldsAfterConditionals", |ctx| {
+            let flags = self.flags;
+            ctx.in_field("foo", |ctx| {
+                if !(flags.contains(GotFlags::FOO)) && self.foo.is_some() {
+                    ctx.report("'foo' is present but FOO not set")
+                }
+                if (flags.contains(GotFlags::FOO)) && self.foo.is_none() {
+                    ctx.report("FOO is set but 'foo' is None")
+                }
+            });
+            ctx.in_field("bar", |ctx| {
+                if !(flags.contains(GotFlags::BAR)) && self.bar.is_some() {
+                    ctx.report("'bar' is present but BAR not set")
+                }
+                if (flags.contains(GotFlags::BAR)) && self.bar.is_none() {
+                    ctx.report("BAR is set but 'bar' is None")
+                }
+            });
+            ctx.in_field("baz", |ctx| {
+                if !(flags.contains(GotFlags::BAZ)) && self.baz.is_some() {
+                    ctx.report("'baz' is present but BAZ not set")
+                }
+                if (flags.contains(GotFlags::BAZ)) && self.baz.is_none() {
+                    ctx.report("BAZ is set but 'baz' is None")
+                }
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::codegen_test::conditions::FieldsAfterConditionals<'a>>
+    for FieldsAfterConditionals
+{
+    fn from_obj_ref(
+        obj: &read_fonts::codegen_test::conditions::FieldsAfterConditionals<'a>,
+        _: FontData,
+    ) -> Self {
+        FieldsAfterConditionals {
+            flags: obj.flags(),
+            foo: obj.foo(),
+            always_here: obj.always_here(),
+            bar: obj.bar(),
+            baz: obj.baz(),
+            also_always_here: obj.also_always_here(),
+            and_me_too: obj.and_me_too(),
+        }
+    }
+}
+
+impl<'a> FromTableRef<read_fonts::codegen_test::conditions::FieldsAfterConditionals<'a>>
+    for FieldsAfterConditionals
+{
+}
+
+impl<'a> FontRead<'a> for FieldsAfterConditionals {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::codegen_test::conditions::FieldsAfterConditionals as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}

--- a/write-fonts/src/codegen_test.rs
+++ b/write-fonts/src/codegen_test.rs
@@ -85,6 +85,9 @@ mod enums {
 }
 
 pub mod conditions {
+    #[cfg(test)]
+    use read_fonts::test_helpers::BeBuffer;
+
     include!("../generated/generated_test_conditions.rs");
 
     #[test]
@@ -115,5 +118,38 @@ pub mod conditions {
     fn flag_present_field_missing_any_flags() {
         let flags_are_wrong = FlagDay::new(42, GotFlags::BAZ);
         crate::dump_table(&flags_are_wrong).unwrap();
+    }
+
+    #[test]
+    fn fields_after_conditions_empty() {
+        let table = FieldsAfterConditionals::new(GotFlags::empty(), 1, 2, 3);
+        let data = crate::dump_table(&table).unwrap();
+        let expected = BeBuffer::new().extend([0u16, 1, 2, 3]);
+        assert_eq!(expected.as_slice(), data);
+    }
+
+    #[test]
+    fn fields_after_conditions_one_present() {
+        let mut table = FieldsAfterConditionals::new(GotFlags::BAR, 1, 2, 3);
+        table.bar = Some(0xba4);
+        let data = crate::dump_table(&table).unwrap();
+        let expected = BeBuffer::new()
+            .push(GotFlags::BAR)
+            .extend([1u16, 0xba4, 2, 3]);
+        assert_eq!(expected.as_slice(), data);
+    }
+
+    #[test]
+    fn fields_after_conditions_all_present() {
+        let mut table =
+            FieldsAfterConditionals::new(GotFlags::BAR | GotFlags::BAZ | GotFlags::FOO, 1, 2, 3);
+        table.bar = Some(0xba4);
+        table.foo = Some(0xf00);
+        table.baz = Some(0xba2);
+        let data = crate::dump_table(&table).unwrap();
+        let expected = BeBuffer::new()
+            .push(GotFlags::BAR | GotFlags::BAZ | GotFlags::FOO)
+            .extend([0xf00u16, 1, 0xba4, 0xba2, 2, 3]);
+        assert_eq!(expected.as_slice(), data);
     }
 }


### PR DESCRIPTION
This relaxes a constraint where previously non-conditional fields could not follow conditional ones, which will make codegen more expressive (and be particularly useful for the in-progress IFT work)



- closes #1093