### PR TITLE
[read-fonts] gvar: improve delta decoding perf

### DIFF
--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -1385,7 +1385,7 @@ mod tests {
     /// with a packed run boundary
     #[test]
     fn packed_delta_run_crosses_coord_boundary() {
-        // 8 deltas with values 0..=8 with a run broken after the first 6; the
+        // 8 deltas with values 0..=7 with a run broken after the first 6; the
         // coordinate boundary occurs after the first 4
         static INPUT: FontData = FontData::new(&[
             // first run: 6 deltas as bytes

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -523,7 +523,7 @@ struct DeltaRunInfo {
 
 /// Helper yields the accumulated count and offset for each run in a delta
 /// stream.
-fn delta_run_info<'a>(data: FontData<'a>) -> impl Iterator<Item = DeltaRunInfo> + 'a {
+fn delta_run_info(data: FontData<'_>) -> impl Iterator<Item = DeltaRunInfo> + '_ {
     let mut info = DeltaRunInfo::default();
     std::iter::from_fn(move || {
         let control = data.read_at::<u8>(info.offset).ok()?;


### PR DESCRIPTION
Determining the delta count and offset to the y-deltas requires processing the full stream, but we really only need to read the control byte for each run to do so.

This gives a roughly 30%(!) boost in loading outlines from variable TrueType fonts.