### PR TITLE
[skrifa] more scaler perf

### DIFF
--- a/font-types/src/raw.rs
+++ b/font-types/src/raw.rs
@@ -97,6 +97,7 @@ impl<T: Scalar> BigEndian<T> {
     }
 
     /// Convert this raw type to its native representation.
+    #[inline(always)]
     pub fn get(&self) -> T {
         T::from_raw(self.0)
     }
@@ -169,6 +170,7 @@ macro_rules! newtype_scalar {
                 self.0.to_raw()
             }
 
+            #[inline(always)]
             fn from_raw(raw: $raw) -> Self {
                 Self($crate::raw::Scalar::from_raw(raw))
             }
@@ -184,6 +186,7 @@ macro_rules! int_scalar {
                 self.to_be_bytes()
             }
 
+            #[inline(always)]
             fn from_raw(raw: $raw) -> $ty {
                 Self::from_be_bytes(raw)
             }

--- a/skrifa/src/outline/hint.rs
+++ b/skrifa/src/outline/hint.rs
@@ -418,7 +418,7 @@ impl HintingInstance {
                 }
                 super::with_glyf_memory(outline, Hinting::Embedded, memory, |buf| {
                     let scaled_outline = FreeTypeScaler::hinted(
-                        glyf.clone(),
+                        glyf,
                         outline,
                         buf,
                         ppem,


### PR DESCRIPTION
Follow up to #1171 for even faster outline loading:

* Some targeted inlining, specifically `<i8 as Scalar>::from_raw` was showing up in the profile. This is a big win
* Use a borrow of the largish `glyf::Outlines` type when constructing a scaler to save the copy.. removes some `_platform_memcpy`
* Add bucketed stack allocations to avoid zeroing excessive memory.. significantly reduces cost of `_platform_memset` in the profile

These changes reduce average time for loading all Noto Sans Regular glyphs from 295ms (previous PR) to 254ms (206ms with LTO). This is down from our starting point of 337ms.
