### PR TITLE
[IFT] Add tests for error cases in Glyph Keyed patching.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -632,7 +632,8 @@ pub fn glyf_u16_glyph_patches() -> BeBuffer {
       // glyph ids * 5
       [2, 7u16],
       {8u16: "gid_8"},
-      [9, 13u16],
+      [9u16],
+      {13u16: "gid_13"},
 
       (Tag::new(b"glyf")),   // tables * 1
 

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -602,7 +602,7 @@ pub fn test_font_for_patching() -> Vec<u8> {
 // Format specification: https://w3c.github.io/IFT/Overview.html#glyph-keyed
 pub fn glyph_keyed_patch_header() -> BeBuffer {
     be_buffer! {
-      (Tag::new(b"ifgk")), // format
+      {(Tag::new(b"ifgk")): "format"}, // format
       0u32,                // reserved
       0u8,                 // flags (0 = u16 gids)
       [6, 7, 8, 9u32],     // compatibility id
@@ -774,8 +774,8 @@ pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
       3u32,       // glyph count
       2u8,        // table count
       [2, 7, 8u16],   // glyph ids * 3
-      (Tag::new(b"glyf")),   // tables[0]
-      (Tag::new(b"gvar")),   // tables[1]
+      (Tag::new(b"glyf")),               // tables[0]
+      {(Tag::new(b"gvar")): "gvar_tag"}, // tables[1]
 
       // glyph data offsets * 7
       {0u32: "glyf_gid_2_offset"},

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -12,7 +12,7 @@
 
 use crate::patchmap::{PatchEncoding, PatchUri};
 
-use crate::glyph_keyed::apply_glyph_keyed_patch;
+use crate::glyph_keyed::apply_glyph_keyed_patches;
 use read_fonts::tables::ift::{
     CompatibilityId, GlyphKeyedPatch, TableKeyedPatch, TablePatch, TablePatchFlags,
 };
@@ -181,7 +181,7 @@ impl IncrementalFontPatchBase for FontRef<'_> {
                 if glyph_keyed_patches.len() != patches.len() {
                     return Err(PatchingError::IncompatiblePatches);
                 }
-                apply_glyph_keyed_patch(&glyph_keyed_patches, self)
+                apply_glyph_keyed_patches(&glyph_keyed_patches, self)
             }
         }
     }

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -637,7 +637,7 @@ mod tests {
     }
 
     #[test]
-    fn glyph_keyed_unkown_table() {
+    fn glyph_keyed_unknown_table() {
         let mut builder = glyf_and_gvar_u16_glyph_patches();
         builder.write_at("gvar_tag", Tag::new(b"hijk"));
 

--- a/read-fonts/src/tables/loca.rs
+++ b/read-fonts/src/tables/loca.rs
@@ -41,6 +41,19 @@ impl<'a> Loca<'a> {
         self.len() == 0
     }
 
+    pub fn all_offsets_are_ascending(&self) -> bool {
+        match self {
+            Loca::Short(data) => !data
+                .iter()
+                .zip(data.iter().skip(1))
+                .any(|(start, end)| start > end),
+            Loca::Long(data) => !data
+                .iter()
+                .zip(data.iter().skip(1))
+                .any(|(start, end)| start > end),
+        }
+    }
+
     /// Attempt to return the offset for a given glyph id.
     pub fn get_raw(&self, idx: usize) -> Option<u32> {
         match self {
@@ -119,5 +132,60 @@ impl<'a> traversal::SomeArray<'a> for Loca<'a> {
 impl<'a> std::fmt::Debug for Loca<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn traversal::SomeTable<'a>).fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use types::Scalar;
+
+    use crate::test_helpers::BeBuffer;
+
+    use super::Loca;
+
+    fn to_loca_bytes<T: Scalar + Copy>(values: &[T]) -> (BeBuffer, bool) {
+        let value_num_bytes = std::mem::size_of::<T>();
+        let is_long = if value_num_bytes == 2 {
+            false
+        } else if value_num_bytes == 4 {
+            true
+        } else {
+            panic!("invalid integer type must be u32 or u16")
+        };
+        let mut buffer = BeBuffer::default();
+
+        for v in values {
+            buffer = buffer.push(*v);
+        }
+
+        (buffer, is_long)
+    }
+
+    fn check_loca_sorting(values: &[u16], is_sorted: bool) {
+        let (bytes, is_long) = to_loca_bytes(values);
+        let loca = Loca::read(bytes.font_data(), is_long).unwrap();
+        assert_eq!(loca.all_offsets_are_ascending(), is_sorted);
+
+        let u32_values: Vec<u32> = values.iter().map(|v| *v as u32).collect();
+        let (bytes, is_long) = to_loca_bytes(&u32_values);
+        let loca = Loca::read(bytes.font_data(), is_long).unwrap();
+        assert_eq!(loca.all_offsets_are_ascending(), is_sorted);
+    }
+
+    #[test]
+    fn all_offsets_are_ascending() {
+        // Sorted
+        let empty: &[u16] = &[];
+        check_loca_sorting(empty, true);
+        check_loca_sorting(&[0], true);
+        check_loca_sorting(&[0, 0], true);
+        check_loca_sorting(&[0, 1], true);
+        check_loca_sorting(&[1, 2, 2, 3, 7], true);
+
+        // Unsorted
+        check_loca_sorting(&[1, 0], false);
+        check_loca_sorting(&[1, 3, 2], false);
+        check_loca_sorting(&[2, 1, 3], false);
+        check_loca_sorting(&[1, 2, 3, 2, 7], false);
     }
 }


### PR DESCRIPTION
Adds a variety of tests that cover error cases when parsing and applying glyph keyed patches.