### PR TITLE
[skrifa] replace todo! with None for color bbox

### DIFF
--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -294,27 +294,34 @@ impl<'a> ColorGlyph<'a> {
         }
     }
 
-    /// Returns the bounding box. For COLRv1 glyphs, this is clipbox of the
-    /// specified COLRv1 glyph, or `None` if there is
-    /// none for the particular glyph.  The `size` argument can optionally be used
-    /// to scale the bounding box to a particular font size. `location` allows
-    /// specifycing a variation instance.
+    /// Returns the bounding box.
+    ///
+    /// For COLRv1 glyphs, this is clip box of the specified COLRv1 glyph, or
+    /// `None` if clip boxes are not present or if there is none for the
+    /// particular glyph.
+    ///
+    /// Always returns `None` for COLRv0 glyphs because precomputed clip boxes
+    /// are never available.
+    ///
+    /// The `size` argument can optionally be used to scale the bounding box
+    /// to a particular font size and `location` allows specifying a variation
+    /// instance.
     pub fn bounding_box(
         &self,
         location: impl Into<LocationRef<'a>>,
         size: Size,
     ) -> Option<BoundingBox<f32>> {
-        let instance = instance::ColrInstance::new(self.colr.clone(), location.into().coords());
-
         match &self.root_paint_ref {
             ColorGlyphRoot::V1Paint(_paint, _paint_id, glyph_id, upem) => {
+                let instance =
+                    instance::ColrInstance::new(self.colr.clone(), location.into().coords());
                 let resolved_bounding_box = get_clipbox_font_units(&instance, *glyph_id);
                 resolved_bounding_box.map(|bounding_box| {
                     let scale_factor = size.linear_scale((*upem).clone().unwrap_or(0));
                     bounding_box.scale(scale_factor)
                 })
             }
-            _ => todo!(),
+            _ => None,
         }
     }
 

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -433,7 +433,8 @@ impl<'a> ColorGlyphCollection<'a> {
 mod tests {
 
     use crate::{
-        color::traversal_tests::test_glyph_defs::PAINTCOLRGLYPH_CYCLE, prelude::LocationRef,
+        color::traversal_tests::test_glyph_defs::PAINTCOLRGLYPH_CYCLE,
+        prelude::{LocationRef, Size},
         MetadataProvider,
     };
 
@@ -516,5 +517,19 @@ mod tests {
             .unwrap()
             .paint(LocationRef::default(), &mut color_painter);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn colrv0_no_bbox_test() {
+        let colr_font = font_test_data::COLRV0V1;
+        let font = FontRef::new(colr_font).unwrap();
+        let colrv0_glyph_id = GlyphId::new(168);
+        let colrv0_glyph = font
+            .color_glyphs()
+            .get_with_format(colrv0_glyph_id, super::ColorGlyphFormat::ColrV0)
+            .unwrap();
+        assert!(colrv0_glyph
+            .bounding_box(LocationRef::default(), Size::unscaled())
+            .is_none());
     }
 }

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -296,8 +296,8 @@ impl<'a> ColorGlyph<'a> {
 
     /// Returns the bounding box.
     ///
-    /// For COLRv1 glyphs, this is clip box of the specified COLRv1 glyph, or
-    /// `None` if clip boxes are not present or if there is none for the
+    /// For COLRv1 glyphs, this is the clip box of the specified COLRv1 glyph,
+    /// or `None` if clip boxes are not present or if there is none for the
     /// particular glyph.
     ///
     /// Always returns `None` for COLRv0 glyphs because precomputed clip boxes


### PR DESCRIPTION
Fixes abort caused by `todo!()` and caught by fuzzing.

ref
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71277 and https://oss-fuzz.com/testcase?key=5794538109599744

JMM if happy