### PR TITLE
[skrifa] path conversion perf improvements

### DIFF
--- a/fauntlet/src/compare_glyphs.rs
+++ b/fauntlet/src/compare_glyphs.rs
@@ -40,36 +40,35 @@ pub fn compare_glyphs(
 
     for gid in 0..glyph_count {
         let gid = GlyphId::from(gid);
-        // Restore this when <https://github.com/googlefonts/fontations/issues/790>
-        // is completed.
-        //
-        // let ft_advance = ft_instance.advance(gid);
-        // let skrifa_advance = skrifa_instance.advance(gid);
-        // if ft_advance != skrifa_advance {
-        //     writeln!(
-        //         std::io::stderr(),
-        //         "[{path:?}#{} ppem: {} coords: {:?}] glyph id {} advance doesn't match:\nFreeType: {ft_advance:?}\nSkrifa:   {skrifa_advance:?}",
-        //         options.index,
-        //         options.ppem,
-        //         options.coords,
-        //         gid.to_u16(),
-        //     )
-        //     .unwrap();
-        //     if exit_on_fail {
-        //         std::process::exit(1);
-        //     }
-        // }
         ft_outline.clear();
-        ft_instance
+        let ft_advance = ft_instance
             .outline(gid, &mut RegularizingPen::new(&mut ft_outline, is_scaled))
             .unwrap();
         skrifa_outline.clear();
-        skrifa_instance
+        let maybe_skrifa_advance = skrifa_instance
             .outline(
                 gid,
                 &mut RegularizingPen::new(&mut skrifa_outline, is_scaled),
             )
             .unwrap();
+        // Compare against adjusted metrics when skrifa returns them (currently
+        // only for TrueType glyphs)
+        if let Some(skrifa_advance) = maybe_skrifa_advance {
+            if ft_advance != skrifa_advance {
+                writeln!(
+                std::io::stderr(),
+                "[{path:?}#{} ppem: {} coords: {:?}] glyph id {} advance doesn't match:\nFreeType: {ft_advance:?}\nSkrifa:   {skrifa_advance:?}",
+                options.index,
+                options.ppem,
+                options.coords,
+                gid.to_u32(),
+            )
+            .unwrap();
+                if exit_on_fail {
+                    std::process::exit(1);
+                }
+            }
+        }
         if ft_outline != skrifa_outline {
             ok = false;
             fn outline_to_string(outline: &[PathElement]) -> String {

--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -60,20 +60,21 @@ impl<'a> SkrifaInstance<'a> {
             .advance_width(glyph_id)
     }
 
+    /// Returns the scaler adjusted advance width when available.
     pub fn outline(
         &mut self,
         glyph_id: GlyphId,
         pen: &mut impl OutlinePen,
-    ) -> Result<(), DrawError> {
+    ) -> Result<Option<f32>, DrawError> {
         let outline = self
             .outlines
             .get(glyph_id)
             .ok_or(DrawError::GlyphNotFound(glyph_id))?;
-        if let Some(hinter) = self.hinter.as_ref() {
-            outline.draw(DrawSettings::hinted(hinter, false), pen)?;
+        let metrics = if let Some(hinter) = self.hinter.as_ref() {
+            outline.draw(DrawSettings::hinted(hinter, false), pen)?
         } else {
-            outline.draw((self.size, self.coords.as_slice()), pen)?;
-        }
-        Ok(())
+            outline.draw((self.size, self.coords.as_slice()), pen)?
+        };
+        Ok(metrics.advance_width)
     }
 }

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -89,16 +89,19 @@ impl PointFlags {
     }
 
     /// Returns true if this is an on curve point.
+    #[inline]
     pub const fn is_on_curve(self) -> bool {
         self.0 & Self::ON_CURVE != 0
     }
 
     /// Returns true if this is an off curve quadratic point.
+    #[inline]
     pub const fn is_off_curve_quad(self) -> bool {
         self.0 & Self::CURVE_MASK == 0
     }
 
     /// Returns true if this is an off curve cubic point.
+    #[inline]
     pub const fn is_off_curve_cubic(self) -> bool {
         self.0 & Self::OFF_CURVE_CUBIC != 0
     }
@@ -739,14 +742,17 @@ impl PointCoord for F26Dot6 {
         x.to_f26dot6()
     }
 
+    #[inline]
     fn from_i32(x: i32) -> Self {
         Self::from_i32(x)
     }
 
+    #[inline]    
     fn to_f32(self) -> f32 {
         self.to_f32()
     }
 
+    #[inline]
     fn midpoint(self, other: Self) -> Self {
         // FreeType uses integer division on 26.6 to compute midpoints.
         // See: https://github.com/freetype/freetype/blob/de8b92dd7ec634e9e2b25ef534c54a3537555c11/src/base/ftoutln.c#L123

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -747,7 +747,7 @@ impl PointCoord for F26Dot6 {
         Self::from_i32(x)
     }
 
-    #[inline]    
+    #[inline]
     fn to_f32(self) -> f32 {
         self.to_f32()
     }

--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -122,7 +122,7 @@ impl Instance {
         outline.fill(glyph, coords)?;
         let hinted_metrics =
             super::latin::hint_outline(&mut outline, &metrics, &scale, Some(style));
-        let h_advance = common.advance_width(glyph_id, coords);
+        let h_advance = outline.advance;
         let mut pp1x = 0;
         let mut pp2x = fixed_mul(h_advance, hinted_metrics.x_scale);
         let is_light = self.target.is_light() || self.target.preserve_linear_metrics();
@@ -136,7 +136,7 @@ impl Instance {
                 let old_lsb = edge_metrics.left_opos;
                 let new_lsb = edge_metrics.left_pos;
                 let mut pp1x_uh = new_lsb - old_lsb;
-                let mut pp2x_uh = edge_metrics.right_opos + old_rsb;
+                let mut pp2x_uh = edge_metrics.right_pos + old_rsb;
                 if old_lsb < 24 {
                     pp1x_uh -= 8;
                 }
@@ -177,7 +177,7 @@ impl Instance {
         Ok(AdjustedMetrics {
             has_overlaps: glyph.has_overlaps().unwrap_or_default(),
             lsb: None,
-            advance_width: Some(F26Dot6::from_bits(advance).to_f32()),
+            advance_width: Some(F26Dot6::from_bits(pix_round(advance)).to_f32()),
         })
     }
 }

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -153,13 +153,15 @@ pub(super) struct Outline {
     pub orientation: Option<Orientation>,
     pub points: SmallVec<Point, MAX_INLINE_POINTS>,
     pub contours: SmallVec<Contour, MAX_INLINE_CONTOURS>,
+    pub advance: i32,
 }
 
 impl Outline {
     /// Fills the outline from the given glyph.
     pub fn fill(&mut self, glyph: &OutlineGlyph, coords: &[F2Dot14]) -> Result<(), DrawError> {
         self.clear();
-        glyph.draw_unscaled(LocationRef::new(coords), None, self)?;
+        let advance = glyph.draw_unscaled(LocationRef::new(coords), None, self)?;
+        self.advance = advance;
         self.units_per_em = glyph.units_per_em() as i32;
         // Heuristic value
         let near_limit = 20 * self.units_per_em / 2048;
@@ -190,6 +192,7 @@ impl Outline {
         self.units_per_em = 0;
         self.points.clear();
         self.contours.clear();
+        self.advance = 0;
     }
 
     pub fn to_path(

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -197,6 +197,17 @@ impl GlyphStyleMap {
         if need_hani {
             map.use_style(StyleClass::HANI);
         }
+        // Step 5: Mark ASCII digits
+        // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afglobal.c#L251>
+        for digit_char in '0'..='9' {
+            if let Some(style) = shaper
+                .charmap()
+                .map(digit_char)
+                .and_then(|gid| map.styles.get_mut(gid.to_u32() as usize))
+            {
+                style.0 |= GlyphStyle::DIGIT;
+            }
+        }
         map
     }
 

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -514,7 +514,7 @@ impl<'a> Scaler for FreeTypeScaler<'a> {
             }
         } else {
             for (phantom, unscaled) in self.phantom.iter_mut().zip(&unscaled) {
-                *phantom = unscaled.map(F26Dot6::from_bits);
+                *phantom = unscaled.map(F26Dot6::from_i32);
             }
         }
         Ok(())

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -262,6 +262,7 @@ trait Scaler {
         tsb: i32,
         vadvance: i32,
     );
+    fn load_empty(&mut self, glyph_id: GlyphId) -> Result<(), DrawError>;
     fn load_simple(&mut self, glyph: &SimpleGlyph, glyph_id: GlyphId) -> Result<(), DrawError>;
     fn load_composite(
         &mut self,
@@ -279,12 +280,10 @@ trait Scaler {
         if recurse_depth > GLYF_COMPOSITE_RECURSION_LIMIT {
             return Err(DrawError::RecursionLimitExceeded(glyph_id));
         }
-        let glyph = match &glyph {
-            Some(glyph) => glyph,
-            // This is a valid empty glyph
-            None => return Ok(()),
+        let bounds = match &glyph {
+            Some(glyph) => [glyph.x_min(), glyph.x_max(), glyph.y_min(), glyph.y_max()],
+            _ => [0; 4],
         };
-        let bounds = [glyph.x_min(), glyph.x_max(), glyph.y_min(), glyph.y_max()];
         let outlines = self.outlines();
         let coords: &[F2Dot14] = self.coords();
         let lsb = outlines.common.lsb(glyph_id, coords);
@@ -294,8 +293,11 @@ trait Scaler {
         let vadvance = ascent - descent;
         self.setup_phantom_points(bounds, lsb, advance, tsb, vadvance);
         match glyph {
-            Glyph::Simple(simple) => self.load_simple(simple, glyph_id),
-            Glyph::Composite(composite) => self.load_composite(composite, glyph_id, recurse_depth),
+            Some(Glyph::Simple(simple)) => self.load_simple(simple, glyph_id),
+            Some(Glyph::Composite(composite)) => {
+                self.load_composite(composite, glyph_id, recurse_depth)
+            }
+            None => self.load_empty(glyph_id),
         }
     }
 }
@@ -485,6 +487,37 @@ impl<'a> Scaler for FreeTypeScaler<'a> {
 
     fn outlines(&self) -> &Outlines {
         &self.outlines
+    }
+
+    fn load_empty(&mut self, glyph_id: GlyphId) -> Result<(), DrawError> {
+        // Roughly corresponds to the FreeType code at
+        // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttgload.c#L1572>
+        let scale = self.scale;
+        let mut unscaled = self.phantom.map(|point| point.map(|x| x.to_bits()));
+        if self.outlines.common.hvar.is_none()
+            && self.outlines.gvar.is_some()
+            && !self.coords.is_empty()
+        {
+            if let Ok(deltas) = self.outlines.gvar.as_ref().unwrap().phantom_point_deltas(
+                &self.outlines.glyf,
+                &self.outlines.loca,
+                self.coords,
+                glyph_id,
+            ) {
+                unscaled[0].x += deltas[0].to_i32();
+                unscaled[1].x += deltas[1].to_i32();
+            }
+        }
+        if self.is_scaled {
+            for (phantom, unscaled) in self.phantom.iter_mut().zip(&unscaled) {
+                *phantom = unscaled.map(F26Dot6::from_bits) * scale;
+            }
+        } else {
+            for (phantom, unscaled) in self.phantom.iter_mut().zip(&unscaled) {
+                *phantom = unscaled.map(F26Dot6::from_bits);
+            }
+        }
+        Ok(())
     }
 
     fn load_simple(&mut self, glyph: &SimpleGlyph, glyph_id: GlyphId) -> Result<(), DrawError> {
@@ -977,6 +1010,37 @@ impl<'a> Scaler for HarfBuzzScaler<'a> {
         &self.outlines
     }
 
+    fn load_empty(&mut self, glyph_id: GlyphId) -> Result<(), DrawError> {
+        // HB doesn't have an equivalent so this version just copies the
+        // FreeType version above but changed to use floating point
+        let scale = self.scale.to_f32();
+        let mut unscaled = self.phantom;
+        if self.outlines.common.hvar.is_none()
+            && self.outlines.gvar.is_some()
+            && !self.coords.is_empty()
+        {
+            if let Ok(deltas) = self.outlines.gvar.as_ref().unwrap().phantom_point_deltas(
+                &self.outlines.glyf,
+                &self.outlines.loca,
+                self.coords,
+                glyph_id,
+            ) {
+                unscaled[0].x += deltas[0].to_f32();
+                unscaled[1].x += deltas[1].to_f32();
+            }
+        }
+        if self.is_scaled {
+            for (phantom, unscaled) in self.phantom.iter_mut().zip(&unscaled) {
+                *phantom = *unscaled * scale;
+            }
+        } else {
+            for (phantom, unscaled) in self.phantom.iter_mut().zip(&unscaled) {
+                *phantom = *unscaled;
+            }
+        }
+        Ok(())
+    }
+
     fn load_simple(&mut self, glyph: &SimpleGlyph, glyph_id: GlyphId) -> Result<(), DrawError> {
         use DrawError::InsufficientMemory;
         // Compute the ranges for our point/flag buffers and slice them.
@@ -1214,6 +1278,7 @@ fn map_point(transform: [f32; 6], p: Point<f32>) -> Point<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MetadataProvider;
     use read_fonts::{FontRef, TableProvider};
 
     #[test]
@@ -1244,5 +1309,30 @@ mod tests {
         let outlines = Outlines::new(&OutlinesCommon::new(&font).unwrap()).unwrap();
         // so let's use it
         assert!(outlines.prefer_interpreter());
+    }
+
+    #[test]
+    fn empty_glyph_advance() {
+        let font = FontRef::new(font_test_data::HVAR_WITH_TRUNCATED_ADVANCE_INDEX_MAP).unwrap();
+        let outlines = Outlines::new(&OutlinesCommon::new(&font).unwrap()).unwrap();
+        let coords = [F2Dot14::from_f32(0.5)];
+        let ppem = Some(24.0);
+        let gid = font.charmap().map(' ').unwrap();
+        let outline = outlines.outline(gid).unwrap();
+        // Make sure this is an empty outline since that's what we're testing
+        assert_eq!(outline.points, 0);
+        let scaler =
+            FreeTypeScaler::unhinted(outlines.clone(), &outline, &mut [], ppem, &coords).unwrap();
+        let scaled = scaler.scale(&outline.glyph, gid).unwrap();
+        let advance_hvar = scaled.adjusted_advance_width();
+        // Set HVAR table to None to force loading metrics from gvar
+        let mut scaler =
+            FreeTypeScaler::unhinted(outlines, &outline, &mut [], ppem, &coords).unwrap();
+        scaler.outlines.common.hvar = None;
+        let scaled = scaler.scale(&outline.glyph, gid).unwrap();
+        let advance_gvar = scaled.adjusted_advance_width();
+        // Make sure we have an advance and that the two are the same
+        assert!(advance_hvar != F26Dot6::ZERO);
+        assert_eq!(advance_hvar, advance_gvar);
     }
 }

--- a/skrifa/src/outline/hint.rs
+++ b/skrifa/src/outline/hint.rs
@@ -431,7 +431,11 @@ impl HintingInstance {
                     Ok(AdjustedMetrics {
                         has_overlaps: outline.has_overlaps,
                         lsb: Some(scaled_outline.adjusted_lsb().to_f32()),
-                        advance_width: Some(scaled_outline.adjusted_advance_width().to_f32()),
+                        // When hinting is requested, we round the advance
+                        // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/base/ftobjs.c#L889>
+                        advance_width: Some(
+                            scaled_outline.adjusted_advance_width().round().to_f32(),
+                        ),
                     })
                 })
             }

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -1391,4 +1391,44 @@ mod tests {
             .draw(DrawSettings::hinted(&hinting, true), &mut BezPen::default())
             .unwrap();
     }
+
+    #[test]
+    fn empty_glyph_advance_unhinted() {
+        let font = FontRef::new(font_test_data::HVAR_WITH_TRUNCATED_ADVANCE_INDEX_MAP).unwrap();
+        let outlines = font.outline_glyphs();
+        let coords = [NormalizedCoord::from_f32(0.5)];
+        let gid = font.charmap().map(' ').unwrap();
+        let outline = outlines.get(gid).unwrap();
+        let advance = outline
+            .draw(
+                (Size::new(24.0), LocationRef::new(&coords)),
+                &mut super::pen::NullPen,
+            )
+            .unwrap()
+            .advance_width
+            .unwrap();
+        assert_eq!(advance, 10.796875);
+    }
+
+    #[test]
+    fn empty_glyph_advance_hinted() {
+        let font = FontRef::new(font_test_data::HVAR_WITH_TRUNCATED_ADVANCE_INDEX_MAP).unwrap();
+        let outlines = font.outline_glyphs();
+        let coords = [NormalizedCoord::from_f32(0.5)];
+        let hinter = HintingInstance::new(
+            &outlines,
+            Size::new(24.0),
+            LocationRef::new(&coords),
+            HintingOptions::default(),
+        )
+        .unwrap();
+        let gid = font.charmap().map(' ').unwrap();
+        let outline = outlines.get(gid).unwrap();
+        let advance = outline
+            .draw(&hinter, &mut super::pen::NullPen)
+            .unwrap()
+            .advance_width
+            .unwrap();
+        assert_eq!(advance, 11.0);
+    }
 }

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -434,7 +434,7 @@ impl<'a> OutlineGlyph<'a> {
         location: impl Into<LocationRef<'a>>,
         user_memory: Option<&mut [u8]>,
         sink: &mut impl unscaled::UnscaledOutlineSink,
-    ) -> Result<(), DrawError> {
+    ) -> Result<i32, DrawError> {
         let coords = location.into().coords();
         let ppem = None;
         match &self.kind {
@@ -462,7 +462,7 @@ impl<'a> OutlineGlyph<'a> {
                         }
                         contour_start = contour_end + 1;
                     }
-                    Ok(())
+                    Ok(outline.adjusted_advance_width().to_bits() >> 6)
                 })
             }
             OutlineKind::Cff(cff, glyph_id, subfont_ix) => {
@@ -470,7 +470,8 @@ impl<'a> OutlineGlyph<'a> {
                 let mut adapter = unscaled::UnscaledPenAdapter::new(sink);
                 cff.draw(&subfont, *glyph_id, coords, false, &mut adapter)?;
                 adapter.finish()?;
-                Ok(())
+                let advance = cff.common.advance_width(*glyph_id, coords);
+                Ok(advance)
             }
         }
     }

--- a/skrifa/src/outline/path.rs
+++ b/skrifa/src/outline/path.rs
@@ -218,7 +218,7 @@ pub(crate) fn contour_to_path<C: PointCoord>(
             state.emit(ix, point, pen)?;
         }
     } else {
-        while let Some((ix, point)) = points.next() {
+        for (ix, point) in points {
             state.emit(ix, point, pen)?;
         }
     }


### PR DESCRIPTION
Reworks the TrueType->path conversion code to capture states explicitly to reduce branches along with some inlining and other code motion.

This gives a roughly 10% improvement based on measured fonts.

Example for Noto Sans Regular (all glyphs 100x):
| FreeType | skrifa (current) | skrifa (this PR) | skrifa (this PR + LTO) |
|-----------|-------------|--------------|--------------------|
| 308ms     | 337ms      |  295ms        | 213ms                  |

The significant difference when enabling LTO suggests that we might be missing some inlining opportunities across the `read-fonts`/`font-types` boundaries. Note that current skrifa + LTO is roughly the same as this PR without it.