### PR TITLE
[IFT] Add support for handling Format 2 entries with string IDs.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -415,3 +415,58 @@ pub fn custom_ids_format2() -> BeBuffer {
 
     buffer
 }
+
+// Format specification: https://w3c.github.io/IFT/Overview.html#patch-map-format-2
+pub fn string_ids_format2() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      2u8,                      // format
+
+      0u32,                     // reserved
+
+      [1, 2, 3, 4u32],          // compat id
+
+      4u8,                      // default patch encoding = glyph keyed
+      (Uint24::new(6)),         // entry count
+      {0u32: "entries_offset"}, // entries offset
+      {0u32: "string_data_offset"},                     // entry id string data offset
+
+      8u16, // uriTemplateLength
+      [b'A', b'B', b'C', b'D', b'E', b'F', 0xc9, 0xa4],  // uriTemplate[8]
+
+      /* ### Entry Data ### */
+
+      // Entry id = ""
+      {0b00000000u8: "entries"},              // format = {}
+
+      // Entry id = abc
+      0b00000100u8,                           // format = ID_DELTA
+      3u16,                                   // id length
+
+      // Entry id = defg
+      0b00000100u8,                           // format = ID_DELTA
+      4u16,                                   // id length
+
+      // Entry id = defg
+      0b00000000u8,                           // format = {}
+
+      // Entry id = hij
+      0b00000100u8,                           // format = ID_DELTA
+      {3u16: "entry[4] id length"},           // id length
+
+      // Entry id = ""
+      0b00000100u8,                           // format = ID_DELTA
+      0u16,                                   // id length
+
+      /* ### String Data ### */
+      {b'a': "string_data"},
+      [b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i', b'j']
+    };
+
+    let offset = buffer.offset_for("string_data") as u32;
+    buffer.write_at("string_data_offset", offset);
+
+    let offset = buffer.offset_for("entries") as u32;
+    buffer.write_at("entries_offset", offset);
+
+    buffer
+}

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -46,6 +46,8 @@ impl ReadArgs for IdDeltaOrLength {
 
 impl ComputeSize for IdDeltaOrLength {
     fn compute_size(entry_id_string_data_offset: &Offset32) -> Result<usize, ReadError> {
+        // This field is either a u16 or an int24 depending on whether or not string data
+        // is present. See: <https://w3c.github.io/IFT/Overview.html#mapping-entry-entryiddelta>
         Ok(if entry_id_string_data_offset.is_null() {
             3
         } else {
@@ -69,7 +71,7 @@ impl FontReadWithArgs<'_> for IdDeltaOrLength {
 
 impl IdDeltaOrLength {
     #[inline]
-    pub fn get(self) -> i32 {
+    pub fn into_inner(self) -> i32 {
         self.0
     }
 }

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -37,6 +37,43 @@ impl U8Or16 {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IdDeltaOrLength(i32);
+
+impl ReadArgs for IdDeltaOrLength {
+    type Args = Offset32;
+}
+
+impl ComputeSize for IdDeltaOrLength {
+    fn compute_size(entry_id_string_data_offset: &Offset32) -> Result<usize, ReadError> {
+        Ok(if entry_id_string_data_offset.is_null() {
+            3
+        } else {
+            2
+        })
+    }
+}
+
+impl FontReadWithArgs<'_> for IdDeltaOrLength {
+    fn read_with_args(
+        data: FontData<'_>,
+        entry_id_string_data_offset: &Self::Args,
+    ) -> Result<Self, ReadError> {
+        if entry_id_string_data_offset.is_null() {
+            data.read_at::<Int24>(0).map(|v| Self(i32::from(v)))
+        } else {
+            data.read_at::<u16>(0).map(|v| Self(v as i32))
+        }
+    }
+}
+
+impl IdDeltaOrLength {
+    #[inline]
+    pub fn get(self) -> i32 {
+        self.0
+    }
+}
+
 impl<'a> PatchMapFormat1<'a> {
     pub fn get_compatibility_id(&self) -> [u32; 4] {
         let fixed_array: &[BigEndian<u32>; 4] = self.compatibility_id().try_into().unwrap();

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -1,6 +1,7 @@
 #![parse_module(read_fonts::tables::ift)]
 
 extern record U8Or16;
+extern record IdDeltaOrLength;
 
 format u8 Ift {
   Format1(PatchMapFormat1),
@@ -140,6 +141,7 @@ table MappingEntries {
   entry_data: [u8],
 }
 
+#[read_args(entry_id_string_data_offset: Offset32)]
 table EntryData {
   format_flags: EntryFormatFlags,
 
@@ -164,9 +166,11 @@ table EntryData {
   copy_indices: [Uint24],
 
   // ENTRY_ID_DELTA
-  // TODO(garretrieger): add alternate id string length field.
+  #[read_with($entry_id_string_data_offset)]
   #[if_flag($format_flags, EntryFormatFlags::ENTRY_ID_DELTA)]
-  entry_id_delta: Int24,
+  #[traverse_with(skip)]
+  #[compile(skip)]
+  entry_id_delta: IdDeltaOrLength,
 
   // PATCH_ENCODING
   #[if_flag($format_flags, EntryFormatFlags::PATCH_ENCODING)]

--- a/skrifa/src/patchmap.rs
+++ b/skrifa/src/patchmap.rs
@@ -286,7 +286,7 @@ fn decode_format2_entries(map: &PatchMapFormat2) -> Result<Vec<Entry>, ReadError
         .entry_id_string_data()
         .transpose()?
         .map(|table| table.id_data())
-        .map(|data| Cursor::new(data));
+        .map(Cursor::new);
     while entry_count > 0 {
         entries_data = decode_format2_entry(
             entries_data,
@@ -394,7 +394,7 @@ fn format2_new_entry_id(
             })
             .unwrap_or(0);
         return Ok(PatchId::Numeric(compute_format2_new_entry_index(
-            &entry_data,
+            entry_data,
             last_entry_index,
         )?));
     };

--- a/skrifa/src/patchmap.rs
+++ b/skrifa/src/patchmap.rs
@@ -399,7 +399,7 @@ fn format2_new_entry_id(
         )?));
     };
 
-    let Some(id_string_length) = entry_data.entry_id_delta().map(|v| v.get()) else {
+    let Some(id_string_length) = entry_data.entry_id_delta().map(|v| v.into_inner()) else {
         let last_id_string = last_entry
             .and_then(|e| match &e.uri.id {
                 PatchId::String(id_string) => Some(id_string.clone()),
@@ -424,7 +424,7 @@ fn compute_format2_new_entry_index(
         + 1
         + entry_data
             .entry_id_delta()
-            .map(|v| v.get() as i64)
+            .map(|v| v.into_inner() as i64)
             .unwrap_or(0);
     if new_index.is_negative() {
         return Err(ReadError::MalformedData("Negative entry id encountered."));


### PR DESCRIPTION
When a string data block is present then entry id deltas are instead interpretted as string lengths in order to assign string ids to entries (instead of the usual numeric ones).

See: https://w3c.github.io/IFT/Overview.html#mapping-entry-entryidstringlength