### PR TITLE
Make traversal non-default feature

### DIFF
--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 ansi_term = "0.12.1"
 atty = "0.2"
 font-types = { workspace = true }
-read-fonts = { workspace = true, default-features = true }
+read-fonts = { workspace = true, features = ["experimental_traverse"] }
 xflags = "0.3.0"
 
 # cargo-release settings

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -16,7 +16,7 @@ scaler_test = []
 # this feature is not stable, but provides untyped traversal of font tables.
 # we do not consider this feature public API for the purposes of semver.
 experimental_traverse = ["std"]
-default = ["experimental_traverse"]
+default = ["std"]
 serde = ["dep:serde", "font-types/serde"]
 libm = ["dep:core_maths"]
 

--- a/read-fonts/src/traversal.rs
+++ b/read-fonts/src/traversal.rs
@@ -1,4 +1,4 @@
-//! Generic traversal of font tables.
+//! Experimental generic traversal of font tables.
 //!
 //! This module defines functionality that allows untyped access to font table
 //! data. This is used as the basis for things like debug printing.
@@ -7,6 +7,11 @@
 //! all font tables. This trait provides the table's name, as well as ordered access
 //! to the table's fields. Using this, it is possible to iterate through a table
 //! and its subtables, records, and values.
+//!
+//! # Warning
+//!
+//! This functionality is considered experimental, and the API may break or be
+//! removed without warning.
 
 use std::{fmt::Debug, ops::Deref};
 

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -29,7 +29,7 @@ diff = "0.1.12"
 ansi_term = "0.12.1"
 font-test-data = { workspace = true }
 read-fonts = { workspace = true, features = [
-  "codegen_test",
+  "codegen_test", "experimental_traverse"
 ] }
 rstest = "0.18.0"
 bincode = "1.0"


### PR DESCRIPTION
This also adds a note to the docs of the 'traversal' module explaining that they are not really public API.