### PR TITLE
Generate docs for most features on docs.rs

### DIFF
--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -9,6 +9,11 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+all-features = true
+
 [features]
 std = []
 bytemuck = ["dep:bytemuck"]

--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [data types]: https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(clippy::doc_markdown)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -9,6 +9,11 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features libm,serde,std
+features = ["libm", "serde", "std"]
+
 [features]
 std = ["font-types/std"]
 codegen_test = []

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -56,6 +56,7 @@
 //! [NameString]: tables::name::NameString
 //! [table-directory]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -9,6 +9,11 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+all-features = true
+
 [features]
 default = ["traversal"]
 std = ["read-fonts/std"]

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -11,6 +11,7 @@
 //! See the [readme](https://github.com/googlefonts/fontations/blob/main/skrifa/README.md)
 //! for additional details.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -9,6 +9,11 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+all-features = true
+
 [features]
 default = []
 read = []

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -120,6 +120,8 @@
 //! [`FromTableRef`]: from_obj::FromTableRef
 //! [`ToOwnedTable`]: from_obj::ToOwnedTable
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 mod collections;
 pub mod error;
 mod font_builder;


### PR DESCRIPTION
This generates docs for all features in `font-types`, `skrifa`, and `write-fonts`. In `read-fonts`, only for `libm`, `serde`, and `std`.