### PR TITLE
[IFT] add patch application call to patch group fuzzer.

### DIFF
--- a/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
+++ b/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use incremental_font_transfer::{
-    font_patch::PatchingError,
     patch_group::{PatchGroup, UriStatus},
     patchmap::SubsetDefinition,
 };

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -13,3 +13,6 @@ all-features = true
 
 [dependencies]
 brotlic-sys = {version = "0.2.2"}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }


### PR DESCRIPTION
To make this effective the brotli decoder has been configured to be disabled during fuzzing. This is needed because the brotli decoder code is c++ based and the fuzzer isn't able to instrument and track coverage through it, which results in the fuzzer being extremely unlikely to generate valid brotli encoded data.