### PR TITLE
Allow manipulating the write_fonts::tables::glyf::Glyph structure

### DIFF
--- a/write-fonts/src/tables/glyf.rs
+++ b/write-fonts/src/tables/glyf.rs
@@ -127,7 +127,7 @@ impl<'a> FontRead<'a> for Glyph {
 
 impl From<SimpleGlyph> for Glyph {
     fn from(value: SimpleGlyph) -> Self {
-        if value.contours().is_empty() {
+        if value.contours.is_empty() {
             Glyph::Empty
         } else {
             Glyph::Simple(value)

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -178,6 +178,18 @@ impl Contour {
     }
 }
 
+impl From<Vec<CurvePoint>> for Contour {
+    fn from(points: Vec<CurvePoint>) -> Self {
+        Self(points)
+    }
+}
+
+impl From<Contour> for Vec<CurvePoint> {
+    fn from(contour: Contour) -> Self {
+        contour.0
+    }
+}
+
 impl MalformedPath {
     fn inconsistent_path_els(idx: usize, elements: &[kurbo::PathEl]) -> Self {
         fn el_types(elements: &[kurbo::PathEl]) -> Vec<&'static str> {

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -18,7 +18,7 @@ use super::Bbox;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SimpleGlyph {
     pub bbox: Bbox,
-    contours: Vec<Contour>,
+    pub contours: Vec<Contour>,
     pub instructions: Vec<u8>,
 }
 
@@ -133,10 +133,6 @@ impl SimpleGlyph {
             flag |= x_flag | y_flag;
             Some((flag, x_data, y_data))
         })
-    }
-
-    pub fn contours(&self) -> &[Contour] {
-        &self.contours
     }
 }
 
@@ -942,8 +938,8 @@ mod tests {
 
     fn assert_contour_points(glyph: &SimpleGlyph, all_points: Vec<Vec<CurvePoint>>) {
         let expected_num_contours = all_points.len();
-        assert_eq!(glyph.contours().len(), expected_num_contours);
-        for (contour, expected_points) in glyph.contours().iter().zip(all_points.iter()) {
+        assert_eq!(glyph.contours.len(), expected_num_contours);
+        for (contour, expected_points) in glyph.contours.iter().zip(all_points.iter()) {
             let points = contour.iter().copied().collect::<Vec<_>>();
             assert_eq!(points, *expected_points);
         }

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -134,6 +134,32 @@ impl SimpleGlyph {
             Some((flag, x_data, y_data))
         })
     }
+
+    /// Recompute the Glyph's bounding box based on the current contours
+    pub fn recompute_bounding_box(&mut self) {
+        let mut points = self
+            .contours
+            .iter()
+            .flat_map(|c| c.iter())
+            .map(|p| (p.x, p.y));
+
+        if let Some((mut x_min, mut y_min)) = points.next() {
+            let mut x_max = x_min;
+            let mut y_max = y_min;
+            for (x, y) in points {
+                x_min = x_min.min(x);
+                y_min = y_min.min(y);
+                x_max = x_max.max(x);
+                y_max = y_max.max(y);
+            }
+            self.bbox = Bbox {
+                x_min,
+                y_min,
+                x_max,
+                y_max,
+            };
+        }
+    }
 }
 
 impl Contour {

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -15,7 +15,7 @@ use read_fonts::{
 use super::Bbox;
 
 /// A simple (without components) glyph
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SimpleGlyph {
     pub bbox: Bbox,
     pub contours: Vec<Contour>,


### PR DESCRIPTION
This solves #1253 for me...

- **Rename and expose instructions**
- **Expose contours**
- **Allow construction of empty Glyph**
- **Recompute bounding box method**
- **Contour to Vec<ContourPoint> and back again**
