### PR TITLE
[IFT] major rework to the IFT API around patch intersection and application.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -185,7 +185,10 @@ pub fn codepoints_only_format2() -> BeBuffer {
 
       0u32,               // reserved
 
-      [1, 2, 3, 4u32],    // compat id
+      {1u32: "compat_id[0]"},
+      {2u32: "compat_id[1]"},
+      {3u32: "compat_id[2]"},
+      {4u32: "compat_id[3]"},
 
       3u8,                // default patch encoding
       (Uint24::new(4)),   // entry count

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -23,6 +23,9 @@ write-fonts = { workspace = true }
 font-types = { workspace = true }
 skrifa = { workspace = true }
 shared-brotli-patch-decoder = { workspace = true }
+uritemplate = "0.1.2"
+data-encoding = "2.6.0"
+data-encoding-macro = "0.1.15"
 
 [dev-dependencies]
 font-test-data = { workspace = true }

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -179,9 +179,11 @@ impl IncrementalFontPatchBase for &[u8] {
     }
 }
 
-// TODO(garretrieger): basic tests for high level apis.
 #[cfg(test)]
 mod tests {
+    // TODO(garretrieger): apply table keyed with mismatched compat ids.
+    // TODO(garretrieger): apply glyph keyed with mismatched compat ids.
+
     /*
     #[test]
       fn table_keyed_patch_compat_id_mismatch() {

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -148,6 +148,9 @@ impl IncrementalFontPatch<'_> {
 
 impl IncrementalFontPatchBase for FontRef<'_> {
     fn apply_patch(&self, patches: &[IncrementalFontPatch]) -> Result<Vec<u8>, PatchingError> {
+        // TODO(garretrieger): we should be verifying the compat ID's match, would need to know the source mapping table from
+        //                     the patch uri.
+
         // TODO(garretrieger): we can support table keyed + glyph keyed where the table keyed is partially invalidation
         // and has a different compat id then the glyph keyed patches.
         if self.table_data(Tag::new(b"IFT ")).is_none()

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -136,9 +136,8 @@ impl IncrementalFontPatchBase for FontRef<'_> {
             let font_compat_id = cached_compat_ids
                 .entry(tag.tag())
                 .or_insert_with(|| {
-                    Ok(tag
-                        .font_compat_id(self)
-                        .map_err(PatchingError::FontParsingFailed)?)
+                    tag.font_compat_id(self)
+                        .map_err(PatchingError::FontParsingFailed)
                 })
                 .as_ref()
                 .map_err(Clone::clone)?;

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -56,6 +56,7 @@ pub enum PatchingError {
     InvalidPatch(&'static str),
     EmptyPatchList,
     InternalError,
+    MissingPatches,
 }
 
 impl From<DecodeError> for PatchingError {
@@ -99,6 +100,7 @@ impl std::fmt::Display for PatchingError {
                 f,
                 "Internal constraint violated, typically should not happen."
             ),
+            PatchingError::MissingPatches => write!(f, "Not all patch data has been supplied."),
         }
     }
 }

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -10,66 +10,40 @@
 //!    glyph id + table. The patch inserts these blobs into the table at the location for
 //!    the corresponding glyph id.
 
-use crate::patchmap::{PatchEncoding, PatchUri};
+use crate::patch_group::{AffectsIft, AffectsIftx, PatchInfo, PatchScope};
 
 use crate::glyph_keyed::apply_glyph_keyed_patches;
-use read_fonts::tables::ift::{
-    CompatibilityId, GlyphKeyedPatch, TableKeyedPatch, TablePatch, TablePatchFlags,
-};
-use read_fonts::types::Tag;
-use read_fonts::{FontData, FontRef};
-use read_fonts::{FontRead, ReadError};
-use shared_brotli_patch_decoder::{shared_brotli_decode, DecodeError};
-use std::collections::BTreeSet;
+use crate::table_keyed::apply_table_keyed_patch;
+use read_fonts::tables::ift::{GlyphKeyedPatch, TableKeyedPatch};
 
-use write_fonts::FontBuilder;
+use read_fonts::{FontData, FontRead, FontRef, ReadError};
 
-/// An incremental font patch which can be used to extend a font.
-///
-/// See: <https://w3c.github.io/IFT/Overview.html#font-patch-formats>
-#[derive(Clone)]
-pub enum IncrementalFontPatch<'a> {
-    TableKeyed(TableKeyedPatch<'a>),
-    GlyphKeyed(GlyphKeyedPatch<'a>),
-}
-
-impl PatchUri {
-    /// Resolves a PatchUri into the actual underlying patch given the data associated with the URI.
-    pub fn into_patch<'a>(
-        &self,
-        patch_data: &'a [u8],
-    ) -> Result<IncrementalFontPatch<'a>, PatchingError> {
-        let patch = match self.encoding() {
-            PatchEncoding::TableKeyed { .. } => IncrementalFontPatch::TableKeyed(
-                TableKeyedPatch::read(FontData::new(patch_data))
-                    .map_err(PatchingError::PatchParsingFailed)?,
-            ),
-            PatchEncoding::GlyphKeyed => IncrementalFontPatch::GlyphKeyed(
-                GlyphKeyedPatch::read(FontData::new(patch_data))
-                    .map_err(PatchingError::PatchParsingFailed)?,
-            ),
-        };
-
-        if *self.expected_compatibility_id() != patch.compatibility_id() {
-            // Compatibility ids must match.
-            return Err(PatchingError::IncompatiblePatch);
-        }
-
-        Ok(patch)
-    }
-}
+use shared_brotli_patch_decoder::DecodeError;
 
 /// A trait for types to which an incremental font transfer patch can be applied.
 ///
 /// See: <https://w3c.github.io/IFT/Overview.html#font-patch-formats> for details on the format of patches.
-pub trait IncrementalFontPatchBase {
-    /// Apply a set of incremental font patches (<https://w3c.github.io/IFT/Overview.html#font-patch-formats>)
+pub(crate) trait IncrementalFontPatchBase {
+    /// Apply a table keyed incremental font patches (<https://w3c.github.io/IFT/Overview.html#font-patch-formats>)
     ///
-    /// Applies the patches to this base. In the base the patch is associated with the supplied
-    /// expected_compatibility_id and has the specified encoding.
+    /// Applies the patches to this base.
     ///
     /// Returns the byte data for the new font produced as a result of the patch applications.
-    fn apply_patch(&self, patch: &[IncrementalFontPatch]) -> Result<Vec<u8>, PatchingError>;
+    fn apply_table_keyed_patch<T: PatchScope>(
+        &self,
+        patch: &PatchInfo<T>,
+    ) -> Result<Vec<u8>, PatchingError>;
+
+    /// Apply a set of glyph keyed incremental font patches (<https://w3c.github.io/IFT/Overview.html#font-patch-formats>)
+    ///
+    /// Applies the patches to this base.
+    ///
+    /// Returns the byte data for the new font produced as a result of the patch applications.
+    fn apply_glyph_keyed_patches<'a>(
+        &self,
+        patches_ift: impl Iterator<Item = &'a PatchInfo<AffectsIft>>,
+        patches_iftx: impl Iterator<Item = &'a PatchInfo<AffectsIftx>>,
+    ) -> Result<Vec<u8>, PatchingError>;
 }
 
 /// An error that occurs while trying to apply an IFT patch to a font file.
@@ -78,7 +52,6 @@ pub enum PatchingError {
     PatchParsingFailed(ReadError),
     FontParsingFailed(ReadError),
     IncompatiblePatch,
-    IncompatiblePatches,
     NonIncrementalFont,
     InvalidPatch(&'static str),
     EmptyPatchList,
@@ -113,12 +86,7 @@ impl std::fmt::Display for PatchingError {
             PatchingError::IncompatiblePatch => {
                 write!(f, "Compatibility ID of the patch does not match the font.")
             }
-            PatchingError::IncompatiblePatches => {
-                write!(
-                    f,
-                    "Cannot apply multiple patches that are incompatible with each other."
-                )
-            }
+
             PatchingError::NonIncrementalFont => {
                 write!(
                     f,
@@ -137,578 +105,91 @@ impl std::fmt::Display for PatchingError {
 
 impl std::error::Error for PatchingError {}
 
-impl IncrementalFontPatch<'_> {
-    fn compatibility_id(&self) -> CompatibilityId {
-        match self {
-            IncrementalFontPatch::TableKeyed(patch_data) => patch_data.compatibility_id(),
-            IncrementalFontPatch::GlyphKeyed(patch_data) => patch_data.compatibility_id(),
-        }
-    }
-}
-
 impl IncrementalFontPatchBase for FontRef<'_> {
-    fn apply_patch(&self, patches: &[IncrementalFontPatch]) -> Result<Vec<u8>, PatchingError> {
-        // TODO(garretrieger): we should be verifying the compat ID's match, would need to know the source mapping table from
-        //                     the patch uri.
+    fn apply_table_keyed_patch<T: PatchScope>(
+        &self,
+        patch: &PatchInfo<T>,
+    ) -> Result<Vec<u8>, PatchingError> {
+        let font_compat_id = T::compat_id(self).map_err(PatchingError::FontParsingFailed)?;
 
-        // TODO(garretrieger): we can support table keyed + glyph keyed where the table keyed is partially invalidation
-        // and has a different compat id then the glyph keyed patches.
-        if self.table_data(Tag::new(b"IFT ")).is_none()
-            && self.table_data(Tag::new(b"IFTX")).is_none()
-        {
-            // This base is not an incremental font, which is an error.
-            // See: https://w3c.github.io/IFT/Overview.html#apply-table-keyed
-            return Err(PatchingError::NonIncrementalFont);
+        let patch_data = patch.data().ok_or(PatchingError::InternalError)?;
+        let patch = TableKeyedPatch::read(FontData::new(patch_data))
+            .map_err(PatchingError::PatchParsingFailed)?;
+
+        if patch.compatibility_id() != font_compat_id {
+            return Err(PatchingError::IncompatiblePatch);
         }
 
-        let first = patches.first().ok_or(PatchingError::EmptyPatchList)?;
+        apply_table_keyed_patch(&patch, self)
+    }
 
-        match first {
-            IncrementalFontPatch::TableKeyed(patch_data) => {
-                if patches.len() > 1 {
-                    // table keyed patches can only be applied one at a time
-                    // (as they are at a minimum partial invalidating)
-                    return Err(PatchingError::IncompatiblePatches);
-                }
-                apply_table_keyed_patch(patch_data, self)
+    fn apply_glyph_keyed_patches<'a>(
+        &self,
+        patches_ift: impl Iterator<Item = &'a PatchInfo<AffectsIft>>,
+        patches_iftx: impl Iterator<Item = &'a PatchInfo<AffectsIftx>>,
+    ) -> Result<Vec<u8>, PatchingError> {
+        let patches_ift =
+            patches_ift.flat_map(|info| info.data().map(|data| (info.font_compat_id(self), data)));
+        let patches_iftx =
+            patches_iftx.flat_map(|info| info.data().map(|data| (info.font_compat_id(self), data)));
+
+        let mut patches: Vec<GlyphKeyedPatch<'_>> = vec![];
+        for (font_compat_id, data) in patches_ift.chain(patches_iftx) {
+            let font_compat_id = font_compat_id.map_err(PatchingError::FontParsingFailed)?;
+            let patch = GlyphKeyedPatch::read(FontData::new(data))
+                .map_err(PatchingError::PatchParsingFailed)?;
+
+            if font_compat_id != patch.compatibility_id() {
+                return Err(PatchingError::IncompatiblePatch);
             }
-            IncrementalFontPatch::GlyphKeyed(_) => {
-                let glyph_keyed_patches: Vec<_> = patches
-                    .iter()
-                    .filter_map(|patch| match patch {
-                        IncrementalFontPatch::GlyphKeyed(patch_data) => Some(patch_data.clone()),
-                        _ => None,
-                    })
-                    .collect();
-                // glyph keyed patches are no invalidation so any number of them may be applied simultaneously
-                if glyph_keyed_patches.len() != patches.len() {
-                    return Err(PatchingError::IncompatiblePatches);
-                }
-                apply_glyph_keyed_patches(&glyph_keyed_patches, self)
-            }
+
+            patches.push(patch);
         }
+
+        apply_glyph_keyed_patches(&patches, self)
     }
 }
 
 impl IncrementalFontPatchBase for &[u8] {
-    fn apply_patch(&self, patches: &[IncrementalFontPatch]) -> Result<Vec<u8>, PatchingError> {
-        let font_ref = FontRef::new(self).map_err(PatchingError::FontParsingFailed)?;
-        font_ref.apply_patch(patches)
+    fn apply_table_keyed_patch<T: PatchScope>(
+        &self,
+        patch: &PatchInfo<T>,
+    ) -> Result<Vec<u8>, PatchingError> {
+        FontRef::new(self)
+            .map_err(PatchingError::FontParsingFailed)?
+            .apply_table_keyed_patch(patch)
+    }
+
+    fn apply_glyph_keyed_patches<'a>(
+        &self,
+        patches_ift: impl Iterator<Item = &'a PatchInfo<AffectsIft>>,
+        patches_iftx: impl Iterator<Item = &'a PatchInfo<AffectsIftx>>,
+    ) -> Result<Vec<u8>, PatchingError> {
+        FontRef::new(self)
+            .map_err(PatchingError::FontParsingFailed)?
+            .apply_glyph_keyed_patches(patches_ift, patches_iftx)
     }
 }
 
-fn apply_table_keyed_patch(
-    patch: &TableKeyedPatch<'_>,
-    font: &FontRef,
-) -> Result<Vec<u8>, PatchingError> {
-    if patch.format() != Tag::new(b"iftk") {
-        return Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'"));
-    }
-
-    // brotli stream starts at the (u32 tag + u8 flags + u32 length) = 9th byte
-    const STREAM_START: u32 = 9;
-    let mut font_builder = FontBuilder::new();
-    let mut processed_tables = BTreeSet::<Tag>::new();
-    // TODO(garretrieger): enforce a max combined size of all decoded tables? say something in the spec about this?
-    for i in 0..patch.patches_count() {
-        let i = i as usize;
-        let next = i + 1;
-
-        let table_patch = patch
-            .patches()
-            .get(i)
-            .map_err(PatchingError::PatchParsingFailed)?;
-        let (Some(offset), Some(next_offset)) = (
-            patch.patch_offsets().get(i),
-            patch.patch_offsets().get(next),
-        ) else {
-            return Err(PatchingError::InvalidPatch("Missing patch offset."));
-        };
-
-        let offset = offset.get().to_u32();
-        let next_offset = next_offset.get().to_u32();
-        let Some(stream_length) = next_offset
-            .checked_sub(offset)
-            .and_then(|v| v.checked_sub(STREAM_START))
-        else {
-            return Err(PatchingError::InvalidPatch(
-                "Patch offsets are not in sorted order.",
-            ));
-        };
-
-        if stream_length as usize > table_patch.brotli_stream().len() {
-            return Err(PatchingError::PatchParsingFailed(ReadError::OutOfBounds));
-        }
-
-        let tag = table_patch.tag();
-        if !processed_tables.insert(tag) {
-            // Table has already been processed.
-            continue;
-        }
-
-        if table_patch.flags().contains(TablePatchFlags::DROP_TABLE) {
-            // Table will not be copied, skip any further processing.
-            continue;
-        }
-
-        let replacement = table_patch.flags().contains(TablePatchFlags::REPLACE_TABLE);
-        let new_table = apply_table_patch(font, table_patch, stream_length, replacement)?;
-        font_builder.add_raw(tag, new_table);
-    }
-
-    copy_unprocessed_tables(font, processed_tables, &mut font_builder);
-
-    Ok(font_builder.build())
-}
-
-pub(crate) fn copy_unprocessed_tables<'a>(
-    font: &FontRef<'a>,
-    processed_tables: BTreeSet<Tag>,
-    font_builder: &mut FontBuilder<'a>,
-) {
-    font.table_directory
-        .table_records()
-        .iter()
-        .map(|r| r.tag())
-        .filter(|tag| !processed_tables.contains(tag))
-        .filter_map(|tag| Some((tag, font.table_data(tag)?)))
-        .for_each(|(tag, data)| {
-            font_builder.add_raw(tag, data);
-        });
-}
-
-fn apply_table_patch(
-    font: &FontRef,
-    table_patch: TablePatch,
-    stream_length: u32,
-    replacement: bool,
-) -> Result<Vec<u8>, PatchingError> {
-    let stream_length = stream_length as usize;
-    let base_data = font.table_data(table_patch.tag());
-    let stream = if table_patch.brotli_stream().len() >= stream_length {
-        &table_patch.brotli_stream()[..stream_length]
-    } else {
-        return Err(PatchingError::InvalidPatch(
-            "Brotli stream is larger then the maxUncompressedLength field.",
-        ));
-    };
-    let r = match (base_data, replacement) {
-        (Some(base_data), false) => shared_brotli_decode(
-            stream,
-            Some(base_data.as_bytes()),
-            table_patch.max_uncompressed_length() as usize,
-        ),
-        (None, false) => {
-            return Err(PatchingError::InvalidPatch(
-                "Trying to patch a base table that doesn't exist.",
-            ))
-        }
-        _ => shared_brotli_decode(stream, None, table_patch.max_uncompressed_length() as usize),
-    };
-
-    r.map_err(PatchingError::from)
-}
-
+// TODO(garretrieger): basic tests for high level apis.
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use font_test_data::ift::{
-        glyph_keyed_patch_header, noop_table_keyed_patch, table_keyed_patch,
-    };
-    use read_fonts::FontRef;
-    use read_fonts::ReadError;
-    use write_fonts::FontBuilder;
-
-    const IFT_TABLE: &[u8] = "IFT PATCH MAP".as_bytes();
-    const TABLE_1_FINAL_STATE: &[u8] = "hijkabcdeflmnohijkabcdeflmno\n".as_bytes();
-    const TABLE_2_FINAL_STATE: &[u8] = "foobarbaz foobarbaz foobarbaz\n".as_bytes();
-    const TABLE_3_FINAL_STATE: &[u8] = "foobaz\n".as_bytes();
-    const TABLE_4_FINAL_STATE: &[u8] = "unchanged\n".as_bytes();
-
-    fn table_keyed_patch_uri() -> PatchUri {
-        PatchUri::from_index(
-            "",
-            0,
-            &CompatibilityId::from_u32s([1, 2, 3, 4]),
-            PatchEncoding::TableKeyed {
-                fully_invalidating: false,
-            },
-        )
-    }
-
-    fn glyph_keyed_patch_uri() -> PatchUri {
-        PatchUri::from_index(
-            "",
-            0,
-            &CompatibilityId::from_u32s([6, 7, 8, 9]),
-            PatchEncoding::GlyphKeyed,
-        )
-    }
-
-    fn test_font() -> Vec<u8> {
-        let mut font_builder = FontBuilder::new();
-        font_builder.add_raw(Tag::new(b"IFT "), IFT_TABLE);
-        font_builder.add_raw(Tag::new(b"tab1"), "abcdef\n".as_bytes());
-        font_builder.add_raw(Tag::new(b"tab2"), "foobar\n".as_bytes());
-        font_builder.add_raw(Tag::new(b"tab3"), "foobaz\n".as_bytes());
-        font_builder.add_raw(Tag::new(b"tab4"), "unchanged\n".as_bytes());
-        font_builder.build()
-    }
-
+    /*
     #[test]
-    fn table_keyed_patch_test() {
-        let patch_data = table_keyed_patch();
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let r = test_font().as_slice().apply_patch(&[patch]);
-
-        let font = r.unwrap();
-        let font = FontRef::new(&font).unwrap();
-
-        assert_eq!(font.table_directory.num_tables(), 4);
-
-        assert_eq!(
-            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
-            IFT_TABLE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
-            TABLE_1_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
-            TABLE_2_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
-            TABLE_4_FINAL_STATE
-        );
-    }
-
-    #[test]
-    fn noop_table_keyed_patch_test() {
-        let patch_data = noop_table_keyed_patch();
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let r = test_font().as_slice().apply_patch(&[patch]);
-
-        let font = r.unwrap();
-        let font = FontRef::new(&font).unwrap();
-        let expected_font = test_font();
-        let expected_font = FontRef::new(&expected_font).unwrap();
-
-        assert_eq!(
-            font.table_directory.num_tables(),
-            expected_font.table_directory.num_tables()
-        );
-
-        for t in expected_font.table_directory.table_records() {
-            let data = font.table_data(t.tag()).unwrap();
-            let expected_data = expected_font.table_data(t.tag()).unwrap();
-            assert_eq!(data.as_bytes(), expected_data.as_bytes());
-        }
-    }
-
-    #[test]
-    fn table_keyed_patch_compat_id_mismatch() {
-        let uri = PatchUri::from_index(
-            "",
-            0,
-            &CompatibilityId::from_u32s([1, 2, 2, 4]),
-            PatchEncoding::TableKeyed {
-                fully_invalidating: false,
-            },
-        );
-        let patch_data = table_keyed_patch();
-        assert_eq!(
-            PatchingError::IncompatiblePatch,
-            uri.into_patch(patch_data.as_slice()).err().unwrap()
-        );
-    }
-
-    #[test]
-    fn table_keyed_patch_bad_top_level_tag() {
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("tag", Tag::new(b"ifgk"));
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'")),
-            test_font().as_slice().apply_patch(&[patch])
-        );
-    }
-
-    #[test]
-    fn table_keyed_ignore_duplicates() {
-        // add a duplicate entry requesting dropping of tab2,
-        // should be ignored.
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("patch[2]", Tag::new(b"tab2"));
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let r = test_font().as_slice().apply_patch(&[patch]);
-
-        let font = r.unwrap();
-        let font = FontRef::new(&font).unwrap();
-
-        assert_eq!(font.table_directory.num_tables(), 5);
-
-        assert_eq!(
-            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
-            IFT_TABLE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
-            TABLE_1_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
-            TABLE_2_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab3")).unwrap().as_bytes(),
-            TABLE_3_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
-            TABLE_4_FINAL_STATE
-        );
-    }
-
-    #[test]
-    fn table_keyed_patch_unsorted_offsets() {
-        // reorder the offsets
-        let mut patch_data = table_keyed_patch();
-
-        let offset = patch_data.offset_for("patch[1]") as u32;
-        patch_data.write_at("patch_off[0]", offset);
-
-        let offset = patch_data.offset_for("patch[0]") as u32;
-        patch_data.write_at("patch_off[1]", offset);
-
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::InvalidPatch(
-                "Patch offsets are not in sorted order."
-            )),
-            test_font().as_slice().apply_patch(&[patch])
-        );
-    }
-
-    #[test]
-    fn table_keyed_patch_out_of_bounds_offsets() {
-        // set last offset out of bounds
-        let mut patch_data = table_keyed_patch();
-        let offset = (patch_data.offset_for("end") + 5) as u32;
-        patch_data.write_at("patch_off[3]", offset);
-
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::PatchParsingFailed(ReadError::OutOfBounds)),
-            test_font().as_slice().apply_patch(&[patch])
-        );
-    }
-
-    #[test]
-    fn table_keyed_patch_drop_and_replace() {
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("flags[2]", 3u8);
-
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        // When DROP and REPLACE are both set DROP takes priority.
-        let r = test_font().as_slice().apply_patch(&[patch]);
-
-        let font = r.unwrap();
-        let font = FontRef::new(&font).unwrap();
-
-        assert_eq!(font.table_directory.num_tables(), 4);
-
-        assert_eq!(
-            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
-            IFT_TABLE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
-            TABLE_1_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
-            TABLE_2_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
-            TABLE_4_FINAL_STATE
-        );
-    }
-
-    #[test]
-    fn table_keyed_patch_missing_table() {
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("flags[1]", 0u8);
-        patch_data.write_at("patch[1]", Tag::new(b"tab5"));
-
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::InvalidPatch(
-                "Trying to patch a base table that doesn't exist."
-            )),
-            test_font().as_slice().apply_patch(&[patch]),
-        );
-    }
-
-    #[test]
-    fn table_keyed_replace_missing_table() {
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("patch[1]", Tag::new(b"tab5"));
-
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let r = test_font().as_slice().apply_patch(&[patch]);
-
-        let font = r.unwrap();
-        let font = FontRef::new(&font).unwrap();
-
-        assert_eq!(font.table_directory.num_tables(), 5);
-
-        assert_eq!(
-            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
-            IFT_TABLE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
-            TABLE_1_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
-            "foobar\n".as_bytes()
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
-            TABLE_4_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab5")).unwrap().as_bytes(),
-            TABLE_2_FINAL_STATE
-        );
-    }
-
-    #[test]
-    fn table_keyed_drop_missing_table() {
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("patch[2]", Tag::new(b"tab5"));
-
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let r = test_font().as_slice().apply_patch(&[patch]);
-
-        let font = r.unwrap();
-        let font = FontRef::new(&font).unwrap();
-
-        assert_eq!(font.table_directory.num_tables(), 5);
-
-        assert_eq!(
-            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
-            IFT_TABLE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
-            TABLE_1_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
-            TABLE_2_FINAL_STATE,
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab3")).unwrap().as_bytes(),
-            TABLE_3_FINAL_STATE
-        );
-        assert_eq!(
-            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
-            TABLE_4_FINAL_STATE
-        );
-    }
-
-    #[test]
-    fn table_keyed_patch_uncompressed_len_too_small() {
-        let mut patch_data = table_keyed_patch();
-        patch_data.write_at("decompressed_len[0]", 28u32);
-        let patch = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::InvalidPatch("Max size exceeded.")),
-            test_font().as_slice().apply_patch(&[patch]),
-        );
-    }
-
-    #[test]
-    fn multiple_table_keyed_patches() {
-        let patch_data = table_keyed_patch();
-        let patch1 = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let patch_data = noop_table_keyed_patch();
-        let patch2 = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::IncompatiblePatches),
-            test_font().as_slice().apply_patch(&[patch1, patch2])
-        );
-    }
-
-    #[test]
-    fn mixed_table_and_glyph_keyed_patches() {
-        let patch_data = table_keyed_patch();
-        let patch1 = table_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        let patch_data = glyph_keyed_patch_header();
-        let patch2 = glyph_keyed_patch_uri()
-            .into_patch(patch_data.as_slice())
-            .unwrap();
-
-        assert_eq!(
-            Err(PatchingError::IncompatiblePatches),
-            test_font()
-                .as_slice()
-                .apply_patch(&[patch1.clone(), patch2.clone()])
-        );
-        assert_eq!(
-            Err(PatchingError::IncompatiblePatches),
-            test_font().as_slice().apply_patch(&[patch2, patch1])
-        );
-    }
-
-    // TODO(garretrieger): test empty patch list fails.
-    // TODO(garretrieger): single glyph keyed patch test
-    // TODO(garretrieger): multiple glyph keyed
+      fn table_keyed_patch_compat_id_mismatch() {
+          let uri = PatchUri::from_index(
+              "",
+              0,
+              &CompatibilityId::from_u32s([1, 2, 2, 4]),
+              PatchEncoding::TableKeyed {
+                  fully_invalidating: false,
+              },
+          );
+          let patch_data = table_keyed_patch();
+          assert_eq!(
+              PatchingError::IncompatiblePatch,
+              uri.into_patch(patch_data.as_slice()).err().unwrap()
+          );
+      }
+     */
 }

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -1,25 +1,28 @@
+//! Implementation of Glyph Keyed patch application.
+//!
+//! Glyph Keyed patches are a type of incremental font patch which stores opaque data blobs
+//! keyed by glyph id. Patch application places the data blobs into the appropriate place
+//! in the base font based on the associated glyph id.
+//!
+//! Glyph Keyed patches are specified here:
+//! <https://w3c.github.io/IFT/Overview.html#glyph-keyed>
 use crate::font_patch::PatchingError;
-/// Implementation of Glyph Keyed patch application.
-///
-/// Glyph Keyed patches are a type of incremental font patch which stores opaque data blobs
-/// keyed by glyph id. Patch application places the data blobs into the appropriate place
-/// in the base font based on the associated glyph id.
-///
-/// Glyph Keyed patches are specified here:
-/// <https://w3c.github.io/IFT/Overview.html#glyph-keyed>
 use crate::table_keyed::copy_unprocessed_tables;
 
 use font_types::Scalar;
-use read_fonts::collections::IntSet;
-use read_fonts::tables::ift::{GlyphKeyedPatch, GlyphPatches};
-use read_fonts::tables::loca::Loca;
-use read_fonts::types::Tag;
-use read_fonts::ReadError;
-use read_fonts::{FontData, FontRef, TableProvider};
+use read_fonts::{
+    collections::IntSet,
+    tables::{
+        ift::{GlyphKeyedPatch, GlyphPatches},
+        loca::Loca,
+    },
+    types::Tag,
+    FontData, FontRef, ReadError, TableProvider,
+};
+
 use shared_brotli_patch_decoder::shared_brotli_decode;
 use skrifa::GlyphId;
-use std::collections::BTreeSet;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::ops::RangeInclusive;
 
 use write_fonts::FontBuilder;

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -1,3 +1,4 @@
+use crate::font_patch::PatchingError;
 /// Implementation of Glyph Keyed patch application.
 ///
 /// Glyph Keyed patches are a type of incremental font patch which stores opaque data blobs
@@ -6,8 +7,7 @@
 ///
 /// Glyph Keyed patches are specified here:
 /// <https://w3c.github.io/IFT/Overview.html#glyph-keyed>
-use crate::font_patch::copy_unprocessed_tables;
-use crate::font_patch::PatchingError;
+use crate::table_keyed::copy_unprocessed_tables;
 
 use font_types::Scalar;
 use read_fonts::collections::IntSet;

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -13,4 +13,5 @@
 
 pub mod font_patch;
 pub mod glyph_keyed;
+pub mod patch_group;
 pub mod patchmap;

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -15,3 +15,4 @@ pub mod font_patch;
 pub mod glyph_keyed;
 pub mod patch_group;
 pub mod patchmap;
+pub mod table_keyed;

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -6,7 +6,7 @@ use crate::{
     patchmap::{intersecting_patches, IftTableTag, PatchEncoding, PatchUri, SubsetDefinition},
 };
 
-/// A group of patches derived from a single IFT font which can be applied simulatenously
+/// A group of patches derived from a single IFT font which can be applied simultaneously
 /// to that font. Patches are initially missing data which must be fetched and supplied to
 /// the group before it can be applied to the font.
 pub struct PatchGroup<'a> {

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -177,7 +177,7 @@ where
 {
     fn from(value: PatchUri) -> Self {
         PatchInfo {
-            uri: value.uri(),
+            uri: value.uri_string(),
             data: None,
             _phantom: Default::default(),
         }

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -1,0 +1,209 @@
+use font_types::Tag;
+use read_fonts::{FontRef, ReadError};
+use std::{collections::BTreeMap, marker::PhantomData};
+
+use crate::patchmap::{intersecting_patches, PatchEncoding, PatchUri, SubsetDefinition};
+
+/// A group of patches derived from a single IFT font which can be applied simulatenously
+/// to that font.
+pub(crate) struct PatchApplicationGroup<'a> {
+    font: FontRef<'a>,
+    patches: CompatibleGroup,
+}
+
+impl PatchApplicationGroup<'_> {
+    pub fn select_next_patches<'a>(
+        font: FontRef<'a>,
+        subset_definition: &SubsetDefinition,
+    ) -> Result<PatchApplicationGroup<'a>, ReadError> {
+        let candidates = intersecting_patches(&font, subset_definition)?;
+        let compat_group = Self::select_next_patches_from_candidates(candidates)?;
+
+        Ok(PatchApplicationGroup {
+            font,
+            patches: compat_group,
+        })
+    }
+
+    fn select_next_patches_from_candidates(
+        candidates: Vec<PatchUri>,
+    ) -> Result<CompatibleGroup, ReadError> {
+        // Some notes about this implementation:
+        // - From candidates we need to form the largest possible group of patches which follow the selection criteria
+        //   from: https://w3c.github.io/IFT/Overview.html#extend-font-subset and won't invalidate each other.
+        //
+        // - Validation constraints are encoded into the structure of CompatibleGroup so the task here is to fill up
+        //   a compatible group appropriately.
+        //
+        // - When multiple valid choices exist the specification allows the implementation to take one of it's choosing.
+        //   Here we use a heuristic that tries to select the patch which has the most value to the extension request.
+
+        // TODO: On construction we need to ensure that there are no PatchInfo's with duplicate URIs.
+
+        let mut full_invalidation: Vec<FullInvalidationPatch> = vec![];
+        let mut partial_invalidation_ift: Vec<PartialInvalidationPatch<AffectsIft>> = vec![];
+        let mut partial_invalidation_iftx: Vec<PartialInvalidationPatch<AffectsIftx>> = vec![];
+        let mut no_invalidation_ift: BTreeMap<String, NoInvalidationPatch<AffectsIft>> =
+            Default::default();
+        let mut no_invalidation_iftx: BTreeMap<String, NoInvalidationPatch<AffectsIftx>> =
+            Default::default();
+
+        // Step 1: sort the candidates into separate lists based on invalidation characteristics.
+        for uri in candidates.into_iter() {
+            match uri.encoding() {
+                PatchEncoding::TableKeyed {
+                    fully_invalidating: true,
+                } => full_invalidation.push(FullInvalidationPatch(uri.into())),
+                PatchEncoding::TableKeyed {
+                    fully_invalidating: false,
+                } => {
+                    if uri.source_table() == Tag::new(b"IFT ") {
+                        partial_invalidation_ift.push(PartialInvalidationPatch::<AffectsIft>(
+                            uri.into(),
+                            Default::default(),
+                        ))
+                    } else if uri.source_table() == Tag::new(b"IFTX") {
+                        partial_invalidation_iftx.push(PartialInvalidationPatch::<AffectsIftx>(
+                            uri.into(),
+                            Default::default(),
+                        ))
+                    }
+                }
+                PatchEncoding::GlyphKeyed => {
+                    if uri.source_table() == Tag::new(b"IFT ") {
+                        no_invalidation_ift.insert(
+                            "TODO".to_string(), // TODO(garretrieger): key should be the fully subbed URI string.
+                            NoInvalidationPatch::<AffectsIft>(uri.into(), Default::default()),
+                        );
+                    } else if uri.source_table() == Tag::new(b"IFTX") {
+                        no_invalidation_iftx.insert(
+                            "TODO".to_string(), // TODO(garretrieger): key should be the fully subbed URI string.
+                            NoInvalidationPatch::<AffectsIftx>(uri.into(), Default::default()),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Step 2 - now make patch selections in priority order: first full invalidation, second partial, lastly none.
+        if let Some(patch) = full_invalidation.into_iter().next() {
+            // TODO(garretrieger): use a heuristic to select the best patch
+            return Ok(CompatibleGroup::Full(patch));
+        }
+
+        let ift_scope = partial_invalidation_ift
+            .into_iter()
+            // TODO(garretrieger): use a heuristic to select the best patch
+            .next()
+            .map(|patch| ScopedGroup::<AffectsIft>::PartialInvalidation(patch));
+
+        let iftx_scope = partial_invalidation_iftx
+            .into_iter()
+            // TODO(garretrieger): use a heuristic to select the best patch
+            .next()
+            .map(|patch| ScopedGroup::<AffectsIftx>::PartialInvalidation(patch));
+
+        match (ift_scope, iftx_scope) {
+            (Some(scope1), Some(scope2)) => Ok(CompatibleGroup::Mixed {
+                ift: scope1,
+                iftx: scope2,
+            }),
+            (Some(scope1), None) => Ok(CompatibleGroup::Mixed {
+                ift: scope1,
+                iftx: ScopedGroup::NoInvalidation::<AffectsIftx>(no_invalidation_iftx),
+            }),
+            (None, Some(scope2)) => Ok(CompatibleGroup::Mixed {
+                ift: ScopedGroup::NoInvalidation::<AffectsIft>(no_invalidation_ift),
+                iftx: scope2,
+            }),
+            (None, None) => Ok(CompatibleGroup::Mixed {
+                ift: ScopedGroup::NoInvalidation::<AffectsIft>(no_invalidation_ift),
+                iftx: ScopedGroup::NoInvalidation::<AffectsIftx>(no_invalidation_iftx),
+            }),
+        }
+    }
+
+    fn add_patch_data(&mut self, uri: String, data: Vec<u8>) {
+        todo!()
+    }
+
+    fn pending_uris(&self) -> Vec<&str> {
+        todo!()
+    }
+
+    // How do we ensure all patch data is present? should we set this up so data is non optional.
+    fn apply_to(&self, font: FontRef) {
+        todo!()
+    }
+}
+
+/// Marks which mappinng table is affected (via invalidation) by application of a patch.
+trait PatchScope {}
+
+/// This patch affects only the "IFT " table.
+struct AffectsIft;
+
+/// This patch affects only the "IFTX" table.
+struct AffectsIftx;
+
+/// This patch affects both the "IFT " and "IFTX" table.
+struct AffectsBoth;
+
+impl PatchScope for AffectsIft {}
+impl PatchScope for AffectsIftx {}
+impl PatchScope for AffectsBoth {}
+
+/// Tracks information related to a patch necessary to apply that patch.
+struct PatchInfo<T>
+where
+    T: PatchScope,
+{
+    uri: String,
+    data: Option<Vec<u8>>,
+    _phantom: PhantomData<T>,
+    // TODO: details for how to mark the patch applied in the mapping table (ie. bit index to flip).
+    // TODO: Signals for heuristic patch selection:
+}
+
+impl<T> From<PatchUri> for PatchInfo<T>
+where
+    T: PatchScope,
+{
+    fn from(value: PatchUri) -> Self {
+        todo!()
+    }
+}
+
+/// Type for a single non invalidating patch.
+struct NoInvalidationPatch<T>(PatchInfo<T>, PhantomData<T>)
+where
+    T: PatchScope;
+
+/// Type for a single partially invalidating patch.
+struct PartialInvalidationPatch<T>(PatchInfo<T>, PhantomData<T>)
+where
+    T: PatchScope;
+
+/// Type for a single fully invalidating patch.
+struct FullInvalidationPatch(PatchInfo<AffectsBoth>);
+
+/// Represents a group of patches which are valid (compatible) to be applied together to
+/// an IFT font.
+enum CompatibleGroup {
+    Full(FullInvalidationPatch),
+    Mixed {
+        ift: ScopedGroup<AffectsIft>,
+        iftx: ScopedGroup<AffectsIftx>,
+    },
+}
+
+/// A set of zero or more compatible patches that are derived from the same scope
+/// ("IFT " vs "IFTX")
+enum ScopedGroup<T>
+where
+    T: PatchScope,
+{
+    None,
+    PartialInvalidation(PartialInvalidationPatch<T>),
+    NoInvalidation(BTreeMap<String, NoInvalidationPatch<T>>),
+}

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -1,3 +1,8 @@
+//! API for selecting and applying a group of IFT patches.
+//!
+//! This provides methods for selecting a maximal group of patches that are compatible with each other and
+//! additionally methods for applying that group of patches.
+
 use read_fonts::{tables::ift::CompatibilityId, FontRef, ReadError, TableProvider};
 use std::collections::{BTreeMap, HashMap};
 
@@ -6,17 +11,20 @@ use crate::{
     patchmap::{intersecting_patches, IftTableTag, PatchEncoding, PatchUri, SubsetDefinition},
 };
 
-/// A group of patches derived from a single IFT font which can be applied simultaneously
-/// to that font. Patches are initially missing data which must be fetched and supplied to
-/// the group before it can be applied to the font.
+/// A group of patches derived from a single IFT font.
+///
+/// This is a group which can be applied simultaneously to that font. Patches are
+/// initially missing data which must be fetched and supplied to patch application
+/// method.
 pub struct PatchGroup<'a> {
     font: FontRef<'a>,
     patches: Option<CompatibleGroup>,
 }
 
 impl<'a> PatchGroup<'a> {
-    /// Intersect the available and unapplied patches in ift_font against subset_definition and return a group
-    /// of patches which would be applied next.
+    /// Intersect the available and unapplied patches in ift_font against subset_definition
+    ///
+    /// Returns a group of patches which would be applied next.
     pub fn select_next_patches<'b>(
         ift_font: FontRef<'b>,
         subset_definition: &SubsetDefinition,
@@ -41,13 +49,14 @@ impl<'a> PatchGroup<'a> {
         })
     }
 
-    /// Returns the list of URIs in this group.
+    /// Returns an iterator over URIs in this group.
     pub fn uris(&self) -> impl Iterator<Item = &str> {
         self.invalidating_patch_iter()
             .chain(self.non_invalidating_patch_iter())
             .map(|info| info.uri.as_str())
     }
 
+    /// Returns true if there is at least one uri associated with this group.
     pub fn has_uris(&self) -> bool {
         let Some(patches) = &self.patches else {
             return false;
@@ -1250,4 +1259,6 @@ mod tests {
             ])
         );
     }
+
+    // TODO(garretrieger): test that previously applied patches are ignored.
 }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -522,19 +522,19 @@ pub enum PatchId {
 /// List of possible IFT mapping table tags.
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub(crate) enum IftTableTag {
-    IFT(CompatibilityId),
-    IFTX(CompatibilityId),
+    Ift(CompatibilityId),
+    Iftx(CompatibilityId),
 }
 
 impl IftTableTag {
     pub(crate) fn tables_in<'a>(font: &'a FontRef) -> impl Iterator<Item = (IftTableTag, Ift<'a>)> {
         let ift = font
             .ift()
-            .map(|t| (IftTableTag::IFT(t.compatibility_id()), t))
+            .map(|t| (IftTableTag::Ift(t.compatibility_id()), t))
             .into_iter();
         let iftx = font
             .iftx()
-            .map(|t| (IftTableTag::IFTX(t.compatibility_id()), t))
+            .map(|t| (IftTableTag::Iftx(t.compatibility_id()), t))
             .into_iter();
         ift.chain(iftx)
     }
@@ -545,8 +545,8 @@ impl IftTableTag {
 
     pub(crate) fn tag(&self) -> Tag {
         match self {
-            Self::IFT(_) => Tag::new(b"IFT "),
-            Self::IFTX(_) => Tag::new(b"IFTx"),
+            Self::Ift(_) => Tag::new(b"IFT "),
+            Self::Iftx(_) => Tag::new(b"IFTX"),
         }
     }
 
@@ -557,7 +557,7 @@ impl IftTableTag {
 
     pub(crate) fn expected_compat_id(&self) -> &CompatibilityId {
         match self {
-            Self::IFT(cid) | Self::IFTX(cid) => cid,
+            Self::Ift(cid) | Self::Iftx(cid) => cid,
         }
     }
 }
@@ -591,10 +591,7 @@ impl PatchUri {
                 let id = &id[Self::count_leading_zeroes(&id)..];
                 (Self::BASE32HEX_NO_PADDING.encode(id), BASE64URL.encode(id))
             }
-            PatchId::String(id) => (
-                Self::BASE32HEX_NO_PADDING.encode(&id),
-                BASE64URL.encode(&id),
-            ),
+            PatchId::String(id) => (Self::BASE32HEX_NO_PADDING.encode(id), BASE64URL.encode(id)),
         };
 
         let mut template = UriTemplate::new(&self.template);
@@ -641,7 +638,7 @@ impl PatchUri {
     }
 
     pub fn expected_compatibility_id(&self) -> &CompatibilityId {
-        &self.source_table.expected_compat_id()
+        self.source_table.expected_compat_id()
     }
 
     pub(crate) fn from_index(
@@ -794,7 +791,7 @@ mod tests {
         ) -> PatchUri {
             PatchUri {
                 template: uri_template.to_string(),
-                id: PatchId::String(entry_id.as_bytes().iter().map(|v| *v).collect()),
+                id: PatchId::String(entry_id.as_bytes().to_vec()),
                 source_table: source_table.clone(),
                 encoding,
             }
@@ -867,7 +864,7 @@ mod tests {
                 PatchUri::from_index(
                     "ABCDEFɤ",
                     *index,
-                    &IftTableTag::IFT(compat_id()),
+                    &IftTableTag::Ift(compat_id()),
                     PatchEncoding::GlyphKeyed,
                 )
             })
@@ -897,7 +894,7 @@ mod tests {
                 PatchUri::from_index(
                     "ABCDEFɤ",
                     *index,
-                    &IftTableTag::IFT(compat_id()),
+                    &IftTableTag::Ift(compat_id()),
                     PatchEncoding::GlyphKeyed,
                 )
             })
@@ -911,7 +908,7 @@ mod tests {
             PatchUri::from_index(
                 template,
                 value,
-                &IftTableTag::IFT(Default::default()),
+                &IftTableTag::Ift(Default::default()),
                 PatchEncoding::GlyphKeyed,
             )
             .uri_string(),
@@ -924,7 +921,7 @@ mod tests {
             PatchUri::from_string(
                 template,
                 value,
-                &IftTableTag::IFT(Default::default()),
+                &IftTableTag::Ift(Default::default()),
                 PatchEncoding::GlyphKeyed,
             )
             .uri_string(),

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -878,7 +878,14 @@ mod tests {
 
     #[test]
     fn uri_template_substitution() {
-        // Test cases are from specification:
+        // These test cases are used in other tests.
+        check_uri_template_substitution("//foo.bar/{id}", 1, "//foo.bar/04");
+        check_uri_template_substitution("//foo.bar/{id}", 2, "//foo.bar/08");
+        check_uri_template_substitution("//foo.bar/{id}", 3, "//foo.bar/0C");
+        check_uri_template_substitution("//foo.bar/{id}", 4, "//foo.bar/0G");
+        check_uri_template_substitution("//foo.bar/{id}", 5, "//foo.bar/0K");
+
+        // These test cases are from specification:
         // https://w3c.github.io/IFT/Overview.html#uri-templates
         check_uri_template_substitution("//foo.bar/{id}", 123, "//foo.bar/FC");
         check_uri_template_substitution("//foo.bar{/d1,d2,id}", 478, "//foo.bar/0/F/07F0");

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -527,6 +527,7 @@ pub enum PatchId {
 pub struct PatchUri {
     template: String, // TODO(garretrieger): Make this a reference?
     id: PatchId,
+    source_table: Tag,
     encoding: PatchEncoding,
     expected_compatibility_id: CompatibilityId,
     // TODO(garretrieger): add a resolve method which when supplied the bytes associated with the URL
@@ -534,6 +535,9 @@ pub struct PatchUri {
 }
 
 impl PatchUri {
+    pub fn source_table(&self) -> Tag {
+        self.source_table
+    }
     pub fn encoding(&self) -> PatchEncoding {
         self.encoding
     }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -665,6 +665,14 @@ pub struct SubsetDefinition {
 }
 
 impl SubsetDefinition {
+    pub fn codepoints(codepoints: IntSet<u32>) -> SubsetDefinition {
+        SubsetDefinition {
+            codepoints,
+            feature_tags: Default::default(),
+            design_space: Default::default(),
+        }
+    }
+
     pub fn new(
         codepoints: IntSet<u32>,
         feature_tags: BTreeSet<Tag>,

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -527,7 +527,6 @@ pub enum PatchId {
 pub struct PatchUri {
     template: String, // TODO(garretrieger): Make this a reference?
     id: PatchId,
-    source_table: Tag,
     encoding: PatchEncoding,
     expected_compatibility_id: CompatibilityId,
     // TODO(garretrieger): add a resolve method which when supplied the bytes associated with the URL
@@ -535,9 +534,11 @@ pub struct PatchUri {
 }
 
 impl PatchUri {
-    pub fn source_table(&self) -> Tag {
-        self.source_table
+    pub fn uri(&self) -> String {
+        // TODO(garretrieger): implement template substitution.
+        self.template.clone()
     }
+
     pub fn encoding(&self) -> PatchEncoding {
         self.encoding
     }

--- a/incremental-font-transfer/src/table_keyed.rs
+++ b/incremental-font-transfer/src/table_keyed.rs
@@ -1,3 +1,11 @@
+//! Implementation of Table Keyed patch application.
+//!
+//! Table Keyed patches are a type of incremental font patch which stores opaque binary diffs
+//! keyed by table tag.
+//!
+//! Table Keyed patches are specified here:
+//! <https://w3c.github.io/IFT/Overview.html#table-keyed>
+//!
 use std::collections::BTreeSet;
 
 use crate::font_patch::PatchingError;

--- a/incremental-font-transfer/src/table_keyed.rs
+++ b/incremental-font-transfer/src/table_keyed.rs
@@ -1,0 +1,441 @@
+use std::collections::BTreeSet;
+
+use crate::font_patch::PatchingError;
+use read_fonts::{
+    tables::ift::{TableKeyedPatch, TablePatch, TablePatchFlags},
+    types::Tag,
+    FontRef, ReadError,
+};
+use shared_brotli_patch_decoder::shared_brotli_decode;
+use write_fonts::FontBuilder;
+
+pub(crate) fn apply_table_keyed_patch(
+    patch: &TableKeyedPatch<'_>,
+    font: &FontRef,
+) -> Result<Vec<u8>, PatchingError> {
+    if patch.format() != Tag::new(b"iftk") {
+        return Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'"));
+    }
+
+    // brotli stream starts at the (u32 tag + u8 flags + u32 length) = 9th byte
+    const STREAM_START: u32 = 9;
+    let mut font_builder = FontBuilder::new();
+    let mut processed_tables = BTreeSet::<Tag>::new();
+    // TODO(garretrieger): enforce a max combined size of all decoded tables? say something in the spec about this?
+    for i in 0..patch.patches_count() {
+        let i = i as usize;
+        let next = i + 1;
+
+        let table_patch = patch
+            .patches()
+            .get(i)
+            .map_err(PatchingError::PatchParsingFailed)?;
+        let (Some(offset), Some(next_offset)) = (
+            patch.patch_offsets().get(i),
+            patch.patch_offsets().get(next),
+        ) else {
+            return Err(PatchingError::InvalidPatch("Missing patch offset."));
+        };
+
+        let offset = offset.get().to_u32();
+        let next_offset = next_offset.get().to_u32();
+        let Some(stream_length) = next_offset
+            .checked_sub(offset)
+            .and_then(|v| v.checked_sub(STREAM_START))
+        else {
+            return Err(PatchingError::InvalidPatch(
+                "Patch offsets are not in sorted order.",
+            ));
+        };
+
+        if stream_length as usize > table_patch.brotli_stream().len() {
+            return Err(PatchingError::PatchParsingFailed(ReadError::OutOfBounds));
+        }
+
+        let tag = table_patch.tag();
+        if !processed_tables.insert(tag) {
+            // Table has already been processed.
+            continue;
+        }
+
+        if table_patch.flags().contains(TablePatchFlags::DROP_TABLE) {
+            // Table will not be copied, skip any further processing.
+            continue;
+        }
+
+        let replacement = table_patch.flags().contains(TablePatchFlags::REPLACE_TABLE);
+        let new_table = apply_table_patch(font, table_patch, stream_length, replacement)?;
+        font_builder.add_raw(tag, new_table);
+    }
+
+    copy_unprocessed_tables(font, processed_tables, &mut font_builder);
+
+    Ok(font_builder.build())
+}
+
+fn apply_table_patch(
+    font: &FontRef,
+    table_patch: TablePatch,
+    stream_length: u32,
+    replacement: bool,
+) -> Result<Vec<u8>, PatchingError> {
+    let stream_length = stream_length as usize;
+    let base_data = font.table_data(table_patch.tag());
+    let stream = if table_patch.brotli_stream().len() >= stream_length {
+        &table_patch.brotli_stream()[..stream_length]
+    } else {
+        return Err(PatchingError::InvalidPatch(
+            "Brotli stream is larger then the maxUncompressedLength field.",
+        ));
+    };
+    let r = match (base_data, replacement) {
+        (Some(base_data), false) => shared_brotli_decode(
+            stream,
+            Some(base_data.as_bytes()),
+            table_patch.max_uncompressed_length() as usize,
+        ),
+        (None, false) => {
+            return Err(PatchingError::InvalidPatch(
+                "Trying to patch a base table that doesn't exist.",
+            ))
+        }
+        _ => shared_brotli_decode(stream, None, table_patch.max_uncompressed_length() as usize),
+    };
+
+    r.map_err(PatchingError::from)
+}
+
+pub(crate) fn copy_unprocessed_tables<'a>(
+    font: &FontRef<'a>,
+    processed_tables: BTreeSet<Tag>,
+    font_builder: &mut FontBuilder<'a>,
+) {
+    font.table_directory
+        .table_records()
+        .iter()
+        .map(|r| r.tag())
+        .filter(|tag| !processed_tables.contains(tag))
+        .filter_map(|tag| Some((tag, font.table_data(tag)?)))
+        .for_each(|(tag, data)| {
+            font_builder.add_raw(tag, data);
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use font_test_data::ift::{noop_table_keyed_patch, table_keyed_patch};
+    use read_fonts::FontData;
+    use read_fonts::FontRead;
+    use read_fonts::FontRef;
+    use read_fonts::ReadError;
+    use write_fonts::FontBuilder;
+
+    const IFT_TABLE: &[u8] = "IFT PATCH MAP".as_bytes();
+    const TABLE_1_FINAL_STATE: &[u8] = "hijkabcdeflmnohijkabcdeflmno\n".as_bytes();
+    const TABLE_2_FINAL_STATE: &[u8] = "foobarbaz foobarbaz foobarbaz\n".as_bytes();
+    const TABLE_3_FINAL_STATE: &[u8] = "foobaz\n".as_bytes();
+    const TABLE_4_FINAL_STATE: &[u8] = "unchanged\n".as_bytes();
+
+    fn test_font() -> Vec<u8> {
+        let mut font_builder = FontBuilder::new();
+        font_builder.add_raw(Tag::new(b"IFT "), IFT_TABLE);
+        font_builder.add_raw(Tag::new(b"tab1"), "abcdef\n".as_bytes());
+        font_builder.add_raw(Tag::new(b"tab2"), "foobar\n".as_bytes());
+        font_builder.add_raw(Tag::new(b"tab3"), "foobaz\n".as_bytes());
+        font_builder.add_raw(Tag::new(b"tab4"), "unchanged\n".as_bytes());
+        font_builder.build()
+    }
+
+    #[test]
+    fn table_keyed_patch_test() {
+        let patch_data = table_keyed_patch();
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+        let r = apply_table_keyed_patch(&patch, &font);
+
+        let font = r.unwrap();
+        let font = FontRef::new(&font).unwrap();
+
+        assert_eq!(font.table_directory.num_tables(), 4);
+
+        assert_eq!(
+            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
+            IFT_TABLE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
+            TABLE_1_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
+            TABLE_2_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
+            TABLE_4_FINAL_STATE
+        );
+    }
+
+    #[test]
+    fn noop_table_keyed_patch_test() {
+        let patch_data = noop_table_keyed_patch();
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+        let r = apply_table_keyed_patch(&patch, &font);
+
+        let font = r.unwrap();
+        let font = FontRef::new(&font).unwrap();
+        let expected_font = test_font();
+        let expected_font = FontRef::new(&expected_font).unwrap();
+
+        assert_eq!(
+            font.table_directory.num_tables(),
+            expected_font.table_directory.num_tables()
+        );
+
+        for t in expected_font.table_directory.table_records() {
+            let data = font.table_data(t.tag()).unwrap();
+            let expected_data = expected_font.table_data(t.tag()).unwrap();
+            assert_eq!(data.as_bytes(), expected_data.as_bytes());
+        }
+    }
+
+    #[test]
+    fn table_keyed_patch_bad_top_level_tag() {
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("tag", Tag::new(b"ifgk"));
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        assert_eq!(
+            Err(PatchingError::InvalidPatch("Patch file tag is not 'iftk'")),
+            apply_table_keyed_patch(&patch, &font)
+        );
+    }
+
+    #[test]
+    fn table_keyed_ignore_duplicates() {
+        // add a duplicate entry requesting dropping of tab2,
+        // should be ignored.
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("patch[2]", Tag::new(b"tab2"));
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+        let r = apply_table_keyed_patch(&patch, &font);
+
+        let font = r.unwrap();
+        let font = FontRef::new(&font).unwrap();
+
+        assert_eq!(font.table_directory.num_tables(), 5);
+
+        assert_eq!(
+            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
+            IFT_TABLE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
+            TABLE_1_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
+            TABLE_2_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab3")).unwrap().as_bytes(),
+            TABLE_3_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
+            TABLE_4_FINAL_STATE
+        );
+    }
+
+    #[test]
+    fn table_keyed_patch_unsorted_offsets() {
+        // reorder the offsets
+        let mut patch_data = table_keyed_patch();
+
+        let offset = patch_data.offset_for("patch[1]") as u32;
+        patch_data.write_at("patch_off[0]", offset);
+
+        let offset = patch_data.offset_for("patch[0]") as u32;
+        patch_data.write_at("patch_off[1]", offset);
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        assert_eq!(
+            Err(PatchingError::InvalidPatch(
+                "Patch offsets are not in sorted order."
+            )),
+            apply_table_keyed_patch(&patch, &font)
+        );
+    }
+
+    #[test]
+    fn table_keyed_patch_out_of_bounds_offsets() {
+        // set last offset out of bounds
+        let mut patch_data = table_keyed_patch();
+        let offset = (patch_data.offset_for("end") + 5) as u32;
+        patch_data.write_at("patch_off[3]", offset);
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        assert_eq!(
+            Err(PatchingError::PatchParsingFailed(ReadError::OutOfBounds)),
+            apply_table_keyed_patch(&patch, &font)
+        );
+    }
+
+    #[test]
+    fn table_keyed_patch_drop_and_replace() {
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("flags[2]", 3u8);
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        // When DROP and REPLACE are both set DROP takes priority.
+        let r = apply_table_keyed_patch(&patch, &font);
+
+        let font = r.unwrap();
+        let font = FontRef::new(&font).unwrap();
+
+        assert_eq!(font.table_directory.num_tables(), 4);
+
+        assert_eq!(
+            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
+            IFT_TABLE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
+            TABLE_1_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
+            TABLE_2_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
+            TABLE_4_FINAL_STATE
+        );
+    }
+
+    #[test]
+    fn table_keyed_patch_missing_table() {
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("flags[1]", 0u8);
+        patch_data.write_at("patch[1]", Tag::new(b"tab5"));
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        assert_eq!(
+            Err(PatchingError::InvalidPatch(
+                "Trying to patch a base table that doesn't exist."
+            )),
+            apply_table_keyed_patch(&patch, &font)
+        );
+    }
+
+    #[test]
+    fn table_keyed_replace_missing_table() {
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("patch[1]", Tag::new(b"tab5"));
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        let r = apply_table_keyed_patch(&patch, &font);
+
+        let font = r.unwrap();
+        let font = FontRef::new(&font).unwrap();
+
+        assert_eq!(font.table_directory.num_tables(), 5);
+
+        assert_eq!(
+            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
+            IFT_TABLE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
+            TABLE_1_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
+            "foobar\n".as_bytes()
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
+            TABLE_4_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab5")).unwrap().as_bytes(),
+            TABLE_2_FINAL_STATE
+        );
+    }
+
+    #[test]
+    fn table_keyed_drop_missing_table() {
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("patch[2]", Tag::new(b"tab5"));
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        let r = apply_table_keyed_patch(&patch, &font);
+
+        let font = r.unwrap();
+        let font = FontRef::new(&font).unwrap();
+
+        assert_eq!(font.table_directory.num_tables(), 5);
+
+        assert_eq!(
+            font.table_data(Tag::new(b"IFT ")).unwrap().as_bytes(),
+            IFT_TABLE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab1")).unwrap().as_bytes(),
+            TABLE_1_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab2")).unwrap().as_bytes(),
+            TABLE_2_FINAL_STATE,
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab3")).unwrap().as_bytes(),
+            TABLE_3_FINAL_STATE
+        );
+        assert_eq!(
+            font.table_data(Tag::new(b"tab4")).unwrap().as_bytes(),
+            TABLE_4_FINAL_STATE
+        );
+    }
+
+    #[test]
+    fn table_keyed_patch_uncompressed_len_too_small() {
+        let mut patch_data = table_keyed_patch();
+        patch_data.write_at("decompressed_len[0]", 28u32);
+
+        let patch = TableKeyedPatch::read(FontData::new(&patch_data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        assert_eq!(
+            Err(PatchingError::InvalidPatch("Max size exceeded.")),
+            apply_table_keyed_patch(&patch, &font)
+        );
+    }
+}

--- a/incremental-font-transfer/src/table_keyed.rs
+++ b/incremental-font-transfer/src/table_keyed.rs
@@ -22,14 +22,15 @@ pub(crate) fn apply_table_keyed_patch(
     let mut font_builder = FontBuilder::new();
     let mut processed_tables = BTreeSet::<Tag>::new();
     // TODO(garretrieger): enforce a max combined size of all decoded tables? say something in the spec about this?
-    for i in 0..patch.patches_count() {
-        let i = i as usize;
+    for (i, table_patch) in patch
+        .patches()
+        .iter()
+        .take(patch.patches_count() as usize)
+        .enumerate()
+    {
         let next = i + 1;
 
-        let table_patch = patch
-            .patches()
-            .get(i)
-            .map_err(PatchingError::PatchParsingFailed)?;
+        let table_patch = table_patch.map_err(PatchingError::PatchParsingFailed)?;
         let (Some(offset), Some(next_offset)) = (
             patch.patch_offsets().get(i),
             patch.patch_offsets().get(next),
@@ -131,7 +132,7 @@ mod tests {
     use read_fonts::ReadError;
     use write_fonts::FontBuilder;
 
-    const IFT_TABLE: &[u8] = "IFT PATCH MAP".as_bytes();
+    const IFT_TABLE: &[u8] = b"IFT PATCH MAP";
     const TABLE_1_FINAL_STATE: &[u8] = "hijkabcdeflmnohijkabcdeflmno\n".as_bytes();
     const TABLE_2_FINAL_STATE: &[u8] = "foobarbaz foobarbaz foobarbaz\n".as_bytes();
     const TABLE_3_FINAL_STATE: &[u8] = "foobaz\n".as_bytes();


### PR DESCRIPTION
Adds a new patch_group module which generates a candidate set of URIs to be applied next based on the list of intersecting patches. The candidate URI group is structured to enforce compatibility constraints between patches. PatchGroup's can then be used to trigger the next iteration of patch application.

Example usage:

```
loop {
  let g = PatchGroup::select_next_patches(font, &subset_definition).unwrap();
  if !g.has_uris() {
    break;
  }

  // g.uris() lists patches to be downloaded, 
  // patch_data is populated with downloaded data.
  let patch_data = ...;

  font = g.apply_next_patches(&mut patch_data).unwrap();
}
```