### PR TITLE
Change sparse bit set decode to take a max value instead of max number of elements.

### DIFF
--- a/fuzz/fuzz_targets/fuzz_int_set.rs
+++ b/fuzz/fuzz_targets/fuzz_int_set.rs
@@ -13,6 +13,7 @@ use int_set_op_processor::process_op_codes;
 use int_set_op_processor::OperationSet;
 use int_set_op_processor::SmallEvenInt;
 use int_set_op_processor::SmallInt;
+use std::io::Cursor;
 
 const OPERATION_COUNT: u64 = 7_500;
 
@@ -24,34 +25,55 @@ fuzz_target!(|data: &[u8]| {
     match mode_byte {
         // These variants provide the primary testing of functionality.
         1 => {
-            let _ = process_op_codes::<u32>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+            let _ = process_op_codes::<u32>(
+                OperationSet::Standard,
+                OPERATION_COUNT,
+                Cursor::new(&data[1..]),
+            );
         }
         2 => {
-            let _ =
-                process_op_codes::<SmallInt>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+            let _ = process_op_codes::<SmallInt>(
+                OperationSet::Standard,
+                OPERATION_COUNT,
+                Cursor::new(&data[1..]),
+            );
         }
         3 => {
             let _ = process_op_codes::<SmallEvenInt>(
                 OperationSet::Standard,
                 OPERATION_COUNT,
-                &data[1..],
+                Cursor::new(&data[1..]),
             );
         }
 
         // And these provide coverage of remaining default supported domains
         4 => {
-            let _ = process_op_codes::<u8>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+            let _ = process_op_codes::<u8>(
+                OperationSet::Standard,
+                OPERATION_COUNT,
+                Cursor::new(&data[1..]),
+            );
         }
         5 => {
-            let _ = process_op_codes::<u16>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+            let _ = process_op_codes::<u16>(
+                OperationSet::Standard,
+                OPERATION_COUNT,
+                Cursor::new(&data[1..]),
+            );
         }
         6 => {
-            let _ =
-                process_op_codes::<GlyphId>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+            let _ = process_op_codes::<GlyphId>(
+                OperationSet::Standard,
+                OPERATION_COUNT,
+                Cursor::new(&data[1..]),
+            );
         }
         7 => {
-            let _ =
-                process_op_codes::<GlyphId16>(OperationSet::Standard, OPERATION_COUNT, &data[1..]);
+            let _ = process_op_codes::<GlyphId16>(
+                OperationSet::Standard,
+                OPERATION_COUNT,
+                Cursor::new(&data[1..]),
+            );
         }
         _ => return,
     };

--- a/fuzz/fuzz_targets/fuzz_sparse_bit_set_encode.rs
+++ b/fuzz/fuzz_targets/fuzz_sparse_bit_set_encode.rs
@@ -6,10 +6,22 @@
 use libfuzzer_sys::fuzz_target;
 mod int_set_op_processor;
 use int_set_op_processor::process_op_codes;
+use int_set_op_processor::read_u32;
 use int_set_op_processor::OperationSet;
+use std::io::Cursor;
 
 const OPERATION_COUNT: u64 = 2000;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = process_op_codes::<u32>(OperationSet::SparseBitSetEncoding, OPERATION_COUNT, data);
+    let mut data = Cursor::new(data);
+
+    let (Some(bias), Some(max_value)) = (read_u32(&mut data), read_u32(&mut data)) else {
+        return;
+    };
+
+    let _ = process_op_codes::<u32>(
+        OperationSet::SparseBitSetEncoding(bias, max_value),
+        OPERATION_COUNT,
+        data,
+    );
 });

--- a/read-fonts/src/collections/int_set/sparse_bit_set.rs
+++ b/read-fonts/src/collections/int_set/sparse_bit_set.rs
@@ -46,10 +46,9 @@ impl IntSet<u32> {
 
     /// Populate this set with the values obtained from decoding the provided sparse bit set bytes.
     ///
-    /// The size (in number of members) of the output set is bounded to be equal to or below the provided max size.
-    /// If the decoded set would contain more members than the limit an error will be returned.
-    ///
-    /// During decoding bias will be added to each decoded set members value.
+    /// During decoding bias will be added to each decoded set members value. The final set will not contain
+    /// any values larger than max_value: any encoded values larger than max_value after the bias is applied
+    /// are ignored.
     ///
     /// Sparse bit sets are a specialized, compact encoding of bit sets defined in the IFT specification:
     /// <https://w3c.github.io/IFT/Overview.html#sparse-bit-set-decoding>


### PR DESCRIPTION
Values beyond the max are ignored instead of causing the decoding to fail. This matches changes in the IFT specification handling of sparse bit set decoding (See: https://github.com/w3c/IFT/pull/203).