### PR TITLE
[codegen] From<Lookup<_>> for lookup enums

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -435,6 +435,7 @@ pub(crate) fn generate_group_compile(
     let mut validate_match_arms = Vec::new();
     let mut from_obj_match_arms = Vec::new();
     let mut type_arms = Vec::new();
+    let mut from_impls = Vec::new();
     let from_type = quote!(#parse_module :: #name);
     for var in &item.variants {
         let var_name = &var.name;
@@ -447,6 +448,13 @@ pub(crate) fn generate_group_compile(
             quote! { #from_type :: #var_name(table) => Self :: #var_name(table.to_owned_obj(data)) },
         );
         type_arms.push(quote! { Self:: #var_name(table) => table.table_type()  });
+        from_impls.push(quote! {
+            impl From<#inner <#typ>> for #name {
+                fn from(src: #inner <#typ>) -> #name {
+                    #name :: #var_name ( src )
+                }
+            }
+        });
     }
     let first_var_name = &item.variants.first().unwrap().name;
 
@@ -495,6 +503,9 @@ pub(crate) fn generate_group_compile(
         }
 
         impl FromTableRef< #from_type <'_>> for #name {}
+
+        #( #from_impls )*
+
     })
 }
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -198,6 +198,60 @@ impl FromObjRef<read_fonts::tables::gpos::PositionLookup<'_>> for PositionLookup
 
 impl FromTableRef<read_fonts::tables::gpos::PositionLookup<'_>> for PositionLookup {}
 
+impl From<Lookup<SinglePos>> for PositionLookup {
+    fn from(src: Lookup<SinglePos>) -> PositionLookup {
+        PositionLookup::Single(src)
+    }
+}
+
+impl From<Lookup<PairPos>> for PositionLookup {
+    fn from(src: Lookup<PairPos>) -> PositionLookup {
+        PositionLookup::Pair(src)
+    }
+}
+
+impl From<Lookup<CursivePosFormat1>> for PositionLookup {
+    fn from(src: Lookup<CursivePosFormat1>) -> PositionLookup {
+        PositionLookup::Cursive(src)
+    }
+}
+
+impl From<Lookup<MarkBasePosFormat1>> for PositionLookup {
+    fn from(src: Lookup<MarkBasePosFormat1>) -> PositionLookup {
+        PositionLookup::MarkToBase(src)
+    }
+}
+
+impl From<Lookup<MarkLigPosFormat1>> for PositionLookup {
+    fn from(src: Lookup<MarkLigPosFormat1>) -> PositionLookup {
+        PositionLookup::MarkToLig(src)
+    }
+}
+
+impl From<Lookup<MarkMarkPosFormat1>> for PositionLookup {
+    fn from(src: Lookup<MarkMarkPosFormat1>) -> PositionLookup {
+        PositionLookup::MarkToMark(src)
+    }
+}
+
+impl From<Lookup<PositionSequenceContext>> for PositionLookup {
+    fn from(src: Lookup<PositionSequenceContext>) -> PositionLookup {
+        PositionLookup::Contextual(src)
+    }
+}
+
+impl From<Lookup<PositionChainContext>> for PositionLookup {
+    fn from(src: Lookup<PositionChainContext>) -> PositionLookup {
+        PositionLookup::ChainContextual(src)
+    }
+}
+
+impl From<Lookup<ExtensionSubtable>> for PositionLookup {
+    fn from(src: Lookup<ExtensionSubtable>) -> PositionLookup {
+        PositionLookup::Extension(src)
+    }
+}
+
 impl FontWrite for ValueFormat {
     fn write_into(&self, writer: &mut TableWriter) {
         writer.write_slice(&self.bits().to_be_bytes())
@@ -2204,3 +2258,51 @@ impl FromObjRef<read_fonts::tables::gpos::ExtensionSubtable<'_>> for ExtensionSu
 }
 
 impl FromTableRef<read_fonts::tables::gpos::ExtensionSubtable<'_>> for ExtensionSubtable {}
+
+impl From<ExtensionPosFormat1<SinglePos>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<SinglePos>) -> ExtensionSubtable {
+        ExtensionSubtable::Single(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<PairPos>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<PairPos>) -> ExtensionSubtable {
+        ExtensionSubtable::Pair(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<CursivePosFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<CursivePosFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::Cursive(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<MarkBasePosFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<MarkBasePosFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::MarkToBase(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<MarkLigPosFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<MarkLigPosFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::MarkToLig(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<MarkMarkPosFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<MarkMarkPosFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::MarkToMark(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<PositionSequenceContext>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<PositionSequenceContext>) -> ExtensionSubtable {
+        ExtensionSubtable::Contextual(src)
+    }
+}
+
+impl From<ExtensionPosFormat1<PositionChainContext>> for ExtensionSubtable {
+    fn from(src: ExtensionPosFormat1<PositionChainContext>) -> ExtensionSubtable {
+        ExtensionSubtable::ChainContextual(src)
+    }
+}

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -193,6 +193,54 @@ impl FromObjRef<read_fonts::tables::gsub::SubstitutionLookup<'_>> for Substituti
 
 impl FromTableRef<read_fonts::tables::gsub::SubstitutionLookup<'_>> for SubstitutionLookup {}
 
+impl From<Lookup<SingleSubst>> for SubstitutionLookup {
+    fn from(src: Lookup<SingleSubst>) -> SubstitutionLookup {
+        SubstitutionLookup::Single(src)
+    }
+}
+
+impl From<Lookup<MultipleSubstFormat1>> for SubstitutionLookup {
+    fn from(src: Lookup<MultipleSubstFormat1>) -> SubstitutionLookup {
+        SubstitutionLookup::Multiple(src)
+    }
+}
+
+impl From<Lookup<AlternateSubstFormat1>> for SubstitutionLookup {
+    fn from(src: Lookup<AlternateSubstFormat1>) -> SubstitutionLookup {
+        SubstitutionLookup::Alternate(src)
+    }
+}
+
+impl From<Lookup<LigatureSubstFormat1>> for SubstitutionLookup {
+    fn from(src: Lookup<LigatureSubstFormat1>) -> SubstitutionLookup {
+        SubstitutionLookup::Ligature(src)
+    }
+}
+
+impl From<Lookup<SubstitutionSequenceContext>> for SubstitutionLookup {
+    fn from(src: Lookup<SubstitutionSequenceContext>) -> SubstitutionLookup {
+        SubstitutionLookup::Contextual(src)
+    }
+}
+
+impl From<Lookup<SubstitutionChainContext>> for SubstitutionLookup {
+    fn from(src: Lookup<SubstitutionChainContext>) -> SubstitutionLookup {
+        SubstitutionLookup::ChainContextual(src)
+    }
+}
+
+impl From<Lookup<ExtensionSubtable>> for SubstitutionLookup {
+    fn from(src: Lookup<ExtensionSubtable>) -> SubstitutionLookup {
+        SubstitutionLookup::Extension(src)
+    }
+}
+
+impl From<Lookup<ReverseChainSingleSubstFormat1>> for SubstitutionLookup {
+    fn from(src: Lookup<ReverseChainSingleSubstFormat1>) -> SubstitutionLookup {
+        SubstitutionLookup::Reverse(src)
+    }
+}
+
 /// LookupType 1: [Single Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#lookuptype-1-single-substitution-subtable) Subtable
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -990,6 +1038,48 @@ impl FromObjRef<read_fonts::tables::gsub::ExtensionSubtable<'_>> for ExtensionSu
 }
 
 impl FromTableRef<read_fonts::tables::gsub::ExtensionSubtable<'_>> for ExtensionSubtable {}
+
+impl From<ExtensionSubstFormat1<SingleSubst>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<SingleSubst>) -> ExtensionSubtable {
+        ExtensionSubtable::Single(src)
+    }
+}
+
+impl From<ExtensionSubstFormat1<MultipleSubstFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<MultipleSubstFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::Multiple(src)
+    }
+}
+
+impl From<ExtensionSubstFormat1<AlternateSubstFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<AlternateSubstFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::Alternate(src)
+    }
+}
+
+impl From<ExtensionSubstFormat1<LigatureSubstFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<LigatureSubstFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::Ligature(src)
+    }
+}
+
+impl From<ExtensionSubstFormat1<SubstitutionSequenceContext>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<SubstitutionSequenceContext>) -> ExtensionSubtable {
+        ExtensionSubtable::Contextual(src)
+    }
+}
+
+impl From<ExtensionSubstFormat1<SubstitutionChainContext>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<SubstitutionChainContext>) -> ExtensionSubtable {
+        ExtensionSubtable::ChainContextual(src)
+    }
+}
+
+impl From<ExtensionSubstFormat1<ReverseChainSingleSubstFormat1>> for ExtensionSubtable {
+    fn from(src: ExtensionSubstFormat1<ReverseChainSingleSubstFormat1>) -> ExtensionSubtable {
+        ExtensionSubtable::Reverse(src)
+    }
+}
 
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
Generate From<Lookup<_>> for PositionLookup/SubstitutionLookup.

This is a little ergonomics improvement, addressing a lingering frustration with these types.