### PR TITLE
[chore] bump font-types/read-fonts/skrifa patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ core_maths = "0.1"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.7.1", path = "font-types" }
-read-fonts = { version = "0.22.2", path = "read-fonts", default-features = false }
+font-types = { version = "0.7.2", path = "font-types" }
+read-fonts = { version = "0.22.3", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.22.2", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.22.3", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.29.0", path = "write-fonts" }
 
 [workspace.metadata.release]

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.7.1"
+version = "0.7.2"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.22.2"
+version = "0.22.3"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.22.2"
+version = "0.22.3"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
Release FreeType advance diff fix and
two perf improvements in path retrieval.