### PR TITLE
[read] Expose table marker, make range fns public

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -908,7 +908,7 @@ impl Table {
                 };
                 let start_field_name = field.shape_byte_start_field_name();
                 return Some(quote! {
-                    fn #fn_name(&self) -> Option<Range<usize>> {
+                    pub fn #fn_name(&self) -> Option<Range<usize>> {
                         let start = self.#start_field_name?;
                         Some(start..start + #len_expr)
                     }
@@ -916,7 +916,7 @@ impl Table {
             }
 
             let result = quote! {
-                fn #fn_name(&self) -> Range<usize> {
+                pub fn #fn_name(&self) -> Range<usize> {
                     let start = #prev_field_end_expr;
                     start..start + #len_expr
                 }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -13,27 +13,32 @@ pub struct TableDirectoryMarker {
 }
 
 impl TableDirectoryMarker {
-    fn sfnt_version_byte_range(&self) -> Range<usize> {
+    pub fn sfnt_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_tables_byte_range(&self) -> Range<usize> {
+
+    pub fn num_tables_byte_range(&self) -> Range<usize> {
         let start = self.sfnt_version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn search_range_byte_range(&self) -> Range<usize> {
+
+    pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.num_tables_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_selector_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_shift_byte_range(&self) -> Range<usize> {
+
+    pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn table_records_byte_range(&self) -> Range<usize> {
+
+    pub fn table_records_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
         start..start + self.table_records_byte_len
     }
@@ -197,31 +202,37 @@ pub struct TTCHeaderMarker {
 }
 
 impl TTCHeaderMarker {
-    fn ttc_tag_byte_range(&self) -> Range<usize> {
+    pub fn ttc_tag_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Tag::RAW_BYTE_LEN
     }
-    fn version_byte_range(&self) -> Range<usize> {
+
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = self.ttc_tag_byte_range().end;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn num_fonts_byte_range(&self) -> Range<usize> {
+
+    pub fn num_fonts_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn table_directory_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn table_directory_offsets_byte_range(&self) -> Range<usize> {
         let start = self.num_fonts_byte_range().end;
         start..start + self.table_directory_offsets_byte_len
     }
-    fn dsig_tag_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn dsig_tag_byte_range(&self) -> Option<Range<usize>> {
         let start = self.dsig_tag_byte_start?;
         Some(start..start + u32::RAW_BYTE_LEN)
     }
-    fn dsig_length_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn dsig_length_byte_range(&self) -> Option<Range<usize>> {
         let start = self.dsig_length_byte_start?;
         Some(start..start + u32::RAW_BYTE_LEN)
     }
-    fn dsig_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn dsig_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.dsig_offset_byte_start?;
         Some(start..start + u32::RAW_BYTE_LEN)
     }

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -102,11 +102,12 @@ pub struct Lookup0Marker {
 }
 
 impl Lookup0Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn values_data_byte_range(&self) -> Range<usize> {
+
+    pub fn values_data_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + self.values_data_byte_len
     }
@@ -177,31 +178,37 @@ pub struct Lookup2Marker {
 }
 
 impl Lookup2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn unit_size_byte_range(&self) -> Range<usize> {
+
+    pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn n_units_byte_range(&self) -> Range<usize> {
+
+    pub fn n_units_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn search_range_byte_range(&self) -> Range<usize> {
+
+    pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_units_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_selector_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_shift_byte_range(&self) -> Range<usize> {
+
+    pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn segments_data_byte_range(&self) -> Range<usize> {
+
+    pub fn segments_data_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
         start..start + self.segments_data_byte_len
     }
@@ -315,31 +322,37 @@ pub struct Lookup4Marker {
 }
 
 impl Lookup4Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn unit_size_byte_range(&self) -> Range<usize> {
+
+    pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn n_units_byte_range(&self) -> Range<usize> {
+
+    pub fn n_units_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn search_range_byte_range(&self) -> Range<usize> {
+
+    pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_units_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_selector_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_shift_byte_range(&self) -> Range<usize> {
+
+    pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn segments_byte_range(&self) -> Range<usize> {
+
+    pub fn segments_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
         start..start + self.segments_byte_len
     }
@@ -507,31 +520,37 @@ pub struct Lookup6Marker {
 }
 
 impl Lookup6Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn unit_size_byte_range(&self) -> Range<usize> {
+
+    pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn n_units_byte_range(&self) -> Range<usize> {
+
+    pub fn n_units_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn search_range_byte_range(&self) -> Range<usize> {
+
+    pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_units_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_selector_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_shift_byte_range(&self) -> Range<usize> {
+
+    pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entries_data_byte_range(&self) -> Range<usize> {
+
+    pub fn entries_data_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
         start..start + self.entries_data_byte_len
     }
@@ -643,19 +662,22 @@ pub struct Lookup8Marker {
 }
 
 impl Lookup8Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn first_glyph_byte_range(&self) -> Range<usize> {
+
+    pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn value_array_byte_range(&self) -> Range<usize> {
+
+    pub fn value_array_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.value_array_byte_len
     }
@@ -743,23 +765,27 @@ pub struct Lookup10Marker {
 }
 
 impl Lookup10Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn unit_size_byte_range(&self) -> Range<usize> {
+
+    pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn first_glyph_byte_range(&self) -> Range<usize> {
+
+    pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn values_data_byte_range(&self) -> Range<usize> {
+
+    pub fn values_data_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.values_data_byte_len
     }
@@ -849,19 +875,22 @@ impl<'a> std::fmt::Debug for Lookup10<'a> {
 pub struct StateHeaderMarker {}
 
 impl StateHeaderMarker {
-    fn state_size_byte_range(&self) -> Range<usize> {
+    pub fn state_size_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_table_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn class_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.state_size_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn state_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn state_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.class_table_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn entry_table_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.state_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -966,15 +995,17 @@ pub struct ClassSubtableMarker {
 }
 
 impl ClassSubtableMarker {
-    fn first_glyph_byte_range(&self) -> Range<usize> {
+    pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn n_glyphs_byte_range(&self) -> Range<usize> {
+
+    pub fn n_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_array_byte_range(&self) -> Range<usize> {
+
+    pub fn class_array_byte_range(&self) -> Range<usize> {
         let start = self.n_glyphs_byte_range().end;
         start..start + self.class_array_byte_len
     }
@@ -1049,7 +1080,7 @@ pub struct RawBytesMarker {
 }
 
 impl RawBytesMarker {
-    fn data_byte_range(&self) -> Range<usize> {
+    pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data_byte_len
     }
@@ -1100,19 +1131,22 @@ impl<'a> std::fmt::Debug for RawBytes<'a> {
 pub struct StxHeaderMarker {}
 
 impl StxHeaderMarker {
-    fn n_classes_byte_range(&self) -> Range<usize> {
+    pub fn n_classes_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn class_table_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn class_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.n_classes_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn state_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn state_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.class_table_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn entry_table_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.state_array_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
@@ -1216,7 +1250,7 @@ pub struct RawWordsMarker {
 }
 
 impl RawWordsMarker {
-    fn data_byte_range(&self) -> Range<usize> {
+    pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data_byte_len
     }

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -11,19 +11,22 @@ use crate::codegen_prelude::*;
 pub struct AnkrMarker {}
 
 impl AnkrMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookup_table_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn glyph_data_table_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_data_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.lookup_table_offset_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -118,11 +121,12 @@ pub struct GlyphDataEntryMarker {
 }
 
 impl GlyphDataEntryMarker {
-    fn num_points_byte_range(&self) -> Range<usize> {
+    pub fn num_points_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn anchor_points_byte_range(&self) -> Range<usize> {
+
+    pub fn anchor_points_byte_range(&self) -> Range<usize> {
         let start = self.num_points_byte_range().end;
         start..start + self.anchor_points_byte_len
     }

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -15,27 +15,32 @@ pub struct AvarMarker {
 }
 
 impl AvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_count_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_segment_maps_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_segment_maps_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
         start..start + self.axis_segment_maps_byte_len
     }
-    fn axis_index_map_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn axis_index_map_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.axis_index_map_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn var_store_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn var_store_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.var_store_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -13,19 +13,22 @@ pub struct BaseMarker {
 }
 
 impl BaseMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn horiz_axis_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn horiz_axis_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn vert_axis_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn vert_axis_offset_byte_range(&self) -> Range<usize> {
         let start = self.horiz_axis_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn item_var_store_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn item_var_store_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.item_var_store_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
@@ -141,11 +144,12 @@ impl<'a> std::fmt::Debug for Base<'a> {
 pub struct AxisMarker {}
 
 impl AxisMarker {
-    fn base_tag_list_offset_byte_range(&self) -> Range<usize> {
+    pub fn base_tag_list_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn base_script_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn base_script_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_tag_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -225,11 +229,12 @@ pub struct BaseTagListMarker {
 }
 
 impl BaseTagListMarker {
-    fn base_tag_count_byte_range(&self) -> Range<usize> {
+    pub fn base_tag_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn baseline_tags_byte_range(&self) -> Range<usize> {
+
+    pub fn baseline_tags_byte_range(&self) -> Range<usize> {
         let start = self.base_tag_count_byte_range().end;
         start..start + self.baseline_tags_byte_len
     }
@@ -297,11 +302,12 @@ pub struct BaseScriptListMarker {
 }
 
 impl BaseScriptListMarker {
-    fn base_script_count_byte_range(&self) -> Range<usize> {
+    pub fn base_script_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_script_records_byte_range(&self) -> Range<usize> {
+
+    pub fn base_script_records_byte_range(&self) -> Range<usize> {
         let start = self.base_script_count_byte_range().end;
         start..start + self.base_script_records_byte_len
     }
@@ -428,19 +434,22 @@ pub struct BaseScriptMarker {
 }
 
 impl BaseScriptMarker {
-    fn base_values_offset_byte_range(&self) -> Range<usize> {
+    pub fn base_values_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn default_min_max_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn default_min_max_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_values_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn base_lang_sys_count_byte_range(&self) -> Range<usize> {
+
+    pub fn base_lang_sys_count_byte_range(&self) -> Range<usize> {
         let start = self.default_min_max_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_lang_sys_records_byte_range(&self) -> Range<usize> {
+
+    pub fn base_lang_sys_records_byte_range(&self) -> Range<usize> {
         let start = self.base_lang_sys_count_byte_range().end;
         start..start + self.base_lang_sys_records_byte_len
     }
@@ -604,15 +613,17 @@ pub struct BaseValuesMarker {
 }
 
 impl BaseValuesMarker {
-    fn default_baseline_index_byte_range(&self) -> Range<usize> {
+    pub fn default_baseline_index_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_coord_count_byte_range(&self) -> Range<usize> {
+
+    pub fn base_coord_count_byte_range(&self) -> Range<usize> {
         let start = self.default_baseline_index_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_coord_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn base_coord_offsets_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_count_byte_range().end;
         start..start + self.base_coord_offsets_byte_len
     }
@@ -714,19 +725,22 @@ pub struct MinMaxMarker {
 }
 
 impl MinMaxMarker {
-    fn min_coord_offset_byte_range(&self) -> Range<usize> {
+    pub fn min_coord_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn max_coord_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn max_coord_offset_byte_range(&self) -> Range<usize> {
         let start = self.min_coord_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn feat_min_max_count_byte_range(&self) -> Range<usize> {
+
+    pub fn feat_min_max_count_byte_range(&self) -> Range<usize> {
         let start = self.max_coord_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn feat_min_max_records_byte_range(&self) -> Range<usize> {
+
+    pub fn feat_min_max_records_byte_range(&self) -> Range<usize> {
         let start = self.feat_min_max_count_byte_range().end;
         start..start + self.feat_min_max_records_byte_len
     }
@@ -994,11 +1008,12 @@ impl Format<u16> for BaseCoordFormat1Marker {
 pub struct BaseCoordFormat1Marker {}
 
 impl BaseCoordFormat1Marker {
-    fn base_coord_format_byte_range(&self) -> Range<usize> {
+    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
@@ -1061,19 +1076,22 @@ impl Format<u16> for BaseCoordFormat2Marker {
 pub struct BaseCoordFormat2Marker {}
 
 impl BaseCoordFormat2Marker {
-    fn base_coord_format_byte_range(&self) -> Range<usize> {
+    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reference_glyph_byte_range(&self) -> Range<usize> {
+
+    pub fn reference_glyph_byte_range(&self) -> Range<usize> {
         let start = self.coordinate_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_coord_point_byte_range(&self) -> Range<usize> {
+
+    pub fn base_coord_point_byte_range(&self) -> Range<usize> {
         let start = self.reference_glyph_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -1152,15 +1170,17 @@ impl Format<u16> for BaseCoordFormat3Marker {
 pub struct BaseCoordFormat3Marker {}
 
 impl BaseCoordFormat3Marker {
-    fn base_coord_format_byte_range(&self) -> Range<usize> {
+    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn device_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn device_offset_byte_range(&self) -> Range<usize> {
         let start = self.coordinate_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -742,15 +742,17 @@ impl<'a> SomeRecord<'a> for SmallGlyphMetrics {
 pub struct IndexSubtableArrayMarker {}
 
 impl IndexSubtableArrayMarker {
-    fn first_glyph_index_byte_range(&self) -> Range<usize> {
+    pub fn first_glyph_index_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + GlyphId16::RAW_BYTE_LEN
     }
-    fn last_glyph_index_byte_range(&self) -> Range<usize> {
+
+    pub fn last_glyph_index_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_index_byte_range().end;
         start..start + GlyphId16::RAW_BYTE_LEN
     }
-    fn additional_offset_to_index_subtable_byte_range(&self) -> Range<usize> {
+
+    pub fn additional_offset_to_index_subtable_byte_range(&self) -> Range<usize> {
         let start = self.last_glyph_index_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -926,19 +928,22 @@ pub struct IndexSubtable1Marker {
 }
 
 impl IndexSubtable1Marker {
-    fn index_format_byte_range(&self) -> Range<usize> {
+    pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_format_byte_range(&self) -> Range<usize> {
+
+    pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn sbit_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn sbit_offsets_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
         start..start + self.sbit_offsets_byte_len
     }
@@ -1022,23 +1027,27 @@ pub struct IndexSubtable2Marker {
 }
 
 impl IndexSubtable2Marker {
-    fn index_format_byte_range(&self) -> Range<usize> {
+    pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_format_byte_range(&self) -> Range<usize> {
+
+    pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn image_size_byte_range(&self) -> Range<usize> {
+
+    pub fn image_size_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn big_metrics_byte_range(&self) -> Range<usize> {
+
+    pub fn big_metrics_byte_range(&self) -> Range<usize> {
         let start = self.image_size_byte_range().end;
         start..start + self.big_metrics_byte_len
     }
@@ -1137,19 +1146,22 @@ pub struct IndexSubtable3Marker {
 }
 
 impl IndexSubtable3Marker {
-    fn index_format_byte_range(&self) -> Range<usize> {
+    pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_format_byte_range(&self) -> Range<usize> {
+
+    pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn sbit_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn sbit_offsets_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
         start..start + self.sbit_offsets_byte_len
     }
@@ -1233,23 +1245,27 @@ pub struct IndexSubtable4Marker {
 }
 
 impl IndexSubtable4Marker {
-    fn index_format_byte_range(&self) -> Range<usize> {
+    pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_format_byte_range(&self) -> Range<usize> {
+
+    pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_glyphs_byte_range(&self) -> Range<usize> {
+
+    pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn glyph_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let start = self.num_glyphs_byte_range().end;
         start..start + self.glyph_array_byte_len
     }
@@ -1393,31 +1409,37 @@ pub struct IndexSubtable5Marker {
 }
 
 impl IndexSubtable5Marker {
-    fn index_format_byte_range(&self) -> Range<usize> {
+    pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_format_byte_range(&self) -> Range<usize> {
+
+    pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn image_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn image_size_byte_range(&self) -> Range<usize> {
+
+    pub fn image_size_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn big_metrics_byte_range(&self) -> Range<usize> {
+
+    pub fn big_metrics_byte_range(&self) -> Range<usize> {
         let start = self.image_size_byte_range().end;
         start..start + self.big_metrics_byte_len
     }
-    fn num_glyphs_byte_range(&self) -> Range<usize> {
+
+    pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.big_metrics_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn glyph_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let start = self.num_glyphs_byte_range().end;
         start..start + self.glyph_array_byte_len
     }

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -11,11 +11,12 @@ use crate::codegen_prelude::*;
 pub struct CbdtMarker {}
 
 impl CbdtMarker {
-    fn major_version_byte_range(&self) -> Range<usize> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn minor_version_byte_range(&self) -> Range<usize> {
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -13,19 +13,22 @@ pub struct CblcMarker {
 }
 
 impl CblcMarker {
-    fn major_version_byte_range(&self) -> Range<usize> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn minor_version_byte_range(&self) -> Range<usize> {
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_sizes_byte_range(&self) -> Range<usize> {
+
+    pub fn num_sizes_byte_range(&self) -> Range<usize> {
         let start = self.minor_version_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn bitmap_sizes_byte_range(&self) -> Range<usize> {
+
+    pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
         let start = self.num_sizes_byte_range().end;
         start..start + self.bitmap_sizes_byte_len
     }

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -14,27 +14,32 @@ pub struct CffHeaderMarker {
 }
 
 impl CffHeaderMarker {
-    fn major_byte_range(&self) -> Range<usize> {
+    pub fn major_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn minor_byte_range(&self) -> Range<usize> {
+
+    pub fn minor_byte_range(&self) -> Range<usize> {
         let start = self.major_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn hdr_size_byte_range(&self) -> Range<usize> {
+
+    pub fn hdr_size_byte_range(&self) -> Range<usize> {
         let start = self.minor_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn off_size_byte_range(&self) -> Range<usize> {
+
+    pub fn off_size_byte_range(&self) -> Range<usize> {
         let start = self.hdr_size_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn _padding_byte_range(&self) -> Range<usize> {
+
+    pub fn _padding_byte_range(&self) -> Range<usize> {
         let start = self.off_size_byte_range().end;
         start..start + self._padding_byte_len
     }
-    fn trailing_data_byte_range(&self) -> Range<usize> {
+
+    pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self._padding_byte_range().end;
         start..start + self.trailing_data_byte_len
     }

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -15,31 +15,37 @@ pub struct Cff2HeaderMarker {
 }
 
 impl Cff2HeaderMarker {
-    fn major_version_byte_range(&self) -> Range<usize> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn minor_version_byte_range(&self) -> Range<usize> {
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn header_size_byte_range(&self) -> Range<usize> {
+
+    pub fn header_size_byte_range(&self) -> Range<usize> {
         let start = self.minor_version_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn top_dict_length_byte_range(&self) -> Range<usize> {
+
+    pub fn top_dict_length_byte_range(&self) -> Range<usize> {
         let start = self.header_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn _padding_byte_range(&self) -> Range<usize> {
+
+    pub fn _padding_byte_range(&self) -> Range<usize> {
         let start = self.top_dict_length_byte_range().end;
         start..start + self._padding_byte_len
     }
-    fn top_dict_data_byte_range(&self) -> Range<usize> {
+
+    pub fn top_dict_data_byte_range(&self) -> Range<usize> {
         let start = self._padding_byte_range().end;
         start..start + self.top_dict_data_byte_len
     }
-    fn trailing_data_byte_range(&self) -> Range<usize> {
+
+    pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self.top_dict_data_byte_range().end;
         start..start + self.trailing_data_byte_len
     }

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -13,15 +13,17 @@ pub struct CmapMarker {
 }
 
 impl CmapMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_tables_byte_range(&self) -> Range<usize> {
+
+    pub fn num_tables_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn encoding_records_byte_range(&self) -> Range<usize> {
+
+    pub fn encoding_records_byte_range(&self) -> Range<usize> {
         let start = self.num_tables_byte_range().end;
         start..start + self.encoding_records_byte_len
     }
@@ -324,19 +326,22 @@ pub struct Cmap0Marker {
 }
 
 impl Cmap0Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_id_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + self.glyph_id_array_byte_len
     }
@@ -423,19 +428,22 @@ pub struct Cmap2Marker {
 }
 
 impl Cmap2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn sub_header_keys_byte_range(&self) -> Range<usize> {
+
+    pub fn sub_header_keys_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + self.sub_header_keys_byte_len
     }
@@ -586,55 +594,67 @@ pub struct Cmap4Marker {
 }
 
 impl Cmap4Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seg_count_x2_byte_range(&self) -> Range<usize> {
+
+    pub fn seg_count_x2_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn search_range_byte_range(&self) -> Range<usize> {
+
+    pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.seg_count_x2_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_selector_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_shift_byte_range(&self) -> Range<usize> {
+
+    pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn end_code_byte_range(&self) -> Range<usize> {
+
+    pub fn end_code_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
         start..start + self.end_code_byte_len
     }
-    fn reserved_pad_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved_pad_byte_range(&self) -> Range<usize> {
         let start = self.end_code_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn start_code_byte_range(&self) -> Range<usize> {
+
+    pub fn start_code_byte_range(&self) -> Range<usize> {
         let start = self.reserved_pad_byte_range().end;
         start..start + self.start_code_byte_len
     }
-    fn id_delta_byte_range(&self) -> Range<usize> {
+
+    pub fn id_delta_byte_range(&self) -> Range<usize> {
         let start = self.start_code_byte_range().end;
         start..start + self.id_delta_byte_len
     }
-    fn id_range_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn id_range_offsets_byte_range(&self) -> Range<usize> {
         let start = self.id_delta_byte_range().end;
         start..start + self.id_range_offsets_byte_len
     }
-    fn glyph_id_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.id_range_offsets_byte_range().end;
         start..start + self.glyph_id_array_byte_len
     }
@@ -805,27 +825,32 @@ pub struct Cmap6Marker {
 }
 
 impl Cmap6Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn first_code_byte_range(&self) -> Range<usize> {
+
+    pub fn first_code_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_count_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_count_byte_range(&self) -> Range<usize> {
         let start = self.first_code_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_id_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.entry_count_byte_range().end;
         start..start + self.glyph_id_array_byte_len
     }
@@ -929,31 +954,37 @@ pub struct Cmap8Marker {
 }
 
 impl Cmap8Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn is32_byte_range(&self) -> Range<usize> {
+
+    pub fn is32_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + self.is32_byte_len
     }
-    fn num_groups_byte_range(&self) -> Range<usize> {
+
+    pub fn num_groups_byte_range(&self) -> Range<usize> {
         let start = self.is32_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn groups_byte_range(&self) -> Range<usize> {
+
+    pub fn groups_byte_range(&self) -> Range<usize> {
         let start = self.num_groups_byte_range().end;
         start..start + self.groups_byte_len
     }
@@ -1128,31 +1159,37 @@ pub struct Cmap10Marker {
 }
 
 impl Cmap10Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn start_char_code_byte_range(&self) -> Range<usize> {
+
+    pub fn start_char_code_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_chars_byte_range(&self) -> Range<usize> {
+
+    pub fn num_chars_byte_range(&self) -> Range<usize> {
         let start = self.start_char_code_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn glyph_id_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.num_chars_byte_range().end;
         start..start + self.glyph_id_array_byte_len
     }
@@ -1255,27 +1292,32 @@ pub struct Cmap12Marker {
 }
 
 impl Cmap12Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_groups_byte_range(&self) -> Range<usize> {
+
+    pub fn num_groups_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn groups_byte_range(&self) -> Range<usize> {
+
+    pub fn groups_byte_range(&self) -> Range<usize> {
         let start = self.num_groups_byte_range().end;
         start..start + self.groups_byte_len
     }
@@ -1376,27 +1418,32 @@ pub struct Cmap13Marker {
 }
 
 impl Cmap13Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn language_byte_range(&self) -> Range<usize> {
+
+    pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_groups_byte_range(&self) -> Range<usize> {
+
+    pub fn num_groups_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn groups_byte_range(&self) -> Range<usize> {
+
+    pub fn groups_byte_range(&self) -> Range<usize> {
         let start = self.num_groups_byte_range().end;
         start..start + self.groups_byte_len
     }
@@ -1549,19 +1596,22 @@ pub struct Cmap14Marker {
 }
 
 impl Cmap14Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn length_byte_range(&self) -> Range<usize> {
+
+    pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_var_selector_records_byte_range(&self) -> Range<usize> {
+
+    pub fn num_var_selector_records_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn var_selector_byte_range(&self) -> Range<usize> {
+
+    pub fn var_selector_byte_range(&self) -> Range<usize> {
         let start = self.num_var_selector_records_byte_range().end;
         start..start + self.var_selector_byte_len
     }
@@ -1735,11 +1785,12 @@ pub struct DefaultUvsMarker {
 }
 
 impl DefaultUvsMarker {
-    fn num_unicode_value_ranges_byte_range(&self) -> Range<usize> {
+    pub fn num_unicode_value_ranges_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn ranges_byte_range(&self) -> Range<usize> {
         let start = self.num_unicode_value_ranges_byte_range().end;
         start..start + self.ranges_byte_len
     }
@@ -1813,11 +1864,12 @@ pub struct NonDefaultUvsMarker {
 }
 
 impl NonDefaultUvsMarker {
-    fn num_uvs_mappings_byte_range(&self) -> Range<usize> {
+    pub fn num_uvs_mappings_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn uvs_mapping_byte_range(&self) -> Range<usize> {
+
+    pub fn uvs_mapping_byte_range(&self) -> Range<usize> {
         let start = self.num_uvs_mappings_byte_range().end;
         start..start + self.uvs_mapping_byte_len
     }

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -17,43 +17,52 @@ pub struct ColrMarker {
 }
 
 impl ColrMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_base_glyph_records_byte_range(&self) -> Range<usize> {
+
+    pub fn num_base_glyph_records_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_glyph_records_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn base_glyph_records_offset_byte_range(&self) -> Range<usize> {
         let start = self.num_base_glyph_records_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn layer_records_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn layer_records_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_glyph_records_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn num_layer_records_byte_range(&self) -> Range<usize> {
+
+    pub fn num_layer_records_byte_range(&self) -> Range<usize> {
         let start = self.layer_records_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_glyph_list_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn base_glyph_list_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.base_glyph_list_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn layer_list_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn layer_list_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.layer_list_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn clip_list_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn clip_list_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.clip_list_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn var_index_map_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn var_index_map_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.var_index_map_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn item_variation_store_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn item_variation_store_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.item_variation_store_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
@@ -398,11 +407,12 @@ pub struct BaseGlyphListMarker {
 }
 
 impl BaseGlyphListMarker {
-    fn num_base_glyph_paint_records_byte_range(&self) -> Range<usize> {
+    pub fn num_base_glyph_paint_records_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn base_glyph_paint_records_byte_range(&self) -> Range<usize> {
+
+    pub fn base_glyph_paint_records_byte_range(&self) -> Range<usize> {
         let start = self.num_base_glyph_paint_records_byte_range().end;
         start..start + self.base_glyph_paint_records_byte_len
     }
@@ -529,11 +539,12 @@ pub struct LayerListMarker {
 }
 
 impl LayerListMarker {
-    fn num_layers_byte_range(&self) -> Range<usize> {
+    pub fn num_layers_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn paint_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offsets_byte_range(&self) -> Range<usize> {
         let start = self.num_layers_byte_range().end;
         start..start + self.paint_offsets_byte_len
     }
@@ -618,15 +629,17 @@ pub struct ClipListMarker {
 }
 
 impl ClipListMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn num_clips_byte_range(&self) -> Range<usize> {
+
+    pub fn num_clips_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn clips_byte_range(&self) -> Range<usize> {
+
+    pub fn clips_byte_range(&self) -> Range<usize> {
         let start = self.num_clips_byte_range().end;
         start..start + self.clips_byte_len
     }
@@ -864,23 +877,27 @@ impl Format<u8> for ClipBoxFormat1Marker {
 pub struct ClipBoxFormat1Marker {}
 
 impl ClipBoxFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn x_min_byte_range(&self) -> Range<usize> {
+
+    pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y_min_byte_range(&self) -> Range<usize> {
+
+    pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x_max_byte_range(&self) -> Range<usize> {
+
+    pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y_max_byte_range(&self) -> Range<usize> {
+
+    pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -967,27 +984,32 @@ impl Format<u8> for ClipBoxFormat2Marker {
 pub struct ClipBoxFormat2Marker {}
 
 impl ClipBoxFormat2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn x_min_byte_range(&self) -> Range<usize> {
+
+    pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y_min_byte_range(&self) -> Range<usize> {
+
+    pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x_max_byte_range(&self) -> Range<usize> {
+
+    pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y_max_byte_range(&self) -> Range<usize> {
+
+    pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -1281,15 +1303,17 @@ pub struct ColorLineMarker {
 }
 
 impl ColorLineMarker {
-    fn extend_byte_range(&self) -> Range<usize> {
+    pub fn extend_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Extend::RAW_BYTE_LEN
     }
-    fn num_stops_byte_range(&self) -> Range<usize> {
+
+    pub fn num_stops_byte_range(&self) -> Range<usize> {
         let start = self.extend_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn color_stops_byte_range(&self) -> Range<usize> {
+
+    pub fn color_stops_byte_range(&self) -> Range<usize> {
         let start = self.num_stops_byte_range().end;
         start..start + self.color_stops_byte_len
     }
@@ -1369,15 +1393,17 @@ pub struct VarColorLineMarker {
 }
 
 impl VarColorLineMarker {
-    fn extend_byte_range(&self) -> Range<usize> {
+    pub fn extend_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Extend::RAW_BYTE_LEN
     }
-    fn num_stops_byte_range(&self) -> Range<usize> {
+
+    pub fn num_stops_byte_range(&self) -> Range<usize> {
         let start = self.extend_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn color_stops_byte_range(&self) -> Range<usize> {
+
+    pub fn color_stops_byte_range(&self) -> Range<usize> {
         let start = self.num_stops_byte_range().end;
         start..start + self.color_stops_byte_len
     }
@@ -1742,15 +1768,17 @@ impl Format<u8> for PaintColrLayersMarker {
 pub struct PaintColrLayersMarker {}
 
 impl PaintColrLayersMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn num_layers_byte_range(&self) -> Range<usize> {
+
+    pub fn num_layers_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn first_layer_index_byte_range(&self) -> Range<usize> {
+
+    pub fn first_layer_index_byte_range(&self) -> Range<usize> {
         let start = self.num_layers_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -1821,15 +1849,17 @@ impl Format<u8> for PaintSolidMarker {
 pub struct PaintSolidMarker {}
 
 impl PaintSolidMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn palette_index_byte_range(&self) -> Range<usize> {
+
+    pub fn palette_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn alpha_byte_range(&self) -> Range<usize> {
+
+    pub fn alpha_byte_range(&self) -> Range<usize> {
         let start = self.palette_index_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -1900,19 +1930,22 @@ impl Format<u8> for PaintVarSolidMarker {
 pub struct PaintVarSolidMarker {}
 
 impl PaintVarSolidMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn palette_index_byte_range(&self) -> Range<usize> {
+
+    pub fn palette_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn alpha_byte_range(&self) -> Range<usize> {
+
+    pub fn alpha_byte_range(&self) -> Range<usize> {
         let start = self.palette_index_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.alpha_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -1991,35 +2024,42 @@ impl Format<u8> for PaintLinearGradientMarker {
 pub struct PaintLinearGradientMarker {}
 
 impl PaintLinearGradientMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn color_line_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x0_byte_range(&self) -> Range<usize> {
+
+    pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y0_byte_range(&self) -> Range<usize> {
+
+    pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x1_byte_range(&self) -> Range<usize> {
+
+    pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y1_byte_range(&self) -> Range<usize> {
+
+    pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x2_byte_range(&self) -> Range<usize> {
+
+    pub fn x2_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y2_byte_range(&self) -> Range<usize> {
+
+    pub fn y2_byte_range(&self) -> Range<usize> {
         let start = self.x2_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -2139,39 +2179,47 @@ impl Format<u8> for PaintVarLinearGradientMarker {
 pub struct PaintVarLinearGradientMarker {}
 
 impl PaintVarLinearGradientMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn color_line_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x0_byte_range(&self) -> Range<usize> {
+
+    pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y0_byte_range(&self) -> Range<usize> {
+
+    pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x1_byte_range(&self) -> Range<usize> {
+
+    pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y1_byte_range(&self) -> Range<usize> {
+
+    pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x2_byte_range(&self) -> Range<usize> {
+
+    pub fn x2_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y2_byte_range(&self) -> Range<usize> {
+
+    pub fn y2_byte_range(&self) -> Range<usize> {
         let start = self.x2_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.y2_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -2305,35 +2353,42 @@ impl Format<u8> for PaintRadialGradientMarker {
 pub struct PaintRadialGradientMarker {}
 
 impl PaintRadialGradientMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn color_line_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x0_byte_range(&self) -> Range<usize> {
+
+    pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y0_byte_range(&self) -> Range<usize> {
+
+    pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn radius0_byte_range(&self) -> Range<usize> {
+
+    pub fn radius0_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
-    fn x1_byte_range(&self) -> Range<usize> {
+
+    pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.radius0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y1_byte_range(&self) -> Range<usize> {
+
+    pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn radius1_byte_range(&self) -> Range<usize> {
+
+    pub fn radius1_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
@@ -2453,39 +2508,47 @@ impl Format<u8> for PaintVarRadialGradientMarker {
 pub struct PaintVarRadialGradientMarker {}
 
 impl PaintVarRadialGradientMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn color_line_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x0_byte_range(&self) -> Range<usize> {
+
+    pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y0_byte_range(&self) -> Range<usize> {
+
+    pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn radius0_byte_range(&self) -> Range<usize> {
+
+    pub fn radius0_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
-    fn x1_byte_range(&self) -> Range<usize> {
+
+    pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.radius0_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y1_byte_range(&self) -> Range<usize> {
+
+    pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn radius1_byte_range(&self) -> Range<usize> {
+
+    pub fn radius1_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.radius1_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -2617,27 +2680,32 @@ impl Format<u8> for PaintSweepGradientMarker {
 pub struct PaintSweepGradientMarker {}
 
 impl PaintSweepGradientMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn color_line_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn start_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn start_angle_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn end_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn end_angle_byte_range(&self) -> Range<usize> {
         let start = self.start_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -2743,31 +2811,37 @@ impl Format<u8> for PaintVarSweepGradientMarker {
 pub struct PaintVarSweepGradientMarker {}
 
 impl PaintVarSweepGradientMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn color_line_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn start_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn start_angle_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn end_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn end_angle_byte_range(&self) -> Range<usize> {
         let start = self.start_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.end_angle_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -2883,15 +2957,17 @@ impl Format<u8> for PaintGlyphMarker {
 pub struct PaintGlyphMarker {}
 
 impl PaintGlyphMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn glyph_id_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + GlyphId16::RAW_BYTE_LEN
     }
@@ -2971,11 +3047,12 @@ impl Format<u8> for PaintColrGlyphMarker {
 pub struct PaintColrGlyphMarker {}
 
 impl PaintColrGlyphMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn glyph_id_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + GlyphId16::RAW_BYTE_LEN
     }
@@ -3038,15 +3115,17 @@ impl Format<u8> for PaintTransformMarker {
 pub struct PaintTransformMarker {}
 
 impl PaintTransformMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn transform_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn transform_offset_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
@@ -3135,15 +3214,17 @@ impl Format<u8> for PaintVarTransformMarker {
 pub struct PaintVarTransformMarker {}
 
 impl PaintVarTransformMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn transform_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn transform_offset_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
@@ -3228,27 +3309,32 @@ impl<'a> std::fmt::Debug for PaintVarTransform<'a> {
 pub struct Affine2x3Marker {}
 
 impl Affine2x3Marker {
-    fn xx_byte_range(&self) -> Range<usize> {
+    pub fn xx_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn yx_byte_range(&self) -> Range<usize> {
+
+    pub fn yx_byte_range(&self) -> Range<usize> {
         let start = self.xx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn xy_byte_range(&self) -> Range<usize> {
+
+    pub fn xy_byte_range(&self) -> Range<usize> {
         let start = self.yx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn yy_byte_range(&self) -> Range<usize> {
+
+    pub fn yy_byte_range(&self) -> Range<usize> {
         let start = self.xy_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn dx_byte_range(&self) -> Range<usize> {
+
+    pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.yy_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn dy_byte_range(&self) -> Range<usize> {
+
+    pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
@@ -3339,31 +3425,37 @@ impl<'a> std::fmt::Debug for Affine2x3<'a> {
 pub struct VarAffine2x3Marker {}
 
 impl VarAffine2x3Marker {
-    fn xx_byte_range(&self) -> Range<usize> {
+    pub fn xx_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn yx_byte_range(&self) -> Range<usize> {
+
+    pub fn yx_byte_range(&self) -> Range<usize> {
         let start = self.xx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn xy_byte_range(&self) -> Range<usize> {
+
+    pub fn xy_byte_range(&self) -> Range<usize> {
         let start = self.yx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn yy_byte_range(&self) -> Range<usize> {
+
+    pub fn yy_byte_range(&self) -> Range<usize> {
         let start = self.xy_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn dx_byte_range(&self) -> Range<usize> {
+
+    pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.yy_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn dy_byte_range(&self) -> Range<usize> {
+
+    pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.dy_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -3470,19 +3562,22 @@ impl Format<u8> for PaintTranslateMarker {
 pub struct PaintTranslateMarker {}
 
 impl PaintTranslateMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn dx_byte_range(&self) -> Range<usize> {
+
+    pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn dy_byte_range(&self) -> Range<usize> {
+
+    pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -3570,23 +3665,27 @@ impl Format<u8> for PaintVarTranslateMarker {
 pub struct PaintVarTranslateMarker {}
 
 impl PaintVarTranslateMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn dx_byte_range(&self) -> Range<usize> {
+
+    pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn dy_byte_range(&self) -> Range<usize> {
+
+    pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.dy_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -3682,19 +3781,22 @@ impl Format<u8> for PaintScaleMarker {
 pub struct PaintScaleMarker {}
 
 impl PaintScaleMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_x_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn scale_y_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -3782,23 +3884,27 @@ impl Format<u8> for PaintVarScaleMarker {
 pub struct PaintVarScaleMarker {}
 
 impl PaintVarScaleMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_x_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn scale_y_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.scale_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -3896,27 +4002,32 @@ impl Format<u8> for PaintScaleAroundCenterMarker {
 pub struct PaintScaleAroundCenterMarker {}
 
 impl PaintScaleAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_x_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn scale_y_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_y_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -4020,31 +4131,37 @@ impl Format<u8> for PaintVarScaleAroundCenterMarker {
 pub struct PaintVarScaleAroundCenterMarker {}
 
 impl PaintVarScaleAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_x_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn scale_y_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_y_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -4160,15 +4277,17 @@ impl Format<u8> for PaintScaleUniformMarker {
 pub struct PaintScaleUniformMarker {}
 
 impl PaintScaleUniformMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -4248,19 +4367,22 @@ impl Format<u8> for PaintVarScaleUniformMarker {
 pub struct PaintVarScaleUniformMarker {}
 
 impl PaintVarScaleUniformMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.scale_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -4349,23 +4471,27 @@ impl Format<u8> for PaintScaleUniformAroundCenterMarker {
 pub struct PaintScaleUniformAroundCenterMarker {}
 
 impl PaintScaleUniformAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -4461,27 +4587,32 @@ impl Format<u8> for PaintVarScaleUniformAroundCenterMarker {
 pub struct PaintVarScaleUniformAroundCenterMarker {}
 
 impl PaintVarScaleUniformAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn scale_byte_range(&self) -> Range<usize> {
+
+    pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -4589,15 +4720,17 @@ impl Format<u8> for PaintRotateMarker {
 pub struct PaintRotateMarker {}
 
 impl PaintRotateMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn angle_byte_range(&self) -> Range<usize> {
+
+    pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -4678,19 +4811,22 @@ impl Format<u8> for PaintVarRotateMarker {
 pub struct PaintVarRotateMarker {}
 
 impl PaintVarRotateMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn angle_byte_range(&self) -> Range<usize> {
+
+    pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.angle_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -4779,23 +4915,27 @@ impl Format<u8> for PaintRotateAroundCenterMarker {
 pub struct PaintRotateAroundCenterMarker {}
 
 impl PaintRotateAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn angle_byte_range(&self) -> Range<usize> {
+
+    pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.angle_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -4892,27 +5032,32 @@ impl Format<u8> for PaintVarRotateAroundCenterMarker {
 pub struct PaintVarRotateAroundCenterMarker {}
 
 impl PaintVarRotateAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn angle_byte_range(&self) -> Range<usize> {
+
+    pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.angle_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -5019,19 +5164,22 @@ impl Format<u8> for PaintSkewMarker {
 pub struct PaintSkewMarker {}
 
 impl PaintSkewMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn y_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -5121,23 +5269,27 @@ impl Format<u8> for PaintVarSkewMarker {
 pub struct PaintVarSkewMarker {}
 
 impl PaintVarSkewMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn y_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.y_skew_angle_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -5237,27 +5389,32 @@ impl Format<u8> for PaintSkewAroundCenterMarker {
 pub struct PaintSkewAroundCenterMarker {}
 
 impl PaintSkewAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn y_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.y_skew_angle_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
@@ -5363,31 +5520,37 @@ impl Format<u8> for PaintVarSkewAroundCenterMarker {
 pub struct PaintVarSkewAroundCenterMarker {}
 
 impl PaintVarSkewAroundCenterMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn x_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn y_skew_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn center_x_byte_range(&self) -> Range<usize> {
+
+    pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.y_skew_angle_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn center_y_byte_range(&self) -> Range<usize> {
+
+    pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn var_index_base_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -5505,19 +5668,22 @@ impl Format<u8> for PaintCompositeMarker {
 pub struct PaintCompositeMarker {}
 
 impl PaintCompositeMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn source_paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn source_paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
-    fn composite_mode_byte_range(&self) -> Range<usize> {
+
+    pub fn composite_mode_byte_range(&self) -> Range<usize> {
         let start = self.source_paint_offset_byte_range().end;
         start..start + CompositeMode::RAW_BYTE_LEN
     }
-    fn backdrop_paint_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn backdrop_paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.composite_mode_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -16,39 +16,47 @@ pub struct CpalMarker {
 }
 
 impl CpalMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_palette_entries_byte_range(&self) -> Range<usize> {
+
+    pub fn num_palette_entries_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_palettes_byte_range(&self) -> Range<usize> {
+
+    pub fn num_palettes_byte_range(&self) -> Range<usize> {
         let start = self.num_palette_entries_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_color_records_byte_range(&self) -> Range<usize> {
+
+    pub fn num_color_records_byte_range(&self) -> Range<usize> {
         let start = self.num_palettes_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn color_records_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn color_records_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.num_color_records_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn color_record_indices_byte_range(&self) -> Range<usize> {
+
+    pub fn color_record_indices_byte_range(&self) -> Range<usize> {
         let start = self.color_records_array_offset_byte_range().end;
         start..start + self.color_record_indices_byte_len
     }
-    fn palette_types_array_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn palette_types_array_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.palette_types_array_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn palette_labels_array_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn palette_labels_array_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.palette_labels_array_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
-    fn palette_entry_labels_array_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn palette_entry_labels_array_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.palette_entry_labels_array_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -13,19 +13,22 @@ pub struct CvarMarker {
 }
 
 impl CvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn tuple_variation_count_byte_range(&self) -> Range<usize> {
+
+    pub fn tuple_variation_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + TupleVariationCount::RAW_BYTE_LEN
     }
-    fn data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn data_offset_byte_range(&self) -> Range<usize> {
         let start = self.tuple_variation_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
+
+    pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
         let start = self.data_offset_byte_range().end;
         start..start + self.tuple_variation_headers_byte_len
     }

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -11,11 +11,12 @@ use crate::codegen_prelude::*;
 pub struct EbdtMarker {}
 
 impl EbdtMarker {
-    fn major_version_byte_range(&self) -> Range<usize> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn minor_version_byte_range(&self) -> Range<usize> {
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -13,19 +13,22 @@ pub struct EblcMarker {
 }
 
 impl EblcMarker {
-    fn major_version_byte_range(&self) -> Range<usize> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn minor_version_byte_range(&self) -> Range<usize> {
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_sizes_byte_range(&self) -> Range<usize> {
+
+    pub fn num_sizes_byte_range(&self) -> Range<usize> {
         let start = self.minor_version_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn bitmap_sizes_byte_range(&self) -> Range<usize> {
+
+    pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
         let start = self.num_sizes_byte_range().end;
         start..start + self.bitmap_sizes_byte_len
     }

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -13,23 +13,27 @@ pub struct FeatMarker {
 }
 
 impl FeatMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn feature_name_count_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_name_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn _reserved1_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved1_byte_range(&self) -> Range<usize> {
         let start = self.feature_name_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn _reserved2_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved2_byte_range(&self) -> Range<usize> {
         let start = self._reserved1_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn names_byte_range(&self) -> Range<usize> {
+
+    pub fn names_byte_range(&self) -> Range<usize> {
         let start = self._reserved2_byte_range().end;
         start..start + self.names_byte_len
     }
@@ -203,7 +207,7 @@ pub struct SettingNameArrayMarker {
 }
 
 impl SettingNameArrayMarker {
-    fn settings_byte_range(&self) -> Range<usize> {
+    pub fn settings_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.settings_byte_len
     }

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -11,31 +11,37 @@ use crate::codegen_prelude::*;
 pub struct FvarMarker {}
 
 impl FvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn axis_instance_arrays_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_instance_arrays_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.axis_instance_arrays_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_count_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_size_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_size_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn instance_count_byte_range(&self) -> Range<usize> {
+
+    pub fn instance_count_byte_range(&self) -> Range<usize> {
         let start = self.axis_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn instance_size_byte_range(&self) -> Range<usize> {
+
+    pub fn instance_size_byte_range(&self) -> Range<usize> {
         let start = self.instance_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -157,11 +163,12 @@ pub struct AxisInstanceArraysMarker {
 }
 
 impl AxisInstanceArraysMarker {
-    fn axes_byte_range(&self) -> Range<usize> {
+    pub fn axes_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.axes_byte_len
     }
-    fn instances_byte_range(&self) -> Range<usize> {
+
+    pub fn instances_byte_range(&self) -> Range<usize> {
         let start = self.axes_byte_range().end;
         start..start + self.instances_byte_len
     }

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -13,15 +13,17 @@ pub struct GaspMarker {
 }
 
 impl GaspMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn num_ranges_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn gasp_ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn gasp_ranges_byte_range(&self) -> Range<usize> {
         let start = self.num_ranges_byte_range().end;
         start..start + self.gasp_ranges_byte_len
     }

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -14,31 +14,37 @@ pub struct GdefMarker {
 }
 
 impl GdefMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn glyph_class_def_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn attach_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn attach_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.glyph_class_def_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lig_caret_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn lig_caret_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.attach_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark_attach_class_def_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_attach_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.lig_caret_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark_glyph_sets_def_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn mark_glyph_sets_def_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.mark_glyph_sets_def_offset_byte_start?;
         Some(start..start + Offset16::RAW_BYTE_LEN)
     }
-    fn item_var_store_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn item_var_store_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.item_var_store_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
@@ -275,15 +281,17 @@ pub struct AttachListMarker {
 }
 
 impl AttachListMarker {
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn attach_point_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn attach_point_offsets_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.attach_point_offsets_byte_len
     }
@@ -387,11 +395,12 @@ pub struct AttachPointMarker {
 }
 
 impl AttachPointMarker {
-    fn point_count_byte_range(&self) -> Range<usize> {
+    pub fn point_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn point_indices_byte_range(&self) -> Range<usize> {
+
+    pub fn point_indices_byte_range(&self) -> Range<usize> {
         let start = self.point_count_byte_range().end;
         start..start + self.point_indices_byte_len
     }
@@ -457,15 +466,17 @@ pub struct LigCaretListMarker {
 }
 
 impl LigCaretListMarker {
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lig_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lig_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lig_glyph_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn lig_glyph_offsets_byte_range(&self) -> Range<usize> {
         let start = self.lig_glyph_count_byte_range().end;
         start..start + self.lig_glyph_offsets_byte_len
     }
@@ -569,11 +580,12 @@ pub struct LigGlyphMarker {
 }
 
 impl LigGlyphMarker {
-    fn caret_count_byte_range(&self) -> Range<usize> {
+    pub fn caret_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn caret_value_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_value_offsets_byte_range(&self) -> Range<usize> {
         let start = self.caret_count_byte_range().end;
         start..start + self.caret_value_offsets_byte_len
     }
@@ -730,11 +742,12 @@ impl Format<u16> for CaretValueFormat1Marker {
 pub struct CaretValueFormat1Marker {}
 
 impl CaretValueFormat1Marker {
-    fn caret_value_format_byte_range(&self) -> Range<usize> {
+    pub fn caret_value_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
@@ -797,11 +810,12 @@ impl Format<u16> for CaretValueFormat2Marker {
 pub struct CaretValueFormat2Marker {}
 
 impl CaretValueFormat2Marker {
-    fn caret_value_format_byte_range(&self) -> Range<usize> {
+    pub fn caret_value_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn caret_value_point_index_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_value_point_index_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -867,15 +881,17 @@ impl Format<u16> for CaretValueFormat3Marker {
 pub struct CaretValueFormat3Marker {}
 
 impl CaretValueFormat3Marker {
-    fn caret_value_format_byte_range(&self) -> Range<usize> {
+    pub fn caret_value_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn device_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn device_offset_byte_range(&self) -> Range<usize> {
         let start = self.coordinate_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -959,15 +975,17 @@ pub struct MarkGlyphSetsMarker {
 }
 
 impl MarkGlyphSetsMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark_glyph_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_glyph_set_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.mark_glyph_set_count_byte_range().end;
         start..start + self.coverage_offsets_byte_len
     }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -61,39 +61,47 @@ pub struct SimpleGlyphMarker {
 }
 
 impl SimpleGlyphMarker {
-    fn number_of_contours_byte_range(&self) -> Range<usize> {
+    pub fn number_of_contours_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn x_min_byte_range(&self) -> Range<usize> {
+
+    pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.number_of_contours_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_min_byte_range(&self) -> Range<usize> {
+
+    pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn x_max_byte_range(&self) -> Range<usize> {
+
+    pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_max_byte_range(&self) -> Range<usize> {
+
+    pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn end_pts_of_contours_byte_range(&self) -> Range<usize> {
+
+    pub fn end_pts_of_contours_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
         start..start + self.end_pts_of_contours_byte_len
     }
-    fn instruction_length_byte_range(&self) -> Range<usize> {
+
+    pub fn instruction_length_byte_range(&self) -> Range<usize> {
         let start = self.end_pts_of_contours_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn instructions_byte_range(&self) -> Range<usize> {
+
+    pub fn instructions_byte_range(&self) -> Range<usize> {
         let start = self.instruction_length_byte_range().end;
         start..start + self.instructions_byte_len
     }
-    fn glyph_data_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_data_byte_range(&self) -> Range<usize> {
         let start = self.instructions_byte_range().end;
         start..start + self.glyph_data_byte_len
     }
@@ -627,27 +635,32 @@ pub struct CompositeGlyphMarker {
 }
 
 impl CompositeGlyphMarker {
-    fn number_of_contours_byte_range(&self) -> Range<usize> {
+    pub fn number_of_contours_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn x_min_byte_range(&self) -> Range<usize> {
+
+    pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.number_of_contours_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_min_byte_range(&self) -> Range<usize> {
+
+    pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn x_max_byte_range(&self) -> Range<usize> {
+
+    pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_max_byte_range(&self) -> Range<usize> {
+
+    pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn component_data_byte_range(&self) -> Range<usize> {
+
+    pub fn component_data_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
         start..start + self.component_data_byte_len
     }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -14,23 +14,27 @@ pub struct GposMarker {
 }
 
 impl GposMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn script_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn script_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn feature_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.script_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lookup_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.feature_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.feature_variations_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
@@ -685,15 +689,17 @@ impl Format<u16> for AnchorFormat1Marker {
 pub struct AnchorFormat1Marker {}
 
 impl AnchorFormat1Marker {
-    fn anchor_format_byte_range(&self) -> Range<usize> {
+    pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn x_coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.anchor_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
@@ -764,19 +770,22 @@ impl Format<u16> for AnchorFormat2Marker {
 pub struct AnchorFormat2Marker {}
 
 impl AnchorFormat2Marker {
-    fn anchor_format_byte_range(&self) -> Range<usize> {
+    pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn x_coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.anchor_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn anchor_point_byte_range(&self) -> Range<usize> {
+
+    pub fn anchor_point_byte_range(&self) -> Range<usize> {
         let start = self.y_coordinate_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -855,23 +864,27 @@ impl Format<u16> for AnchorFormat3Marker {
 pub struct AnchorFormat3Marker {}
 
 impl AnchorFormat3Marker {
-    fn anchor_format_byte_range(&self) -> Range<usize> {
+    pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn x_coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.anchor_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_coordinate_byte_range(&self) -> Range<usize> {
+
+    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn x_device_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn x_device_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_coordinate_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn y_device_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn y_device_offset_byte_range(&self) -> Range<usize> {
         let start = self.x_device_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -978,11 +991,12 @@ pub struct MarkArrayMarker {
 }
 
 impl MarkArrayMarker {
-    fn mark_count_byte_range(&self) -> Range<usize> {
+    pub fn mark_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark_records_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_records_byte_range(&self) -> Range<usize> {
         let start = self.mark_count_byte_range().end;
         start..start + self.mark_records_byte_len
     }
@@ -1192,19 +1206,22 @@ pub struct SinglePosFormat1Marker {
 }
 
 impl SinglePosFormat1Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn value_format_byte_range(&self) -> Range<usize> {
+
+    pub fn value_format_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + ValueFormat::RAW_BYTE_LEN
     }
-    fn value_record_byte_range(&self) -> Range<usize> {
+
+    pub fn value_record_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
         start..start + self.value_record_byte_len
     }
@@ -1303,23 +1320,27 @@ pub struct SinglePosFormat2Marker {
 }
 
 impl SinglePosFormat2Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn value_format_byte_range(&self) -> Range<usize> {
+
+    pub fn value_format_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + ValueFormat::RAW_BYTE_LEN
     }
-    fn value_count_byte_range(&self) -> Range<usize> {
+
+    pub fn value_count_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn value_records_byte_range(&self) -> Range<usize> {
+
+    pub fn value_records_byte_range(&self) -> Range<usize> {
         let start = self.value_count_byte_range().end;
         start..start + self.value_records_byte_len
     }
@@ -1521,27 +1542,32 @@ pub struct PairPosFormat1Marker {
 }
 
 impl PairPosFormat1Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn value_format1_byte_range(&self) -> Range<usize> {
+
+    pub fn value_format1_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + ValueFormat::RAW_BYTE_LEN
     }
-    fn value_format2_byte_range(&self) -> Range<usize> {
+
+    pub fn value_format2_byte_range(&self) -> Range<usize> {
         let start = self.value_format1_byte_range().end;
         start..start + ValueFormat::RAW_BYTE_LEN
     }
-    fn pair_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn pair_set_count_byte_range(&self) -> Range<usize> {
         let start = self.value_format2_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn pair_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn pair_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.pair_set_count_byte_range().end;
         start..start + self.pair_set_offsets_byte_len
     }
@@ -1675,11 +1701,12 @@ pub struct PairSetMarker {
 }
 
 impl PairSetMarker {
-    fn pair_value_count_byte_range(&self) -> Range<usize> {
+    pub fn pair_value_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn pair_value_records_byte_range(&self) -> Range<usize> {
+
+    pub fn pair_value_records_byte_range(&self) -> Range<usize> {
         let start = self.pair_value_count_byte_range().end;
         start..start + self.pair_value_records_byte_len
     }
@@ -1899,39 +1926,47 @@ pub struct PairPosFormat2Marker {
 }
 
 impl PairPosFormat2Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn value_format1_byte_range(&self) -> Range<usize> {
+
+    pub fn value_format1_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + ValueFormat::RAW_BYTE_LEN
     }
-    fn value_format2_byte_range(&self) -> Range<usize> {
+
+    pub fn value_format2_byte_range(&self) -> Range<usize> {
         let start = self.value_format1_byte_range().end;
         start..start + ValueFormat::RAW_BYTE_LEN
     }
-    fn class_def1_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn class_def1_offset_byte_range(&self) -> Range<usize> {
         let start = self.value_format2_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn class_def2_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn class_def2_offset_byte_range(&self) -> Range<usize> {
         let start = self.class_def1_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn class1_count_byte_range(&self) -> Range<usize> {
+
+    pub fn class1_count_byte_range(&self) -> Range<usize> {
         let start = self.class_def2_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class2_count_byte_range(&self) -> Range<usize> {
+
+    pub fn class2_count_byte_range(&self) -> Range<usize> {
         let start = self.class1_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class1_records_byte_range(&self) -> Range<usize> {
+
+    pub fn class1_records_byte_range(&self) -> Range<usize> {
         let start = self.class2_count_byte_range().end;
         start..start + self.class1_records_byte_len
     }
@@ -2280,19 +2315,22 @@ pub struct CursivePosFormat1Marker {
 }
 
 impl CursivePosFormat1Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn entry_exit_count_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_exit_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_exit_record_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_exit_record_byte_range(&self) -> Range<usize> {
         let start = self.entry_exit_count_byte_range().end;
         start..start + self.entry_exit_record_byte_len
     }
@@ -2468,27 +2506,32 @@ impl Format<u16> for MarkBasePosFormat1Marker {
 pub struct MarkBasePosFormat1Marker {}
 
 impl MarkBasePosFormat1Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark_coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn base_coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn base_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_coverage_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark_class_count_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_class_count_byte_range(&self) -> Range<usize> {
         let start = self.base_coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_class_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn base_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn base_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -2623,11 +2666,12 @@ pub struct BaseArrayMarker {
 }
 
 impl BaseArrayMarker {
-    fn base_count_byte_range(&self) -> Range<usize> {
+    pub fn base_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn base_records_byte_range(&self) -> Range<usize> {
+
+    pub fn base_records_byte_range(&self) -> Range<usize> {
         let start = self.base_count_byte_range().end;
         start..start + self.base_records_byte_len
     }
@@ -2820,27 +2864,32 @@ impl Format<u16> for MarkLigPosFormat1Marker {
 pub struct MarkLigPosFormat1Marker {}
 
 impl MarkLigPosFormat1Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark_coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn ligature_coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn ligature_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_coverage_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark_class_count_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_class_count_byte_range(&self) -> Range<usize> {
         let start = self.ligature_coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_class_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn ligature_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn ligature_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -2975,11 +3024,12 @@ pub struct LigatureArrayMarker {
 }
 
 impl LigatureArrayMarker {
-    fn ligature_count_byte_range(&self) -> Range<usize> {
+    pub fn ligature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ligature_attach_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn ligature_attach_offsets_byte_range(&self) -> Range<usize> {
         let start = self.ligature_count_byte_range().end;
         start..start + self.ligature_attach_offsets_byte_len
     }
@@ -3091,11 +3141,12 @@ pub struct LigatureAttachMarker {
 }
 
 impl LigatureAttachMarker {
-    fn component_count_byte_range(&self) -> Range<usize> {
+    pub fn component_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn component_records_byte_range(&self) -> Range<usize> {
+
+    pub fn component_records_byte_range(&self) -> Range<usize> {
         let start = self.component_count_byte_range().end;
         start..start + self.component_records_byte_len
     }
@@ -3288,27 +3339,32 @@ impl Format<u16> for MarkMarkPosFormat1Marker {
 pub struct MarkMarkPosFormat1Marker {}
 
 impl MarkMarkPosFormat1Marker {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark1_coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark1_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark2_coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark2_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark1_coverage_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark_class_count_byte_range(&self) -> Range<usize> {
+
+    pub fn mark_class_count_byte_range(&self) -> Range<usize> {
         let start = self.mark2_coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark1_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark1_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_class_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn mark2_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn mark2_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark1_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
@@ -3443,11 +3499,12 @@ pub struct Mark2ArrayMarker {
 }
 
 impl Mark2ArrayMarker {
-    fn mark2_count_byte_range(&self) -> Range<usize> {
+    pub fn mark2_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn mark2_records_byte_range(&self) -> Range<usize> {
+
+    pub fn mark2_records_byte_range(&self) -> Range<usize> {
         let start = self.mark2_count_byte_range().end;
         start..start + self.mark2_records_byte_len
     }
@@ -3642,15 +3699,17 @@ pub struct ExtensionPosFormat1Marker<T = ()> {
 }
 
 impl<T> ExtensionPosFormat1Marker<T> {
-    fn pos_format_byte_range(&self) -> Range<usize> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn extension_lookup_type_byte_range(&self) -> Range<usize> {
+
+    pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn extension_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -13,23 +13,27 @@ pub struct GsubMarker {
 }
 
 impl GsubMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn script_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn script_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn feature_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.script_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lookup_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.feature_list_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.feature_variations_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
@@ -323,15 +327,17 @@ impl Format<u16> for SingleSubstFormat1Marker {
 pub struct SingleSubstFormat1Marker {}
 
 impl SingleSubstFormat1Marker {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn delta_glyph_id_byte_range(&self) -> Range<usize> {
+
+    pub fn delta_glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
@@ -414,19 +420,22 @@ pub struct SingleSubstFormat2Marker {
 }
 
 impl SingleSubstFormat2Marker {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
+
+    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.substitute_glyph_ids_byte_len
     }
@@ -525,19 +534,22 @@ pub struct MultipleSubstFormat1Marker {
 }
 
 impl MultipleSubstFormat1Marker {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn sequence_count_byte_range(&self) -> Range<usize> {
+
+    pub fn sequence_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn sequence_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn sequence_offsets_byte_range(&self) -> Range<usize> {
         let start = self.sequence_count_byte_range().end;
         start..start + self.sequence_offsets_byte_len
     }
@@ -650,11 +662,12 @@ pub struct SequenceMarker {
 }
 
 impl SequenceMarker {
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
+
+    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.substitute_glyph_ids_byte_len
     }
@@ -728,19 +741,22 @@ pub struct AlternateSubstFormat1Marker {
 }
 
 impl AlternateSubstFormat1Marker {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn alternate_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn alternate_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn alternate_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn alternate_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.alternate_set_count_byte_range().end;
         start..start + self.alternate_set_offsets_byte_len
     }
@@ -856,11 +872,12 @@ pub struct AlternateSetMarker {
 }
 
 impl AlternateSetMarker {
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn alternate_glyph_ids_byte_range(&self) -> Range<usize> {
+
+    pub fn alternate_glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.alternate_glyph_ids_byte_len
     }
@@ -933,19 +950,22 @@ pub struct LigatureSubstFormat1Marker {
 }
 
 impl LigatureSubstFormat1Marker {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn ligature_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn ligature_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ligature_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn ligature_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.ligature_set_count_byte_range().end;
         start..start + self.ligature_set_offsets_byte_len
     }
@@ -1058,11 +1078,12 @@ pub struct LigatureSetMarker {
 }
 
 impl LigatureSetMarker {
-    fn ligature_count_byte_range(&self) -> Range<usize> {
+    pub fn ligature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ligature_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn ligature_offsets_byte_range(&self) -> Range<usize> {
         let start = self.ligature_count_byte_range().end;
         start..start + self.ligature_offsets_byte_len
     }
@@ -1149,15 +1170,17 @@ pub struct LigatureMarker {
 }
 
 impl LigatureMarker {
-    fn ligature_glyph_byte_range(&self) -> Range<usize> {
+    pub fn ligature_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + GlyphId16::RAW_BYTE_LEN
     }
-    fn component_count_byte_range(&self) -> Range<usize> {
+
+    pub fn component_count_byte_range(&self) -> Range<usize> {
         let start = self.ligature_glyph_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn component_glyph_ids_byte_range(&self) -> Range<usize> {
+
+    pub fn component_glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.component_count_byte_range().end;
         start..start + self.component_glyph_ids_byte_len
     }
@@ -1239,15 +1262,17 @@ pub struct ExtensionSubstFormat1Marker<T = ()> {
 }
 
 impl<T> ExtensionSubstFormat1Marker<T> {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn extension_lookup_type_byte_range(&self) -> Range<usize> {
+
+    pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn extension_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
@@ -1454,35 +1479,42 @@ pub struct ReverseChainSingleSubstFormat1Marker {
 }
 
 impl ReverseChainSingleSubstFormat1Marker {
-    fn subst_format_byte_range(&self) -> Range<usize> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_glyph_count_byte_range().end;
         start..start + self.backtrack_coverage_offsets_byte_len
     }
-    fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_coverage_offsets_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_glyph_count_byte_range().end;
         start..start + self.lookahead_coverage_offsets_byte_len
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_coverage_offsets_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
+
+    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.substitute_glyph_ids_byte_len
     }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -13,35 +13,42 @@ pub struct GvarMarker {
 }
 
 impl GvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn axis_count_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn shared_tuple_count_byte_range(&self) -> Range<usize> {
+
+    pub fn shared_tuple_count_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn shared_tuples_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn shared_tuples_offset_byte_range(&self) -> Range<usize> {
         let start = self.shared_tuple_count_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.shared_tuples_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + GvarFlags::RAW_BYTE_LEN
     }
-    fn glyph_variation_data_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_variation_data_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn glyph_variation_data_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_variation_data_offsets_byte_range(&self) -> Range<usize> {
         let start = self.glyph_variation_data_array_offset_byte_range().end;
         start..start + self.glyph_variation_data_offsets_byte_len
     }
@@ -487,7 +494,7 @@ pub struct SharedTuplesMarker {
 }
 
 impl SharedTuplesMarker {
-    fn tuples_byte_range(&self) -> Range<usize> {
+    pub fn tuples_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.tuples_byte_len
     }
@@ -572,15 +579,17 @@ pub struct GlyphVariationDataHeaderMarker {
 }
 
 impl GlyphVariationDataHeaderMarker {
-    fn tuple_variation_count_byte_range(&self) -> Range<usize> {
+    pub fn tuple_variation_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + TupleVariationCount::RAW_BYTE_LEN
     }
-    fn serialized_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn serialized_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.tuple_variation_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
+
+    pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
         let start = self.serialized_data_offset_byte_range().end;
         start..start + self.tuple_variation_headers_byte_len
     }

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -14,19 +14,22 @@ pub struct HdmxMarker {
 }
 
 impl HdmxMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn num_records_byte_range(&self) -> Range<usize> {
+
+    pub fn num_records_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn size_device_record_byte_range(&self) -> Range<usize> {
+
+    pub fn size_device_record_byte_range(&self) -> Range<usize> {
         let start = self.num_records_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn records_byte_range(&self) -> Range<usize> {
+
+    pub fn records_byte_range(&self) -> Range<usize> {
         let start = self.size_device_record_byte_range().end;
         start..start + self.records_byte_len
     }

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -346,71 +346,87 @@ impl<'a> From<MacStyle> for FieldType<'a> {
 pub struct HeadMarker {}
 
 impl HeadMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn font_revision_byte_range(&self) -> Range<usize> {
+
+    pub fn font_revision_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn checksum_adjustment_byte_range(&self) -> Range<usize> {
+
+    pub fn checksum_adjustment_byte_range(&self) -> Range<usize> {
         let start = self.font_revision_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn magic_number_byte_range(&self) -> Range<usize> {
+
+    pub fn magic_number_byte_range(&self) -> Range<usize> {
         let start = self.checksum_adjustment_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.magic_number_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn units_per_em_byte_range(&self) -> Range<usize> {
+
+    pub fn units_per_em_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn created_byte_range(&self) -> Range<usize> {
+
+    pub fn created_byte_range(&self) -> Range<usize> {
         let start = self.units_per_em_byte_range().end;
         start..start + LongDateTime::RAW_BYTE_LEN
     }
-    fn modified_byte_range(&self) -> Range<usize> {
+
+    pub fn modified_byte_range(&self) -> Range<usize> {
         let start = self.created_byte_range().end;
         start..start + LongDateTime::RAW_BYTE_LEN
     }
-    fn x_min_byte_range(&self) -> Range<usize> {
+
+    pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.modified_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_min_byte_range(&self) -> Range<usize> {
+
+    pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn x_max_byte_range(&self) -> Range<usize> {
+
+    pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_max_byte_range(&self) -> Range<usize> {
+
+    pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn mac_style_byte_range(&self) -> Range<usize> {
+
+    pub fn mac_style_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
         start..start + MacStyle::RAW_BYTE_LEN
     }
-    fn lowest_rec_ppem_byte_range(&self) -> Range<usize> {
+
+    pub fn lowest_rec_ppem_byte_range(&self) -> Range<usize> {
         let start = self.mac_style_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn font_direction_hint_byte_range(&self) -> Range<usize> {
+
+    pub fn font_direction_hint_byte_range(&self) -> Range<usize> {
         let start = self.lowest_rec_ppem_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn index_to_loc_format_byte_range(&self) -> Range<usize> {
+
+    pub fn index_to_loc_format_byte_range(&self) -> Range<usize> {
         let start = self.font_direction_hint_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn glyph_data_format_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_data_format_byte_range(&self) -> Range<usize> {
         let start = self.index_to_loc_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -11,71 +11,87 @@ use crate::codegen_prelude::*;
 pub struct HheaMarker {}
 
 impl HheaMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn ascender_byte_range(&self) -> Range<usize> {
+
+    pub fn ascender_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn descender_byte_range(&self) -> Range<usize> {
+
+    pub fn descender_byte_range(&self) -> Range<usize> {
         let start = self.ascender_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn line_gap_byte_range(&self) -> Range<usize> {
+
+    pub fn line_gap_byte_range(&self) -> Range<usize> {
         let start = self.descender_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn advance_width_max_byte_range(&self) -> Range<usize> {
+
+    pub fn advance_width_max_byte_range(&self) -> Range<usize> {
         let start = self.line_gap_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
-    fn min_left_side_bearing_byte_range(&self) -> Range<usize> {
+
+    pub fn min_left_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.advance_width_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn min_right_side_bearing_byte_range(&self) -> Range<usize> {
+
+    pub fn min_right_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.min_left_side_bearing_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn x_max_extent_byte_range(&self) -> Range<usize> {
+
+    pub fn x_max_extent_byte_range(&self) -> Range<usize> {
         let start = self.min_right_side_bearing_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn caret_slope_rise_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_slope_rise_byte_range(&self) -> Range<usize> {
         let start = self.x_max_extent_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn caret_slope_run_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_slope_run_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_rise_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn caret_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_offset_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_run_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved1_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved1_byte_range(&self) -> Range<usize> {
         let start = self.caret_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved2_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved2_byte_range(&self) -> Range<usize> {
         let start = self.reserved1_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved3_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved3_byte_range(&self) -> Range<usize> {
         let start = self.reserved2_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved4_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved4_byte_range(&self) -> Range<usize> {
         let start = self.reserved3_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn metric_data_format_byte_range(&self) -> Range<usize> {
+
+    pub fn metric_data_format_byte_range(&self) -> Range<usize> {
         let start = self.reserved4_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn number_of_long_metrics_byte_range(&self) -> Range<usize> {
+
+    pub fn number_of_long_metrics_byte_range(&self) -> Range<usize> {
         let start = self.metric_data_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -14,11 +14,12 @@ pub struct HmtxMarker {
 }
 
 impl HmtxMarker {
-    fn h_metrics_byte_range(&self) -> Range<usize> {
+    pub fn h_metrics_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.h_metrics_byte_len
     }
-    fn left_side_bearings_byte_range(&self) -> Range<usize> {
+
+    pub fn left_side_bearings_byte_range(&self) -> Range<usize> {
         let start = self.h_metrics_byte_range().end;
         start..start + self.left_side_bearings_byte_len
     }

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -11,23 +11,27 @@ use crate::codegen_prelude::*;
 pub struct HvarMarker {}
 
 impl HvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn advance_width_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn advance_width_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_store_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn lsb_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn lsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.advance_width_mapping_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn rsb_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn rsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.lsb_mapping_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -102,51 +102,62 @@ pub struct PatchMapFormat1Marker {
 }
 
 impl PatchMapFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn compatibility_id_byte_range(&self) -> Range<usize> {
+
+    pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + CompatibilityId::RAW_BYTE_LEN
     }
-    fn max_entry_index_byte_range(&self) -> Range<usize> {
+
+    pub fn max_entry_index_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn max_glyph_map_entry_index_byte_range(&self) -> Range<usize> {
+
+    pub fn max_glyph_map_entry_index_byte_range(&self) -> Range<usize> {
         let start = self.max_entry_index_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.max_glyph_map_entry_index_byte_range().end;
         start..start + Uint24::RAW_BYTE_LEN
     }
-    fn glyph_map_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_map_offset_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn feature_map_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_map_offset_byte_range(&self) -> Range<usize> {
         let start = self.glyph_map_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn applied_entries_bitmap_byte_range(&self) -> Range<usize> {
+
+    pub fn applied_entries_bitmap_byte_range(&self) -> Range<usize> {
         let start = self.feature_map_offset_byte_range().end;
         start..start + self.applied_entries_bitmap_byte_len
     }
-    fn uri_template_length_byte_range(&self) -> Range<usize> {
+
+    pub fn uri_template_length_byte_range(&self) -> Range<usize> {
         let start = self.applied_entries_bitmap_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn uri_template_byte_range(&self) -> Range<usize> {
+
+    pub fn uri_template_byte_range(&self) -> Range<usize> {
         let start = self.uri_template_length_byte_range().end;
         start..start + self.uri_template_byte_len
     }
-    fn patch_encoding_byte_range(&self) -> Range<usize> {
+
+    pub fn patch_encoding_byte_range(&self) -> Range<usize> {
         let start = self.uri_template_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
@@ -317,11 +328,12 @@ pub struct GlyphMapMarker {
 }
 
 impl GlyphMapMarker {
-    fn first_mapped_glyph_byte_range(&self) -> Range<usize> {
+    pub fn first_mapped_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn entry_index_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_index_byte_range(&self) -> Range<usize> {
         let start = self.first_mapped_glyph_byte_range().end;
         start..start + self.entry_index_byte_len
     }
@@ -412,15 +424,17 @@ pub struct FeatureMapMarker {
 }
 
 impl FeatureMapMarker {
-    fn feature_count_byte_range(&self) -> Range<usize> {
+    pub fn feature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn feature_records_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_records_byte_range(&self) -> Range<usize> {
         let start = self.feature_count_byte_range().end;
         start..start + self.feature_records_byte_len
     }
-    fn entry_map_data_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_map_data_byte_range(&self) -> Range<usize> {
         let start = self.feature_records_byte_range().end;
         start..start + self.entry_map_data_byte_len
     }
@@ -685,39 +699,47 @@ pub struct PatchMapFormat2Marker {
 }
 
 impl PatchMapFormat2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn compatibility_id_byte_range(&self) -> Range<usize> {
+
+    pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + CompatibilityId::RAW_BYTE_LEN
     }
-    fn default_patch_encoding_byte_range(&self) -> Range<usize> {
+
+    pub fn default_patch_encoding_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn entry_count_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_count_byte_range(&self) -> Range<usize> {
         let start = self.default_patch_encoding_byte_range().end;
         start..start + Uint24::RAW_BYTE_LEN
     }
-    fn entries_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn entries_offset_byte_range(&self) -> Range<usize> {
         let start = self.entry_count_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn entry_id_string_data_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_id_string_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.entries_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn uri_template_length_byte_range(&self) -> Range<usize> {
+
+    pub fn uri_template_length_byte_range(&self) -> Range<usize> {
         let start = self.entry_id_string_data_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn uri_template_byte_range(&self) -> Range<usize> {
+
+    pub fn uri_template_byte_range(&self) -> Range<usize> {
         let start = self.uri_template_length_byte_range().end;
         start..start + self.uri_template_byte_len
     }
@@ -856,7 +878,7 @@ pub struct MappingEntriesMarker {
 }
 
 impl MappingEntriesMarker {
-    fn entry_data_byte_range(&self) -> Range<usize> {
+    pub fn entry_data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.entry_data_byte_len
     }
@@ -922,43 +944,52 @@ pub struct EntryDataMarker {
 }
 
 impl EntryDataMarker {
-    fn format_flags_byte_range(&self) -> Range<usize> {
+    pub fn format_flags_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + EntryFormatFlags::RAW_BYTE_LEN
     }
-    fn feature_count_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn feature_count_byte_range(&self) -> Option<Range<usize>> {
         let start = self.feature_count_byte_start?;
         Some(start..start + u8::RAW_BYTE_LEN)
     }
-    fn feature_tags_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn feature_tags_byte_range(&self) -> Option<Range<usize>> {
         let start = self.feature_tags_byte_start?;
         Some(start..start + self.feature_tags_byte_len?)
     }
-    fn design_space_count_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn design_space_count_byte_range(&self) -> Option<Range<usize>> {
         let start = self.design_space_count_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn design_space_segments_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn design_space_segments_byte_range(&self) -> Option<Range<usize>> {
         let start = self.design_space_segments_byte_start?;
         Some(start..start + self.design_space_segments_byte_len?)
     }
-    fn copy_count_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn copy_count_byte_range(&self) -> Option<Range<usize>> {
         let start = self.copy_count_byte_start?;
         Some(start..start + u8::RAW_BYTE_LEN)
     }
-    fn copy_indices_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn copy_indices_byte_range(&self) -> Option<Range<usize>> {
         let start = self.copy_indices_byte_start?;
         Some(start..start + self.copy_indices_byte_len?)
     }
-    fn entry_id_delta_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn entry_id_delta_byte_range(&self) -> Option<Range<usize>> {
         let start = self.entry_id_delta_byte_start?;
         Some(start..start + self.entry_id_delta_byte_len?)
     }
-    fn patch_encoding_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn patch_encoding_byte_range(&self) -> Option<Range<usize>> {
         let start = self.patch_encoding_byte_start?;
         Some(start..start + u8::RAW_BYTE_LEN)
     }
-    fn codepoint_data_byte_range(&self) -> Range<usize> {
+
+    pub fn codepoint_data_byte_range(&self) -> Range<usize> {
         let start = self . patch_encoding_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . entry_id_delta_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . copy_indices_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . copy_count_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . design_space_segments_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . design_space_count_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . feature_tags_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . feature_count_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . format_flags_byte_range () . end)))))))) ;
         start..start + self.codepoint_data_byte_len
     }
@@ -1592,7 +1623,7 @@ pub struct IdStringDataMarker {
 }
 
 impl IdStringDataMarker {
-    fn id_data_byte_range(&self) -> Range<usize> {
+    pub fn id_data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.id_data_byte_len
     }
@@ -1644,23 +1675,27 @@ pub struct TableKeyedPatchMarker {
 }
 
 impl TableKeyedPatchMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Tag::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn compatibility_id_byte_range(&self) -> Range<usize> {
+
+    pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + CompatibilityId::RAW_BYTE_LEN
     }
-    fn patches_count_byte_range(&self) -> Range<usize> {
+
+    pub fn patches_count_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn patch_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn patch_offsets_byte_range(&self) -> Range<usize> {
         let start = self.patches_count_byte_range().end;
         start..start + self.patch_offsets_byte_len
     }
@@ -1763,19 +1798,22 @@ pub struct TablePatchMarker {
 }
 
 impl TablePatchMarker {
-    fn tag_byte_range(&self) -> Range<usize> {
+    pub fn tag_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Tag::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.tag_byte_range().end;
         start..start + TablePatchFlags::RAW_BYTE_LEN
     }
-    fn max_uncompressed_length_byte_range(&self) -> Range<usize> {
+
+    pub fn max_uncompressed_length_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn brotli_stream_byte_range(&self) -> Range<usize> {
+
+    pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
         start..start + self.brotli_stream_byte_len
     }
@@ -2159,27 +2197,32 @@ pub struct GlyphKeyedPatchMarker {
 }
 
 impl GlyphKeyedPatchMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Tag::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + GlyphKeyedFlags::RAW_BYTE_LEN
     }
-    fn compatibility_id_byte_range(&self) -> Range<usize> {
+
+    pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + CompatibilityId::RAW_BYTE_LEN
     }
-    fn max_uncompressed_length_byte_range(&self) -> Range<usize> {
+
+    pub fn max_uncompressed_length_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn brotli_stream_byte_range(&self) -> Range<usize> {
+
+    pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
         start..start + self.brotli_stream_byte_len
     }
@@ -2577,23 +2620,27 @@ pub struct GlyphPatchesMarker {
 }
 
 impl GlyphPatchesMarker {
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn table_count_byte_range(&self) -> Range<usize> {
+
+    pub fn table_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn glyph_ids_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.table_count_byte_range().end;
         start..start + self.glyph_ids_byte_len
     }
-    fn tables_byte_range(&self) -> Range<usize> {
+
+    pub fn tables_byte_range(&self) -> Range<usize> {
         let start = self.glyph_ids_byte_range().end;
         start..start + self.tables_byte_len
     }
-    fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
         let start = self.tables_byte_range().end;
         start..start + self.glyph_data_offsets_byte_len
     }
@@ -2727,7 +2774,7 @@ pub struct GlyphDataMarker {
 }
 
 impl GlyphDataMarker {
-    fn data_byte_range(&self) -> Range<usize> {
+    pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data_byte_len
     }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -13,11 +13,12 @@ pub struct ScriptListMarker {
 }
 
 impl ScriptListMarker {
-    fn script_count_byte_range(&self) -> Range<usize> {
+    pub fn script_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn script_records_byte_range(&self) -> Range<usize> {
+
+    pub fn script_records_byte_range(&self) -> Range<usize> {
         let start = self.script_count_byte_range().end;
         start..start + self.script_records_byte_len
     }
@@ -143,15 +144,17 @@ pub struct ScriptMarker {
 }
 
 impl ScriptMarker {
-    fn default_lang_sys_offset_byte_range(&self) -> Range<usize> {
+    pub fn default_lang_sys_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lang_sys_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lang_sys_count_byte_range(&self) -> Range<usize> {
         let start = self.default_lang_sys_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lang_sys_records_byte_range(&self) -> Range<usize> {
+
+    pub fn lang_sys_records_byte_range(&self) -> Range<usize> {
         let start = self.lang_sys_count_byte_range().end;
         start..start + self.lang_sys_records_byte_len
     }
@@ -295,19 +298,22 @@ pub struct LangSysMarker {
 }
 
 impl LangSysMarker {
-    fn lookup_order_offset_byte_range(&self) -> Range<usize> {
+    pub fn lookup_order_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn required_feature_index_byte_range(&self) -> Range<usize> {
+
+    pub fn required_feature_index_byte_range(&self) -> Range<usize> {
         let start = self.lookup_order_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn feature_index_count_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_index_count_byte_range(&self) -> Range<usize> {
         let start = self.required_feature_index_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn feature_indices_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_indices_byte_range(&self) -> Range<usize> {
         let start = self.feature_index_count_byte_range().end;
         start..start + self.feature_indices_byte_len
     }
@@ -390,11 +396,12 @@ pub struct FeatureListMarker {
 }
 
 impl FeatureListMarker {
-    fn feature_count_byte_range(&self) -> Range<usize> {
+    pub fn feature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn feature_records_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_records_byte_range(&self) -> Range<usize> {
         let start = self.feature_count_byte_range().end;
         start..start + self.feature_records_byte_len
     }
@@ -523,15 +530,17 @@ pub struct FeatureMarker {
 }
 
 impl FeatureMarker {
-    fn feature_params_offset_byte_range(&self) -> Range<usize> {
+    pub fn feature_params_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lookup_index_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_index_count_byte_range(&self) -> Range<usize> {
         let start = self.feature_params_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookup_list_indices_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_list_indices_byte_range(&self) -> Range<usize> {
         let start = self.lookup_index_count_byte_range().end;
         start..start + self.lookup_list_indices_byte_len
     }
@@ -641,11 +650,12 @@ pub struct LookupListMarker<T = ()> {
 }
 
 impl<T> LookupListMarker<T> {
-    fn lookup_count_byte_range(&self) -> Range<usize> {
+    pub fn lookup_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookup_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_offsets_byte_range(&self) -> Range<usize> {
         let start = self.lookup_count_byte_range().end;
         start..start + self.lookup_offsets_byte_len
     }
@@ -775,23 +785,27 @@ pub struct LookupMarker<T = ()> {
 }
 
 impl<T> LookupMarker<T> {
-    fn lookup_type_byte_range(&self) -> Range<usize> {
+    pub fn lookup_type_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookup_flag_byte_range(&self) -> Range<usize> {
+
+    pub fn lookup_flag_byte_range(&self) -> Range<usize> {
         let start = self.lookup_type_byte_range().end;
         start..start + LookupFlag::RAW_BYTE_LEN
     }
-    fn sub_table_count_byte_range(&self) -> Range<usize> {
+
+    pub fn sub_table_count_byte_range(&self) -> Range<usize> {
         let start = self.lookup_flag_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn subtable_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
         let start = self.sub_table_count_byte_range().end;
         start..start + self.subtable_offsets_byte_len
     }
-    fn mark_filtering_set_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn mark_filtering_set_byte_range(&self) -> Option<Range<usize>> {
         let start = self.mark_filtering_set_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
@@ -962,15 +976,17 @@ pub struct CoverageFormat1Marker {
 }
 
 impl CoverageFormat1Marker {
-    fn coverage_format_byte_range(&self) -> Range<usize> {
+    pub fn coverage_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_array_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.glyph_array_byte_len
     }
@@ -1048,15 +1064,17 @@ pub struct CoverageFormat2Marker {
 }
 
 impl CoverageFormat2Marker {
-    fn coverage_format_byte_range(&self) -> Range<usize> {
+    pub fn coverage_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_count_byte_range(&self) -> Range<usize> {
+
+    pub fn range_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_records_byte_range(&self) -> Range<usize> {
+
+    pub fn range_records_byte_range(&self) -> Range<usize> {
         let start = self.range_count_byte_range().end;
         start..start + self.range_records_byte_len
     }
@@ -1258,19 +1276,22 @@ pub struct ClassDefFormat1Marker {
 }
 
 impl ClassDefFormat1Marker {
-    fn class_format_byte_range(&self) -> Range<usize> {
+    pub fn class_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn start_glyph_id_byte_range(&self) -> Range<usize> {
+
+    pub fn start_glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.class_format_byte_range().end;
         start..start + GlyphId16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.start_glyph_id_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_value_array_byte_range(&self) -> Range<usize> {
+
+    pub fn class_value_array_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + self.class_value_array_byte_len
     }
@@ -1356,15 +1377,17 @@ pub struct ClassDefFormat2Marker {
 }
 
 impl ClassDefFormat2Marker {
-    fn class_format_byte_range(&self) -> Range<usize> {
+    pub fn class_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_range_count_byte_range(&self) -> Range<usize> {
+
+    pub fn class_range_count_byte_range(&self) -> Range<usize> {
         let start = self.class_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_range_records_byte_range(&self) -> Range<usize> {
+
+    pub fn class_range_records_byte_range(&self) -> Range<usize> {
         let start = self.class_range_count_byte_range().end;
         start..start + self.class_range_records_byte_len
     }
@@ -1605,19 +1628,22 @@ pub struct SequenceContextFormat1Marker {
 }
 
 impl SequenceContextFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn seq_rule_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.seq_rule_set_count_byte_range().end;
         start..start + self.seq_rule_set_offsets_byte_len
     }
@@ -1730,11 +1756,12 @@ pub struct SequenceRuleSetMarker {
 }
 
 impl SequenceRuleSetMarker {
-    fn seq_rule_count_byte_range(&self) -> Range<usize> {
+    pub fn seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_rule_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let start = self.seq_rule_count_byte_range().end;
         start..start + self.seq_rule_offsets_byte_len
     }
@@ -1822,19 +1849,22 @@ pub struct SequenceRuleMarker {
 }
 
 impl SequenceRuleMarker {
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn input_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let start = self.seq_lookup_count_byte_range().end;
         start..start + self.input_sequence_byte_len
     }
-    fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let start = self.input_sequence_byte_range().end;
         start..start + self.seq_lookup_records_byte_len
     }
@@ -1931,23 +1961,27 @@ pub struct SequenceContextFormat2Marker {
 }
 
 impl SequenceContextFormat2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn class_def_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn class_seq_rule_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn class_seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.class_def_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.class_seq_rule_set_count_byte_range().end;
         start..start + self.class_seq_rule_set_offsets_byte_len
     }
@@ -2083,11 +2117,12 @@ pub struct ClassSequenceRuleSetMarker {
 }
 
 impl ClassSequenceRuleSetMarker {
-    fn class_seq_rule_count_byte_range(&self) -> Range<usize> {
+    pub fn class_seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let start = self.class_seq_rule_count_byte_range().end;
         start..start + self.class_seq_rule_offsets_byte_len
     }
@@ -2178,19 +2213,22 @@ pub struct ClassSequenceRuleMarker {
 }
 
 impl ClassSequenceRuleMarker {
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn input_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let start = self.seq_lookup_count_byte_range().end;
         start..start + self.input_sequence_byte_len
     }
-    fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let start = self.input_sequence_byte_range().end;
         start..start + self.seq_lookup_records_byte_len
     }
@@ -2289,23 +2327,27 @@ pub struct SequenceContextFormat3Marker {
 }
 
 impl SequenceContextFormat3Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.seq_lookup_count_byte_range().end;
         start..start + self.coverage_offsets_byte_len
     }
-    fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offsets_byte_range().end;
         start..start + self.seq_lookup_records_byte_len
     }
@@ -2498,19 +2540,22 @@ pub struct ChainedSequenceContextFormat1Marker {
 }
 
 impl ChainedSequenceContextFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn chained_seq_rule_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn chained_seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn chained_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn chained_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.chained_seq_rule_set_count_byte_range().end;
         start..start + self.chained_seq_rule_set_offsets_byte_len
     }
@@ -2628,11 +2673,12 @@ pub struct ChainedSequenceRuleSetMarker {
 }
 
 impl ChainedSequenceRuleSetMarker {
-    fn chained_seq_rule_count_byte_range(&self) -> Range<usize> {
+    pub fn chained_seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn chained_seq_rule_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn chained_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let start = self.chained_seq_rule_count_byte_range().end;
         start..start + self.chained_seq_rule_offsets_byte_len
     }
@@ -2725,35 +2771,42 @@ pub struct ChainedSequenceRuleMarker {
 }
 
 impl ChainedSequenceRuleMarker {
-    fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn backtrack_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_glyph_count_byte_range().end;
         start..start + self.backtrack_sequence_byte_len
     }
-    fn input_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_sequence_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn input_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let start = self.input_glyph_count_byte_range().end;
         start..start + self.input_sequence_byte_len
     }
-    fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.input_sequence_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookahead_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_glyph_count_byte_range().end;
         start..start + self.lookahead_sequence_byte_len
     }
-    fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_sequence_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let start = self.seq_lookup_count_byte_range().end;
         start..start + self.seq_lookup_records_byte_len
     }
@@ -2896,31 +2949,37 @@ pub struct ChainedSequenceContextFormat2Marker {
 }
 
 impl ChainedSequenceContextFormat2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn backtrack_class_def_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn input_class_def_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn input_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_class_def_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn lookahead_class_def_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.input_class_def_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn chained_class_seq_rule_set_count_byte_range(&self) -> Range<usize> {
+
+    pub fn chained_class_seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_class_def_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn chained_class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn chained_class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.chained_class_seq_rule_set_count_byte_range().end;
         start..start + self.chained_class_seq_rule_set_offsets_byte_len
     }
@@ -3099,11 +3158,12 @@ pub struct ChainedClassSequenceRuleSetMarker {
 }
 
 impl ChainedClassSequenceRuleSetMarker {
-    fn chained_class_seq_rule_count_byte_range(&self) -> Range<usize> {
+    pub fn chained_class_seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn chained_class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn chained_class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let start = self.chained_class_seq_rule_count_byte_range().end;
         start..start + self.chained_class_seq_rule_offsets_byte_len
     }
@@ -3198,35 +3258,42 @@ pub struct ChainedClassSequenceRuleMarker {
 }
 
 impl ChainedClassSequenceRuleMarker {
-    fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn backtrack_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_glyph_count_byte_range().end;
         start..start + self.backtrack_sequence_byte_len
     }
-    fn input_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_sequence_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn input_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let start = self.input_glyph_count_byte_range().end;
         start..start + self.input_sequence_byte_len
     }
-    fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.input_sequence_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookahead_sequence_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_glyph_count_byte_range().end;
         start..start + self.lookahead_sequence_byte_len
     }
-    fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_sequence_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let start = self.seq_lookup_count_byte_range().end;
         start..start + self.seq_lookup_records_byte_len
     }
@@ -3373,39 +3440,47 @@ pub struct ChainedSequenceContextFormat3Marker {
 }
 
 impl ChainedSequenceContextFormat3Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_glyph_count_byte_range().end;
         start..start + self.backtrack_coverage_offsets_byte_len
     }
-    fn input_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_coverage_offsets_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn input_coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn input_coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.input_glyph_count_byte_range().end;
         start..start + self.input_coverage_offsets_byte_len
     }
-    fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.input_coverage_offsets_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_glyph_count_byte_range().end;
         start..start + self.lookahead_coverage_offsets_byte_len
     }
-    fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_coverage_offsets_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let start = self.seq_lookup_count_byte_range().end;
         start..start + self.seq_lookup_records_byte_len
     }
@@ -3733,19 +3808,22 @@ pub struct DeviceMarker {
 }
 
 impl DeviceMarker {
-    fn start_size_byte_range(&self) -> Range<usize> {
+    pub fn start_size_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn end_size_byte_range(&self) -> Range<usize> {
+
+    pub fn end_size_byte_range(&self) -> Range<usize> {
         let start = self.start_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn delta_format_byte_range(&self) -> Range<usize> {
+
+    pub fn delta_format_byte_range(&self) -> Range<usize> {
         let start = self.end_size_byte_range().end;
         start..start + DeltaFormat::RAW_BYTE_LEN
     }
-    fn delta_value_byte_range(&self) -> Range<usize> {
+
+    pub fn delta_value_byte_range(&self) -> Range<usize> {
         let start = self.delta_format_byte_range().end;
         start..start + self.delta_value_byte_len
     }
@@ -3825,15 +3903,17 @@ impl<'a> std::fmt::Debug for Device<'a> {
 pub struct VariationIndexMarker {}
 
 impl VariationIndexMarker {
-    fn delta_set_outer_index_byte_range(&self) -> Range<usize> {
+    pub fn delta_set_outer_index_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn delta_set_inner_index_byte_range(&self) -> Range<usize> {
+
+    pub fn delta_set_inner_index_byte_range(&self) -> Range<usize> {
         let start = self.delta_set_outer_index_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn delta_format_byte_range(&self) -> Range<usize> {
+
+    pub fn delta_format_byte_range(&self) -> Range<usize> {
         let start = self.delta_set_inner_index_byte_range().end;
         start..start + DeltaFormat::RAW_BYTE_LEN
     }
@@ -3971,15 +4051,17 @@ pub struct FeatureVariationsMarker {
 }
 
 impl FeatureVariationsMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn feature_variation_record_count_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_variation_record_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn feature_variation_records_byte_range(&self) -> Range<usize> {
+
+    pub fn feature_variation_records_byte_range(&self) -> Range<usize> {
         let start = self.feature_variation_record_count_byte_range().end;
         start..start + self.feature_variation_records_byte_len
     }
@@ -4141,11 +4223,12 @@ pub struct ConditionSetMarker {
 }
 
 impl ConditionSetMarker {
-    fn condition_count_byte_range(&self) -> Range<usize> {
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn condition_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let start = self.condition_count_byte_range().end;
         start..start + self.condition_offsets_byte_len
     }
@@ -4315,19 +4398,22 @@ impl Format<u16> for ConditionFormat1Marker {
 pub struct ConditionFormat1Marker {}
 
 impl ConditionFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_index_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn filter_range_min_value_byte_range(&self) -> Range<usize> {
+
+    pub fn filter_range_min_value_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-    fn filter_range_max_value_byte_range(&self) -> Range<usize> {
+
+    pub fn filter_range_max_value_byte_range(&self) -> Range<usize> {
         let start = self.filter_range_min_value_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
@@ -4415,15 +4501,17 @@ impl Format<u16> for ConditionFormat2Marker {
 pub struct ConditionFormat2Marker {}
 
 impl ConditionFormat2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn default_value_byte_range(&self) -> Range<usize> {
+
+    pub fn default_value_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn var_index_byte_range(&self) -> Range<usize> {
+
+    pub fn var_index_byte_range(&self) -> Range<usize> {
         let start = self.default_value_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -4496,15 +4584,17 @@ pub struct ConditionFormat3Marker {
 }
 
 impl ConditionFormat3Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn condition_count_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn condition_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let start = self.condition_count_byte_range().end;
         start..start + self.condition_offsets_byte_len
     }
@@ -4602,15 +4692,17 @@ pub struct ConditionFormat4Marker {
 }
 
 impl ConditionFormat4Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn condition_count_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn condition_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let start = self.condition_count_byte_range().end;
         start..start + self.condition_offsets_byte_len
     }
@@ -4706,11 +4798,12 @@ impl Format<u16> for ConditionFormat5Marker {
 pub struct ConditionFormat5Marker {}
 
 impl ConditionFormat5Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn condition_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset24::RAW_BYTE_LEN
     }
@@ -4780,15 +4873,17 @@ pub struct FeatureTableSubstitutionMarker {
 }
 
 impl FeatureTableSubstitutionMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn substitution_count_byte_range(&self) -> Range<usize> {
+
+    pub fn substitution_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn substitutions_byte_range(&self) -> Range<usize> {
+
+    pub fn substitutions_byte_range(&self) -> Range<usize> {
         let start = self.substitution_count_byte_range().end;
         start..start + self.substitutions_byte_len
     }
@@ -4916,23 +5011,27 @@ impl<'a> SomeRecord<'a> for FeatureTableSubstitutionRecord {
 pub struct SizeParamsMarker {}
 
 impl SizeParamsMarker {
-    fn design_size_byte_range(&self) -> Range<usize> {
+    pub fn design_size_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn identifier_byte_range(&self) -> Range<usize> {
+
+    pub fn identifier_byte_range(&self) -> Range<usize> {
         let start = self.design_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn name_entry_byte_range(&self) -> Range<usize> {
+
+    pub fn name_entry_byte_range(&self) -> Range<usize> {
         let start = self.identifier_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_start_byte_range(&self) -> Range<usize> {
+
+    pub fn range_start_byte_range(&self) -> Range<usize> {
         let start = self.name_entry_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn range_end_byte_range(&self) -> Range<usize> {
+
+    pub fn range_end_byte_range(&self) -> Range<usize> {
         let start = self.range_start_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -5033,11 +5132,12 @@ impl<'a> std::fmt::Debug for SizeParams<'a> {
 pub struct StylisticSetParamsMarker {}
 
 impl StylisticSetParamsMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ui_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn ui_name_id_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
@@ -5108,35 +5208,42 @@ pub struct CharacterVariantParamsMarker {
 }
 
 impl CharacterVariantParamsMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn feat_ui_label_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn feat_ui_label_name_id_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn feat_ui_tooltip_text_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn feat_ui_tooltip_text_name_id_byte_range(&self) -> Range<usize> {
         let start = self.feat_ui_label_name_id_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn sample_text_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn sample_text_name_id_byte_range(&self) -> Range<usize> {
         let start = self.feat_ui_tooltip_text_name_id_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn num_named_parameters_byte_range(&self) -> Range<usize> {
+
+    pub fn num_named_parameters_byte_range(&self) -> Range<usize> {
         let start = self.sample_text_name_id_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn first_param_ui_label_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn first_param_ui_label_name_id_byte_range(&self) -> Range<usize> {
         let start = self.num_named_parameters_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn char_count_byte_range(&self) -> Range<usize> {
+
+    pub fn char_count_byte_range(&self) -> Range<usize> {
         let start = self.first_param_ui_label_name_id_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn character_byte_range(&self) -> Range<usize> {
+
+    pub fn character_byte_range(&self) -> Range<usize> {
         let start = self.char_count_byte_range().end;
         start..start + self.character_byte_len
     }

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -13,19 +13,22 @@ pub struct LtagMarker {
 }
 
 impl LtagMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_tags_byte_range(&self) -> Range<usize> {
+
+    pub fn num_tags_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn tag_ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn tag_ranges_byte_range(&self) -> Range<usize> {
         let start = self.num_tags_byte_range().end;
         start..start + self.tag_ranges_byte_len
     }

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -25,63 +25,77 @@ pub struct MaxpMarker {
 }
 
 impl MaxpMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Version16Dot16::RAW_BYTE_LEN
     }
-    fn num_glyphs_byte_range(&self) -> Range<usize> {
+
+    pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn max_points_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_points_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_points_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_contours_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_contours_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_contours_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_composite_points_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_composite_points_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_composite_points_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_composite_contours_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_composite_contours_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_composite_contours_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_zones_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_zones_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_zones_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_twilight_points_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_twilight_points_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_twilight_points_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_storage_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_storage_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_storage_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_function_defs_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_function_defs_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_function_defs_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_instruction_defs_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_instruction_defs_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_instruction_defs_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_stack_elements_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_stack_elements_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_stack_elements_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_size_of_instructions_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_size_of_instructions_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_size_of_instructions_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_component_elements_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_component_elements_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_component_elements_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn max_component_depth_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn max_component_depth_byte_range(&self) -> Option<Range<usize>> {
         let start = self.max_component_depth_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -13,27 +13,32 @@ pub struct MvarMarker {
 }
 
 impl MvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn value_record_size_byte_range(&self) -> Range<usize> {
+
+    pub fn value_record_size_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn value_record_count_byte_range(&self) -> Range<usize> {
+
+    pub fn value_record_count_byte_range(&self) -> Range<usize> {
         let start = self.value_record_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.value_record_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn value_records_byte_range(&self) -> Range<usize> {
+
+    pub fn value_records_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_store_offset_byte_range().end;
         start..start + self.value_records_byte_len
     }

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -16,27 +16,32 @@ pub struct NameMarker {
 }
 
 impl NameMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn count_byte_range(&self) -> Range<usize> {
+
+    pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn storage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn storage_offset_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn name_record_byte_range(&self) -> Range<usize> {
+
+    pub fn name_record_byte_range(&self) -> Range<usize> {
         let start = self.storage_offset_byte_range().end;
         start..start + self.name_record_byte_len
     }
-    fn lang_tag_count_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn lang_tag_count_byte_range(&self) -> Option<Range<usize>> {
         let start = self.lang_tag_count_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn lang_tag_record_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn lang_tag_record_byte_range(&self) -> Option<Range<usize>> {
         let start = self.lang_tag_record_byte_start?;
         Some(start..start + self.lang_tag_record_byte_len?)
     }

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -375,159 +375,197 @@ pub struct Os2Marker {
 }
 
 impl Os2Marker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn x_avg_char_width_byte_range(&self) -> Range<usize> {
+
+    pub fn x_avg_char_width_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn us_weight_class_byte_range(&self) -> Range<usize> {
+
+    pub fn us_weight_class_byte_range(&self) -> Range<usize> {
         let start = self.x_avg_char_width_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn us_width_class_byte_range(&self) -> Range<usize> {
+
+    pub fn us_width_class_byte_range(&self) -> Range<usize> {
         let start = self.us_weight_class_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn fs_type_byte_range(&self) -> Range<usize> {
+
+    pub fn fs_type_byte_range(&self) -> Range<usize> {
         let start = self.us_width_class_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn y_subscript_x_size_byte_range(&self) -> Range<usize> {
+
+    pub fn y_subscript_x_size_byte_range(&self) -> Range<usize> {
         let start = self.fs_type_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_subscript_y_size_byte_range(&self) -> Range<usize> {
+
+    pub fn y_subscript_y_size_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_x_size_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_subscript_x_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn y_subscript_x_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_y_size_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_subscript_y_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn y_subscript_y_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_x_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_superscript_x_size_byte_range(&self) -> Range<usize> {
+
+    pub fn y_superscript_x_size_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_y_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_superscript_y_size_byte_range(&self) -> Range<usize> {
+
+    pub fn y_superscript_y_size_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_x_size_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_superscript_x_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn y_superscript_x_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_y_size_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_superscript_y_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn y_superscript_y_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_x_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_strikeout_size_byte_range(&self) -> Range<usize> {
+
+    pub fn y_strikeout_size_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_y_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn y_strikeout_position_byte_range(&self) -> Range<usize> {
+
+    pub fn y_strikeout_position_byte_range(&self) -> Range<usize> {
         let start = self.y_strikeout_size_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn s_family_class_byte_range(&self) -> Range<usize> {
+
+    pub fn s_family_class_byte_range(&self) -> Range<usize> {
         let start = self.y_strikeout_position_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn panose_10_byte_range(&self) -> Range<usize> {
+
+    pub fn panose_10_byte_range(&self) -> Range<usize> {
         let start = self.s_family_class_byte_range().end;
         start..start + self.panose_10_byte_len
     }
-    fn ul_unicode_range_1_byte_range(&self) -> Range<usize> {
+
+    pub fn ul_unicode_range_1_byte_range(&self) -> Range<usize> {
         let start = self.panose_10_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn ul_unicode_range_2_byte_range(&self) -> Range<usize> {
+
+    pub fn ul_unicode_range_2_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_1_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn ul_unicode_range_3_byte_range(&self) -> Range<usize> {
+
+    pub fn ul_unicode_range_3_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_2_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn ul_unicode_range_4_byte_range(&self) -> Range<usize> {
+
+    pub fn ul_unicode_range_4_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_3_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn ach_vend_id_byte_range(&self) -> Range<usize> {
+
+    pub fn ach_vend_id_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_4_byte_range().end;
         start..start + Tag::RAW_BYTE_LEN
     }
-    fn fs_selection_byte_range(&self) -> Range<usize> {
+
+    pub fn fs_selection_byte_range(&self) -> Range<usize> {
         let start = self.ach_vend_id_byte_range().end;
         start..start + SelectionFlags::RAW_BYTE_LEN
     }
-    fn us_first_char_index_byte_range(&self) -> Range<usize> {
+
+    pub fn us_first_char_index_byte_range(&self) -> Range<usize> {
         let start = self.fs_selection_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn us_last_char_index_byte_range(&self) -> Range<usize> {
+
+    pub fn us_last_char_index_byte_range(&self) -> Range<usize> {
         let start = self.us_first_char_index_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn s_typo_ascender_byte_range(&self) -> Range<usize> {
+
+    pub fn s_typo_ascender_byte_range(&self) -> Range<usize> {
         let start = self.us_last_char_index_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn s_typo_descender_byte_range(&self) -> Range<usize> {
+
+    pub fn s_typo_descender_byte_range(&self) -> Range<usize> {
         let start = self.s_typo_ascender_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn s_typo_line_gap_byte_range(&self) -> Range<usize> {
+
+    pub fn s_typo_line_gap_byte_range(&self) -> Range<usize> {
         let start = self.s_typo_descender_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn us_win_ascent_byte_range(&self) -> Range<usize> {
+
+    pub fn us_win_ascent_byte_range(&self) -> Range<usize> {
         let start = self.s_typo_line_gap_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn us_win_descent_byte_range(&self) -> Range<usize> {
+
+    pub fn us_win_descent_byte_range(&self) -> Range<usize> {
         let start = self.us_win_ascent_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ul_code_page_range_1_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn ul_code_page_range_1_byte_range(&self) -> Option<Range<usize>> {
         let start = self.ul_code_page_range_1_byte_start?;
         Some(start..start + u32::RAW_BYTE_LEN)
     }
-    fn ul_code_page_range_2_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn ul_code_page_range_2_byte_range(&self) -> Option<Range<usize>> {
         let start = self.ul_code_page_range_2_byte_start?;
         Some(start..start + u32::RAW_BYTE_LEN)
     }
-    fn sx_height_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn sx_height_byte_range(&self) -> Option<Range<usize>> {
         let start = self.sx_height_byte_start?;
         Some(start..start + i16::RAW_BYTE_LEN)
     }
-    fn s_cap_height_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn s_cap_height_byte_range(&self) -> Option<Range<usize>> {
         let start = self.s_cap_height_byte_start?;
         Some(start..start + i16::RAW_BYTE_LEN)
     }
-    fn us_default_char_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn us_default_char_byte_range(&self) -> Option<Range<usize>> {
         let start = self.us_default_char_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn us_break_char_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn us_break_char_byte_range(&self) -> Option<Range<usize>> {
         let start = self.us_break_char_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn us_max_context_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn us_max_context_byte_range(&self) -> Option<Range<usize>> {
         let start = self.us_max_context_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn us_lower_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn us_lower_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
         let start = self.us_lower_optical_point_size_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn us_upper_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn us_upper_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
         let start = self.us_upper_optical_point_size_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -17,51 +17,62 @@ pub struct PostMarker {
 }
 
 impl PostMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Version16Dot16::RAW_BYTE_LEN
     }
-    fn italic_angle_byte_range(&self) -> Range<usize> {
+
+    pub fn italic_angle_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn underline_position_byte_range(&self) -> Range<usize> {
+
+    pub fn underline_position_byte_range(&self) -> Range<usize> {
         let start = self.italic_angle_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn underline_thickness_byte_range(&self) -> Range<usize> {
+
+    pub fn underline_thickness_byte_range(&self) -> Range<usize> {
         let start = self.underline_position_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn is_fixed_pitch_byte_range(&self) -> Range<usize> {
+
+    pub fn is_fixed_pitch_byte_range(&self) -> Range<usize> {
         let start = self.underline_thickness_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn min_mem_type42_byte_range(&self) -> Range<usize> {
+
+    pub fn min_mem_type42_byte_range(&self) -> Range<usize> {
         let start = self.is_fixed_pitch_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn max_mem_type42_byte_range(&self) -> Range<usize> {
+
+    pub fn max_mem_type42_byte_range(&self) -> Range<usize> {
         let start = self.min_mem_type42_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn min_mem_type1_byte_range(&self) -> Range<usize> {
+
+    pub fn min_mem_type1_byte_range(&self) -> Range<usize> {
         let start = self.max_mem_type42_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn max_mem_type1_byte_range(&self) -> Range<usize> {
+
+    pub fn max_mem_type1_byte_range(&self) -> Range<usize> {
         let start = self.min_mem_type1_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn num_glyphs_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn num_glyphs_byte_range(&self) -> Option<Range<usize>> {
         let start = self.num_glyphs_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn glyph_name_index_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn glyph_name_index_byte_range(&self) -> Option<Range<usize>> {
         let start = self.glyph_name_index_byte_start?;
         Some(start..start + self.glyph_name_index_byte_len?)
     }
-    fn string_data_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn string_data_byte_range(&self) -> Option<Range<usize>> {
         let start = self.string_data_byte_start?;
         Some(start..start + self.string_data_byte_len?)
     }

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -14,19 +14,22 @@ pub struct Index1Marker {
 }
 
 impl Index1Marker {
-    fn count_byte_range(&self) -> Range<usize> {
+    pub fn count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn off_size_byte_range(&self) -> Range<usize> {
+
+    pub fn off_size_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn offsets_byte_range(&self) -> Range<usize> {
         let start = self.off_size_byte_range().end;
         start..start + self.offsets_byte_len
     }
-    fn data_byte_range(&self) -> Range<usize> {
+
+    pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.offsets_byte_range().end;
         start..start + self.data_byte_len
     }
@@ -111,19 +114,22 @@ pub struct Index2Marker {
 }
 
 impl Index2Marker {
-    fn count_byte_range(&self) -> Range<usize> {
+    pub fn count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn off_size_byte_range(&self) -> Range<usize> {
+
+    pub fn off_size_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn offsets_byte_range(&self) -> Range<usize> {
         let start = self.off_size_byte_range().end;
         start..start + self.offsets_byte_len
     }
-    fn data_byte_range(&self) -> Range<usize> {
+
+    pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.offsets_byte_range().end;
         start..start + self.data_byte_len
     }
@@ -279,11 +285,12 @@ pub struct FdSelectFormat0Marker {
 }
 
 impl FdSelectFormat0Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn fds_byte_range(&self) -> Range<usize> {
+
+    pub fn fds_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + self.fds_byte_len
     }
@@ -349,19 +356,22 @@ pub struct FdSelectFormat3Marker {
 }
 
 impl FdSelectFormat3Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn n_ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn n_ranges_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn ranges_byte_range(&self) -> Range<usize> {
         let start = self.n_ranges_byte_range().end;
         start..start + self.ranges_byte_len
     }
-    fn sentinel_byte_range(&self) -> Range<usize> {
+
+    pub fn sentinel_byte_range(&self) -> Range<usize> {
         let start = self.ranges_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -494,19 +504,22 @@ pub struct FdSelectFormat4Marker {
 }
 
 impl FdSelectFormat4Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn n_ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn n_ranges_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn ranges_byte_range(&self) -> Range<usize> {
+
+    pub fn ranges_byte_range(&self) -> Range<usize> {
         let start = self.n_ranges_byte_range().end;
         start..start + self.ranges_byte_len
     }
-    fn sentinel_byte_range(&self) -> Range<usize> {
+
+    pub fn sentinel_byte_range(&self) -> Range<usize> {
         let start = self.ranges_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -322,19 +322,22 @@ pub struct SbixMarker {
 }
 
 impl SbixMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + HeaderFlags::RAW_BYTE_LEN
     }
-    fn num_strikes_byte_range(&self) -> Range<usize> {
+
+    pub fn num_strikes_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn strike_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn strike_offsets_byte_range(&self) -> Range<usize> {
         let start = self.num_strikes_byte_range().end;
         start..start + self.strike_offsets_byte_len
     }
@@ -466,15 +469,17 @@ pub struct StrikeMarker {
 }
 
 impl StrikeMarker {
-    fn ppem_byte_range(&self) -> Range<usize> {
+    pub fn ppem_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn ppi_byte_range(&self) -> Range<usize> {
+
+    pub fn ppi_byte_range(&self) -> Range<usize> {
         let start = self.ppem_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
         let start = self.ppi_byte_range().end;
         start..start + self.glyph_data_offsets_byte_len
     }
@@ -564,19 +569,22 @@ pub struct GlyphDataMarker {
 }
 
 impl GlyphDataMarker {
-    fn origin_offset_x_byte_range(&self) -> Range<usize> {
+    pub fn origin_offset_x_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn origin_offset_y_byte_range(&self) -> Range<usize> {
+
+    pub fn origin_offset_y_byte_range(&self) -> Range<usize> {
         let start = self.origin_offset_x_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn graphic_type_byte_range(&self) -> Range<usize> {
+
+    pub fn graphic_type_byte_range(&self) -> Range<usize> {
         let start = self.origin_offset_y_byte_range().end;
         start..start + Tag::RAW_BYTE_LEN
     }
-    fn data_byte_range(&self) -> Range<usize> {
+
+    pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.graphic_type_byte_range().end;
         start..start + self.data_byte_len
     }

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -13,31 +13,37 @@ pub struct StatMarker {
 }
 
 impl StatMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn design_axis_size_byte_range(&self) -> Range<usize> {
+
+    pub fn design_axis_size_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn design_axis_count_byte_range(&self) -> Range<usize> {
+
+    pub fn design_axis_count_byte_range(&self) -> Range<usize> {
         let start = self.design_axis_size_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn design_axes_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn design_axes_offset_byte_range(&self) -> Range<usize> {
         let start = self.design_axis_count_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn axis_value_count_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_value_count_byte_range(&self) -> Range<usize> {
         let start = self.design_axes_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn offset_to_axis_value_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn offset_to_axis_value_offsets_byte_range(&self) -> Range<usize> {
         let start = self.axis_value_count_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn elided_fallback_name_id_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn elided_fallback_name_id_byte_range(&self) -> Option<Range<usize>> {
         let start = self.elided_fallback_name_id_byte_start?;
         Some(start..start + NameId::RAW_BYTE_LEN)
     }
@@ -251,7 +257,7 @@ pub struct AxisValueArrayMarker {
 }
 
 impl AxisValueArrayMarker {
-    fn axis_value_offsets_byte_range(&self) -> Range<usize> {
+    pub fn axis_value_offsets_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.axis_value_offsets_byte_len
     }
@@ -442,23 +448,27 @@ impl Format<u16> for AxisValueFormat1Marker {
 pub struct AxisValueFormat1Marker {}
 
 impl AxisValueFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_index_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
         start..start + AxisValueTableFlags::RAW_BYTE_LEN
     }
-    fn value_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn value_byte_range(&self) -> Range<usize> {
+
+    pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
@@ -548,31 +558,37 @@ impl Format<u16> for AxisValueFormat2Marker {
 pub struct AxisValueFormat2Marker {}
 
 impl AxisValueFormat2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_index_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
         start..start + AxisValueTableFlags::RAW_BYTE_LEN
     }
-    fn value_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn nominal_value_byte_range(&self) -> Range<usize> {
+
+    pub fn nominal_value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn range_min_value_byte_range(&self) -> Range<usize> {
+
+    pub fn range_min_value_byte_range(&self) -> Range<usize> {
         let start = self.nominal_value_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn range_max_value_byte_range(&self) -> Range<usize> {
+
+    pub fn range_max_value_byte_range(&self) -> Range<usize> {
         let start = self.range_min_value_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
@@ -680,27 +696,32 @@ impl Format<u16> for AxisValueFormat3Marker {
 pub struct AxisValueFormat3Marker {}
 
 impl AxisValueFormat3Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_index_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
         start..start + AxisValueTableFlags::RAW_BYTE_LEN
     }
-    fn value_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn value_byte_range(&self) -> Range<usize> {
+
+    pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-    fn linked_value_byte_range(&self) -> Range<usize> {
+
+    pub fn linked_value_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
@@ -800,23 +821,27 @@ pub struct AxisValueFormat4Marker {
 }
 
 impl AxisValueFormat4Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn axis_count_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
         start..start + AxisValueTableFlags::RAW_BYTE_LEN
     }
-    fn value_name_id_byte_range(&self) -> Range<usize> {
+
+    pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
     }
-    fn axis_values_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_values_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
         start..start + self.axis_values_byte_len
     }

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -11,15 +11,17 @@ use crate::codegen_prelude::*;
 pub struct SvgMarker {}
 
 impl SvgMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn svg_document_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn svg_document_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.svg_document_list_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -96,11 +98,12 @@ pub struct SVGDocumentListMarker {
 }
 
 impl SVGDocumentListMarker {
-    fn num_entries_byte_range(&self) -> Range<usize> {
+    pub fn num_entries_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn document_records_byte_range(&self) -> Range<usize> {
+
+    pub fn document_records_byte_range(&self) -> Range<usize> {
         let start = self.num_entries_byte_range().end;
         start..start + self.document_records_byte_len
     }

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -13,19 +13,22 @@ pub struct MajorMinorVersionMarker {
 }
 
 impl MajorMinorVersionMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn always_present_byte_range(&self) -> Range<usize> {
+
+    pub fn always_present_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn if_11_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn if_11_byte_range(&self) -> Option<Range<usize>> {
         let start = self.if_11_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn if_20_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn if_20_byte_range(&self) -> Option<Range<usize>> {
         let start = self.if_20_byte_start?;
         Some(start..start + u32::RAW_BYTE_LEN)
     }
@@ -423,23 +426,27 @@ pub struct FlagDayMarker {
 }
 
 impl FlagDayMarker {
-    fn volume_byte_range(&self) -> Range<usize> {
+    pub fn volume_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn flags_byte_range(&self) -> Range<usize> {
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.volume_byte_range().end;
         start..start + GotFlags::RAW_BYTE_LEN
     }
-    fn foo_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn foo_byte_range(&self) -> Option<Range<usize>> {
         let start = self.foo_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn bar_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn bar_byte_range(&self) -> Option<Range<usize>> {
         let start = self.bar_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn baz_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn baz_byte_range(&self) -> Option<Range<usize>> {
         let start = self.baz_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
@@ -544,30 +551,35 @@ pub struct FieldsAfterConditionalsMarker {
 }
 
 impl FieldsAfterConditionalsMarker {
-    fn flags_byte_range(&self) -> Range<usize> {
+    pub fn flags_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + GotFlags::RAW_BYTE_LEN
     }
-    fn foo_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn foo_byte_range(&self) -> Option<Range<usize>> {
         let start = self.foo_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn always_here_byte_range(&self) -> Range<usize> {
+
+    pub fn always_here_byte_range(&self) -> Range<usize> {
         let start = self
             .foo_byte_range()
             .map(|range| range.end)
             .unwrap_or_else(|| self.flags_byte_range().end);
         start..start + u16::RAW_BYTE_LEN
     }
-    fn bar_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn bar_byte_range(&self) -> Option<Range<usize>> {
         let start = self.bar_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn baz_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn baz_byte_range(&self) -> Option<Range<usize>> {
         let start = self.baz_byte_start?;
         Some(start..start + u16::RAW_BYTE_LEN)
     }
-    fn also_always_here_byte_range(&self) -> Range<usize> {
+
+    pub fn also_always_here_byte_range(&self) -> Range<usize> {
         let start = self
             .baz_byte_range()
             .map(|range| range.end)
@@ -578,7 +590,8 @@ impl FieldsAfterConditionalsMarker {
             });
         start..start + u16::RAW_BYTE_LEN
     }
-    fn and_me_too_byte_range(&self) -> Range<usize> {
+
+    pub fn and_me_too_byte_range(&self) -> Range<usize> {
         let start = self.also_always_here_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -12,11 +12,12 @@ pub struct CountAll16Marker {
 }
 
 impl CountAll16Marker {
-    fn some_field_byte_range(&self) -> Range<usize> {
+    pub fn some_field_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn remainder_byte_range(&self) -> Range<usize> {
+
+    pub fn remainder_byte_range(&self) -> Range<usize> {
         let start = self.some_field_byte_range().end;
         start..start + self.remainder_byte_len
     }
@@ -74,11 +75,12 @@ pub struct CountAll32Marker {
 }
 
 impl CountAll32Marker {
-    fn some_field_byte_range(&self) -> Range<usize> {
+    pub fn some_field_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn remainder_byte_range(&self) -> Range<usize> {
+
+    pub fn remainder_byte_range(&self) -> Range<usize> {
         let start = self.some_field_byte_range().end;
         start..start + self.remainder_byte_len
     }

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -14,15 +14,17 @@ impl Format<u16> for Table1Marker {
 pub struct Table1Marker {}
 
 impl Table1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn heft_byte_range(&self) -> Range<usize> {
+
+    pub fn heft_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn flex_byte_range(&self) -> Range<usize> {
+
+    pub fn flex_byte_range(&self) -> Range<usize> {
         let start = self.heft_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -90,15 +92,17 @@ pub struct Table2Marker {
 }
 
 impl Table2Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn value_count_byte_range(&self) -> Range<usize> {
+
+    pub fn value_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn values_byte_range(&self) -> Range<usize> {
+
+    pub fn values_byte_range(&self) -> Range<usize> {
         let start = self.value_count_byte_range().end;
         start..start + self.values_byte_len
     }
@@ -167,11 +171,12 @@ impl Format<u16> for Table3Marker {
 pub struct Table3Marker {}
 
 impl Table3Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn something_byte_range(&self) -> Range<usize> {
+
+    pub fn something_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -14,39 +14,47 @@ pub struct KindsOfOffsetsMarker {
 }
 
 impl KindsOfOffsetsMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn nonnullable_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn nonnullable_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn nullable_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn nullable_offset_byte_range(&self) -> Range<usize> {
         let start = self.nonnullable_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn array_offset_count_byte_range(&self) -> Range<usize> {
+
+    pub fn array_offset_count_byte_range(&self) -> Range<usize> {
         let start = self.nullable_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn array_offset_byte_range(&self) -> Range<usize> {
         let start = self.array_offset_count_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn record_array_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn record_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-    fn versioned_nullable_record_array_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_nullable_record_array_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_nullable_record_array_offset_byte_start?;
         Some(start..start + Offset16::RAW_BYTE_LEN)
     }
-    fn versioned_nonnullable_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_nonnullable_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_nonnullable_offset_byte_start?;
         Some(start..start + Offset16::RAW_BYTE_LEN)
     }
-    fn versioned_nullable_offset_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_nullable_offset_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_nullable_offset_byte_start?;
         Some(start..start + Offset32::RAW_BYTE_LEN)
     }
@@ -274,27 +282,32 @@ pub struct KindsOfArraysOfOffsetsMarker {
 }
 
 impl KindsOfArraysOfOffsetsMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn count_byte_range(&self) -> Range<usize> {
+
+    pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn nonnullable_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn nonnullable_offsets_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
         start..start + self.nonnullable_offsets_byte_len
     }
-    fn nullable_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn nullable_offsets_byte_range(&self) -> Range<usize> {
         let start = self.nonnullable_offsets_byte_range().end;
         start..start + self.nullable_offsets_byte_len
     }
-    fn versioned_nonnullable_offsets_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_nonnullable_offsets_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_nonnullable_offsets_byte_start?;
         Some(start..start + self.versioned_nonnullable_offsets_byte_len?)
     }
-    fn versioned_nullable_offsets_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_nullable_offsets_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_nullable_offsets_byte_start?;
         Some(start..start + self.versioned_nullable_offsets_byte_len?)
     }
@@ -506,27 +519,32 @@ pub struct KindsOfArraysMarker {
 }
 
 impl KindsOfArraysMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn count_byte_range(&self) -> Range<usize> {
+
+    pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn scalars_byte_range(&self) -> Range<usize> {
+
+    pub fn scalars_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
         start..start + self.scalars_byte_len
     }
-    fn records_byte_range(&self) -> Range<usize> {
+
+    pub fn records_byte_range(&self) -> Range<usize> {
         let start = self.scalars_byte_range().end;
         start..start + self.records_byte_len
     }
-    fn versioned_scalars_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_scalars_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_scalars_byte_start?;
         Some(start..start + self.versioned_scalars_byte_len?)
     }
-    fn versioned_records_byte_range(&self) -> Option<Range<usize>> {
+
+    pub fn versioned_records_byte_range(&self) -> Option<Range<usize>> {
         let start = self.versioned_records_byte_start?;
         Some(start..start + self.versioned_records_byte_len?)
     }
@@ -669,15 +687,17 @@ pub struct VarLenHaverMarker {
 }
 
 impl VarLenHaverMarker {
-    fn count_byte_range(&self) -> Range<usize> {
+    pub fn count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn var_len_byte_range(&self) -> Range<usize> {
+
+    pub fn var_len_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
         start..start + self.var_len_byte_len
     }
-    fn other_field_byte_range(&self) -> Range<usize> {
+
+    pub fn other_field_byte_range(&self) -> Range<usize> {
         let start = self.var_len_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
@@ -743,11 +763,12 @@ impl<'a> std::fmt::Debug for VarLenHaver<'a> {
 pub struct DummyMarker {}
 
 impl DummyMarker {
-    fn value_byte_range(&self) -> Range<usize> {
+    pub fn value_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn _reserved_byte_range(&self) -> Range<usize> {
+
+    pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -13,23 +13,27 @@ pub struct BasicTableMarker {
 }
 
 impl BasicTableMarker {
-    fn simple_count_byte_range(&self) -> Range<usize> {
+    pub fn simple_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn simple_records_byte_range(&self) -> Range<usize> {
+
+    pub fn simple_records_byte_range(&self) -> Range<usize> {
         let start = self.simple_count_byte_range().end;
         start..start + self.simple_records_byte_len
     }
-    fn arrays_inner_count_byte_range(&self) -> Range<usize> {
+
+    pub fn arrays_inner_count_byte_range(&self) -> Range<usize> {
         let start = self.simple_records_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn array_records_count_byte_range(&self) -> Range<usize> {
+
+    pub fn array_records_count_byte_range(&self) -> Range<usize> {
         let start = self.arrays_inner_count_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn array_records_byte_range(&self) -> Range<usize> {
+
+    pub fn array_records_byte_range(&self) -> Range<usize> {
         let start = self.array_records_count_byte_range().end;
         start..start + self.array_records_byte_len
     }

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -13,27 +13,32 @@ use crate::codegen_prelude::*;
 pub struct VarcMarker {}
 
 impl VarcMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn coverage_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn multi_var_store_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn multi_var_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn condition_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.multi_var_store_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn axis_indices_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn axis_indices_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.condition_list_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn var_composite_glyphs_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn var_composite_glyphs_offset_byte_range(&self) -> Range<usize> {
         let start = self.axis_indices_list_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
@@ -181,19 +186,22 @@ pub struct MultiItemVariationStoreMarker {
 }
 
 impl MultiItemVariationStoreMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn region_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn variation_data_count_byte_range(&self) -> Range<usize> {
+
+    pub fn variation_data_count_byte_range(&self) -> Range<usize> {
         let start = self.region_list_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn variation_data_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn variation_data_offsets_byte_range(&self) -> Range<usize> {
         let start = self.variation_data_count_byte_range().end;
         start..start + self.variation_data_offsets_byte_len
     }
@@ -303,11 +311,12 @@ pub struct SparseVariationRegionListMarker {
 }
 
 impl SparseVariationRegionListMarker {
-    fn region_count_byte_range(&self) -> Range<usize> {
+    pub fn region_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn region_offsets_byte_range(&self) -> Range<usize> {
         let start = self.region_count_byte_range().end;
         start..start + self.region_offsets_byte_len
     }
@@ -389,11 +398,12 @@ pub struct SparseVariationRegionMarker {
 }
 
 impl SparseVariationRegionMarker {
-    fn region_axis_count_byte_range(&self) -> Range<usize> {
+    pub fn region_axis_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_axis_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn region_axis_offsets_byte_range(&self) -> Range<usize> {
         let start = self.region_axis_count_byte_range().end;
         start..start + self.region_axis_offsets_byte_len
     }
@@ -517,19 +527,22 @@ pub struct MultiItemVariationDataMarker {
 }
 
 impl MultiItemVariationDataMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn region_index_count_byte_range(&self) -> Range<usize> {
+
+    pub fn region_index_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_indices_byte_range(&self) -> Range<usize> {
+
+    pub fn region_indices_byte_range(&self) -> Range<usize> {
         let start = self.region_index_count_byte_range().end;
         start..start + self.region_indices_byte_len
     }
-    fn raw_delta_sets_byte_range(&self) -> Range<usize> {
+
+    pub fn raw_delta_sets_byte_range(&self) -> Range<usize> {
         let start = self.region_indices_byte_range().end;
         start..start + self.raw_delta_sets_byte_len
     }
@@ -608,11 +621,12 @@ pub struct ConditionListMarker {
 }
 
 impl ConditionListMarker {
-    fn condition_count_byte_range(&self) -> Range<usize> {
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn condition_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let start = self.condition_count_byte_range().end;
         start..start + self.condition_offsets_byte_len
     }

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -15,23 +15,27 @@ pub struct TupleVariationHeaderMarker {
 }
 
 impl TupleVariationHeaderMarker {
-    fn variation_data_size_byte_range(&self) -> Range<usize> {
+    pub fn variation_data_size_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn tuple_index_byte_range(&self) -> Range<usize> {
+
+    pub fn tuple_index_byte_range(&self) -> Range<usize> {
         let start = self.variation_data_size_byte_range().end;
         start..start + TupleIndex::RAW_BYTE_LEN
     }
-    fn peak_tuple_byte_range(&self) -> Range<usize> {
+
+    pub fn peak_tuple_byte_range(&self) -> Range<usize> {
         let start = self.tuple_index_byte_range().end;
         start..start + self.peak_tuple_byte_len
     }
-    fn intermediate_start_tuple_byte_range(&self) -> Range<usize> {
+
+    pub fn intermediate_start_tuple_byte_range(&self) -> Range<usize> {
         let start = self.peak_tuple_byte_range().end;
         start..start + self.intermediate_start_tuple_byte_len
     }
-    fn intermediate_end_tuple_byte_range(&self) -> Range<usize> {
+
+    pub fn intermediate_end_tuple_byte_range(&self) -> Range<usize> {
         let start = self.intermediate_start_tuple_byte_range().end;
         start..start + self.intermediate_end_tuple_byte_len
     }
@@ -208,19 +212,22 @@ pub struct DeltaSetIndexMapFormat0Marker {
 }
 
 impl DeltaSetIndexMapFormat0Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn entry_format_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_format_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + EntryFormat::RAW_BYTE_LEN
     }
-    fn map_count_byte_range(&self) -> Range<usize> {
+
+    pub fn map_count_byte_range(&self) -> Range<usize> {
         let start = self.entry_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn map_data_byte_range(&self) -> Range<usize> {
+
+    pub fn map_data_byte_range(&self) -> Range<usize> {
         let start = self.map_count_byte_range().end;
         start..start + self.map_data_byte_len
     }
@@ -305,19 +312,22 @@ pub struct DeltaSetIndexMapFormat1Marker {
 }
 
 impl DeltaSetIndexMapFormat1Marker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
     }
-    fn entry_format_byte_range(&self) -> Range<usize> {
+
+    pub fn entry_format_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + EntryFormat::RAW_BYTE_LEN
     }
-    fn map_count_byte_range(&self) -> Range<usize> {
+
+    pub fn map_count_byte_range(&self) -> Range<usize> {
         let start = self.entry_format_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-    fn map_data_byte_range(&self) -> Range<usize> {
+
+    pub fn map_data_byte_range(&self) -> Range<usize> {
         let start = self.map_count_byte_range().end;
         start..start + self.map_data_byte_len
     }
@@ -789,15 +799,17 @@ pub struct VariationRegionListMarker {
 }
 
 impl VariationRegionListMarker {
-    fn axis_count_byte_range(&self) -> Range<usize> {
+    pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_count_byte_range(&self) -> Range<usize> {
+
+    pub fn region_count_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn variation_regions_byte_range(&self) -> Range<usize> {
+
+    pub fn variation_regions_byte_range(&self) -> Range<usize> {
         let start = self.region_count_byte_range().end;
         start..start + self.variation_regions_byte_len
     }
@@ -1003,19 +1015,22 @@ pub struct ItemVariationStoreMarker {
 }
 
 impl ItemVariationStoreMarker {
-    fn format_byte_range(&self) -> Range<usize> {
+    pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn variation_region_list_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn variation_region_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn item_variation_data_count_byte_range(&self) -> Range<usize> {
+
+    pub fn item_variation_data_count_byte_range(&self) -> Range<usize> {
         let start = self.variation_region_list_offset_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn item_variation_data_offsets_byte_range(&self) -> Range<usize> {
+
+    pub fn item_variation_data_offsets_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_data_count_byte_range().end;
         start..start + self.item_variation_data_offsets_byte_len
     }
@@ -1137,23 +1152,27 @@ pub struct ItemVariationDataMarker {
 }
 
 impl ItemVariationDataMarker {
-    fn item_count_byte_range(&self) -> Range<usize> {
+    pub fn item_count_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn word_delta_count_byte_range(&self) -> Range<usize> {
+
+    pub fn word_delta_count_byte_range(&self) -> Range<usize> {
         let start = self.item_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_index_count_byte_range(&self) -> Range<usize> {
+
+    pub fn region_index_count_byte_range(&self) -> Range<usize> {
         let start = self.word_delta_count_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn region_indexes_byte_range(&self) -> Range<usize> {
+
+    pub fn region_indexes_byte_range(&self) -> Range<usize> {
         let start = self.region_index_count_byte_range().end;
         start..start + self.region_indexes_byte_len
     }
-    fn delta_sets_byte_range(&self) -> Range<usize> {
+
+    pub fn delta_sets_byte_range(&self) -> Range<usize> {
         let start = self.region_indexes_byte_range().end;
         start..start + self.delta_sets_byte_len
     }

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -11,71 +11,87 @@ use crate::codegen_prelude::*;
 pub struct VheaMarker {}
 
 impl VheaMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Version16Dot16::RAW_BYTE_LEN
     }
-    fn ascender_byte_range(&self) -> Range<usize> {
+
+    pub fn ascender_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn descender_byte_range(&self) -> Range<usize> {
+
+    pub fn descender_byte_range(&self) -> Range<usize> {
         let start = self.ascender_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn line_gap_byte_range(&self) -> Range<usize> {
+
+    pub fn line_gap_byte_range(&self) -> Range<usize> {
         let start = self.descender_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn advance_height_max_byte_range(&self) -> Range<usize> {
+
+    pub fn advance_height_max_byte_range(&self) -> Range<usize> {
         let start = self.line_gap_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
-    fn min_top_side_bearing_byte_range(&self) -> Range<usize> {
+
+    pub fn min_top_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.advance_height_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn min_bottom_side_bearing_byte_range(&self) -> Range<usize> {
+
+    pub fn min_bottom_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.min_top_side_bearing_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn y_max_extent_byte_range(&self) -> Range<usize> {
+
+    pub fn y_max_extent_byte_range(&self) -> Range<usize> {
         let start = self.min_bottom_side_bearing_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-    fn caret_slope_rise_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_slope_rise_byte_range(&self) -> Range<usize> {
         let start = self.y_max_extent_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn caret_slope_run_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_slope_run_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_rise_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn caret_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn caret_offset_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_run_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved1_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved1_byte_range(&self) -> Range<usize> {
         let start = self.caret_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved2_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved2_byte_range(&self) -> Range<usize> {
         let start = self.reserved1_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved3_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved3_byte_range(&self) -> Range<usize> {
         let start = self.reserved2_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn reserved4_byte_range(&self) -> Range<usize> {
+
+    pub fn reserved4_byte_range(&self) -> Range<usize> {
         let start = self.reserved3_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn metric_data_format_byte_range(&self) -> Range<usize> {
+
+    pub fn metric_data_format_byte_range(&self) -> Range<usize> {
         let start = self.reserved4_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn number_of_long_ver_metrics_byte_range(&self) -> Range<usize> {
+
+    pub fn number_of_long_ver_metrics_byte_range(&self) -> Range<usize> {
         let start = self.metric_data_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -14,11 +14,12 @@ pub struct VmtxMarker {
 }
 
 impl VmtxMarker {
-    fn v_metrics_byte_range(&self) -> Range<usize> {
+    pub fn v_metrics_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.v_metrics_byte_len
     }
-    fn top_side_bearings_byte_range(&self) -> Range<usize> {
+
+    pub fn top_side_bearings_byte_range(&self) -> Range<usize> {
         let start = self.v_metrics_byte_range().end;
         start..start + self.top_side_bearings_byte_len
     }

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -13,19 +13,22 @@ pub struct VorgMarker {
 }
 
 impl VorgMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn default_vert_origin_y_byte_range(&self) -> Range<usize> {
+
+    pub fn default_vert_origin_y_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-    fn num_vert_origin_y_metrics_byte_range(&self) -> Range<usize> {
+
+    pub fn num_vert_origin_y_metrics_byte_range(&self) -> Range<usize> {
         let start = self.default_vert_origin_y_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-    fn vert_origin_y_metrics_byte_range(&self) -> Range<usize> {
+
+    pub fn vert_origin_y_metrics_byte_range(&self) -> Range<usize> {
         let start = self.num_vert_origin_y_metrics_byte_range().end;
         start..start + self.vert_origin_y_metrics_byte_len
     }

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -11,27 +11,32 @@ use crate::codegen_prelude::*;
 pub struct VvarMarker {}
 
 impl VvarMarker {
-    fn version_byte_range(&self) -> Range<usize> {
+    pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
     }
-    fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn advance_height_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn advance_height_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_store_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn tsb_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn tsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.advance_height_mapping_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn bsb_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn bsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.tsb_mapping_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }
-    fn v_org_mapping_offset_byte_range(&self) -> Range<usize> {
+
+    pub fn v_org_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.bsb_mapping_offset_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
     }

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -25,6 +25,15 @@ impl<'a, T> TableRef<'a, T> {
     pub fn offset_data(&self) -> FontData<'a> {
         self.data
     }
+
+    /// Return a reference to the table's 'Shape' struct.
+    ///
+    /// This is a low level implementation detail, but it can be useful in
+    /// some cases where you want to know things about a table's layout, such
+    /// as the byte offsets of specific fields.
+    pub fn shape(&self) -> &T {
+        &self.shape
+    }
 }
 
 // a blanket impl so that the format is available through a TableRef


### PR DESCRIPTION
This is useful for applications like subsetting.

The individual markers are still #[doc(hidden)] because they really aren't intended to be public API, so this flood of new methods should also not show up in the docs.
