### PR TITLE
Extend BeBuffer to allow locations to be tagged.

### DIFF
--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -15,3 +15,6 @@ repository.workspace = true
 # cargo-release settings
 #[package.metadata.release]
 #release = false
+
+[dependencies]
+read-fonts = { workspace = true }

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -144,7 +144,8 @@ mod tests {
 
     #[test]
     fn format_1_gid_to_u8_entry_iter() {
-        let table = Ift::read(test_data::SIMPLE_FORMAT1.into()).unwrap();
+        let data = test_data::simple_format1();
+        let table = Ift::read(FontData::new(&data)).unwrap();
         let Ift::Format1(map) = table else {
             panic!("Not format 1.");
         };
@@ -206,7 +207,8 @@ mod tests {
 
     #[test]
     fn compatibility_id() {
-        let table = Ift::read(test_data::SIMPLE_FORMAT1.into()).unwrap();
+        let data = test_data::simple_format1();
+        let table = Ift::read(FontData::new(&data)).unwrap();
         let Ift::Format1(map) = table else {
             panic!("Not format 1.");
         };
@@ -216,7 +218,8 @@ mod tests {
 
     #[test]
     fn is_entry_applied() {
-        let table = Ift::read(test_data::SIMPLE_FORMAT1.into()).unwrap();
+        let data = test_data::simple_format1();
+        let table = Ift::read(FontData::new(&data)).unwrap();
         let Ift::Format1(map) = table else {
             panic!("Not format 1.");
         };
@@ -227,7 +230,8 @@ mod tests {
 
     #[test]
     fn uri_template_as_string() {
-        let table = Ift::read(test_data::SIMPLE_FORMAT1.into()).unwrap();
+        let data = test_data::simple_format1();
+        let table = Ift::read(FontData::new(&data)).unwrap();
         let Ift::Format1(map) = table else {
             panic!("Not format 1.");
         };

--- a/read-fonts/src/tests/test_helpers.rs
+++ b/read-fonts/src/tests/test_helpers.rs
@@ -1,10 +1,14 @@
 //! small utilities used in tests
 
 use crate::{FontData, Scalar};
+use std::collections::HashMap;
 
 /// A convenience type for generating a buffer of big-endian bytes.
 #[derive(Debug, Clone, Default)]
-pub struct BeBuffer(Vec<u8>);
+pub struct BeBuffer {
+    data: Vec<u8>,
+    tagged_locations: HashMap<String, usize>,
+}
 
 impl BeBuffer {
     pub fn new() -> Self {
@@ -13,41 +17,72 @@ impl BeBuffer {
 
     /// The current length of the buffer in bytes.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.data.len()
     }
 
     /// Returns `true` if the buffer contains zero bytes.
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.data.is_empty()
     }
 
     /// Return a reference to the contents of the buffer
     pub fn as_slice(&self) -> &[u8] {
-        &self.0
+        &self.data
     }
 
     /// Write any scalar to this buffer.
     pub fn push(mut self, item: impl Scalar) -> Self {
-        self.0.extend(item.to_raw().as_ref());
+        self.data.extend(item.to_raw().as_ref());
+        self
+    }
+
+    pub fn push_with_tag(mut self, item: impl Scalar, tag: &str) -> Self {
+        self.tagged_locations
+            .insert(tag.to_string(), self.data.len());
+        self.data.extend(item.to_raw().as_ref());
         self
     }
 
     /// Write multiple scalars into the buffer
     pub fn extend<T: Scalar>(mut self, iter: impl IntoIterator<Item = T>) -> Self {
         for item in iter {
-            self.0.extend(item.to_raw().as_ref());
+            self.data.extend(item.to_raw().as_ref());
         }
         self
     }
 
+    pub fn offset_for(&self, tag: &str) -> usize {
+        // panic on unrecognized tags
+        self.tagged_locations.get(tag).copied().unwrap()
+    }
+
+    fn data_for(&mut self, tag: &str) -> &mut [u8] {
+        let offset = self.offset_for(tag);
+        &mut self.data[offset..]
+    }
+
+    pub fn write_at(&mut self, tag: &str, item: impl Scalar) {
+        let data = self.data_for(tag);
+        let raw = item.to_raw();
+        let new_data: &[u8] = raw.as_ref();
+
+        if data.len() < new_data.len() {
+            panic!("not enough room left in buffer for the requested write.");
+        }
+
+        for (left, right) in data.iter_mut().zip(new_data) {
+            *left = *right
+        }
+    }
+
     pub fn font_data(&self) -> FontData {
-        FontData::new(&self.0)
+        FontData::new(&self.data)
     }
 }
 
 impl std::ops::Deref for BeBuffer {
     type Target = [u8];
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.data
     }
 }

--- a/skrifa/src/patchmap.rs
+++ b/skrifa/src/patchmap.rs
@@ -537,7 +537,7 @@ impl Entry {
 mod tests {
     use super::*;
     use font_test_data as test_data;
-    use font_test_data::ift::SIMPLE_FORMAT1;
+    use font_test_data::ift::simple_format1;
     use read_fonts::tables::ift::{IFTX_TAG, IFT_TAG};
     use read_fonts::FontRef;
     use write_fonts::FontBuilder;
@@ -629,7 +629,7 @@ mod tests {
     fn format_1_patch_map_u8_entries() {
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),
-            Some(test_data::ift::SIMPLE_FORMAT1),
+            Some(&simple_format1()),
             None,
         );
         let font = FontRef::new(&font_bytes).unwrap();
@@ -646,8 +646,8 @@ mod tests {
 
     #[test]
     fn format_1_patch_map_bad_entry_index() {
-        let mut data = Vec::<u8>::from(test_data::ift::SIMPLE_FORMAT1);
-        data[50] = 0x03;
+        let mut data = simple_format1();
+        data.write_at("entry_index[1]", 3u8);
 
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),
@@ -661,9 +661,12 @@ mod tests {
 
     #[test]
     fn format_1_patch_map_glyph_map_too_short() {
+        let data: &[u8] = &simple_format1();
+        let data = &data[..data.len() - 1];
+
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),
-            Some(&test_data::ift::SIMPLE_FORMAT1[..SIMPLE_FORMAT1.len() - 1]),
+            Some(data),
             None,
         );
         let font = FontRef::new(&font_bytes).unwrap();
@@ -681,7 +684,7 @@ mod tests {
     fn format_1_patch_map_bad_glyph_count() {
         let font_bytes = create_ift_font(
             FontRef::new(test_data::CMAP12_FONT1).unwrap(),
-            Some(test_data::ift::SIMPLE_FORMAT1),
+            Some(&simple_format1()),
             None,
         );
         let font = FontRef::new(&font_bytes).unwrap();
@@ -697,8 +700,8 @@ mod tests {
 
     #[test]
     fn format_1_patch_map_bad_max_entry() {
-        let mut data = Vec::<u8>::from(test_data::ift::SIMPLE_FORMAT1);
-        data[24] = 0x03;
+        let mut data = simple_format1();
+        data.write_at("max_glyph_map_entry_id", 3u16);
 
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),
@@ -718,9 +721,9 @@ mod tests {
 
     #[test]
     fn format_1_patch_map_bad_uri_template() {
-        let mut data = Vec::<u8>::from(test_data::ift::SIMPLE_FORMAT1);
-        data[39] = 0x80;
-        data[40] = 0x81;
+        let mut data = simple_format1();
+        data.write_at("uri_template[0]", 0x80u8);
+        data.write_at("uri_template[1]", 0x81u8);
 
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),
@@ -740,8 +743,8 @@ mod tests {
 
     #[test]
     fn format_1_patch_map_bad_encoding_number() {
-        let mut data = Vec::<u8>::from(test_data::ift::SIMPLE_FORMAT1);
-        data[47] = 0x12;
+        let mut data = simple_format1();
+        data.write_at("patch_encoding", 0x12u8);
 
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),


### PR DESCRIPTION
This allows constructing test data which tests can then modify specific parts of the data via the tag names. Updates one of the IFT test data items to use BeBuffer.