### PR TITLE
[codegen] Better handling of computed lengths

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1304,7 +1304,7 @@ impl Field {
                     let typ = self.typ.cooked_type_tokens();
                     let expr = inline_expr.compile_expr();
                     if !inline_expr.referenced_fields.is_empty() {
-                        quote!(#expr.unwrap() as #typ)
+                        quote!( #typ :: try_from(#expr).unwrap() )
                     } else {
                         quote!(#expr as #typ)
                     }

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -33,7 +33,7 @@ impl FontWrite for Avar {
         let version = self.compute_version() as MajorMinor;
         version.write_into(writer);
         (0 as u16).write_into(writer);
-        (array_len(&self.axis_segment_maps).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.axis_segment_maps)).unwrap()).write_into(writer);
         self.axis_segment_maps.write_into(writer);
         version
             .compatible((2u16, 0u16))
@@ -113,7 +113,7 @@ impl SegmentMaps {
 impl FontWrite for SegmentMaps {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.axis_value_maps).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.axis_value_maps)).unwrap()).write_into(writer);
         self.axis_value_maps.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -164,7 +164,7 @@ impl BaseTagList {
 impl FontWrite for BaseTagList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.baseline_tags).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.baseline_tags)).unwrap()).write_into(writer);
         self.baseline_tags.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -222,7 +222,7 @@ impl BaseScriptList {
 impl FontWrite for BaseScriptList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.base_script_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.base_script_records)).unwrap()).write_into(writer);
         self.base_script_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -346,7 +346,7 @@ impl FontWrite for BaseScript {
     fn write_into(&self, writer: &mut TableWriter) {
         self.base_values.write_into(writer);
         self.default_min_max.write_into(writer);
-        (array_len(&self.base_lang_sys_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.base_lang_sys_records)).unwrap()).write_into(writer);
         self.base_lang_sys_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -472,7 +472,7 @@ impl FontWrite for BaseValues {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.default_baseline_index.write_into(writer);
-        (array_len(&self.base_coords).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.base_coords)).unwrap()).write_into(writer);
         self.base_coords.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -545,7 +545,7 @@ impl FontWrite for MinMax {
     fn write_into(&self, writer: &mut TableWriter) {
         self.min_coord.write_into(writer);
         self.max_coord.write_into(writer);
-        (array_len(&self.feat_min_max_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.feat_min_max_records)).unwrap()).write_into(writer);
         self.feat_min_max_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -27,7 +27,7 @@ impl FontWrite for Cmap {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (0 as u16).write_into(writer);
-        (array_len(&self.encoding_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.encoding_records)).unwrap()).write_into(writer);
         self.encoding_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -592,7 +592,7 @@ impl FontWrite for Cmap4 {
         (4 as u16).write_into(writer);
         (self.compute_length() as u16).write_into(writer);
         self.language.write_into(writer);
-        (2 * array_len(&self.end_code).unwrap() as u16).write_into(writer);
+        (u16::try_from(2 * array_len(&self.end_code)).unwrap()).write_into(writer);
         (self.compute_search_range() as u16).write_into(writer);
         (self.compute_entry_selector() as u16).write_into(writer);
         (self.compute_range_shift() as u16).write_into(writer);
@@ -963,7 +963,7 @@ impl FontWrite for Cmap12 {
         (0 as u16).write_into(writer);
         (self.compute_length() as u32).write_into(writer);
         self.language.write_into(writer);
-        (array_len(&self.groups).unwrap() as u32).write_into(writer);
+        (u32::try_from(array_len(&self.groups)).unwrap()).write_into(writer);
         self.groups.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -41,7 +41,7 @@ impl FontWrite for TableDirectory {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.sfnt_version.write_into(writer);
-        (array_len(&self.table_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.table_records)).unwrap()).write_into(writer);
         self.search_range.write_into(writer);
         self.entry_selector.write_into(writer);
         self.range_shift.write_into(writer);

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -152,7 +152,7 @@ impl FontWrite for AttachList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.coverage.write_into(writer);
-        (array_len(&self.attach_points).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.attach_points)).unwrap()).write_into(writer);
         self.attach_points.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -213,7 +213,7 @@ impl AttachPoint {
 impl FontWrite for AttachPoint {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.point_indices).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.point_indices)).unwrap()).write_into(writer);
         self.point_indices.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -275,7 +275,7 @@ impl FontWrite for LigCaretList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.coverage.write_into(writer);
-        (array_len(&self.lig_glyphs).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lig_glyphs)).unwrap()).write_into(writer);
         self.lig_glyphs.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -337,7 +337,7 @@ impl LigGlyph {
 impl FontWrite for LigGlyph {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.caret_values).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.caret_values)).unwrap()).write_into(writer);
         self.caret_values.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -650,7 +650,7 @@ impl FontWrite for MarkGlyphSets {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        (array_len(&self.coverages).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.coverages)).unwrap()).write_into(writer);
         self.coverages.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -581,7 +581,7 @@ impl MarkArray {
 impl FontWrite for MarkArray {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.mark_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.mark_records)).unwrap()).write_into(writer);
         self.mark_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -837,7 +837,7 @@ impl FontWrite for SinglePosFormat2 {
         (2 as u16).write_into(writer);
         self.coverage.write_into(writer);
         (self.compute_value_format() as ValueFormat).write_into(writer);
-        (array_len(&self.value_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.value_records)).unwrap()).write_into(writer);
         self.value_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1002,7 +1002,7 @@ impl FontWrite for PairPosFormat1 {
         self.coverage.write_into(writer);
         (self.compute_value_format1() as ValueFormat).write_into(writer);
         (self.compute_value_format2() as ValueFormat).write_into(writer);
-        (array_len(&self.pair_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.pair_sets)).unwrap()).write_into(writer);
         self.pair_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1063,7 +1063,7 @@ impl PairSet {
 impl FontWrite for PairSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.pair_value_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.pair_value_records)).unwrap()).write_into(writer);
         self.pair_value_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1371,7 +1371,7 @@ impl FontWrite for CursivePosFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.entry_exit_record).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.entry_exit_record)).unwrap()).write_into(writer);
         self.entry_exit_record.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1578,7 +1578,7 @@ impl BaseArray {
 impl FontWrite for BaseArray {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.base_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.base_records)).unwrap()).write_into(writer);
         self.base_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1774,7 +1774,7 @@ impl LigatureArray {
 impl FontWrite for LigatureArray {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.ligature_attaches).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.ligature_attaches)).unwrap()).write_into(writer);
         self.ligature_attaches.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1823,7 +1823,7 @@ impl LigatureAttach {
 impl FontWrite for LigatureAttach {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.component_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.component_records)).unwrap()).write_into(writer);
         self.component_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2018,7 +2018,7 @@ impl Mark2Array {
 impl FontWrite for Mark2Array {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.mark2_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.mark2_records)).unwrap()).write_into(writer);
         self.mark2_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -408,7 +408,7 @@ impl FontWrite for SingleSubstFormat2 {
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.substitute_glyph_ids)).unwrap()).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -477,7 +477,7 @@ impl FontWrite for MultipleSubstFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.sequences).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.sequences)).unwrap()).write_into(writer);
         self.sequences.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -539,7 +539,7 @@ impl Sequence {
 impl FontWrite for Sequence {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.substitute_glyph_ids)).unwrap()).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -603,7 +603,7 @@ impl FontWrite for AlternateSubstFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.alternate_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.alternate_sets)).unwrap()).write_into(writer);
         self.alternate_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -671,7 +671,7 @@ impl AlternateSet {
 impl FontWrite for AlternateSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.alternate_glyph_ids).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.alternate_glyph_ids)).unwrap()).write_into(writer);
         self.alternate_glyph_ids.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -735,7 +735,7 @@ impl FontWrite for LigatureSubstFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.ligature_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.ligature_sets)).unwrap()).write_into(writer);
         self.ligature_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -798,7 +798,7 @@ impl LigatureSet {
 impl FontWrite for LigatureSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.ligatures).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.ligatures)).unwrap()).write_into(writer);
         self.ligatures.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -860,7 +860,7 @@ impl FontWrite for Ligature {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.ligature_glyph.write_into(writer);
-        (plus_one(&self.component_glyph_ids.len()).unwrap() as u16).write_into(writer);
+        (u16::try_from(plus_one(&self.component_glyph_ids.len())).unwrap()).write_into(writer);
         self.component_glyph_ids.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1120,11 +1120,11 @@ impl FontWrite for ReverseChainSingleSubstFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.backtrack_coverages).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.backtrack_coverages)).unwrap()).write_into(writer);
         self.backtrack_coverages.write_into(writer);
-        (array_len(&self.lookahead_coverages).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lookahead_coverages)).unwrap()).write_into(writer);
         self.lookahead_coverages.write_into(writer);
-        (array_len(&self.substitute_glyph_ids).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.substitute_glyph_ids)).unwrap()).write_into(writer);
         self.substitute_glyph_ids.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -26,7 +26,7 @@ impl FontWrite for Gvar {
     fn write_into(&self, writer: &mut TableWriter) {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         self.axis_count.write_into(writer);
-        (array_len(&self.shared_tuples).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.shared_tuples)).unwrap()).write_into(writer);
         self.shared_tuples.write_into(writer);
         (self.compute_glyph_count() as u16).write_into(writer);
         (self.compute_flags() as GvarFlags).write_into(writer);

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -27,7 +27,7 @@ impl ScriptList {
 impl FontWrite for ScriptList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.script_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.script_records)).unwrap()).write_into(writer);
         self.script_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -139,7 +139,7 @@ impl FontWrite for Script {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.default_lang_sys.write_into(writer);
-        (array_len(&self.lang_sys_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lang_sys_records)).unwrap()).write_into(writer);
         self.lang_sys_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -267,7 +267,7 @@ impl FontWrite for LangSys {
     fn write_into(&self, writer: &mut TableWriter) {
         (0 as u16).write_into(writer);
         self.required_feature_index.write_into(writer);
-        (array_len(&self.feature_indices).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.feature_indices)).unwrap()).write_into(writer);
         self.feature_indices.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -326,7 +326,7 @@ impl FeatureList {
 impl FontWrite for FeatureList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.feature_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.feature_records)).unwrap()).write_into(writer);
         self.feature_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -442,7 +442,7 @@ impl FontWrite for Feature {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.feature_params.write_into(writer);
-        (array_len(&self.lookup_list_indices).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lookup_list_indices)).unwrap()).write_into(writer);
         self.lookup_list_indices.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -498,7 +498,7 @@ impl<T: Default> LookupList<T> {
 impl<T: FontWrite> FontWrite for LookupList<T> {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.lookups).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lookups)).unwrap()).write_into(writer);
         self.lookups.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -632,7 +632,7 @@ impl FontWrite for CoverageFormat1 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
-        (array_len(&self.glyph_array).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.glyph_array)).unwrap()).write_into(writer);
         self.glyph_array.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -691,7 +691,7 @@ impl FontWrite for CoverageFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        (array_len(&self.range_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.range_records)).unwrap()).write_into(writer);
         self.range_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -888,7 +888,7 @@ impl FontWrite for ClassDefFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.start_glyph_id.write_into(writer);
-        (array_len(&self.class_value_array).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.class_value_array)).unwrap()).write_into(writer);
         self.class_value_array.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -948,7 +948,7 @@ impl FontWrite for ClassDefFormat2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        (array_len(&self.class_range_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.class_range_records)).unwrap()).write_into(writer);
         self.class_range_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1191,7 +1191,7 @@ impl FontWrite for SequenceContextFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.seq_rule_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.seq_rule_sets)).unwrap()).write_into(writer);
         self.seq_rule_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1262,7 +1262,7 @@ impl SequenceRuleSet {
 impl FontWrite for SequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.seq_rules).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.seq_rules)).unwrap()).write_into(writer);
         self.seq_rules.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1326,8 +1326,8 @@ impl SequenceRule {
 impl FontWrite for SequenceRule {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (plus_one(&self.input_sequence.len()).unwrap() as u16).write_into(writer);
-        (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(plus_one(&self.input_sequence.len())).unwrap()).write_into(writer);
+        (u16::try_from(array_len(&self.seq_lookup_records)).unwrap()).write_into(writer);
         self.input_sequence.write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
@@ -1404,7 +1404,7 @@ impl FontWrite for SequenceContextFormat2 {
         (2 as u16).write_into(writer);
         self.coverage.write_into(writer);
         self.class_def.write_into(writer);
-        (array_len(&self.class_seq_rule_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.class_seq_rule_sets)).unwrap()).write_into(writer);
         self.class_seq_rule_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1479,7 +1479,7 @@ impl ClassSequenceRuleSet {
 impl FontWrite for ClassSequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.class_seq_rules).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.class_seq_rules)).unwrap()).write_into(writer);
         self.class_seq_rules.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1547,8 +1547,8 @@ impl ClassSequenceRule {
 impl FontWrite for ClassSequenceRule {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (plus_one(&self.input_sequence.len()).unwrap() as u16).write_into(writer);
-        (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(plus_one(&self.input_sequence.len())).unwrap()).write_into(writer);
+        (u16::try_from(array_len(&self.seq_lookup_records)).unwrap()).write_into(writer);
         self.input_sequence.write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
@@ -1617,8 +1617,8 @@ impl FontWrite for SequenceContextFormat3 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
-        (array_len(&self.coverages).unwrap() as u16).write_into(writer);
-        (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.coverages)).unwrap()).write_into(writer);
+        (u16::try_from(array_len(&self.seq_lookup_records)).unwrap()).write_into(writer);
         self.coverages.write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
@@ -1810,7 +1810,7 @@ impl FontWrite for ChainedSequenceContextFormat1 {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.coverage.write_into(writer);
-        (array_len(&self.chained_seq_rule_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.chained_seq_rule_sets)).unwrap()).write_into(writer);
         self.chained_seq_rule_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1881,7 +1881,7 @@ impl ChainedSequenceRuleSet {
 impl FontWrite for ChainedSequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.chained_seq_rules).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.chained_seq_rules)).unwrap()).write_into(writer);
         self.chained_seq_rules.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -1961,13 +1961,13 @@ impl ChainedSequenceRule {
 impl FontWrite for ChainedSequenceRule {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.backtrack_sequence).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.backtrack_sequence)).unwrap()).write_into(writer);
         self.backtrack_sequence.write_into(writer);
-        (plus_one(&self.input_sequence.len()).unwrap() as u16).write_into(writer);
+        (u16::try_from(plus_one(&self.input_sequence.len())).unwrap()).write_into(writer);
         self.input_sequence.write_into(writer);
-        (array_len(&self.lookahead_sequence).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lookahead_sequence)).unwrap()).write_into(writer);
         self.lookahead_sequence.write_into(writer);
-        (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.seq_lookup_records)).unwrap()).write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2073,7 +2073,7 @@ impl FontWrite for ChainedSequenceContextFormat2 {
         self.backtrack_class_def.write_into(writer);
         self.input_class_def.write_into(writer);
         self.lookahead_class_def.write_into(writer);
-        (array_len(&self.chained_class_seq_rule_sets).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.chained_class_seq_rule_sets)).unwrap()).write_into(writer);
         self.chained_class_seq_rule_sets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2159,7 +2159,7 @@ impl ChainedClassSequenceRuleSet {
 impl FontWrite for ChainedClassSequenceRuleSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.chained_class_seq_rules).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.chained_class_seq_rules)).unwrap()).write_into(writer);
         self.chained_class_seq_rules.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2240,13 +2240,13 @@ impl ChainedClassSequenceRule {
 impl FontWrite for ChainedClassSequenceRule {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.backtrack_sequence).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.backtrack_sequence)).unwrap()).write_into(writer);
         self.backtrack_sequence.write_into(writer);
-        (plus_one(&self.input_sequence.len()).unwrap() as u16).write_into(writer);
+        (u16::try_from(plus_one(&self.input_sequence.len())).unwrap()).write_into(writer);
         self.input_sequence.write_into(writer);
-        (array_len(&self.lookahead_sequence).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lookahead_sequence)).unwrap()).write_into(writer);
         self.lookahead_sequence.write_into(writer);
-        (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.seq_lookup_records)).unwrap()).write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2341,13 +2341,13 @@ impl FontWrite for ChainedSequenceContextFormat3 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u16).write_into(writer);
-        (array_len(&self.backtrack_coverages).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.backtrack_coverages)).unwrap()).write_into(writer);
         self.backtrack_coverages.write_into(writer);
-        (array_len(&self.input_coverages).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.input_coverages)).unwrap()).write_into(writer);
         self.input_coverages.write_into(writer);
-        (array_len(&self.lookahead_coverages).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.lookahead_coverages)).unwrap()).write_into(writer);
         self.lookahead_coverages.write_into(writer);
-        (array_len(&self.seq_lookup_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.seq_lookup_records)).unwrap()).write_into(writer);
         self.seq_lookup_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2806,7 +2806,7 @@ impl FontWrite for FeatureVariations {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
-        (array_len(&self.feature_variation_records).unwrap() as u32).write_into(writer);
+        (u32::try_from(array_len(&self.feature_variation_records)).unwrap()).write_into(writer);
         self.feature_variation_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -2928,7 +2928,7 @@ impl ConditionSet {
 impl FontWrite for ConditionSet {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.conditions).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.conditions)).unwrap()).write_into(writer);
         self.conditions.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -3431,7 +3431,7 @@ impl FontWrite for FeatureTableSubstitution {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
-        (array_len(&self.substitutions).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.substitutions)).unwrap()).write_into(writer);
         self.substitutions.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -3734,7 +3734,7 @@ impl FontWrite for CharacterVariantParams {
         self.sample_text_name_id.write_into(writer);
         self.num_named_parameters.write_into(writer);
         self.first_param_ui_label_name_id.write_into(writer);
-        (array_len(&self.character).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.character)).unwrap()).write_into(writer);
         self.character.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -31,14 +31,14 @@ impl FontWrite for Name {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.compute_version() as u16;
         version.write_into(writer);
-        (array_len(&self.name_record).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.name_record)).unwrap()).write_into(writer);
         (self.compute_storage_offset() as u16).write_into(writer);
         writer.adjust_offsets(self.compute_storage_offset() as u32, |writer| {
             self.name_record.write_into(writer);
         });
         version
             .compatible(1u16)
-            .then(|| (array_len(&self.lang_tag_record).unwrap() as u16).write_into(writer));
+            .then(|| (u16::try_from(array_len(&self.lang_tag_record)).unwrap()).write_into(writer));
         writer.adjust_offsets(self.compute_storage_offset() as u32, |writer| {
             version.compatible(1u16).then(|| {
                 self.lang_tag_record

--- a/write-fonts/generated/generated_postscript.rs
+++ b/write-fonts/generated/generated_postscript.rs
@@ -303,7 +303,7 @@ impl FontWrite for FdSelectFormat3 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (3 as u8).write_into(writer);
-        (array_len(&self.ranges).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.ranges)).unwrap()).write_into(writer);
         self.ranges.write_into(writer);
         self.sentinel.write_into(writer);
     }
@@ -411,7 +411,7 @@ impl FontWrite for FdSelectFormat4 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (4 as u8).write_into(writer);
-        (array_len(&self.ranges).unwrap() as u32).write_into(writer);
+        (u32::try_from(array_len(&self.ranges)).unwrap()).write_into(writer);
         self.ranges.write_into(writer);
         self.sentinel.write_into(writer);
     }

--- a/write-fonts/generated/generated_sbix.rs
+++ b/write-fonts/generated/generated_sbix.rs
@@ -40,7 +40,7 @@ impl FontWrite for Sbix {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         (self.compile_header_flags()).write_into(writer);
-        (array_len(&self.strikes).unwrap() as u32).write_into(writer);
+        (u32::try_from(array_len(&self.strikes)).unwrap()).write_into(writer);
         self.strikes.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -33,9 +33,9 @@ impl FontWrite for Stat {
         let version = MajorMinor::VERSION_1_2 as MajorMinor;
         version.write_into(writer);
         (8 as u16).write_into(writer);
-        (array_len(&self.design_axes).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.design_axes)).unwrap()).write_into(writer);
         self.design_axes.write_into(writer);
-        (array_len(&self.offset_to_axis_values).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.offset_to_axis_values)).unwrap()).write_into(writer);
         self.offset_to_axis_values.write_into(writer);
         version.compatible((1u16, 1u16)).then(|| {
             self.elided_fallback_name_id
@@ -613,7 +613,7 @@ impl FontWrite for AxisValueFormat4 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (4 as u16).write_into(writer);
-        (array_len(&self.axis_values).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.axis_values)).unwrap()).write_into(writer);
         self.flags.write_into(writer);
         self.value_name_id.write_into(writer);
         self.axis_values.write_into(writer);

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -72,7 +72,7 @@ impl FontWrite for Table2 {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         (2 as u16).write_into(writer);
-        (array_len(&self.values).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.values)).unwrap()).write_into(writer);
         self.values.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -48,7 +48,7 @@ impl FontWrite for KindsOfOffsets {
         version.write_into(writer);
         self.nonnullable.write_into(writer);
         self.nullable.write_into(writer);
-        (array_len(&self.array).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.array)).unwrap()).write_into(writer);
         self.array.write_into(writer);
         self.record_array.write_into(writer);
         version
@@ -151,7 +151,7 @@ impl FontWrite for KindsOfArraysOfOffsets {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = MajorMinor::VERSION_1_1 as MajorMinor;
         version.write_into(writer);
-        (array_len(&self.nonnullables).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.nonnullables)).unwrap()).write_into(writer);
         self.nonnullables.write_into(writer);
         self.nullables.write_into(writer);
         version.compatible((1u16, 1u16)).then(|| {
@@ -273,7 +273,7 @@ impl FontWrite for KindsOfArrays {
     fn write_into(&self, writer: &mut TableWriter) {
         let version = self.version;
         version.write_into(writer);
-        (array_len(&self.scalars).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.scalars)).unwrap()).write_into(writer);
         self.scalars.write_into(writer);
         self.records.write_into(writer);
         version.compatible(1u16).then(|| {

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -25,10 +25,10 @@ impl BasicTable {
 impl FontWrite for BasicTable {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.simple_records).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.simple_records)).unwrap()).write_into(writer);
         self.simple_records.write_into(writer);
         (self.compute_arrays_inner_count() as u16).write_into(writer);
-        (array_len(&self.array_records).unwrap() as u32).write_into(writer);
+        (u32::try_from(array_len(&self.array_records)).unwrap()).write_into(writer);
         self.array_records.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -193,7 +193,7 @@ impl ContainsOffsets {
 impl FontWrite for ContainsOffsets {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
-        (array_len(&self.array).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.array)).unwrap()).write_into(writer);
         self.array.write_into(writer);
         self.other.write_into(writer);
     }

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -380,7 +380,7 @@ impl FontWrite for VariationRegionList {
     #[allow(clippy::unnecessary_cast)]
     fn write_into(&self, writer: &mut TableWriter) {
         self.axis_count.write_into(writer);
-        (array_len(&self.variation_regions).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.variation_regions)).unwrap()).write_into(writer);
         self.variation_regions.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -564,7 +564,7 @@ impl FontWrite for ItemVariationStore {
     fn write_into(&self, writer: &mut TableWriter) {
         (1 as u16).write_into(writer);
         self.variation_region_list.write_into(writer);
-        (array_len(&self.item_variation_data).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.item_variation_data)).unwrap()).write_into(writer);
         self.item_variation_data.write_into(writer);
     }
     fn table_type(&self) -> TableType {
@@ -649,7 +649,7 @@ impl FontWrite for ItemVariationData {
     fn write_into(&self, writer: &mut TableWriter) {
         self.item_count.write_into(writer);
         self.word_delta_count.write_into(writer);
-        (array_len(&self.region_indexes).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.region_indexes)).unwrap()).write_into(writer);
         self.region_indexes.write_into(writer);
         self.delta_sets.write_into(writer);
     }

--- a/write-fonts/generated/generated_vorg.rs
+++ b/write-fonts/generated/generated_vorg.rs
@@ -32,7 +32,7 @@ impl FontWrite for Vorg {
     fn write_into(&self, writer: &mut TableWriter) {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         self.default_vert_origin_y.write_into(writer);
-        (array_len(&self.vert_origin_y_metrics).unwrap() as u16).write_into(writer);
+        (u16::try_from(array_len(&self.vert_origin_y_metrics)).unwrap()).write_into(writer);
         self.vert_origin_y_metrics.write_into(writer);
     }
     fn table_type(&self) -> TableType {

--- a/write-fonts/src/collections.rs
+++ b/write-fonts/src/collections.rs
@@ -8,10 +8,6 @@ use crate::{NullableOffsetMarker, OffsetMarker};
 /// the length in order to populate another field.
 pub trait HasLen {
     fn len(&self) -> usize;
-
-    fn checked_len<T: TryFrom<usize>>(&self) -> Result<T, <T as TryFrom<usize>>::Error> {
-        self.len().try_into()
-    }
 }
 
 impl<T> HasLen for [T] {

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -183,11 +183,11 @@ pub(crate) mod codegen_prelude {
     };
 
     /// checked conversion to u16
-    pub fn array_len<T: super::collections::HasLen>(s: &T) -> Result<u16, TryFromIntError> {
-        s.checked_len()
+    pub fn array_len<T: super::collections::HasLen>(s: &T) -> usize {
+        s.len()
     }
 
-    pub fn plus_one(val: &usize) -> Result<u16, TryFromIntError> {
-        val.saturating_add(1).try_into()
+    pub fn plus_one(val: &usize) -> usize {
+        val.saturating_add(1)
     }
 }


### PR DESCRIPTION
This fixes an issue where we were incorrectly truncating all computed lengths to u16, even if the resulting value is storedwould be stored as a u32.

We now keep computed values as usize and then generate a conversion for the appropriate type only at the callsite, instead of blindly converting to a u16 earlier on.

(this issue was pointed out in https://github.com/googlefonts/fontations/pull/1244#discussion_r1847439465; thanks @Hoolean!)