### PR TITLE
[write] Use Vec instead of BTreeSet for name records

### DIFF
--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -17,7 +17,7 @@ table Name {
     #[count($count)]
     #[offset_data_method(string_data)]
     #[offset_adjustment(self.compute_storage_offset() as u32)]
-    #[compile_type(BTreeSet<NameRecord>)]
+    #[validate(check_sorted_and_unique_name_records)]
     name_record: [NameRecord],
     /// Number of language-tag records.
     #[since_version(1)]

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -10,15 +10,14 @@ use crate::codegen_prelude::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Name {
     /// The name records where count is the number of records.
-    pub name_record: BTreeSet<NameRecord>,
+    pub name_record: Vec<NameRecord>,
     /// The language-tag records where langTagCount is the number of records.
     pub lang_tag_record: Option<Vec<LangTagRecord>>,
 }
 
 impl Name {
     /// Construct a new `Name`
-    #[allow(clippy::useless_conversion)]
-    pub fn new(name_record: BTreeSet<NameRecord>) -> Self {
+    pub fn new(name_record: Vec<NameRecord>) -> Self {
         Self {
             name_record: name_record.into_iter().map(Into::into).collect(),
             ..Default::default()
@@ -61,7 +60,7 @@ impl Validate for Name {
                 if self.name_record.len() > (u16::MAX as usize) {
                     ctx.report("array exceeds max length");
                 }
-                self.name_record.validate_impl(ctx);
+                self.check_sorted_and_unique_name_records(ctx);
             });
             ctx.in_field("lang_tag_record", |ctx| {
                 if version.compatible(1u16) && self.lang_tag_record.is_none() {


### PR DESCRIPTION
It is an invariant that entries in the name_records array are sorted, and to enforce this at the type level the initial design used a BTreeSet for these records.

This didn't fully help, though, because it was still possible to have a duplicate entry in the array (the same
platform/encoding/language/nameId, mapped to different strings) since the string itself is included in the Eq method of `NameRecord`.

This patch tries to be less cute: it is now the responsibility of the caller to make sure that their data is right, and we will verify this at validation time.

Ultimately this probably deserves a builder (there's one in fea-rs that should maybe get moved over here?)


cc @simoncozens; I recall you not enjoying the ergonomics of the `BTreeSet` approach, so here you go 💁 