### PR TITLE
Use `Self` to avoid new `elided_named_lifetime` warning.

### DIFF
--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -597,8 +597,8 @@ pub(crate) struct BitSetBuilder<'a> {
 }
 
 impl<'a> BitSetBuilder<'a> {
-    pub(crate) fn start(set: &'a mut BitSet) -> BitSetBuilder {
-        BitSetBuilder {
+    pub(crate) fn start(set: &'a mut BitSet) -> Self {
+        Self {
             set,
             last_page_index: usize::MAX,
             last_major_value: u32::MAX,

--- a/read-fonts/src/collections/int_set/input_bit_stream.rs
+++ b/read-fonts/src/collections/int_set/input_bit_stream.rs
@@ -63,8 +63,8 @@ impl<'a, const BF: u8> InputBitStream<'a, BF> {
         Some((branch_factor, depth_bits))
     }
 
-    pub(crate) fn from(data: &'a [u8]) -> InputBitStream<BF> {
-        InputBitStream {
+    pub(crate) fn from(data: &'a [u8]) -> Self {
+        Self {
             data,
             byte_index: 1,
             sub_index: 0,


### PR DESCRIPTION
Current nightly Rust has a new warning about elided named lifetimes enabled by default:

https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#elided-named-lifetimes