### PR TITLE
[read-fonts] feature gate cubic glyf support

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -21,6 +21,9 @@ scaler_test = []
 # this feature is not stable, but provides untyped traversal of font tables.
 # we do not consider this feature public API for the purposes of semver.
 experimental_traverse = ["std"]
+# Enables experimental implementations of proposed changes to the spec
+# as discussed at https://github.com/harfbuzz/boring-expansion-spec
+spec_next = []
 default = ["std"]
 serde = ["dep:serde", "font-types/serde"]
 libm = ["dep:core_maths"]

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -263,11 +263,13 @@ impl<'a> SimpleGlyph<'a> {
             }
             y = y.wrapping_add(delta);
             point.y = C::from_i32(y);
-            // Ignore the cubic off curve bit until the cubic glyf portion of
-            // the spec is finalized
-            // See <https://github.com/googlefonts/fontations/issues/1221>
-            //*point_flags = PointFlags::from_bits(point_flags.0);
-            *point_flags = PointFlags(point_flags.0 & PointFlags::ON_CURVE);
+            let flags_mask = if cfg!(feature = "spec_next") {
+                PointFlags::CURVE_MASK
+            } else {
+                // Drop the cubic bit if the spec_next feature is not enabled
+                PointFlags::ON_CURVE
+            };
+            point_flags.0 &= flags_mask;
         }
         Ok(())
     }

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -263,7 +263,11 @@ impl<'a> SimpleGlyph<'a> {
             }
             y = y.wrapping_add(delta);
             point.y = C::from_i32(y);
-            *point_flags = PointFlags::from_bits(point_flags.0);
+            // Ignore the cubic off curve bit until the cubic glyf portion of
+            // the spec is finalized
+            // See <https://github.com/googlefonts/fontations/issues/1221>
+            //*point_flags = PointFlags::from_bits(point_flags.0);
+            *point_flags = PointFlags(point_flags.0 & PointFlags::ON_CURVE);
         }
         Ok(())
     }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -22,6 +22,9 @@ traversal = ["std", "read-fonts/experimental_traverse"]
 # This exists as a feature because shaping support is "best effort" and
 # we want the ability to disable it for testing against FreeType.
 autohint_shaping = []
+# Enables experimental implementations of proposed changes to the spec
+# as discussed at https://github.com/harfbuzz/boring-expansion-spec
+spec_next = ["read-fonts/spec_next"]
 libm = ["dep:core_maths", "read-fonts/libm"]
 
 [dependencies]

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -1349,12 +1349,11 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "spec_next")]
     const CUBIC_GLYPH: GlyphId = GlyphId::new(2);
 
     #[test]
-    // Ignore test until cubic glyf spec finalizes
-    // See <https://github.com/googlefonts/fontations/issues/1221>
-    #[ignore]
+    #[cfg(feature = "spec_next")]
     fn draw_cubic() {
         let font = FontRef::new(font_test_data::CUBIC_GLYF).unwrap();
         assert_glyph_path_start_with(

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -1352,6 +1352,9 @@ mod tests {
     const CUBIC_GLYPH: GlyphId = GlyphId::new(2);
 
     #[test]
+    // Ignore test until cubic glyf spec finalizes
+    // See <https://github.com/googlefonts/fontations/issues/1221>
+    #[ignore]
     fn draw_cubic() {
         let font = FontRef::new(font_test_data::CUBIC_GLYF).unwrap();
         assert_glyph_path_start_with(

--- a/skrifa/src/outline/unscaled.rs
+++ b/skrifa/src/outline/unscaled.rs
@@ -260,6 +260,9 @@ mod tests {
     }
 
     #[test]
+    // Ignore test until cubic glyf spec finalizes
+    // See <https://github.com/googlefonts/fontations/issues/1221>
+    #[ignore]
     fn read_cubic_glyf_outline() {
         let font = FontRef::new(font_test_data::CUBIC_GLYF).unwrap();
         let glyph = font.outline_glyphs().get(GlyphId::new(2)).unwrap();

--- a/skrifa/src/outline/unscaled.rs
+++ b/skrifa/src/outline/unscaled.rs
@@ -260,9 +260,7 @@ mod tests {
     }
 
     #[test]
-    // Ignore test until cubic glyf spec finalizes
-    // See <https://github.com/googlefonts/fontations/issues/1221>
-    #[ignore]
+    #[cfg(feature = "spec_next")]
     fn read_cubic_glyf_outline() {
         let font = FontRef::new(font_test_data::CUBIC_GLYF).unwrap();
         let glyph = font.outline_glyphs().get(GlyphId::new(2)).unwrap();


### PR DESCRIPTION
We don't want to ship experimental functionality in Chrome. Resolved per #1221 to mask out the bit and re-enable later. Also ignores two tests for this.

cc @drott