### PR TITLE
typos: Check for `sftn` instead of `sfnt`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -34,3 +34,6 @@ wdth = "wdth"
 ot = "ot"
 vai = "vai"
 beng = "beng"
+
+# Possible typos that are more specific to this codebase.
+sftn = "sfnt"


### PR DESCRIPTION
This would have caught 45d9e53 (PR #1225).