### PR TITLE
[skrifa] autohint: latin edge metrics

### DIFF
--- a/skrifa/src/outline/autohint/hint.rs
+++ b/skrifa/src/outline/autohint/hint.rs
@@ -314,9 +314,9 @@ mod tests {
     };
 
     #[test]
-    fn hinted_coords() {
+    fn hinted_coords_and_metrics() {
         let font = FontRef::new(font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS).unwrap();
-        let outline = hint_latin_outline(
+        let (outline, metrics) = hint_latin_outline(
             &font,
             16.0,
             Default::default(),
@@ -364,6 +364,14 @@ mod tests {
             .map(|point| (point.x, point.y))
             .collect::<Vec<_>>();
         assert_eq!(coords, expected_coords);
+        let expected_metrics = latin::HintedMetrics {
+            x_scale: 67109,
+            left_opos: 15,
+            left_pos: 0,
+            right_opos: 210,
+            right_pos: 192,
+        };
+        assert_eq!(metrics.unwrap(), expected_metrics);
     }
 
     // Specific test case for <https://issues.skia.org/issues/344529168> which
@@ -380,7 +388,8 @@ mod tests {
             // font description above more detail.
             GlyphId::new(5),
             &style::STYLE_CLASSES[style::StyleClass::LATN],
-        );
+        )
+        .0;
         let expected_coords = [(0, 1216), (1536, 1216), (1536, -320), (0, -320)];
         // See <https://issues.skia.org/issues/344529168#comment3>
         // Note that Skia inverts y coords
@@ -404,7 +413,7 @@ mod tests {
         coords: &[F2Dot14],
         gid: GlyphId,
         style: &style::StyleClass,
-    ) -> Outline {
+    ) -> (Outline, Option<latin::HintedMetrics>) {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(gid).unwrap();
         let mut outline = Outline::default();
@@ -416,7 +425,7 @@ mod tests {
             Style::Normal,
             Default::default(),
         );
-        latin::hint_outline(&mut outline, &metrics, &scale);
-        outline
+        let hinted_metrics = latin::hint_outline(&mut outline, &metrics, &scale);
+        (outline, hinted_metrics)
     }
 }

--- a/skrifa/src/outline/autohint/latin/edges.rs
+++ b/skrifa/src/outline/autohint/latin/edges.rs
@@ -20,6 +20,7 @@ pub(crate) fn compute_edges(
     axis: &mut Axis,
     metrics: &ScaledAxisMetrics,
     top_to_bottom_hinting: bool,
+    y_scale: i32,
 ) {
     axis.edges.clear();
     let scale = metrics.scale;
@@ -30,7 +31,7 @@ pub(crate) fn compute_edges(
     };
     // Ignore horizontal segments less than 1 pixel in length
     let segment_length_threshold = if axis.dim == Axis::HORIZONTAL {
-        fixed_div(64, scale)
+        fixed_div(64, y_scale)
     } else {
         0
     };
@@ -118,13 +119,13 @@ fn link_segments_to_edges(axis: &mut Axis) {
         loop {
             let segment = &mut segments[ix];
             segment.edge_ix = Some(edge_ix as u16);
+            if ix == last_ix {
+                break;
+            }
             ix = segment
                 .edge_next_ix
                 .map(|ix| ix as usize)
                 .unwrap_or(last_ix);
-            if ix == last_ix {
-                break;
-            }
         }
     }
 }
@@ -193,12 +194,12 @@ fn compute_edge_properties(axis: &mut Axis) {
                     edges[edge_ix].link_ix = edge2_ix;
                 }
             }
-            segment_ix = next_segment_ix
-                .map(|ix| ix as usize)
-                .unwrap_or(last_segment_ix);
             if segment_ix == last_segment_ix {
                 break;
             }
+            segment_ix = next_segment_ix
+                .map(|ix| ix as usize)
+                .unwrap_or(last_segment_ix);
         }
         let edge = &mut edges[edge_ix];
         edge.flags = Edge::NORMAL;
@@ -320,6 +321,7 @@ mod tests {
                 axis,
                 &scaled_metrics.axes[dim],
                 class.script.hint_top_to_bottom,
+                scaled_metrics.axes[1].scale,
             );
             if dim == Axis::VERTICAL {
                 compute_blue_edges(

--- a/skrifa/src/outline/autohint/latin/hint.rs
+++ b/skrifa/src/outline/autohint/latin/hint.rs
@@ -60,17 +60,19 @@ fn align_edges_to_blues(
             let edge2 = edge2_ix.map(|ix| &edges[ix]);
             // If we have two neutral zones, skip one of them
             if let (true, Some(edge2)) = (edge.blue_edge.is_some(), edge2) {
-                let skip_ix = if edge2.flags & Edge::NEUTRAL != 0 {
-                    edge2_ix
-                } else if edge.flags & Edge::NEUTRAL != 0 {
-                    Some(edge_ix)
-                } else {
-                    None
-                };
-                if let Some(skip_ix) = skip_ix {
-                    let skip_edge = &mut edges[skip_ix];
-                    skip_edge.blue_edge = None;
-                    skip_edge.flags &= !Edge::NEUTRAL;
+                if edge2.blue_edge.is_some() {
+                    let skip_ix = if edge2.flags & Edge::NEUTRAL != 0 {
+                        edge2_ix
+                    } else if edge.flags & Edge::NEUTRAL != 0 {
+                        Some(edge_ix)
+                    } else {
+                        None
+                    };
+                    if let Some(skip_ix) = skip_ix {
+                        let skip_edge = &mut edges[skip_ix];
+                        skip_edge.blue_edge = None;
+                        skip_edge.flags &= !Edge::NEUTRAL;
+                    }
                 }
             }
             // Flip edges if the other is aligned to a blue zone
@@ -90,8 +92,10 @@ fn align_edges_to_blues(
             edge1.flags |= Edge::DONE;
             if let Some(edge2_ix) = edge2_ix {
                 let edge2 = &mut edges[edge2_ix];
-                edge2.flags |= Edge::DONE;
-                align_linked_edge(axis, metrics, scale, edge1_ix, edge2_ix);
+                if edge2.blue_edge.is_none() {
+                    edge2.flags |= Edge::DONE;
+                    align_linked_edge(axis, metrics, scale, edge1_ix, edge2_ix);
+                }
             }
             if anchor_ix.is_none() {
                 anchor_ix = Some(edge_ix);
@@ -166,10 +170,6 @@ fn align_stem_edges(
                 edges[edge_ix].pos = cur_pos1 - cur_len / 2;
                 edges[edge2_ix].pos = cur_pos1 + cur_len / 2;
             } else {
-                let original_pos = anchor.pos - (edge.opos - anchor.opos);
-                let original_center = original_pos + (original_len >> 1);
-                // Note: FreeType recomputes original_len and cur_len here but
-                // they are the same as above
                 let cur_pos1 = pix_round(original_pos);
                 let delta1 = (cur_pos1 + (cur_len >> 1) - original_center).abs();
                 let cur_pos2 = pix_round(original_pos + original_len) - cur_len;
@@ -178,6 +178,11 @@ fn align_stem_edges(
                 let new_pos2 = new_pos + cur_len;
                 edges[edge_ix].pos = new_pos;
                 edges[edge2_ix].pos = new_pos2;
+            }
+            edges[edge_ix].flags |= Edge::DONE;
+            edges[edge2_ix].flags |= Edge::DONE;
+            if edge_ix > 0 {
+                adjust_link(edges, edge_ix, LinkDir::Prev, top_to_bottom_hinting);
             }
         } else {
             // No stem has been aligned yet
@@ -209,7 +214,7 @@ fn align_stem_edges(
                 if error1 < error2 {
                     cur_pos1 -= u_off;
                 } else {
-                    cur_pos1 -= d_off;
+                    cur_pos1 += d_off;
                 }
                 let edge_pos = cur_pos1 - cur_len / 2;
                 edges[edge_ix].pos = edge_pos;
@@ -220,13 +225,6 @@ fn align_stem_edges(
             edges[edge_ix].flags |= Edge::DONE;
             align_linked_edge(axis, metrics, scale, edge_ix, edge2_ix);
             anchor_ix = Some(edge_ix);
-        }
-        // Reborrow edges
-        let edges = axis.edges.as_mut_slice();
-        edges[edge_ix].flags |= Edge::DONE;
-        edges[edge2_ix].flags |= Edge::DONE;
-        if edge_ix > 0 {
-            adjust_link(edges, edge_ix, LinkDir::Prev, top_to_bottom_hinting);
         }
     }
     (serif_count, anchor_ix)
@@ -309,11 +307,12 @@ fn align_remaining_edges(
                 let new_pos = if after.opos == before.opos {
                     before.pos
                 } else {
-                    fixed_mul_div(
-                        edge.opos - before.opos,
-                        after.pos - before.pos,
-                        after.opos - before.opos,
-                    )
+                    before.pos
+                        + fixed_mul_div(
+                            edge.opos - before.opos,
+                            after.pos - before.pos,
+                            after.opos - before.opos,
+                        )
                 };
                 edges[edge_ix].pos = new_pos;
             } else {
@@ -593,6 +592,7 @@ mod tests {
                 axis,
                 &scaled_metrics.axes[0],
                 class.script.hint_top_to_bottom,
+                scaled_metrics.axes[1].scale,
             );
             if dim == Axis::VERTICAL {
                 latin::edges::compute_blue_edges(

--- a/skrifa/src/outline/autohint/latin/mod.rs
+++ b/skrifa/src/outline/autohint/latin/mod.rs
@@ -22,18 +22,41 @@ fn derived_constant(units_per_em: i32, value: i32) -> i32 {
     value * units_per_em / 2048
 }
 
-pub(crate) fn hint_outline(outline: &mut Outline, metrics: &UnscaledStyleMetrics, scale: &Scale) {
+/// Captures adjusted horizontal scale and outer edge positions to be used
+/// for horizontal metrics adjustments.
+#[derive(Copy, Clone, PartialEq, Default, Debug)]
+pub(crate) struct HintedMetrics {
+    pub x_scale: i32,
+    pub left_opos: i32,
+    pub left_pos: i32,
+    pub right_opos: i32,
+    pub right_pos: i32,
+}
+
+/// Applies the complete hinting process to a latin outline.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L3554>
+pub(crate) fn hint_outline(
+    outline: &mut Outline,
+    metrics: &UnscaledStyleMetrics,
+    scale: &Scale,
+) -> Option<HintedMetrics> {
     let scaled_metrics = metrics::scale_style_metrics(metrics, *scale);
+    let y_scale = scaled_metrics.axes[1].scale;
     let mut axis = Axis::default();
-    let hint_top_to_bottom = super::style::STYLE_CLASSES[metrics.class_ix as usize]
-        .script
-        .hint_top_to_bottom;
+    let hint_top_to_bottom = metrics.style_class().script.hint_top_to_bottom;
     outline.scale(&scaled_metrics.scale);
+    let mut hinted_metrics = None;
     for dim in 0..2 {
         axis.reset(dim, outline.orientation);
         segments::compute_segments(outline, &mut axis);
         segments::link_segments(outline, &mut axis, metrics.axes[dim].max_width());
-        edges::compute_edges(&mut axis, &scaled_metrics.axes[dim], hint_top_to_bottom);
+        edges::compute_edges(
+            &mut axis,
+            &scaled_metrics.axes[dim],
+            hint_top_to_bottom,
+            scaled_metrics.scale.y_scale,
+        );
         if dim == Axis::VERTICAL {
             edges::compute_blue_edges(
                 &mut axis,
@@ -51,5 +74,17 @@ pub(crate) fn hint_outline(outline: &mut Outline, metrics: &UnscaledStyleMetrics
         super::hint::align_edge_points(outline, &axis);
         super::hint::align_strong_points(outline, &mut axis);
         super::hint::align_weak_points(outline, dim);
+        if dim == 0 && axis.edges.len() > 1 {
+            let left = axis.edges.first().unwrap();
+            let right = axis.edges.last().unwrap();
+            hinted_metrics = Some(HintedMetrics {
+                x_scale: scaled_metrics.axes[0].scale,
+                left_pos: left.pos,
+                left_opos: left.opos,
+                right_pos: right.pos,
+                right_opos: right.opos,
+            });
+        }
     }
+    hinted_metrics
 }

--- a/skrifa/src/outline/autohint/latin/mod.rs
+++ b/skrifa/src/outline/autohint/latin/mod.rs
@@ -25,12 +25,21 @@ fn derived_constant(units_per_em: i32, value: i32) -> i32 {
 /// Captures adjusted horizontal scale and outer edge positions to be used
 /// for horizontal metrics adjustments.
 #[derive(Copy, Clone, PartialEq, Default, Debug)]
-pub(crate) struct HintedMetrics {
-    pub x_scale: i32,
+pub(crate) struct EdgeMetrics {
     pub left_opos: i32,
     pub left_pos: i32,
     pub right_opos: i32,
     pub right_pos: i32,
+}
+
+#[derive(Copy, Clone, PartialEq, Default, Debug)]
+pub(crate) struct HintedMetrics {
+    pub x_scale: i32,
+    /// This will be `None` when we've identified fewer than two horizontal
+    /// edges in the outline. This will occur for empty outlines and outlines
+    /// that are degenerate (all x coordinates have the same value, within
+    /// a threshold). In these cases, horizontal metrics will not be adjusted.
+    pub edge_metrics: Option<EdgeMetrics>,
 }
 
 /// Applies the complete hinting process to a latin outline.
@@ -40,13 +49,13 @@ pub(crate) fn hint_outline(
     outline: &mut Outline,
     metrics: &UnscaledStyleMetrics,
     scale: &Scale,
-) -> Option<HintedMetrics> {
+) -> HintedMetrics {
     let scaled_metrics = metrics::scale_style_metrics(metrics, *scale);
     let y_scale = scaled_metrics.axes[1].scale;
     let mut axis = Axis::default();
     let hint_top_to_bottom = metrics.style_class().script.hint_top_to_bottom;
     outline.scale(&scaled_metrics.scale);
-    let mut hinted_metrics = None;
+    let mut hinted_metrics = HintedMetrics::default();
     for dim in 0..2 {
         axis.reset(dim, outline.orientation);
         segments::compute_segments(outline, &mut axis);
@@ -64,6 +73,8 @@ pub(crate) fn hint_outline(
                 &metrics.axes[dim].blues,
                 &scaled_metrics.axes[dim].blues,
             );
+        } else {
+            hinted_metrics.x_scale = scaled_metrics.axes[0].scale;
         }
         hint::hint_edges(
             &mut axis,
@@ -77,8 +88,7 @@ pub(crate) fn hint_outline(
         if dim == 0 && axis.edges.len() > 1 {
             let left = axis.edges.first().unwrap();
             let right = axis.edges.last().unwrap();
-            hinted_metrics = Some(HintedMetrics {
-                x_scale: scaled_metrics.axes[0].scale,
+            hinted_metrics.edge_metrics = Some(EdgeMetrics {
                 left_pos: left.pos,
                 left_opos: left.opos,
                 right_pos: right.pos,

--- a/skrifa/src/outline/autohint/metrics.rs
+++ b/skrifa/src/outline/autohint/metrics.rs
@@ -72,6 +72,12 @@ pub(crate) struct UnscaledStyleMetrics {
     pub axes: [UnscaledAxisMetrics; 2],
 }
 
+impl UnscaledStyleMetrics {
+    pub fn style_class(&self) -> &'static StyleClass {
+        &super::style::STYLE_CLASSES[self.class_ix as usize]
+    }
+}
+
 /// The set of unscaled style metrics for a single font.
 ///
 /// For a variable font, this is dependent on the location in variation space.


### PR DESCRIPTION
Updates latin outline hinting to return a structure describing positions of the left and right-most edges which will be used for advance width adjustment. Updates the outer hinting function test to check these.

Includes a bit of additional code shuffling in the edge computation to better match FT.