### PR TITLE
[IFT] Add code gen definitions for GlyphKeyed patches

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -200,8 +200,8 @@ The following annotations are supported on top-level objects:
   in a table), the name of a field (preceded by the `$` token) or a literal
   integer. The less-simple form begins with a function identifier, and then one
   or more arguments, comma separated. Currently accepted function identifiers
-  are 'add', 'subtract', 'add_multiply', 'half', 'map_delta_size', and
-  'delta_value_count'.
+  are 'add', 'subtract', 'add_multiply', 'multiply_add', 'half', 'map_delta_size',
+  and 'delta_value_count'.
 - `#[compile(arg)]`: If present, this field will not be included in the compile
   type. The value may be either the literal 'skip', or an expression that
   evaluates to the field's type: the skip case is only expected in cases where

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -302,7 +302,7 @@ pub(crate) enum CountTransform {
     Add,
     /// requires exactly three args, defined as ($arg1 + $arg2) * $arg3
     AddMul,
-    /// requires exactly three args, defined as ($arg1 * $arg2) + 1
+    /// requires exactly three args, defined as ($arg1 * $arg2) + $arg3
     MulAdd,
     /// requires exactly one arg. defined as $arg1 / 2
     Half,

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -302,6 +302,8 @@ pub(crate) enum CountTransform {
     Add,
     /// requires exactly three args, defined as ($arg1 + $arg2) * $arg3
     AddMul,
+    /// requires exactly three args, defined as ($arg1 * $arg2) + 1
+    MulAdd,
     /// requires exactly one arg. defined as $arg1 / 2
     Half,
     DeltaValueCount,
@@ -1452,6 +1454,7 @@ static TRANSFORM_IDENTS: &[(CountTransform, &str)] = &[
     (CountTransform::Sub, "subtract"),
     (CountTransform::Add, "add"),
     (CountTransform::AddMul, "add_multiply"),
+    (CountTransform::MulAdd, "multiply_add"),
     (CountTransform::Half, "half"),
     (CountTransform::DeltaValueCount, "delta_value_count"),
     (CountTransform::DeltaSetIndexData, "delta_set_index_data"),
@@ -1490,6 +1493,7 @@ impl CountTransform {
             CountTransform::Sub => 2,
             CountTransform::Add => 2,
             CountTransform::AddMul => 3,
+            CountTransform::MulAdd => 3,
             CountTransform::Half => 1,
             CountTransform::DeltaValueCount => 3,
             CountTransform::DeltaSetIndexData => 2,
@@ -1626,6 +1630,9 @@ impl Count {
                 }
                 (CountTransform::AddMul, [a, b, c]) => {
                     quote!(transforms::add_multiply(#a, #b, #c))
+                }
+                (CountTransform::MulAdd, [a, b, c]) => {
+                    quote!(transforms::multiply_add(#a, #b, #c))
                 }
                 (CountTransform::Half, [a]) => {
                     quote!(transforms::half(#a))

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -539,3 +539,161 @@ pub fn noop_table_keyed_patch() -> BeBuffer {
         {0u32: "patch_off[0]"}
     }
 }
+
+// Format specification: https://w3c.github.io/IFT/Overview.html#glyphpatches
+pub fn glyf_u16_glyph_patches() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      5u32,       // glyph count
+      {1u8: "table_count"},        // table count
+
+      // glyph ids * 5
+      [2, 7u16],
+      {8u16: "gid_8"},
+      [9, 13u16],
+
+      (Tag::new(b"glyf")),   // tables * 1
+
+      // glyph data offsets * 6
+      {0u32: "gid_2_offset"},
+      {0u32: "gid_7_offset"},
+      {0u32: "gid_8_offset"},
+      {0u32: "gid_9_offset"},
+      {0u32: "gid_13_offset"},
+      {0u32: "end_offset"},
+
+      // data blocks
+      {b'a': "gid_2_data"},
+      [b'b', b'c'],
+
+      {b'd': "gid_7_data"},
+      [b'e', b'f', b'g'],
+
+      {b'h': "gid_8_and_9_data"},
+      [b'i', b'j', b'k', b'l'],
+
+      {b'm': "gid_13_data"},
+      [b'n']
+    };
+
+    let offset = buffer.offset_for("gid_2_data") as u32;
+    buffer.write_at("gid_2_offset", offset);
+
+    let offset = buffer.offset_for("gid_7_data") as u32;
+    buffer.write_at("gid_7_offset", offset);
+
+    let offset = buffer.offset_for("gid_8_and_9_data") as u32;
+    buffer.write_at("gid_8_offset", offset);
+
+    let offset = buffer.offset_for("gid_8_and_9_data") as u32;
+    buffer.write_at("gid_9_offset", offset);
+
+    let offset = buffer.offset_for("gid_13_data") as u32;
+    buffer.write_at("gid_13_offset", offset);
+    buffer.write_at("end_offset", offset + 2);
+
+    buffer
+}
+
+// Format specification: https://w3c.github.io/IFT/Overview.html#glyphpatches
+pub fn glyf_u24_glyph_patches() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      5u32,       // glyph count
+      1u8,        // table count
+      (Uint24::new(2)), (Uint24::new(7)), (Uint24::new(8)), (Uint24::new(9)), (Uint24::new(13)),   // glyph ids * 5
+      (Tag::new(b"glyf")),   // tables * 1
+
+      // glyph data offsets * 6
+      {0u32: "gid_2_offset"},
+      {0u32: "gid_7_offset"},
+      {0u32: "gid_8_offset"},
+      {0u32: "gid_9_offset"},
+      {0u32: "gid_13_offset"},
+      {0u32: "end_offset"},
+
+      // data blocks
+      {b'a': "gid_2_data"},
+      [b'b', b'c'],
+
+      {b'd': "gid_7_data"},
+      [b'e', b'f', b'g'],
+
+      {b'h': "gid_8_and_9_data"},
+      [b'i', b'j', b'k', b'l'],
+
+      {b'm': "gid_13_data"},
+      [b'n']
+    };
+
+    let offset = buffer.offset_for("gid_2_data") as u32;
+    buffer.write_at("gid_2_offset", offset);
+
+    let offset = buffer.offset_for("gid_7_data") as u32;
+    buffer.write_at("gid_7_offset", offset);
+
+    let offset = buffer.offset_for("gid_8_and_9_data") as u32;
+    buffer.write_at("gid_8_offset", offset);
+
+    let offset = buffer.offset_for("gid_8_and_9_data") as u32;
+    buffer.write_at("gid_9_offset", offset);
+
+    let offset = buffer.offset_for("gid_13_data") as u32;
+    buffer.write_at("gid_13_offset", offset);
+    buffer.write_at("end_offset", offset + 2);
+
+    buffer
+}
+
+// Format specification: https://w3c.github.io/IFT/Overview.html#glyphpatches
+pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      3u32,       // glyph count
+      2u8,        // table count
+      [2, 7, 8u16],   // glyph ids * 3
+      (Tag::new(b"glyf")),   // tables[0]
+      (Tag::new(b"gvar")),   // tables[1]
+
+      // glyph data offsets * 7
+      {0u32: "glyf_gid_2_offset"},
+      {0u32: "glyf_gid_7_offset"},
+      {0u32: "glyf_gid_8_offset"},
+      {0u32: "gvar_gid_2_offset"},
+      {0u32: "gvar_gid_7_offset"},
+      {0u32: "gvar_gid_8_offset"},
+      {0u32: "end_offset"},
+
+      // data blocks
+      {b'a': "glyf_gid_2_data"},
+      [b'b', b'c'],
+
+      {b'd': "glyf_gid_7_data"},
+      [b'e', b'f', b'g'],
+
+      {b'h': "glyf_gid_8_data"},
+      [b'i', b'j', b'k', b'l'],
+
+      {b'm': "gvar_gid_2_data"},
+      [b'n'],
+
+      {b'o': "gvar_gid_7_data"},
+      [b'p', b'q'],
+
+      {b'r': "gvar_gid_8_data"}
+    };
+
+    let offset = buffer.offset_for("glyf_gid_2_data") as u32;
+    buffer.write_at("glyf_gid_2_offset", offset);
+    let offset = buffer.offset_for("glyf_gid_7_data") as u32;
+    buffer.write_at("glyf_gid_7_offset", offset);
+    let offset = buffer.offset_for("glyf_gid_8_data") as u32;
+    buffer.write_at("glyf_gid_8_offset", offset);
+
+    let offset = buffer.offset_for("gvar_gid_2_data") as u32;
+    buffer.write_at("gvar_gid_2_offset", offset);
+    let offset = buffer.offset_for("gvar_gid_7_data") as u32;
+    buffer.write_at("gvar_gid_7_offset", offset);
+    let offset = buffer.offset_for("gvar_gid_8_data") as u32;
+    buffer.write_at("gvar_gid_8_offset", offset);
+    buffer.write_at("end_offset", offset + 1);
+
+    buffer
+}

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -595,4 +595,6 @@ mod tests {
             test_font().as_slice().apply_patch(patch),
         );
     }
+
+    // TODO glyph keyed test with large number of offsets to check type conversion on (glyphCount * tableCount)
 }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -159,6 +159,17 @@ pub(crate) mod codegen_prelude {
                 .saturating_mul(c.try_into().unwrap_or_default())
         }
 
+        pub fn multiply_add<T: TryInto<usize>, U: TryInto<usize>, V: TryInto<usize>>(
+            a: T,
+            b: U,
+            c: V,
+        ) -> usize {
+            a.try_into()
+                .unwrap_or_default()
+                .saturating_mul(b.try_into().unwrap_or_default())
+                .saturating_add(c.try_into().unwrap_or_default())
+        }
+
         pub fn half<T: TryInto<usize>>(val: T) -> usize {
             val.try_into().unwrap_or_default() / 2
         }

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -77,6 +77,41 @@ impl U8Or16 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct U16Or24(u32);
+
+impl ReadArgs for U16Or24 {
+    type Args = GlyphKeyedFlags;
+}
+
+impl ComputeSize for U16Or24 {
+    fn compute_size(flags: &GlyphKeyedFlags) -> Result<usize, ReadError> {
+        // See: https://w3c.github.io/IFT/Overview.html#glyph-keyed-patch-flags
+        Ok(if flags.contains(GlyphKeyedFlags::WIDE_GLYPH_IDS) {
+            3
+        } else {
+            2
+        })
+    }
+}
+
+impl FontReadWithArgs<'_> for U16Or24 {
+    fn read_with_args(data: FontData<'_>, flags: &Self::Args) -> Result<Self, ReadError> {
+        if flags.contains(GlyphKeyedFlags::WIDE_GLYPH_IDS) {
+            data.read_at::<Uint24>(0).map(|v| Self(v.to_u32()))
+        } else {
+            data.read_at::<u16>(0).map(|v| Self(v as u32))
+        }
+    }
+}
+
+impl U16Or24 {
+    #[inline]
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IdDeltaOrLength(i32);
 
 impl ReadArgs for IdDeltaOrLength {

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -229,6 +229,7 @@ impl<'a> Iterator for GidToEntryIter<'a> {
 }
 
 impl<'a> GlyphPatches<'a> {
+    /// Returns an iterator over the per glyph data for the table with the given index.
     pub fn glyph_data_for_table(
         &'a self,
         table_index: u32,


### PR DESCRIPTION
Second patch format for IFT, see: https://w3c.github.io/IFT/Overview.html#glyph-keyed