### PR TITLE
Avoid various overflows in CFF

### DIFF
--- a/read-fonts/src/tables/postscript/stack.rs
+++ b/read-fonts/src/tables/postscript/stack.rs
@@ -204,6 +204,9 @@ impl Stack {
     /// "The second and subsequent numbers in a delta are encoded as the
     /// difference between successive values."
     ///
+    /// Roughly equivalent to the FreeType logic at
+    /// <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/cff/cffparse.c#L1431>
+    ///
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#table-6-operand-types>
     pub fn apply_delta_prefix_sum(&mut self) {
         if self.top > 1 {

--- a/read-fonts/src/tables/postscript/stack.rs
+++ b/read-fonts/src/tables/postscript/stack.rs
@@ -212,7 +212,7 @@ impl Stack {
                 .iter_mut()
                 .zip(&mut self.value_is_fixed)
             {
-                sum += if *is_fixed {
+                let fixed_value = if *is_fixed {
                     // FreeType reads delta values using cff_parse_num which
                     // which truncates the fractional parts of 16.16 values
                     // See delta parsing:
@@ -224,6 +224,12 @@ impl Stack {
                 } else {
                     Fixed::from_i32(*value)
                 };
+                // See <https://github.com/googlefonts/fontations/issues/1193>
+                // The "DIN Alternate" font contains incorrect blue values
+                // that cause an overflow in this computation. FreeType does
+                // not use checked arithmetic so we need to explicitly use
+                // wrapping behavior to produce matching outlines.
+                sum = sum.wrapping_add(fixed_value);
                 *value = sum.to_bits();
                 *is_fixed = true;
             }

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -282,7 +282,7 @@ impl HintState {
                 // Bottom edge captured by bottom zone.
                 adjustment = if self.suppress_overshoot {
                     zone.ds_flat_edge
-                } else if zone.cs_top_edge - bottom_edge.cs_coord >= self.blue_shift {
+                } else if zone.cs_top_edge.wrapping_sub(bottom_edge.cs_coord) >= self.blue_shift {
                     // Guarantee minimum of 1 pixel overshoot
                     bottom_edge
                         .ds_coord
@@ -303,7 +303,7 @@ impl HintState {
                 // Top edge captured by top zone.
                 adjustment = if self.suppress_overshoot {
                     zone.ds_flat_edge
-                } else if top_edge.cs_coord - zone.cs_bottom_edge >= self.blue_shift {
+                } else if top_edge.cs_coord.wrapping_sub(zone.cs_bottom_edge) >= self.blue_shift {
                     // Guarantee minimum of 1 pixel overshoot
                     top_edge
                         .ds_coord


### PR DESCRIPTION
Add targeted `wrapping_add` and `wrapping_sub` calls to avoid panics on arithmetic overflows for the specific case in #1193