### PR TITLE
[read-fonts] avar2 resolution might panic

### DIFF
--- a/read-fonts/src/tables/fvar.rs
+++ b/read-fonts/src/tables/fvar.rs
@@ -84,7 +84,9 @@ impl<'a> Fvar<'a> {
         let axis_count = axes.len();
         let mut new_coords = [F2Dot14::ZERO; 64];
         if axis_count > 64 {
-            return; // No avar2 for monster fonts.
+            // No avar2 for monster fonts.
+            // <https://github.com/googlefonts/fontations/issues/1148>
+            return;
         }
         new_coords[..axis_count].copy_from_slice(normalized_coords);
 
@@ -270,5 +272,19 @@ mod tests {
             assert_eq!(normalized_coords[0], F2Dot14::from_f32(expected.0));
             assert_eq!(normalized_coords[1], F2Dot14::from_f32(expected.1));
         }
+    }
+
+    #[test]
+    fn avar2_no_panic_with_wrong_size_coords_array() {
+        // this font has 2 axes
+        let font = FontRef::new(font_test_data::AVAR2_CHECKER).unwrap();
+        let avar = font.avar().ok();
+        let fvar = font.fvar().unwrap();
+        // output array too small
+        let mut normalized_coords = [F2Dot14::default(); 1];
+        fvar.user_to_normalized(avar.as_ref(), [], &mut normalized_coords);
+        // output array too large
+        let mut normalized_coords = [F2Dot14::default(); 4];
+        fvar.user_to_normalized(avar.as_ref(), [], &mut normalized_coords);
     }
 }

--- a/read-fonts/src/tables/fvar.rs
+++ b/read-fonts/src/tables/fvar.rs
@@ -81,14 +81,17 @@ impl<'a> Fvar<'a> {
         let var_store = avar.var_store();
         let var_index_map = avar.axis_index_map();
 
-        let axis_count = axes.len();
+        let actual_len = axes.len().min(normalized_coords.len());
         let mut new_coords = [F2Dot14::ZERO; 64];
-        if axis_count > 64 {
+        if actual_len > 64 {
             // No avar2 for monster fonts.
             // <https://github.com/googlefonts/fontations/issues/1148>
             return;
         }
-        new_coords[..axis_count].copy_from_slice(normalized_coords);
+
+        let new_coords = &mut new_coords[..actual_len];
+        let normalized_coords = &mut normalized_coords[..actual_len];
+        new_coords.copy_from_slice(normalized_coords);
 
         for (i, v) in normalized_coords.iter().enumerate() {
             let var_index = if let Some(Ok(ref map)) = var_index_map {
@@ -111,7 +114,7 @@ impl<'a> Fvar<'a> {
                 }
             }
         }
-        normalized_coords.copy_from_slice(&new_coords[..axis_count]);
+        normalized_coords.copy_from_slice(new_coords);
     }
 }
 


### PR DESCRIPTION
Fixes a slight oversight in the new avar2 code where we will panic if the given slice is not exactly the expected size which does not match our API guarantees according to the docs.

First commit contains a test that demonstrates the panic.

Also add link to issue for fixing 64 axis limit.