### PR TITLE
[skrifa] autohint: CJK segments

### DIFF
--- a/skrifa/src/outline/autohint/axis.rs
+++ b/skrifa/src/outline/autohint/axis.rs
@@ -126,6 +126,8 @@ pub(crate) struct Segment {
     pub height: i16,
     /// Used during stem matching.
     pub score: i32,
+    /// Used during stem matching.
+    pub len: i32,
     /// Index of best candidate for a stem link.
     pub link_ix: Option<u16>,
     /// Index of best candidate for a serif link.
@@ -180,6 +182,10 @@ impl Segment {
 
     pub fn edge<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
         edges.get(self.edge_ix.map(|ix| ix as usize)?)
+    }
+
+    pub fn link<'a>(&self, segments: &'a [Segment]) -> Option<&'a Segment> {
+        segments.get(self.link_ix.map(|ix| ix as usize)?)
     }
 }
 

--- a/skrifa/src/outline/autohint/latin/edges.rs
+++ b/skrifa/src/outline/autohint/latin/edges.rs
@@ -235,7 +235,7 @@ pub(crate) fn compute_blue_edges(
         let mut best_dist = fixed_mul(scale.units_per_em / 40, scale.y_scale).min(64 / 2);
         for (unscaled_blue, blue) in unscaled_blues.iter().zip(blues) {
             // Ignore inactive blue zones
-            if blue.flags & blue_flags::LATIN_ACTIVE == 0 {
+            if blue.flags & blue_flags::ACTIVE == 0 {
                 continue;
             }
             let is_top = blue.flags & (blue_flags::TOP | blue_flags::LATIN_SUB_TOP) != 0;

--- a/skrifa/src/outline/autohint/latin/edges.rs
+++ b/skrifa/src/outline/autohint/latin/edges.rs
@@ -315,8 +315,14 @@ mod tests {
             Axis::new(Axis::VERTICAL, outline.orientation),
         ];
         for (dim, axis) in axes.iter_mut().enumerate() {
-            latin::segments::compute_segments(&mut outline, axis);
-            latin::segments::link_segments(&outline, axis, unscaled_metrics.axes[dim].max_width());
+            latin::segments::compute_segments(&mut outline, axis, class.script.group);
+            latin::segments::link_segments(
+                &outline,
+                axis,
+                scaled_metrics.axes[dim].scale,
+                class.script.group,
+                unscaled_metrics.axes[dim].max_width(),
+            );
             compute_edges(
                 axis,
                 &scaled_metrics.axes[dim],

--- a/skrifa/src/outline/autohint/latin/hint.rs
+++ b/skrifa/src/outline/autohint/latin/hint.rs
@@ -586,8 +586,14 @@ mod tests {
             Axis::new(Axis::VERTICAL, outline.orientation),
         ];
         for (dim, axis) in axes.iter_mut().enumerate() {
-            latin::segments::compute_segments(&mut outline, axis);
-            latin::segments::link_segments(&outline, axis, unscaled_metrics.axes[dim].max_width());
+            latin::segments::compute_segments(&mut outline, axis, class.script.group);
+            latin::segments::link_segments(
+                &outline,
+                axis,
+                scaled_metrics.axes[dim].scale,
+                class.script.group,
+                unscaled_metrics.axes[dim].max_width(),
+            );
             latin::edges::compute_edges(
                 axis,
                 &scaled_metrics.axes[0],

--- a/skrifa/src/outline/autohint/latin/metrics.rs
+++ b/skrifa/src/outline/autohint/latin/metrics.rs
@@ -13,9 +13,9 @@ use super::super::{
         ScaledStyleMetrics, ScaledWidth, UnscaledAxisMetrics, UnscaledBlue, UnscaledBlues,
         UnscaledStyleMetrics, WidthMetrics,
     },
-    style::{blue_flags, ScriptClass, StyleClass},
+    style::{blue_flags, ScriptClass, ScriptGroup, StyleClass},
 };
-use crate::{prelude::Size, MetadataProvider};
+use crate::{outline::autohint::metrics::fixed_div, prelude::Size, MetadataProvider};
 use raw::{types::F2Dot14, FontRef};
 
 /// Computes unscaled metrics for the Latin writing system.
@@ -71,8 +71,13 @@ pub(crate) fn scale_style_metrics(
     unscaled_metrics: &UnscaledStyleMetrics,
     mut scale: Scale,
 ) -> ScaledStyleMetrics {
+    let scale_axis_fn = if unscaled_metrics.style_class().script.group == ScriptGroup::Default {
+        scale_default_axis_metrics
+    } else {
+        scale_cjk_axis_metrics
+    };
     let mut scale_axis = |axis: &UnscaledAxisMetrics| {
-        scale_axis_metrics(
+        scale_axis_fn(
             axis.dim,
             &axis.widths,
             axis.width_metrics,
@@ -90,7 +95,7 @@ pub(crate) fn scale_style_metrics(
 /// Computes scaled metrics for a single axis.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L1168>
-fn scale_axis_metrics(
+fn scale_default_axis_metrics(
     dim: Dimension,
     widths: &[i32],
     width_metrics: WidthMetrics,
@@ -155,7 +160,7 @@ fn scale_axis_metrics(
                     scaled: scaled_overshoot,
                     fitted: scaled_overshoot,
                 },
-                flags: unscaled_blue.flags & !blue_flags::LATIN_ACTIVE,
+                flags: unscaled_blue.flags & !blue_flags::ACTIVE,
             };
             // Only activate blue zones less than 3/4 pixel tall
             let dist = fixed_mul(unscaled_blue.position - unscaled_blue.overshoot, axis.scale);
@@ -173,14 +178,14 @@ fn scale_axis_metrics(
                 }
                 blue.position.fitted = pix_round(blue.position.scaled);
                 blue.overshoot.fitted = blue.position.fitted - delta;
-                blue.flags |= blue_flags::LATIN_ACTIVE;
+                blue.flags |= blue_flags::ACTIVE;
             }
             axis.blues.push(blue);
         }
         // Use sub-top blue zone if it doesn't overlap with another
         // non-sub-top blue zone
         for blue_ix in 0..axis.blues.len() {
-            const REQUIRED_FLAGS: u32 = blue_flags::LATIN_SUB_TOP | blue_flags::LATIN_ACTIVE;
+            const REQUIRED_FLAGS: u32 = blue_flags::LATIN_SUB_TOP | blue_flags::ACTIVE;
             let blue = axis.blues[blue_ix];
             if blue.flags & REQUIRED_FLAGS != REQUIRED_FLAGS {
                 continue;
@@ -190,17 +195,80 @@ fn scale_axis_metrics(
                 if blue2.flags & blue_flags::LATIN_SUB_TOP != 0 {
                     continue;
                 }
-                if blue2.flags & blue_flags::LATIN_ACTIVE == 0 {
+                if blue2.flags & blue_flags::ACTIVE == 0 {
                     continue;
                 }
                 if blue2.position.fitted <= blue.overshoot.fitted
                     && blue2.overshoot.fitted >= blue.position.fitted
                 {
-                    axis.blues[blue_ix].flags &= !blue_flags::LATIN_ACTIVE;
+                    axis.blues[blue_ix].flags &= !blue_flags::ACTIVE;
                     break;
                 }
             }
         }
+    }
+    axis
+}
+
+/// Computes scaled metrics for a single axis for the CJK script gorup.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L661>
+fn scale_cjk_axis_metrics(
+    dim: Dimension,
+    widths: &[i32],
+    width_metrics: WidthMetrics,
+    blues: &[UnscaledBlue],
+    scale: &mut Scale,
+) -> ScaledAxisMetrics {
+    let mut axis = ScaledAxisMetrics::default();
+    if dim == Axis::HORIZONTAL {
+        axis.scale = scale.x_scale;
+        axis.delta = scale.x_delta;
+    } else {
+        axis.scale = scale.y_scale;
+        axis.delta = scale.y_delta;
+    };
+    let scale = axis.scale;
+    // Scale the blue zones
+    for unscaled_blue in blues {
+        let position = fixed_mul(unscaled_blue.position, scale) + axis.delta;
+        let overshoot = fixed_mul(unscaled_blue.overshoot, scale) + axis.delta;
+        let mut blue = ScaledBlue {
+            position: ScaledWidth {
+                scaled: position,
+                fitted: position,
+            },
+            overshoot: ScaledWidth {
+                scaled: overshoot,
+                fitted: overshoot,
+            },
+            flags: unscaled_blue.flags,
+        };
+        // A blue zone is only active if it is less than 3/4 pixels tall
+        let dist = fixed_mul(unscaled_blue.position - unscaled_blue.overshoot, scale);
+        if dist <= 48 || dist >= -48 {
+            blue.position.fitted = pix_round(blue.position.scaled);
+            // For CJK, "overshoot" is actually undershoot
+            let delta1 = fixed_div(blue.position.fitted, scale) - unscaled_blue.overshoot;
+            let mut delta2 = fixed_mul(delta1.abs(), scale);
+            if delta2 < 32 {
+                delta2 = 0;
+            } else {
+                delta2 = pix_round(delta2);
+            }
+            if delta1 < 0 {
+                delta2 = -delta2;
+            }
+            blue.overshoot.fitted = blue.position.fitted - delta2;
+            blue.flags |= blue_flags::ACTIVE;
+        }
+        axis.blues.push(blue);
+    }
+    // FreeType never seems to compute scaled width values. We'll just
+    // match this behavior for now.
+    // <https://github.com/googlefonts/fontations/issues/1129>
+    for _ in 0..widths.len() {
+        axis.widths.push(ScaledWidth::default());
     }
     axis
 }
@@ -212,17 +280,13 @@ mod tests {
     use raw::{FontRef, TableProvider};
 
     #[test]
-    fn scaled_metrics() {
-        let font = FontRef::new(font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS).unwrap();
-        let class = &style::STYLE_CLASSES[StyleClass::HEBR];
-        let unscaled_metrics = compute_unscaled_style_metrics(&font, Default::default(), class);
-        let scale = Scale::new(
-            16.0,
-            font.head().unwrap().units_per_em() as i32,
-            Style::Normal,
-            Default::default(),
+    fn scaled_metrics_default() {
+        // Note: expected values scraped from a FreeType debugging
+        // session
+        let scaled_metrics = make_scaled_metrics(
+            font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS,
+            StyleClass::HEBR,
         );
-        let scaled_metrics = scale_style_metrics(&unscaled_metrics, scale);
         // Check scale and deltas
         assert_eq!(scaled_metrics.scale.x_scale, 67109);
         assert_eq!(scaled_metrics.scale.y_scale, 67109);
@@ -231,46 +295,104 @@ mod tests {
         // Horizontal widths
         let h_axis = &scaled_metrics.axes[0];
         let expected_h_widths = [55];
-        let h_widths = h_axis
-            .widths
-            .iter()
-            .map(|width| width.scaled)
-            .collect::<Vec<_>>();
-        assert_eq!(h_widths, expected_h_widths);
-        // Latin never has horizontal blues
-        assert!(h_axis.blues.is_empty());
+        // No horizontal blues
+        check_axis(h_axis, &expected_h_widths, &[]);
         // Not extra light
         assert!(!h_axis.width_metrics.is_extra_light);
         // Vertical widths
         let v_axis = &scaled_metrics.axes[1];
         let expected_v_widths = [22, 112];
-        let v_widths = v_axis
-            .widths
-            .iter()
-            .map(|width| width.scaled)
-            .collect::<Vec<_>>();
-        assert_eq!(v_widths, expected_v_widths);
         // Vertical blues
         #[rustfmt::skip]
         let expected_v_blues = [
             // ((scaled_pos, fitted_pos), (scaled_shoot, fitted_shoot), flags)
-            ((606, 576), (606, 576), blue_flags::LATIN_ACTIVE | blue_flags::TOP),
-            ((0, 0), (-9, 0), blue_flags::LATIN_ACTIVE),
-            ((-246, -256), (-246, -256), blue_flags::LATIN_ACTIVE),
+            ScaledBlue::from(((606, 576), (606, 576), blue_flags::ACTIVE | blue_flags::TOP)),
+            ScaledBlue::from(((0, 0), (-9, 0), blue_flags::ACTIVE)),
+            ScaledBlue::from(((-246, -256), (-246, -256), blue_flags::ACTIVE)),
         ];
-        let v_blues = v_axis
-            .blues
-            .iter()
-            .map(|blue| {
-                (
-                    (blue.position.scaled, blue.position.fitted),
-                    (blue.overshoot.scaled, blue.overshoot.fitted),
-                    blue.flags,
-                )
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(v_blues, expected_v_blues);
+        check_axis(v_axis, &expected_v_widths, &expected_v_blues);
         // This one is extra light
         assert!(v_axis.width_metrics.is_extra_light);
+    }
+
+    #[test]
+    fn cjk_scaled_metrics() {
+        // Note: expected values scraped from a FreeType debugging
+        // session
+        let scaled_metrics = make_scaled_metrics(
+            font_test_data::NOTOSERIFTC_AUTOHINT_METRICS,
+            StyleClass::HANI,
+        );
+        // Check scale and deltas
+        assert_eq!(scaled_metrics.scale.x_scale, 67109);
+        assert_eq!(scaled_metrics.scale.y_scale, 67109);
+        assert_eq!(scaled_metrics.scale.x_delta, 0);
+        assert_eq!(scaled_metrics.scale.y_delta, 0);
+        // Horizontal widths
+        let h_axis = &scaled_metrics.axes[0];
+        let expected_h_widths = [0];
+        check_axis(h_axis, &expected_h_widths, &[]);
+        // Not extra light
+        assert!(!h_axis.width_metrics.is_extra_light);
+        // Vertical widths
+        let v_axis = &scaled_metrics.axes[1];
+        let expected_v_widths = [0];
+        // Vertical blues
+        #[rustfmt::skip]
+        let expected_v_blues = [
+            // ((scaled_pos, fitted_pos), (scaled_shoot, fitted_shoot), flags)
+            ScaledBlue::from(((857, 832), (844, 832), blue_flags::ACTIVE | blue_flags::TOP)),
+            ScaledBlue::from(((-80, -64), (-68, -64), blue_flags::ACTIVE)),
+        ];
+        // No horizontal blues
+        check_axis(v_axis, &expected_v_widths, &expected_v_blues);
+        // Also not extra light
+        assert!(!v_axis.width_metrics.is_extra_light);
+    }
+
+    fn make_scaled_metrics(font_data: &[u8], style_class: usize) -> ScaledStyleMetrics {
+        let font = FontRef::new(font_data).unwrap();
+        let class = &style::STYLE_CLASSES[style_class];
+        let unscaled_metrics = compute_unscaled_style_metrics(&font, Default::default(), class);
+        let scale = Scale::new(
+            16.0,
+            font.head().unwrap().units_per_em() as i32,
+            Style::Normal,
+            Default::default(),
+        );
+        scale_style_metrics(&unscaled_metrics, scale)
+    }
+
+    fn check_axis(
+        axis: &ScaledAxisMetrics,
+        expected_widths: &[i32],
+        expected_blues: &[ScaledBlue],
+    ) {
+        let widths = axis
+            .widths
+            .iter()
+            .map(|width| width.scaled)
+            .collect::<Vec<_>>();
+        assert_eq!(widths, expected_widths);
+        assert_eq!(axis.blues.as_slice(), expected_blues);
+    }
+
+    impl From<(i32, i32)> for ScaledWidth {
+        fn from(value: (i32, i32)) -> Self {
+            Self {
+                scaled: value.0,
+                fitted: value.1,
+            }
+        }
+    }
+
+    impl From<((i32, i32), (i32, i32), u32)> for ScaledBlue {
+        fn from(value: ((i32, i32), (i32, i32), u32)) -> Self {
+            Self {
+                position: value.0.into(),
+                overshoot: value.1.into(),
+                flags: value.2,
+            }
+        }
     }
 }

--- a/skrifa/src/outline/autohint/latin/metrics.rs
+++ b/skrifa/src/outline/autohint/latin/metrics.rs
@@ -210,7 +210,7 @@ fn scale_default_axis_metrics(
     axis
 }
 
-/// Computes scaled metrics for a single axis for the CJK script gorup.
+/// Computes scaled metrics for a single axis for the CJK script group.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L661>
 fn scale_cjk_axis_metrics(

--- a/skrifa/src/outline/autohint/latin/metrics.rs
+++ b/skrifa/src/outline/autohint/latin/metrics.rs
@@ -9,13 +9,13 @@
 use super::super::{
     axis::{Axis, Dimension},
     metrics::{
-        fixed_mul, fixed_mul_div, pix_round, Scale, ScaledAxisMetrics, ScaledBlue,
+        fixed_div, fixed_mul, fixed_mul_div, pix_round, Scale, ScaledAxisMetrics, ScaledBlue,
         ScaledStyleMetrics, ScaledWidth, UnscaledAxisMetrics, UnscaledBlue, UnscaledBlues,
         UnscaledStyleMetrics, WidthMetrics,
     },
     style::{blue_flags, ScriptClass, ScriptGroup, StyleClass},
 };
-use crate::{outline::autohint::metrics::fixed_div, prelude::Size, MetadataProvider};
+use crate::{prelude::Size, MetadataProvider};
 use raw::{types::F2Dot14, FontRef};
 
 /// Computes unscaled metrics for the Latin writing system.

--- a/skrifa/src/outline/autohint/latin/mod.rs
+++ b/skrifa/src/outline/autohint/latin/mod.rs
@@ -56,10 +56,17 @@ pub(crate) fn hint_outline(
     let hint_top_to_bottom = metrics.style_class().script.hint_top_to_bottom;
     outline.scale(&scaled_metrics.scale);
     let mut hinted_metrics = HintedMetrics::default();
+    let group = metrics.style_class().script.group;
     for dim in 0..2 {
         axis.reset(dim, outline.orientation);
-        segments::compute_segments(outline, &mut axis);
-        segments::link_segments(outline, &mut axis, metrics.axes[dim].max_width());
+        segments::compute_segments(outline, &mut axis, group);
+        segments::link_segments(
+            outline,
+            &mut axis,
+            scaled_metrics.axes[dim].scale,
+            group,
+            metrics.axes[dim].max_width(),
+        );
         edges::compute_edges(
             &mut axis,
             &scaled_metrics.axes[dim],

--- a/skrifa/src/outline/autohint/latin/segments.rs
+++ b/skrifa/src/outline/autohint/latin/segments.rs
@@ -10,7 +10,9 @@ use raw::tables::glyf::PointFlags;
 
 use super::super::{
     axis::{Axis, Dimension, Segment},
+    metrics::fixed_div,
     outline::{Outline, Point},
+    style::ScriptGroup,
 };
 
 // Bounds for score, position and coordinate values.
@@ -21,12 +23,17 @@ const MIN_SCORE: i32 = -32000;
 /// Computes segments for the Latin writing system.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L1537>
-pub(crate) fn compute_segments(outline: &mut Outline, axis: &mut Axis) -> bool {
+pub(crate) fn compute_segments(outline: &mut Outline, axis: &mut Axis, group: ScriptGroup) -> bool {
     assign_point_uvs(outline, axis.dim);
     if !build_segments(outline, axis) {
         return false;
     }
     adjust_segment_heights(outline, axis);
+    // This is never actually executed due to a bug in FreeType
+    // See point 2 at <https://github.com/googlefonts/fontations/issues/1129>
+    // if group != ScriptGroup::Default {
+    //     _detect_round_segments_cjk(outline, axis);
+    // }
     true
 }
 
@@ -35,7 +42,26 @@ pub(crate) fn compute_segments(outline: &mut Outline, axis: &mut Axis) -> bool {
 /// If `max_width` is provided, use it to refine the scoring function.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L1990>
-pub(crate) fn link_segments(outline: &Outline, axis: &mut Axis, max_width: Option<i32>) {
+pub(crate) fn link_segments(
+    outline: &Outline,
+    axis: &mut Axis,
+    scale: i32,
+    group: ScriptGroup,
+    max_width: Option<i32>,
+) {
+    if group == ScriptGroup::Default {
+        link_segments_default(outline, axis, max_width);
+    } else {
+        link_segments_cjk(outline, axis, scale)
+    }
+}
+
+/// Link segments to form stems and serifs.
+///
+/// If `max_width` is provided, use it to refine the scoring function.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L1990>
+fn link_segments_default(outline: &Outline, axis: &mut Axis, max_width: Option<i32>) {
     let max_width = max_width.unwrap_or_default();
     // Heuristic value to set up a minimum for overlapping
     let len_threshold = super::derived_constant(outline.units_per_em, 8).max(1);
@@ -120,6 +146,128 @@ pub(crate) fn link_segments(outline: &Outline, axis: &mut Axis, max_width: Optio
             let seg1 = &mut segments[ix1];
             seg1.link_ix = None;
             seg1.serif_ix = seg2_link;
+        }
+    }
+}
+
+/// Link segments to form stems and serifs for the CJK script group.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L848>
+fn link_segments_cjk(outline: &Outline, axis: &mut Axis, scale: i32) {
+    // Heuristic value to set up a minimum for overlapping
+    let len_threshold = super::derived_constant(outline.units_per_em, 8);
+    let dist_threshold = fixed_div(64 * 3, scale);
+    // Compare each segment to the others.. O(n^2)
+    let segments = axis.segments.as_mut_slice();
+    for ix1 in 0..segments.len() {
+        let seg1 = segments[ix1];
+        if seg1.dir != axis.major_dir {
+            continue;
+        }
+        let pos1 = seg1.pos as i32;
+        // Search for stems having opposite directions with seg1 to the
+        // "left" of seg2
+        for ix2 in 0..segments.len() {
+            let seg1 = segments[ix1];
+            let seg2 = segments[ix2];
+            if ix1 == ix2 || !seg1.dir.is_opposite(seg2.dir) {
+                continue;
+            }
+            let pos2 = seg2.pos as i32;
+            let dist = pos2 - pos1;
+            if dist < 0 {
+                continue;
+            }
+            // Compute distance between the segments
+            // Note: the min/max functions chosen here are intentional
+            let min = seg1.min_coord.max(seg2.min_coord) as i32;
+            let max = seg1.max_coord.min(seg2.max_coord) as i32;
+            // Compute maximum coordinate difference or how much they
+            // overlap
+            let len = max - min;
+            if len >= len_threshold {
+                let check_seg = |seg: &Segment| {
+                    // Some more magic heuristics...
+                    // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L896>
+                    (dist * 8 < seg.score * 9) && (dist * 8 < seg.score * 7 || seg.len < len)
+                };
+                if check_seg(&seg1) {
+                    let seg = &mut segments[ix1];
+                    seg.score = dist;
+                    seg.len = len;
+                    seg.link_ix = Some(ix2 as _);
+                }
+                if check_seg(&seg2) {
+                    let seg = &mut segments[ix2];
+                    seg.score = dist;
+                    seg.len = len;
+                    seg.link_ix = Some(ix1 as _);
+                }
+            }
+        }
+    }
+    // Now compute "serif" segments
+    // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L917>
+    for ix1 in 0..segments.len() {
+        let seg1 = segments[ix1];
+        if seg1.score >= dist_threshold {
+            continue;
+        }
+        let Some(link1) = seg1.link(segments).copied() else {
+            continue;
+        };
+        // Unwrap is fine because we checked for existence above
+        let link1_ix = seg1.link_ix.unwrap() as usize;
+        if link1.link_ix != Some(ix1 as u16) || link1.pos <= seg1.pos {
+            continue;
+        }
+        for ix2 in 0..segments.len() {
+            let seg2 = segments[ix2];
+            if seg2.pos > seg1.pos || ix1 == ix2 {
+                continue;
+            }
+            let Some(link2) = seg2.link(segments).copied() else {
+                continue;
+            };
+            if link2.link_ix != Some(ix2 as u16) || link2.pos <= link1.pos {
+                continue;
+            }
+            if seg1.pos == seg2.pos && link1.pos == link2.pos {
+                continue;
+            }
+            if seg2.score <= seg1.score || seg1.score * 4 <= seg2.score {
+                continue;
+            }
+            if seg1.len >= seg2.len * 3 {
+                // Again, we definitely have a valid link2
+                let link2_ix = seg2.link_ix.unwrap() as usize;
+                for seg in segments.iter_mut() {
+                    let link_ix = seg.link_ix;
+                    if link_ix == Some(ix2 as u16) {
+                        seg.link_ix = None;
+                        seg.serif_ix = Some(link1_ix as u16);
+                    } else if link_ix == Some(link2_ix as u16) {
+                        seg.link_ix = None;
+                        seg.serif_ix = Some(ix1 as u16);
+                    }
+                }
+            } else {
+                segments[ix1].link_ix = None;
+                segments[link1_ix].link_ix = None;
+                break;
+            }
+        }
+    }
+    for ix1 in 0..segments.len() {
+        let seg1 = segments[ix1];
+        let Some(seg2) = seg1.link(segments).copied() else {
+            continue;
+        };
+        if seg2.link_ix != Some(ix1 as u16) {
+            segments[ix1].link_ix = None;
+            if seg2.score < dist_threshold || seg1.score < seg2.score * 4 {
+                segments[ix1].serif_ix = seg2.link_ix;
+            }
         }
     }
 }
@@ -347,6 +495,40 @@ fn adjust_segment_heights(outline: &mut Outline, axis: &mut Axis) {
     }
 }
 
+/// Performs the additional step of detecting round segments for the CJK script
+/// group.
+///
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L818>
+fn _detect_round_segments_cjk(outline: &mut Outline, axis: &mut Axis) {
+    let points = outline.points.as_slice();
+    // A segment is considered round if it doesn't have successive on-curve
+    // points
+    for segment in &mut axis.segments {
+        segment.flags &= !Segment::ROUND;
+        let mut point_ix = segment.first();
+        let last_ix = segment.last();
+        let first_point = &points[point_ix];
+        let mut is_prev_on_curve = first_point.is_on_curve();
+        point_ix = first_point.next();
+        loop {
+            let point = &points[point_ix];
+            let is_on_curve = point.is_on_curve();
+            if is_prev_on_curve && is_on_curve {
+                // Two on-curves in a row means we're not a round segment
+                break;
+            }
+            is_prev_on_curve = is_on_curve;
+            point_ix = point.next();
+            if point_ix == last_ix {
+                // We've reached the last point without two successive
+                // on-curves so we're round
+                segment.flags |= Segment::ROUND;
+                break;
+            }
+        }
+    }
+}
+
 /// Capture current and previous state while computing segments.
 ///
 /// Values measured along a segment (point.v) are called "coordinates" and
@@ -411,8 +593,8 @@ mod tests {
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
         let mut axis = Axis::new(Axis::HORIZONTAL, outline.orientation);
-        compute_segments(&mut outline, &mut axis);
-        link_segments(&outline, &mut axis, None);
+        compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
+        link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
         let segments = retain_segment_test_fields(&axis.segments);
         let expected = [
             Segment {
@@ -523,8 +705,8 @@ mod tests {
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
         let mut axis = Axis::new(Axis::VERTICAL, outline.orientation);
-        compute_segments(&mut outline, &mut axis);
-        link_segments(&outline, &mut axis, None);
+        compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
+        link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
         let segments = retain_segment_test_fields(&axis.segments);
         let expected = [
             Segment {
@@ -597,6 +779,266 @@ mod tests {
                 height: 346,
                 link_ix: None,
                 serif_ix: Some(1),
+                ..Default::default()
+            },
+        ];
+        assert_eq!(segments, &expected);
+    }
+
+    #[test]
+    fn cjk_horizontal_segments() {
+        let font = FontRef::new(font_test_data::NOTOSERIFTC_AUTOHINT_METRICS).unwrap();
+        let glyphs = font.outline_glyphs();
+        let glyph = glyphs.get(GlyphId::new(9)).unwrap();
+        let mut outline = Outline::default();
+        outline.fill(&glyph, Default::default()).unwrap();
+        let mut axis = Axis::new(Axis::HORIZONTAL, outline.orientation);
+        compute_segments(&mut outline, &mut axis, ScriptGroup::Cjk);
+        link_segments(&outline, &mut axis, 67109, ScriptGroup::Cjk, None);
+        let segments = retain_segment_test_fields(&axis.segments);
+        let expected = [
+            Segment {
+                flags: 0,
+                dir: Direction::Down,
+                pos: 731,
+                delta: 0,
+                min_coord: 155,
+                max_coord: 676,
+                height: 524,
+                link_ix: Some(1),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Up,
+                pos: 670,
+                delta: 0,
+                min_coord: 133,
+                max_coord: 712,
+                height: 579,
+                link_ix: Some(0),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Down,
+                pos: 458,
+                delta: 0,
+                min_coord: 741,
+                max_coord: 757,
+                height: 88,
+                link_ix: None,
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Down,
+                pos: 911,
+                delta: 0,
+                min_coord: -9,
+                max_coord: 791,
+                height: 821,
+                link_ix: Some(5),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Up,
+                pos: 693,
+                delta: 0,
+                min_coord: -7,
+                max_coord: 9,
+                height: 18,
+                link_ix: None,
+                serif_ix: Some(5),
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Up,
+                pos: 849,
+                delta: 0,
+                min_coord: 11,
+                max_coord: 829,
+                height: 823,
+                link_ix: Some(3),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Down,
+                pos: 569,
+                delta: 0,
+                min_coord: 547,
+                max_coord: 576,
+                height: 29,
+                link_ix: None,
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Down,
+                pos: 201,
+                delta: 0,
+                min_coord: -57,
+                max_coord: 540,
+                height: 599,
+                link_ix: Some(8),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Up,
+                pos: 138,
+                delta: 0,
+                min_coord: -78,
+                max_coord: 543,
+                height: 640,
+                link_ix: Some(7),
+                serif_ix: None,
+                ..Default::default()
+            },
+        ];
+        assert_eq!(segments, &expected);
+    }
+
+    #[test]
+    fn cjk_vertical_segments() {
+        let font = FontRef::new(font_test_data::NOTOSERIFTC_AUTOHINT_METRICS).unwrap();
+        let glyphs = font.outline_glyphs();
+        let glyph = glyphs.get(GlyphId::new(9)).unwrap();
+        let mut outline = Outline::default();
+        outline.fill(&glyph, Default::default()).unwrap();
+        let mut axis = Axis::new(Axis::VERTICAL, outline.orientation);
+        compute_segments(&mut outline, &mut axis, ScriptGroup::Cjk);
+        link_segments(&outline, &mut axis, 67109, ScriptGroup::Cjk, None);
+        let segments = retain_segment_test_fields(&axis.segments);
+        let expected = [
+            Segment {
+                flags: 0,
+                dir: Direction::Right,
+                pos: 758,
+                delta: 0,
+                min_coord: 280,
+                max_coord: 545,
+                height: 288,
+                link_ix: Some(1),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Left,
+                pos: 729,
+                delta: 0,
+                min_coord: 288,
+                max_coord: 674,
+                height: 391,
+                link_ix: Some(0),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 1,
+                dir: Direction::Left,
+                pos: 133,
+                delta: 0,
+                min_coord: 670,
+                max_coord: 693,
+                height: 34,
+                link_ix: None,
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Right,
+                pos: 757,
+                delta: 0,
+                min_coord: 393,
+                max_coord: 458,
+                height: 70,
+                link_ix: None,
+                serif_ix: Some(0),
+                ..Default::default()
+            },
+            Segment {
+                flags: 1,
+                dir: Direction::Right,
+                pos: 3,
+                delta: 2,
+                min_coord: 727,
+                max_coord: 838,
+                height: 133,
+                link_ix: None,
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Right,
+                pos: 576,
+                delta: 0,
+                min_coord: 397,
+                max_coord: 569,
+                height: 177,
+                link_ix: Some(7),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Left,
+                pos: 547,
+                delta: 0,
+                min_coord: 387,
+                max_coord: 569,
+                height: 182,
+                link_ix: None,
+                serif_ix: Some(7),
+                ..Default::default()
+            },
+            Segment {
+                flags: 0,
+                dir: Direction::Left,
+                pos: 576,
+                delta: 0,
+                min_coord: 536,
+                max_coord: 546,
+                height: 10,
+                link_ix: Some(5),
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 1,
+                dir: Direction::Left,
+                pos: -78,
+                delta: 0,
+                min_coord: 138,
+                max_coord: 161,
+                height: 34,
+                link_ix: None,
+                serif_ix: None,
+                ..Default::default()
+            },
+            Segment {
+                flags: 1,
+                dir: Direction::Left,
+                pos: 788,
+                delta: 0,
+                min_coord: 262,
+                max_coord: 294,
+                height: 46,
+                link_ix: None,
+                serif_ix: None,
                 ..Default::default()
             },
         ];

--- a/skrifa/src/outline/autohint/latin/widths.rs
+++ b/skrifa/src/outline/autohint/latin/widths.rs
@@ -4,7 +4,7 @@ use super::super::{
     axis::Axis,
     metrics::{self, UnscaledWidths, WidthMetrics, MAX_WIDTHS},
     outline::Outline,
-    style::ScriptClass,
+    style::{ScriptClass, ScriptGroup},
 };
 use crate::MetadataProvider;
 use raw::{types::F2Dot14, FontRef, TableProvider};
@@ -40,8 +40,10 @@ pub(super) fn compute_widths(
             // Now process each dimension
             for (dim, (_metrics, widths)) in result.iter_mut().enumerate() {
                 axis.reset(dim, outline.orientation);
-                super::segments::compute_segments(&mut outline, &mut axis);
-                super::segments::link_segments(&outline, &mut axis, None);
+                // Segment computation for widths always uses the default
+                // script group
+                super::segments::compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
+                super::segments::link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
                 let segments = axis.segments.as_slice();
                 for (segment_ix, segment) in segments.iter().enumerate() {
                     let segment_ix = segment_ix as u16;

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -279,7 +279,7 @@ impl StyleRange {
 // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L68>
 // so that when don't need to keep two sets and adjust during blue computation.
 pub(super) mod blue_flags {
-    pub const LATIN_ACTIVE: u32 = 1 << 0;
+    pub const ACTIVE: u32 = 1 << 0;
     pub const TOP: u32 = 1 << 1;
     pub const LATIN_SUB_TOP: u32 = 1 << 2;
     pub const LATIN_NEUTRAL: u32 = 1 << 3;


### PR DESCRIPTION
Adds the segment computation for CJK.

There's some dead code here that exists in FT but is never executed due to bugs. See #1129

Based on #1130 which should land first