### PR TITLE
bump read-fonts to 0.23.1 and write-fonts to 0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.7.2", path = "font-types" }
-read-fonts = { version = "0.23.0", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.23.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.24.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.29.0", path = "write-fonts" }
+write-fonts = { version = "0.30.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder" }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.23.0"
+version = "0.23.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.29.0"
+version = "0.30.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
```
$ cargo release changes
     Changes for read-fonts from read-fonts-v0.23.0 to 0.23.1
             7914440 [IFT] enforce loca offset sortedness in glyph keyed patching.
             9bed00d [IFT] Add checks in glyph keyed patches.
             f5e359d [read-fonts] helper methods for layout tables (#1208)
             d52fd0c [read-fonts] avoid overflow in private dict range (#1203)
     Changes for write-fonts from write-fonts-v0.29.0 to 0.30.0
             002872e define OtRound for/to float types
             aa417e7 [write] Fixup doctest
             fa707c0 write-fonts: Fix `clippy::single_match` lint
             1110a3f [IFT] Add codegen definitions for Glyph Keyed patches.
             a9377e3 Mention trait in first example
             b4bea97 Highlight to_owned_table more strongly
             221c525 [IFT] Add a CompatibilityId type.
             f535d81 [IFT] in font_patch.rs add public method comments.
             a8ae76d Fix pluralization of 'patch' in codegen.
             f292aeb [ift] Finish implementing support for TableKeyed patches.
             8eff075 [ift] Begin implementing per table brotli patches.
             d4e29ac [read-fonts] add hdmx table (#1164)
             6364aef [codegen] From<Lookup<_>> for lookup enums
             79254d1 Regen the table
             cd89d23 Generate docs for most features on docs.rs
             5780ca0 avar2 support (#1120)
             1da14b0 [codegen] Support explicit #[count] arg for VarLenArray
             ed12575 [clippy] Push the rock back up the hill
             0e31241 Make traversal non-default feature
             a9d4f49 IFT Format 2: add handling for reading in id strings.
             7c5e968 IFT Format 2: Respect the 'ignored' flag bit.
             6b5de38 Switch codepoint_data to be non conditional now that it can be supported.
             6a2b474 s/enty/entry/
             5f116df Cleanup unused CopyIndices table in IFT Format 2.
             6cfaf56 Add basic test of format 2 parsing.
             ee9b0fd Update IFT format 2 decoding to add codepoint set parsing.
             f8b37ba Add calculation of entry id to format 2 decoding.
             91ece77 Use if_cond(any_flags(..)) to control presence of codepoint fields.
             1491439 Begin to implement parsing of entries in IFT format 2.
             da318c0 Switch IFT Format 1 glyph_count to u24.
             45b2105 [codegen] non-conditional fields after conditionals
             b631b7c [write-fonts] post table: de-duplicate psNames
```