### PR TITLE
[write-fonts] update meta codegen

### DIFF
--- a/write-fonts/generated/generated_meta.rs
+++ b/write-fonts/generated/generated_meta.rs
@@ -28,7 +28,7 @@ impl FontWrite for Meta {
         (1 as u32).write_into(writer);
         (0 as u32).write_into(writer);
         (0 as u32).write_into(writer);
-        (array_len(&self.data_maps).unwrap() as u32).write_into(writer);
+        (u32::try_from(array_len(&self.data_maps)).unwrap()).write_into(writer);
         self.data_maps.write_into(writer);
     }
     fn table_type(&self) -> TableType {


### PR DESCRIPTION
This somehow ended up broken on main after I merged the autohint reorg which amusingly didn't even touch that code.

This patch is just a rerun of codegen to fix the error.

JMM