### PR TITLE
Improve head.macStyle docs

### DIFF
--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -531,7 +531,7 @@ impl<'a> Head<'a> {
         self.data.read_at(range.start).unwrap()
     }
 
-    /// see somewhere else
+    /// Bits identifying the font's style; see [MacStyle]
     pub fn mac_style(&self) -> MacStyle {
         let range = self.shape.mac_style_byte_range();
         self.data.read_at(range.start).unwrap()

--- a/resources/codegen_inputs/head.rs
+++ b/resources/codegen_inputs/head.rs
@@ -58,7 +58,7 @@ table Head {
     x_max: i16,
     /// Maximum y coordinate across all glyph bounding boxes.
     y_max: i16,
-    /// see somewhere else
+    /// Bits identifying the font's style; see [MacStyle]
     mac_style: MacStyle,
     /// Smallest readable size in pixels.
     lowest_rec_ppem: u16,

--- a/write-fonts/generated/generated_head.rs
+++ b/write-fonts/generated/generated_head.rs
@@ -49,7 +49,7 @@ pub struct Head {
     pub x_max: i16,
     /// Maximum y coordinate across all glyph bounding boxes.
     pub y_max: i16,
-    /// see somewhere else
+    /// Bits identifying the font's style; see [MacStyle]
     pub mac_style: MacStyle,
     /// Smallest readable size in pixels.
     pub lowest_rec_ppem: u16,


### PR DESCRIPTION
It's true that the OpenType spec doesn't contain a description for this field, but "See somewhere else" was an odd thing to see pop up in my IDE.