### PR TITLE
[IFT] Add beginning implementation for Glyph Keyed patches

### DIFF
--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -18,3 +18,5 @@ repository.workspace = true
 
 [dependencies]
 read-fonts = { workspace = true }
+write-fonts = { workspace = true }
+

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -560,7 +560,7 @@ pub fn test_font_for_patching() -> Vec<u8> {
     font_builder.add_table(&head).unwrap();
 
     // ## glyf ##
-    // glyphs are padded to even number of bytes since loca format wil be short.
+    // glyphs are padded to even number of bytes since loca format will be short.
     let glyf = BeBuffer::new()
         .push_with_tag(1u8, "gid_0")
         .extend([2, 3, 4, 5u8, 0u8])

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -666,6 +666,48 @@ pub fn glyf_u16_glyph_patches() -> BeBuffer {
 }
 
 // Format specification: https://w3c.github.io/IFT/Overview.html#glyphpatches
+pub fn glyf_u16_glyph_patches_2() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      3u32,       // glyph count
+      {1u8: "table_count"},        // table count
+
+      // glyph ids * 3
+      7u16,
+      12u16,
+      14u16,
+
+      (Tag::new(b"glyf")),   // tables * 1
+
+      // glyph data offsets * 6
+      {0u32: "gid_7_offset"},
+      {0u32: "gid_12_offset"},
+      {0u32: "gid_14_offset"},
+      {0u32: "end_offset"},
+
+      // data blocks
+      {b'q': "gid_7_data"},
+      [b'r'],
+
+      {b's': "gid_12_data"},
+      [b't', b'u'],
+
+      {b'v': "gid_14_data"}
+    };
+
+    let offset = buffer.offset_for("gid_7_data") as u32;
+    buffer.write_at("gid_7_offset", offset);
+
+    let offset = buffer.offset_for("gid_12_data") as u32;
+    buffer.write_at("gid_12_offset", offset);
+
+    let offset = buffer.offset_for("gid_14_data") as u32;
+    buffer.write_at("gid_14_offset", offset);
+    buffer.write_at("end_offset", offset + 1);
+
+    buffer
+}
+
+// Format specification: https://w3c.github.io/IFT/Overview.html#glyphpatches
 pub fn glyf_u24_glyph_patches() -> BeBuffer {
     let mut buffer = be_buffer! {
       5u32,       // glyph count

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -5,10 +5,10 @@
 
 use read_fonts::types::Tag;
 use read_fonts::{be_buffer, be_buffer_add, test_helpers::BeBuffer, types::Int24, types::Uint24};
-use write_fonts::tables::head::Head;
-use write_fonts::tables::loca::Loca;
-use write_fonts::tables::maxp::Maxp;
-use write_fonts::FontBuilder;
+use write_fonts::{
+    tables::{head::Head, loca::Loca, maxp::Maxp},
+    FontBuilder,
+};
 
 pub static IFT_BASE: &[u8] = include_bytes!("../test_data/ttf/ift_base.ttf");
 

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -589,7 +589,6 @@ pub fn test_font_for_patching() -> Vec<u8> {
         end,   // gid 12
         end,   // gid 13
         end,   // gid 14
-        end,   // gid 15
         end,   // end
     ]);
 
@@ -606,8 +605,21 @@ pub fn glyph_keyed_patch_header() -> BeBuffer {
       (Tag::new(b"ifgk")), // format
       0u32,                // reserved
       0u8,                 // flags (0 = u16 gids)
-      [1, 2, 3, 4u32],     // compatibility id
+      [6, 7, 8, 9u32],     // compatibility id
       {0u32: "max_uncompressed_length"}
+    }
+}
+
+// Format specification: https://w3c.github.io/IFT/Overview.html#glyphpatches
+pub fn noop_glyf_glyph_patches() -> BeBuffer {
+    be_buffer! {
+      0u32,       // glyph count
+      {1u8: "table_count"},        // table count
+
+      (Tag::new(b"glyf")),   // tables * 1
+
+      // glyph data offsets * 1
+      0u32
     }
 }
 

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -27,3 +27,4 @@ shared-brotli-patch-decoder = { workspace = true }
 [dev-dependencies]
 font-test-data = { workspace = true }
 read-fonts = { workspace = true }
+brotlic = {version = "0.8.2"}

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -84,8 +84,8 @@ pub enum PatchingError {
     InternalError,
 }
 
-impl PatchingError {
-    pub(crate) fn from(decoding_error: DecodeError) -> Self {
+impl From<DecodeError> for PatchingError {
+    fn from(decoding_error: DecodeError) -> Self {
         match decoding_error {
             DecodeError::InitFailure => {
                 PatchingError::InvalidPatch("Failure to init brotli encoder.")

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -12,20 +12,31 @@
 
 use crate::patchmap::{PatchEncoding, PatchUri};
 
-use read_fonts::tables::ift::{CompatibilityId, TablePatchFlags};
-use read_fonts::tables::ift::{TableKeyedPatch, TablePatch};
+use font_types::Scalar;
+use read_fonts::collections::IntSet;
+use read_fonts::tables::ift::{
+    CompatibilityId, GlyphKeyedPatch, GlyphPatches, TableKeyedPatch, TablePatch, TablePatchFlags,
+};
+use read_fonts::tables::loca::Loca;
 use read_fonts::types::Tag;
-use read_fonts::{FontData, FontRef};
+use read_fonts::{FontData, FontRef, TableProvider};
 use read_fonts::{FontRead, ReadError};
 use shared_brotli_patch_decoder::{shared_brotli_decode, DecodeError};
+use skrifa::GlyphId;
+use std::cmp::min;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
+
 use write_fonts::FontBuilder;
+
+// TODO(garretrieger): support applying multiple glyph keyed patches in a single operation at the top level API.
 
 /// An incremental font patch which can be used to extend a font.
 ///
 /// See: <https://w3c.github.io/IFT/Overview.html#font-patch-formats>
 pub enum IncrementalFontPatch<'a> {
     TableKeyed(TableKeyedPatch<'a>),
+    GlyphKeyed(GlyphKeyedPatch<'a>),
 }
 
 impl PatchUri {
@@ -39,9 +50,10 @@ impl PatchUri {
                 TableKeyedPatch::read(FontData::new(patch_data))
                     .map_err(PatchingError::PatchParsingFailed)?,
             ),
-            PatchEncoding::GlyphKeyed => {
-                todo!()
-            }
+            PatchEncoding::GlyphKeyed => IncrementalFontPatch::GlyphKeyed(
+                GlyphKeyedPatch::read(FontData::new(patch_data))
+                    .map_err(PatchingError::PatchParsingFailed)?,
+            ),
         };
 
         if *self.expected_compatibility_id() != patch.compatibility_id() {
@@ -74,6 +86,23 @@ pub enum PatchingError {
     IncompatiblePatch,
     NonIncrementalFont,
     InvalidPatch(&'static str),
+    InternalError,
+}
+
+impl PatchingError {
+    fn from(decoding_error: DecodeError) -> Self {
+        match decoding_error {
+            DecodeError::InitFailure => {
+                PatchingError::InvalidPatch("Failure to init brotli encoder.")
+            }
+            DecodeError::InvalidStream => PatchingError::InvalidPatch("Malformed brotli stream."),
+            DecodeError::InvalidDictionary => PatchingError::InvalidPatch("Malformed dictionary."),
+            DecodeError::MaxSizeExceeded => PatchingError::InvalidPatch("Max size exceeded."),
+            DecodeError::ExcessInputData => {
+                PatchingError::InvalidPatch("Input brotli stream has excess bytes.")
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for PatchingError {
@@ -95,6 +124,10 @@ impl std::fmt::Display for PatchingError {
                 )
             }
             PatchingError::InvalidPatch(msg) => write!(f, "Invalid patch file: '{msg}'"),
+            PatchingError::InternalError => write!(
+                f,
+                "Internal constraint violated, typically should not happen."
+            ),
         }
     }
 }
@@ -105,6 +138,7 @@ impl IncrementalFontPatch<'_> {
     fn compatibility_id(&self) -> CompatibilityId {
         match self {
             IncrementalFontPatch::TableKeyed(patch_data) => patch_data.compatibility_id(),
+            IncrementalFontPatch::GlyphKeyed(patch_data) => patch_data.compatibility_id(),
         }
     }
 
@@ -112,6 +146,9 @@ impl IncrementalFontPatch<'_> {
         match self {
             IncrementalFontPatch::TableKeyed(patch_data) => {
                 apply_table_keyed_patch(patch_data, font)
+            }
+            IncrementalFontPatch::GlyphKeyed(patch_data) => {
+                apply_glyph_keyed_patch(patch_data, font)
             }
         }
     }
@@ -197,6 +234,16 @@ fn apply_table_keyed_patch(
         font_builder.add_raw(tag, new_table);
     }
 
+    copy_unprocessed_tables(font, processed_tables, &mut font_builder);
+
+    Ok(font_builder.build())
+}
+
+fn copy_unprocessed_tables<'a>(
+    font: &FontRef<'a>,
+    processed_tables: BTreeSet<Tag>,
+    font_builder: &mut FontBuilder<'a>,
+) {
     font.table_directory
         .table_records()
         .iter()
@@ -206,8 +253,6 @@ fn apply_table_keyed_patch(
         .for_each(|(tag, data)| {
             font_builder.add_raw(tag, data);
         });
-
-    Ok(font_builder.build())
 }
 
 fn apply_table_patch(
@@ -239,15 +284,333 @@ fn apply_table_patch(
         _ => shared_brotli_decode(stream, None, table_patch.max_uncompressed_length() as usize),
     };
 
-    r.map_err(|decode_error| match decode_error {
-        DecodeError::InitFailure => PatchingError::InvalidPatch("Failure to init brotli encoder."),
-        DecodeError::InvalidStream => PatchingError::InvalidPatch("Malformed brotli stream."),
-        DecodeError::InvalidDictionary => PatchingError::InvalidPatch("Malformed dictionary."),
-        DecodeError::MaxSizeExceeded => PatchingError::InvalidPatch("Max size exceeded."),
-        DecodeError::ExcessInputData => {
-            PatchingError::InvalidPatch("Input brotli stream has excess bytes.")
+    r.map_err(PatchingError::from)
+}
+
+fn apply_glyph_keyed_patch(
+    patch: &GlyphKeyedPatch<'_>,
+    font: &FontRef,
+) -> Result<Vec<u8>, PatchingError> {
+    if patch.format() != Tag::new(b"ifgk") {
+        return Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'"));
+    }
+
+    let raw_data = shared_brotli_decode(
+        patch.brotli_stream(),
+        None,
+        patch.max_uncompressed_length() as usize,
+    )
+    .map_err(PatchingError::from)?;
+    let glyph_patches = GlyphPatches::read(FontData::new(&raw_data), patch.flags())
+        .map_err(PatchingError::PatchParsingFailed)?;
+
+    let mut processed_tables = BTreeSet::<Tag>::new();
+    let mut font_builder = FontBuilder::new();
+    for table_tag in glyph_patches.tables().iter() {
+        let table_tag = table_tag.get();
+        // TODO(garretrieger): add CFF, CFF2, and gvar support as well.
+        if table_tag == Tag::new(b"glyf") {
+            let (Some(glyf), Ok(loca)) = (font.table_data(Tag::new(b"glyf")), font.loca(None))
+            else {
+                return Err(PatchingError::InvalidPatch(
+                    "Trying to patch glyf/loca but base font doesn't have them.",
+                ));
+            };
+            patch_glyf_and_loca(
+                &[glyph_patches.clone()],
+                glyf.as_bytes(),
+                loca,
+                GlyphId::new(0),
+                &mut font_builder,
+            )?;
+        } else {
+            return Err(PatchingError::InvalidPatch(
+                "Glyph keyed patch against unsupported table.",
+            ));
         }
-    })
+
+        processed_tables.insert(table_tag);
+    }
+
+    // TODO(garretrieger): mark the patch applied in the appropriate IFT table.
+
+    copy_unprocessed_tables(font, processed_tables, &mut font_builder);
+
+    Ok(font_builder.build())
+}
+
+fn table_tag_list<'a>(glyph_patches: impl Iterator<Item = &'a GlyphPatches<'a>>) -> BTreeSet<Tag> {
+    let mut result = BTreeSet::new();
+    for glyph_patch in glyph_patches {
+        result.extend(glyph_patch.tables().iter().map(|tag| tag.get()));
+    }
+    result
+}
+
+fn dedup_gid_replacement_data<'a>(
+    glyph_patches: impl Iterator<Item = &'a GlyphPatches<'a>>,
+    table_tag: Tag,
+) -> Result<(IntSet<GlyphId>, Vec<&'a [u8]>), ReadError> {
+    // TODO consider making return an iterator?
+    // TODO in the spec require sorted glyph ids?
+
+    // Since the specification allows us to freely choose patch application order (for groups of glyph keyed patches,
+    // see: https://w3c.github.io/IFT/Overview.html#extend-font-subset) if two patches affect the same gid we can choose
+    // one arbitrarily to remain applied. In this case we choose the first applied patch for each gid be the one that takes
+    // priority.
+    let mut gids: IntSet<GlyphId> = IntSet::default();
+    let mut data_for_gid: HashMap<GlyphId, &'a [u8]> = HashMap::default();
+    for glyph_patch in glyph_patches {
+        let Some((table_index, _)) = glyph_patch
+            .tables()
+            .iter()
+            .enumerate()
+            .find(|(i, tag)| tag.get() == table_tag)
+        else {
+            continue;
+        };
+
+        glyph_patch
+            .glyph_data_for_table(table_index)
+            .try_for_each(|result| {
+                let (gid, data) = result?;
+                data_for_gid.entry(gid).or_insert(data);
+                gids.insert(gid);
+                Ok(())
+            })?;
+    }
+
+    let mut deduped: Vec<&'a [u8]> = Vec::with_capacity(data_for_gid.len());
+    gids.iter().for_each(|gid| {
+        // in the above loop for each gid in gids there is always an  entry in data_for_gid
+        deduped.push(data_for_gid.get(&gid).unwrap());
+    });
+
+    Ok((gids, deduped))
+}
+
+fn retained_glyph_total_size<'a>(
+    gids: &IntSet<GlyphId>,
+    loca: &Loca<'a>,
+    max_glyph_id: GlyphId,
+) -> Result<u64, PatchingError> {
+    let mut total_size = 0u64;
+    for keep_range in gids.iter_excluded_ranges() {
+        if *keep_range.start() > max_glyph_id {
+            break;
+        }
+
+        let start = keep_range.start();
+        let end = min(*keep_range.end(), max_glyph_id);
+
+        let start_offset = loca
+            .get_raw(start.to_u32() as usize)
+            .ok_or(PatchingError::InvalidPatch("Start loca entry is missing."))?;
+        let end_offset = loca
+            .get_raw(end.to_u32() as usize + 1)
+            .ok_or(PatchingError::InvalidPatch("End loca entry is missing."))?;
+
+        total_size += end_offset
+            .checked_sub(start_offset) // TODO: this can be removed if we pre-verify ascending order
+            .ok_or(PatchingError::FontParsingFailed(ReadError::MalformedData(
+                "loca entries are not in ascending order",
+            )))? as u64;
+    }
+
+    Ok(total_size)
+}
+
+trait LocaOffset {
+    fn write_to(self, dest: &mut [u8]);
+}
+
+impl LocaOffset for u32 {
+    fn write_to(self, dest: &mut [u8]) {
+        let data: [u8; 4] = self.to_raw();
+        dest[..4].copy_from_slice(&data);
+    }
+}
+
+impl LocaOffset for u16 {
+    fn write_to(self, dest: &mut [u8]) {
+        let data: [u8; 2] = self.to_raw();
+        dest[..2].copy_from_slice(&data);
+    }
+}
+
+fn synthesize_glyf_and_loca<OffsetType: LocaOffset + TryFrom<usize>>(
+    gids: &IntSet<GlyphId>,
+    replacement_data: &[&[u8]],
+    glyf: &[u8],
+    loca: &Loca<'_>,
+    new_glyf: &mut [u8],
+    new_loca: &mut [u8],
+) -> Result<(), PatchingError> {
+    let mut replace_it = gids.iter_ranges().peekable();
+    let mut keep_it = gids.iter_excluded_ranges().peekable();
+    let mut replacement_data_it = replacement_data.iter();
+    let mut write_index = 0;
+    let is_short_loca = match loca {
+        Loca::Short(_) => true,
+        Loca::Long(_) => false,
+    };
+    let off_size = std::mem::size_of::<OffsetType>();
+
+    loop {
+        let (range, replace) = match (replace_it.peek(), keep_it.peek()) {
+            (Some(replace), Some(keep)) => {
+                if replace.start() <= keep.start() {
+                    (replace_it.next().unwrap(), true)
+                } else {
+                    (keep_it.next().unwrap(), false)
+                }
+            }
+            (Some(_), None) => (replace_it.next().unwrap(), true),
+            (None, Some(_)) => (keep_it.next().unwrap(), false),
+            (None, None) => break,
+        };
+
+        let (start, end) = (
+            range.start().to_u32() as usize,
+            range.end().to_u32() as usize,
+        );
+
+        if replace {
+            for gid in start..=end {
+                let data = *replacement_data_it
+                    .next()
+                    .ok_or(PatchingError::InternalError)?;
+
+                new_glyf
+                    .get_mut(write_index..write_index + data.len())
+                    .ok_or(PatchingError::InternalError)?
+                    .copy_from_slice(data);
+
+                let loca_off: OffsetType = write_index
+                    .try_into()
+                    .map_err(|_| PatchingError::InternalError)?;
+                loca_off.write_to(
+                    new_loca
+                        .get_mut(gid * off_size..)
+                        .ok_or(PatchingError::InternalError)?,
+                );
+
+                write_index += data.len();
+                if is_short_loca {
+                    // Add padding for short loca.
+                    write_index += data.len() % 2;
+                }
+            }
+        } else {
+            let start_off = loca.get_raw(start).ok_or(PatchingError::InternalError)? as usize;
+            let end_off = loca.get_raw(end).ok_or(PatchingError::InternalError)? as usize;
+            let len = end_off
+                .checked_sub(start_off)
+                .ok_or(PatchingError::InternalError)?;
+            new_glyf
+                .get_mut(write_index..write_index + len)
+                .ok_or(PatchingError::InternalError)?
+                .copy_from_slice(
+                    glyf.get(start_off..end_off)
+                        .ok_or(PatchingError::InternalError)?,
+                );
+
+            for gid in start..=end {
+                let cur_off = loca.get_raw(gid).ok_or(PatchingError::InternalError)? as usize;
+                let new_off = cur_off - start_off + write_index;
+                let new_off: OffsetType = new_off
+                    .try_into()
+                    .map_err(|_| PatchingError::InternalError)?;
+                new_off.write_to(
+                    new_loca
+                        .get_mut(gid * off_size..)
+                        .ok_or(PatchingError::InternalError)?,
+                );
+            }
+
+            write_index += len;
+        }
+    }
+
+    // Write the last loca offset
+    let loca_off: OffsetType = write_index
+        .try_into()
+        .map_err(|_| PatchingError::InternalError)?;
+    loca_off.write_to(
+        new_loca
+            .get_mut(new_loca.len() - 2..)
+            .ok_or(PatchingError::InternalError)?,
+    );
+
+    Ok(())
+}
+
+// TODO: Idea - can we actually construct the new glyf table on the fly during the brotli decompression process?
+//              ie. eliminate the intermediate buffer that stores GlyphPatches?
+
+fn patch_glyf_and_loca<'a>(
+    glyph_patches: &'a [GlyphPatches<'a>],
+    glyf: &[u8],
+    loca: Loca<'a>,
+    max_glyph_id: GlyphId,
+    font_builder: &mut FontBuilder,
+) -> Result<(), PatchingError> {
+    // TODO(garretrieger) using traits, generalize this approach to any of the supported table types.
+
+    let is_short = match loca {
+        Loca::Short(_) => true,
+        Loca::Long(_) => false,
+    };
+
+    // Step 0: merge the invidual patches into a list of replacement data for gid.
+    // TODO(garretrieger): special case where gids is empty, just returned umodified copy of glyf + loca?
+    let (gids, replacement_data) =
+        dedup_gid_replacement_data(glyph_patches.iter(), Tag::new(b"glyf"))
+            .map_err(PatchingError::PatchParsingFailed)?;
+
+    // Step 1: determine the new total size of glyf
+    let mut total_glyf_size = retained_glyph_total_size(&gids, &loca, max_glyph_id)?;
+    for data in replacement_data.iter() {
+        total_glyf_size += data.len() as u64;
+    }
+
+    // TODO(garretrieger): check if loca format will need to switch, if so that's an error.
+
+    if gids.last().unwrap_or(GlyphId::new(0)) > max_glyph_id {
+        return Err(PatchingError::InvalidPatch(
+            "Patch would add a glyph beyond this fonts maximum.",
+        ));
+    }
+
+    // Step 2: patch together the new glyf (by copying in ranges of data in the correct order).
+    let loca_size = (max_glyph_id.to_u32() as usize + 1) * if is_short { 2 } else { 4 };
+    let mut new_glyf = vec![0u8; total_glyf_size as usize];
+    let mut new_loca = vec![0u8; loca_size];
+    if is_short {
+        synthesize_glyf_and_loca::<u16>(
+            &gids,
+            &replacement_data,
+            glyf,
+            &loca,
+            new_glyf.as_mut_slice(),
+            new_loca.as_mut_slice(),
+        )?;
+    } else {
+        synthesize_glyf_and_loca::<u32>(
+            &gids,
+            &replacement_data,
+            glyf,
+            &loca,
+            new_glyf.as_mut_slice(),
+            new_loca.as_mut_slice(),
+        )?;
+    }
+
+    // Step 3: add new tables to the output builder
+    font_builder.add_raw(Tag::new(b"glyf"), new_glyf);
+    font_builder.add_raw(Tag::new(b"loca"), new_loca);
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -597,4 +960,5 @@ mod tests {
     }
 
     // TODO glyph keyed test with large number of offsets to check type conversion on (glyphCount * tableCount)
+    // TODO glyph keyed test with multiple patches that have different bytes for the same gid.
 }

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -12,20 +12,15 @@
 
 use crate::patchmap::{PatchEncoding, PatchUri};
 
-use font_types::Scalar;
-use read_fonts::collections::IntSet;
+use crate::glyph_keyed::apply_glyph_keyed_patch;
 use read_fonts::tables::ift::{
-    CompatibilityId, GlyphKeyedPatch, GlyphPatches, TableKeyedPatch, TablePatch, TablePatchFlags,
+    CompatibilityId, GlyphKeyedPatch, TableKeyedPatch, TablePatch, TablePatchFlags,
 };
-use read_fonts::tables::loca::Loca;
 use read_fonts::types::Tag;
-use read_fonts::{FontData, FontRef, TableProvider};
+use read_fonts::{FontData, FontRef};
 use read_fonts::{FontRead, ReadError};
 use shared_brotli_patch_decoder::{shared_brotli_decode, DecodeError};
-use skrifa::GlyphId;
-use std::cmp::min;
 use std::collections::BTreeSet;
-use std::collections::HashMap;
 
 use write_fonts::FontBuilder;
 
@@ -90,7 +85,7 @@ pub enum PatchingError {
 }
 
 impl PatchingError {
-    fn from(decoding_error: DecodeError) -> Self {
+    pub(crate) fn from(decoding_error: DecodeError) -> Self {
         match decoding_error {
             DecodeError::InitFailure => {
                 PatchingError::InvalidPatch("Failure to init brotli encoder.")
@@ -239,7 +234,7 @@ fn apply_table_keyed_patch(
     Ok(font_builder.build())
 }
 
-fn copy_unprocessed_tables<'a>(
+pub(crate) fn copy_unprocessed_tables<'a>(
     font: &FontRef<'a>,
     processed_tables: BTreeSet<Tag>,
     font_builder: &mut FontBuilder<'a>,
@@ -285,332 +280,6 @@ fn apply_table_patch(
     };
 
     r.map_err(PatchingError::from)
-}
-
-fn apply_glyph_keyed_patch(
-    patch: &GlyphKeyedPatch<'_>,
-    font: &FontRef,
-) -> Result<Vec<u8>, PatchingError> {
-    if patch.format() != Tag::new(b"ifgk") {
-        return Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'"));
-    }
-
-    let raw_data = shared_brotli_decode(
-        patch.brotli_stream(),
-        None,
-        patch.max_uncompressed_length() as usize,
-    )
-    .map_err(PatchingError::from)?;
-    let glyph_patches = GlyphPatches::read(FontData::new(&raw_data), patch.flags())
-        .map_err(PatchingError::PatchParsingFailed)?;
-
-    let mut processed_tables = BTreeSet::<Tag>::new();
-    let mut font_builder = FontBuilder::new();
-    for table_tag in glyph_patches.tables().iter() {
-        let table_tag = table_tag.get();
-        // TODO(garretrieger): add CFF, CFF2, and gvar support as well.
-        if table_tag == Tag::new(b"glyf") {
-            let (Some(glyf), Ok(loca)) = (font.table_data(Tag::new(b"glyf")), font.loca(None))
-            else {
-                return Err(PatchingError::InvalidPatch(
-                    "Trying to patch glyf/loca but base font doesn't have them.",
-                ));
-            };
-            patch_glyf_and_loca(
-                &[glyph_patches.clone()],
-                glyf.as_bytes(),
-                loca,
-                GlyphId::new(0),
-                &mut font_builder,
-            )?;
-        } else {
-            return Err(PatchingError::InvalidPatch(
-                "Glyph keyed patch against unsupported table.",
-            ));
-        }
-
-        processed_tables.insert(table_tag);
-    }
-
-    // TODO(garretrieger): mark the patch applied in the appropriate IFT table.
-
-    copy_unprocessed_tables(font, processed_tables, &mut font_builder);
-
-    Ok(font_builder.build())
-}
-
-fn table_tag_list<'a>(glyph_patches: impl Iterator<Item = &'a GlyphPatches<'a>>) -> BTreeSet<Tag> {
-    let mut result = BTreeSet::new();
-    for glyph_patch in glyph_patches {
-        result.extend(glyph_patch.tables().iter().map(|tag| tag.get()));
-    }
-    result
-}
-
-fn dedup_gid_replacement_data<'a>(
-    glyph_patches: impl Iterator<Item = &'a GlyphPatches<'a>>,
-    table_tag: Tag,
-) -> Result<(IntSet<GlyphId>, Vec<&'a [u8]>), ReadError> {
-    // TODO consider making return an iterator?
-    // TODO in the spec require sorted glyph ids?
-
-    // Since the specification allows us to freely choose patch application order (for groups of glyph keyed patches,
-    // see: https://w3c.github.io/IFT/Overview.html#extend-font-subset) if two patches affect the same gid we can choose
-    // one arbitrarily to remain applied. In this case we choose the first applied patch for each gid be the one that takes
-    // priority.
-    let mut gids: IntSet<GlyphId> = IntSet::default();
-    let mut data_for_gid: HashMap<GlyphId, &'a [u8]> = HashMap::default();
-    for glyph_patch in glyph_patches {
-        let Some((table_index, _)) = glyph_patch
-            .tables()
-            .iter()
-            .enumerate()
-            .find(|(i, tag)| tag.get() == table_tag)
-        else {
-            continue;
-        };
-
-        glyph_patch
-            .glyph_data_for_table(table_index)
-            .try_for_each(|result| {
-                let (gid, data) = result?;
-                data_for_gid.entry(gid).or_insert(data);
-                gids.insert(gid);
-                Ok(())
-            })?;
-    }
-
-    let mut deduped: Vec<&'a [u8]> = Vec::with_capacity(data_for_gid.len());
-    gids.iter().for_each(|gid| {
-        // in the above loop for each gid in gids there is always an  entry in data_for_gid
-        deduped.push(data_for_gid.get(&gid).unwrap());
-    });
-
-    Ok((gids, deduped))
-}
-
-fn retained_glyph_total_size<'a>(
-    gids: &IntSet<GlyphId>,
-    loca: &Loca<'a>,
-    max_glyph_id: GlyphId,
-) -> Result<u64, PatchingError> {
-    let mut total_size = 0u64;
-    for keep_range in gids.iter_excluded_ranges() {
-        if *keep_range.start() > max_glyph_id {
-            break;
-        }
-
-        let start = keep_range.start();
-        let end = min(*keep_range.end(), max_glyph_id);
-
-        let start_offset = loca
-            .get_raw(start.to_u32() as usize)
-            .ok_or(PatchingError::InvalidPatch("Start loca entry is missing."))?;
-        let end_offset = loca
-            .get_raw(end.to_u32() as usize + 1)
-            .ok_or(PatchingError::InvalidPatch("End loca entry is missing."))?;
-
-        total_size += end_offset
-            .checked_sub(start_offset) // TODO: this can be removed if we pre-verify ascending order
-            .ok_or(PatchingError::FontParsingFailed(ReadError::MalformedData(
-                "loca entries are not in ascending order",
-            )))? as u64;
-    }
-
-    Ok(total_size)
-}
-
-trait LocaOffset {
-    fn write_to(self, dest: &mut [u8]);
-}
-
-impl LocaOffset for u32 {
-    fn write_to(self, dest: &mut [u8]) {
-        let data: [u8; 4] = self.to_raw();
-        dest[..4].copy_from_slice(&data);
-    }
-}
-
-impl LocaOffset for u16 {
-    fn write_to(self, dest: &mut [u8]) {
-        let data: [u8; 2] = self.to_raw();
-        dest[..2].copy_from_slice(&data);
-    }
-}
-
-fn synthesize_glyf_and_loca<OffsetType: LocaOffset + TryFrom<usize>>(
-    gids: &IntSet<GlyphId>,
-    replacement_data: &[&[u8]],
-    glyf: &[u8],
-    loca: &Loca<'_>,
-    new_glyf: &mut [u8],
-    new_loca: &mut [u8],
-) -> Result<(), PatchingError> {
-    let mut replace_it = gids.iter_ranges().peekable();
-    let mut keep_it = gids.iter_excluded_ranges().peekable();
-    let mut replacement_data_it = replacement_data.iter();
-    let mut write_index = 0;
-    let is_short_loca = match loca {
-        Loca::Short(_) => true,
-        Loca::Long(_) => false,
-    };
-    let off_size = std::mem::size_of::<OffsetType>();
-
-    loop {
-        let (range, replace) = match (replace_it.peek(), keep_it.peek()) {
-            (Some(replace), Some(keep)) => {
-                if replace.start() <= keep.start() {
-                    (replace_it.next().unwrap(), true)
-                } else {
-                    (keep_it.next().unwrap(), false)
-                }
-            }
-            (Some(_), None) => (replace_it.next().unwrap(), true),
-            (None, Some(_)) => (keep_it.next().unwrap(), false),
-            (None, None) => break,
-        };
-
-        let (start, end) = (
-            range.start().to_u32() as usize,
-            range.end().to_u32() as usize,
-        );
-
-        if replace {
-            for gid in start..=end {
-                let data = *replacement_data_it
-                    .next()
-                    .ok_or(PatchingError::InternalError)?;
-
-                new_glyf
-                    .get_mut(write_index..write_index + data.len())
-                    .ok_or(PatchingError::InternalError)?
-                    .copy_from_slice(data);
-
-                let loca_off: OffsetType = write_index
-                    .try_into()
-                    .map_err(|_| PatchingError::InternalError)?;
-                loca_off.write_to(
-                    new_loca
-                        .get_mut(gid * off_size..)
-                        .ok_or(PatchingError::InternalError)?,
-                );
-
-                write_index += data.len();
-                if is_short_loca {
-                    // Add padding for short loca.
-                    write_index += data.len() % 2;
-                }
-            }
-        } else {
-            let start_off = loca.get_raw(start).ok_or(PatchingError::InternalError)? as usize;
-            let end_off = loca.get_raw(end).ok_or(PatchingError::InternalError)? as usize;
-            let len = end_off
-                .checked_sub(start_off)
-                .ok_or(PatchingError::InternalError)?;
-            new_glyf
-                .get_mut(write_index..write_index + len)
-                .ok_or(PatchingError::InternalError)?
-                .copy_from_slice(
-                    glyf.get(start_off..end_off)
-                        .ok_or(PatchingError::InternalError)?,
-                );
-
-            for gid in start..=end {
-                let cur_off = loca.get_raw(gid).ok_or(PatchingError::InternalError)? as usize;
-                let new_off = cur_off - start_off + write_index;
-                let new_off: OffsetType = new_off
-                    .try_into()
-                    .map_err(|_| PatchingError::InternalError)?;
-                new_off.write_to(
-                    new_loca
-                        .get_mut(gid * off_size..)
-                        .ok_or(PatchingError::InternalError)?,
-                );
-            }
-
-            write_index += len;
-        }
-    }
-
-    // Write the last loca offset
-    let loca_off: OffsetType = write_index
-        .try_into()
-        .map_err(|_| PatchingError::InternalError)?;
-    loca_off.write_to(
-        new_loca
-            .get_mut(new_loca.len() - 2..)
-            .ok_or(PatchingError::InternalError)?,
-    );
-
-    Ok(())
-}
-
-// TODO: Idea - can we actually construct the new glyf table on the fly during the brotli decompression process?
-//              ie. eliminate the intermediate buffer that stores GlyphPatches?
-
-fn patch_glyf_and_loca<'a>(
-    glyph_patches: &'a [GlyphPatches<'a>],
-    glyf: &[u8],
-    loca: Loca<'a>,
-    max_glyph_id: GlyphId,
-    font_builder: &mut FontBuilder,
-) -> Result<(), PatchingError> {
-    // TODO(garretrieger) using traits, generalize this approach to any of the supported table types.
-
-    let is_short = match loca {
-        Loca::Short(_) => true,
-        Loca::Long(_) => false,
-    };
-
-    // Step 0: merge the invidual patches into a list of replacement data for gid.
-    // TODO(garretrieger): special case where gids is empty, just returned umodified copy of glyf + loca?
-    let (gids, replacement_data) =
-        dedup_gid_replacement_data(glyph_patches.iter(), Tag::new(b"glyf"))
-            .map_err(PatchingError::PatchParsingFailed)?;
-
-    // Step 1: determine the new total size of glyf
-    let mut total_glyf_size = retained_glyph_total_size(&gids, &loca, max_glyph_id)?;
-    for data in replacement_data.iter() {
-        total_glyf_size += data.len() as u64;
-    }
-
-    // TODO(garretrieger): check if loca format will need to switch, if so that's an error.
-
-    if gids.last().unwrap_or(GlyphId::new(0)) > max_glyph_id {
-        return Err(PatchingError::InvalidPatch(
-            "Patch would add a glyph beyond this fonts maximum.",
-        ));
-    }
-
-    // Step 2: patch together the new glyf (by copying in ranges of data in the correct order).
-    let loca_size = (max_glyph_id.to_u32() as usize + 1) * if is_short { 2 } else { 4 };
-    let mut new_glyf = vec![0u8; total_glyf_size as usize];
-    let mut new_loca = vec![0u8; loca_size];
-    if is_short {
-        synthesize_glyf_and_loca::<u16>(
-            &gids,
-            &replacement_data,
-            glyf,
-            &loca,
-            new_glyf.as_mut_slice(),
-            new_loca.as_mut_slice(),
-        )?;
-    } else {
-        synthesize_glyf_and_loca::<u32>(
-            &gids,
-            &replacement_data,
-            glyf,
-            &loca,
-            new_glyf.as_mut_slice(),
-            new_loca.as_mut_slice(),
-        )?;
-    }
-
-    // Step 3: add new tables to the output builder
-    font_builder.add_raw(Tag::new(b"glyf"), new_glyf);
-    font_builder.add_raw(Tag::new(b"loca"), new_loca);
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -143,7 +143,7 @@ impl IncrementalFontPatch<'_> {
                 apply_table_keyed_patch(patch_data, font)
             }
             IncrementalFontPatch::GlyphKeyed(patch_data) => {
-                apply_glyph_keyed_patch(patch_data, font)
+                apply_glyph_keyed_patch(&[patch_data.clone()], font)
             }
         }
     }

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -24,8 +24,6 @@ use std::collections::BTreeSet;
 
 use write_fonts::FontBuilder;
 
-// TODO(garretrieger): support applying multiple glyph keyed patches in a single operation at the top level API.
-
 /// An incremental font patch which can be used to extend a font.
 ///
 /// See: <https://w3c.github.io/IFT/Overview.html#font-patch-formats>

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -81,6 +81,7 @@ pub enum PatchingError {
     IncompatiblePatches,
     NonIncrementalFont,
     InvalidPatch(&'static str),
+    EmptyPatchList,
     InternalError,
 }
 
@@ -125,6 +126,7 @@ impl std::fmt::Display for PatchingError {
                 )
             }
             PatchingError::InvalidPatch(msg) => write!(f, "Invalid patch file: '{msg}'"),
+            PatchingError::EmptyPatchList => write!(f, "At least one patch file must be provided."),
             PatchingError::InternalError => write!(
                 f,
                 "Internal constraint violated, typically should not happen."
@@ -156,9 +158,7 @@ impl IncrementalFontPatchBase for FontRef<'_> {
             return Err(PatchingError::NonIncrementalFont);
         }
 
-        let first = patches.first().ok_or(PatchingError::InvalidPatch(
-            "At least one patch must be provided.",
-        ))?;
+        let first = patches.first().ok_or(PatchingError::EmptyPatchList)?;
 
         match first {
             IncrementalFontPatch::TableKeyed(patch_data) => {
@@ -705,6 +705,7 @@ mod tests {
         );
     }
 
+    // TODO(garretrieger): test empty patch list fails.
     // TODO(garretrieger): single glyph keyed patch test
     // TODO(garretrieger): multiple glyph keyed
 }

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -1,5 +1,11 @@
-//! TODO write me.
-
+/// Implementation of Glyph Keyed patch application.
+///
+/// Glyph Keyed patches are a type of incremental font patch which stores opaque data blobs
+/// keyed by glyph id. Patch application places the data blobs into the appropriate place
+/// in the base font based on the associated glyph id.
+///
+/// Glyph Keyed patches are specified here:
+/// <https://w3c.github.io/IFT/Overview.html#glyph-keyed>
 use crate::font_patch::copy_unprocessed_tables;
 use crate::font_patch::PatchingError;
 
@@ -314,9 +320,6 @@ fn synthesize_glyf_and_loca<OffsetType: LocaOffset + TryFrom<usize>>(
     Ok(())
 }
 
-// TODO: Idea - can we actually construct the new glyf table on the fly during the brotli decompression process?
-//              ie. eliminate the intermediate buffer that stores GlyphPatches?
-
 fn patch_glyf_and_loca<'a>(
     glyph_patches: &'a [GlyphPatches<'a>],
     glyf: &[u8],
@@ -331,7 +334,7 @@ fn patch_glyf_and_loca<'a>(
         Loca::Long(_) => false,
     };
 
-    // Step 0: merge the invidual patches into a list of replacement data for gid.
+    // Step 0: merge the individual patches into a list of replacement data for gid.
     // TODO(garretrieger): special case where gids is empty, just returned umodified copy of glyf + loca?
     let (gids, replacement_data) =
         dedup_gid_replacement_data(glyph_patches.iter(), Tag::new(b"glyf"))

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -1,0 +1,353 @@
+//! TODO write me.
+
+use crate::font_patch::copy_unprocessed_tables;
+use crate::font_patch::PatchingError;
+
+use font_types::Scalar;
+use read_fonts::collections::IntSet;
+use read_fonts::tables::ift::{GlyphKeyedPatch, GlyphPatches};
+use read_fonts::tables::loca::Loca;
+use read_fonts::types::Tag;
+use read_fonts::ReadError;
+use read_fonts::{FontData, FontRef, TableProvider};
+use shared_brotli_patch_decoder::shared_brotli_decode;
+use skrifa::GlyphId;
+use std::cmp::min;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+
+use write_fonts::FontBuilder;
+
+pub(crate) fn apply_glyph_keyed_patch(
+    patch: &GlyphKeyedPatch<'_>,
+    font: &FontRef,
+) -> Result<Vec<u8>, PatchingError> {
+    if patch.format() != Tag::new(b"ifgk") {
+        return Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'"));
+    }
+
+    let raw_data = shared_brotli_decode(
+        patch.brotli_stream(),
+        None,
+        patch.max_uncompressed_length() as usize,
+    )
+    .map_err(PatchingError::from)?;
+    let glyph_patches = GlyphPatches::read(FontData::new(&raw_data), patch.flags())
+        .map_err(PatchingError::PatchParsingFailed)?;
+
+    let mut processed_tables = BTreeSet::<Tag>::new();
+    let mut font_builder = FontBuilder::new();
+    for table_tag in glyph_patches.tables().iter() {
+        let table_tag = table_tag.get();
+        // TODO(garretrieger): add CFF, CFF2, and gvar support as well.
+        if table_tag == Tag::new(b"glyf") {
+            let (Some(glyf), Ok(loca)) = (font.table_data(Tag::new(b"glyf")), font.loca(None))
+            else {
+                return Err(PatchingError::InvalidPatch(
+                    "Trying to patch glyf/loca but base font doesn't have them.",
+                ));
+            };
+            patch_glyf_and_loca(
+                &[glyph_patches.clone()],
+                glyf.as_bytes(),
+                loca,
+                GlyphId::new(0),
+                &mut font_builder,
+            )?;
+        } else {
+            return Err(PatchingError::InvalidPatch(
+                "Glyph keyed patch against unsupported table.",
+            ));
+        }
+
+        processed_tables.insert(table_tag);
+    }
+
+    // TODO(garretrieger): mark the patch applied in the appropriate IFT table.
+
+    copy_unprocessed_tables(font, processed_tables, &mut font_builder);
+
+    Ok(font_builder.build())
+}
+
+fn table_tag_list<'a>(glyph_patches: impl Iterator<Item = &'a GlyphPatches<'a>>) -> BTreeSet<Tag> {
+    let mut result = BTreeSet::new();
+    for glyph_patch in glyph_patches {
+        result.extend(glyph_patch.tables().iter().map(|tag| tag.get()));
+    }
+    result
+}
+
+fn dedup_gid_replacement_data<'a>(
+    glyph_patches: impl Iterator<Item = &'a GlyphPatches<'a>>,
+    table_tag: Tag,
+) -> Result<(IntSet<GlyphId>, Vec<&'a [u8]>), ReadError> {
+    // TODO consider making return an iterator?
+    // TODO in the spec require sorted glyph ids?
+
+    // Since the specification allows us to freely choose patch application order (for groups of glyph keyed patches,
+    // see: https://w3c.github.io/IFT/Overview.html#extend-font-subset) if two patches affect the same gid we can choose
+    // one arbitrarily to remain applied. In this case we choose the first applied patch for each gid be the one that takes
+    // priority.
+    let mut gids: IntSet<GlyphId> = IntSet::default();
+    let mut data_for_gid: HashMap<GlyphId, &'a [u8]> = HashMap::default();
+    for glyph_patch in glyph_patches {
+        let Some((table_index, _)) = glyph_patch
+            .tables()
+            .iter()
+            .enumerate()
+            .find(|(_, tag)| tag.get() == table_tag)
+        else {
+            continue;
+        };
+
+        glyph_patch
+            .glyph_data_for_table(table_index)
+            .try_for_each(|result| {
+                let (gid, data) = result?;
+                data_for_gid.entry(gid).or_insert(data);
+                gids.insert(gid);
+                Ok(())
+            })?;
+    }
+
+    let mut deduped: Vec<&'a [u8]> = Vec::with_capacity(data_for_gid.len());
+    gids.iter().for_each(|gid| {
+        // in the above loop for each gid in gids there is always an  entry in data_for_gid
+        deduped.push(data_for_gid.get(&gid).unwrap());
+    });
+
+    Ok((gids, deduped))
+}
+
+fn retained_glyph_total_size<'a>(
+    gids: &IntSet<GlyphId>,
+    loca: &Loca<'a>,
+    max_glyph_id: GlyphId,
+) -> Result<u64, PatchingError> {
+    let mut total_size = 0u64;
+    for keep_range in gids.iter_excluded_ranges() {
+        if *keep_range.start() > max_glyph_id {
+            break;
+        }
+
+        let start = keep_range.start();
+        let end = min(*keep_range.end(), max_glyph_id);
+
+        let start_offset = loca
+            .get_raw(start.to_u32() as usize)
+            .ok_or(PatchingError::InvalidPatch("Start loca entry is missing."))?;
+        let end_offset = loca
+            .get_raw(end.to_u32() as usize + 1)
+            .ok_or(PatchingError::InvalidPatch("End loca entry is missing."))?;
+
+        total_size += end_offset
+            .checked_sub(start_offset) // TODO: this can be removed if we pre-verify ascending order
+            .ok_or(PatchingError::FontParsingFailed(ReadError::MalformedData(
+                "loca entries are not in ascending order",
+            )))? as u64;
+    }
+
+    Ok(total_size)
+}
+
+trait LocaOffset {
+    fn write_to(self, dest: &mut [u8]);
+}
+
+impl LocaOffset for u32 {
+    fn write_to(self, dest: &mut [u8]) {
+        let data: [u8; 4] = self.to_raw();
+        dest[..4].copy_from_slice(&data);
+    }
+}
+
+impl LocaOffset for u16 {
+    fn write_to(self, dest: &mut [u8]) {
+        let data: [u8; 2] = self.to_raw();
+        dest[..2].copy_from_slice(&data);
+    }
+}
+
+fn synthesize_glyf_and_loca<OffsetType: LocaOffset + TryFrom<usize>>(
+    gids: &IntSet<GlyphId>,
+    replacement_data: &[&[u8]],
+    glyf: &[u8],
+    loca: &Loca<'_>,
+    new_glyf: &mut [u8],
+    new_loca: &mut [u8],
+) -> Result<(), PatchingError> {
+    let mut replace_it = gids.iter_ranges().peekable();
+    let mut keep_it = gids.iter_excluded_ranges().peekable();
+    let mut replacement_data_it = replacement_data.iter();
+    let mut write_index = 0;
+    let is_short_loca = match loca {
+        Loca::Short(_) => true,
+        Loca::Long(_) => false,
+    };
+    let off_size = std::mem::size_of::<OffsetType>();
+
+    loop {
+        let (range, replace) = match (replace_it.peek(), keep_it.peek()) {
+            (Some(replace), Some(keep)) => {
+                if replace.start() <= keep.start() {
+                    (replace_it.next().unwrap(), true)
+                } else {
+                    (keep_it.next().unwrap(), false)
+                }
+            }
+            (Some(_), None) => (replace_it.next().unwrap(), true),
+            (None, Some(_)) => (keep_it.next().unwrap(), false),
+            (None, None) => break,
+        };
+
+        let (start, end) = (
+            range.start().to_u32() as usize,
+            range.end().to_u32() as usize,
+        );
+
+        if replace {
+            for gid in start..=end {
+                let data = *replacement_data_it
+                    .next()
+                    .ok_or(PatchingError::InternalError)?;
+
+                new_glyf
+                    .get_mut(write_index..write_index + data.len())
+                    .ok_or(PatchingError::InternalError)?
+                    .copy_from_slice(data);
+
+                let loca_off: OffsetType = write_index
+                    .try_into()
+                    .map_err(|_| PatchingError::InternalError)?;
+                loca_off.write_to(
+                    new_loca
+                        .get_mut(gid * off_size..)
+                        .ok_or(PatchingError::InternalError)?,
+                );
+
+                write_index += data.len();
+                if is_short_loca {
+                    // Add padding for short loca.
+                    write_index += data.len() % 2;
+                }
+            }
+        } else {
+            let start_off = loca.get_raw(start).ok_or(PatchingError::InternalError)? as usize;
+            let end_off = loca.get_raw(end).ok_or(PatchingError::InternalError)? as usize;
+            let len = end_off
+                .checked_sub(start_off)
+                .ok_or(PatchingError::InternalError)?;
+            new_glyf
+                .get_mut(write_index..write_index + len)
+                .ok_or(PatchingError::InternalError)?
+                .copy_from_slice(
+                    glyf.get(start_off..end_off)
+                        .ok_or(PatchingError::InternalError)?,
+                );
+
+            for gid in start..=end {
+                let cur_off = loca.get_raw(gid).ok_or(PatchingError::InternalError)? as usize;
+                let new_off = cur_off - start_off + write_index;
+                let new_off: OffsetType = new_off
+                    .try_into()
+                    .map_err(|_| PatchingError::InternalError)?;
+                new_off.write_to(
+                    new_loca
+                        .get_mut(gid * off_size..)
+                        .ok_or(PatchingError::InternalError)?,
+                );
+            }
+
+            write_index += len;
+        }
+    }
+
+    // Write the last loca offset
+    let loca_off: OffsetType = write_index
+        .try_into()
+        .map_err(|_| PatchingError::InternalError)?;
+    loca_off.write_to(
+        new_loca
+            .get_mut(new_loca.len() - 2..)
+            .ok_or(PatchingError::InternalError)?,
+    );
+
+    Ok(())
+}
+
+// TODO: Idea - can we actually construct the new glyf table on the fly during the brotli decompression process?
+//              ie. eliminate the intermediate buffer that stores GlyphPatches?
+
+fn patch_glyf_and_loca<'a>(
+    glyph_patches: &'a [GlyphPatches<'a>],
+    glyf: &[u8],
+    loca: Loca<'a>,
+    max_glyph_id: GlyphId,
+    font_builder: &mut FontBuilder,
+) -> Result<(), PatchingError> {
+    // TODO(garretrieger) using traits, generalize this approach to any of the supported table types.
+
+    let is_short = match loca {
+        Loca::Short(_) => true,
+        Loca::Long(_) => false,
+    };
+
+    // Step 0: merge the invidual patches into a list of replacement data for gid.
+    // TODO(garretrieger): special case where gids is empty, just returned umodified copy of glyf + loca?
+    let (gids, replacement_data) =
+        dedup_gid_replacement_data(glyph_patches.iter(), Tag::new(b"glyf"))
+            .map_err(PatchingError::PatchParsingFailed)?;
+
+    // Step 1: determine the new total size of glyf
+    let mut total_glyf_size = retained_glyph_total_size(&gids, &loca, max_glyph_id)?;
+    for data in replacement_data.iter() {
+        total_glyf_size += data.len() as u64;
+    }
+
+    // TODO(garretrieger): check if loca format will need to switch, if so that's an error.
+
+    if gids.last().unwrap_or(GlyphId::new(0)) > max_glyph_id {
+        return Err(PatchingError::InvalidPatch(
+            "Patch would add a glyph beyond this fonts maximum.",
+        ));
+    }
+
+    // Step 2: patch together the new glyf (by copying in ranges of data in the correct order).
+    let loca_size = (max_glyph_id.to_u32() as usize + 1) * if is_short { 2 } else { 4 };
+    let mut new_glyf = vec![0u8; total_glyf_size as usize];
+    let mut new_loca = vec![0u8; loca_size];
+    if is_short {
+        synthesize_glyf_and_loca::<u16>(
+            &gids,
+            &replacement_data,
+            glyf,
+            &loca,
+            new_glyf.as_mut_slice(),
+            new_loca.as_mut_slice(),
+        )?;
+    } else {
+        synthesize_glyf_and_loca::<u32>(
+            &gids,
+            &replacement_data,
+            glyf,
+            &loca,
+            new_glyf.as_mut_slice(),
+            new_loca.as_mut_slice(),
+        )?;
+    }
+
+    // Step 3: add new tables to the output builder
+    font_builder.add_raw(Tag::new(b"glyf"), new_glyf);
+    font_builder.add_raw(Tag::new(b"loca"), new_loca);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn basic_glyph_keyed() {
+        todo!()
+    }
+}

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -12,4 +12,5 @@
 #![forbid(unsafe_code)]
 
 pub mod font_patch;
+pub mod glyph_keyed;
 pub mod patchmap;

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -26,6 +26,8 @@ use read_fonts::collections::IntSet;
 use skrifa::charmap::Charmap;
 
 // TODO(garretrieger): implement support for building and compiling mapping tables.
+// TODO(garretrieger): implement coalescing of patches by patch URI, ensuring that all entries with the same
+//                     uri have matching encoding and compat id.
 
 /// Find the set of patches which intersect the specified subset definition.
 pub fn intersecting_patches(
@@ -161,6 +163,8 @@ fn intersect_format1_glyph_map_inner(
         } else {
             glyph_map
                 .entry_index()
+                // TODO(garretrieger): this branches to determine item size on each individual lookup, would
+                //                     likely be faster if we bypassed that since all items have the same length.
                 .get((gid.to_u32() - first_gid) as usize)?
                 .get()
         };

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -232,10 +232,10 @@ impl<'a> GlyphPatches<'a> {
     /// Returns an iterator over the per glyph data for the table with the given index.
     pub fn glyph_data_for_table(
         &'a self,
-        table_index: u32,
+        table_index: usize,
     ) -> impl Iterator<Item = Result<(GlyphId, &'a [u8]), ReadError>> {
         let glyph_count = self.glyph_count() as usize;
-        let start_index = table_index as usize * glyph_count;
+        let start_index = table_index * glyph_count;
         let start_it = self.glyph_data_offsets().iter().skip(start_index);
         let end_it = self.glyph_data_offsets().iter().skip(start_index + 1);
         let glyphs = self.glyph_ids().iter().take(glyph_count);


### PR DESCRIPTION
https://w3c.github.io/IFT/Overview.html#glyph-keyed

Currently only supports glyf/loca modification and is missing functionality to mark applied patches in the IFT tables.