### PR TITLE
[IFT] Implement spec compliant selection order for invalidating patches

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -239,7 +239,7 @@ pub fn features_and_design_space_format2() -> BeBuffer {
 
       [1, 2, 3, 4u32], // compat id
 
-      3u8, // default patch encoding
+      {3u8: "patch_encoding"}, // default patch encoding
       (Uint24::new(3)), // entry count
       {0u32: "entries_offset"},
       0u32, // entry id string data offset

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -671,7 +671,8 @@ pub fn glyph_keyed_patch_header() -> BeBuffer {
       {(Tag::new(b"ifgk")): "format"}, // format
       0u32,                // reserved
       0u8,                 // flags (0 = u16 gids)
-      [6, 7, 8, 9u32],     // compatibility id
+      {6u32: "compatibility_id"},
+      [7, 8, 9u32],     // compatibility id
       {0u32: "max_uncompressed_length"}
     }
 }

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -107,13 +107,18 @@ pub fn feature_map_format1() -> BeBuffer {
       {0u32: "glyph_map_offset"},
       {0u32: "feature_map_offset"},
 
-      // applied entry bitmap (51 bytes) - 300 is applied
+      // applied entry bitmap (51 bytes) - 299 is applied
+      {0u8: "applied_entries"},
       [
-        0, 0, 0, 0, 0, 0, 0, 0,           // [0, 64)
+        0, 0, 0, 0, 0, 0, 0,           // [0, 64)
         0, 0, 0, 0, 0, 0, 0, 0,           // [64, 128)
         0, 0, 0, 0, 0, 0, 0, 0,           // [128, 192)
         0, 0, 0, 0, 0, 0, 0, 0,           // [192, 256)
-        0, 0, 0, 0, 0, 0b00001000, 0, 0,  // [256, 320)
+        0, 0, 0, 0, 0u8
+      ],
+      {0b00001000u8: "applied_entries_296"},
+      [
+        0, 0,  // [256, 320)
         0, 0, 0, 0, 0, 0, 0, 0,           // [320, 384)
         0, 0, 0u8                         // [384, 400)
       ],
@@ -121,19 +126,19 @@ pub fn feature_map_format1() -> BeBuffer {
       8u16, // uriTemplateLength
       [b'A', b'B', b'C', b'D', b'E', b'F', 0xc9, 0xa4],  // uriTemplate[8]
 
-      3u8,                    // patch encoding = glyph keyed
+      {3u8: "patch_encoding"},            // patch encoding = glyph keyed
 
       /* ### Glyph Map ### */
       {2u16: "glyph_map"}, // first mapped glyph
 
       // entryIndex[2..6]
       [
-        80,  // gid 2
-        81,  // gid 3
-        300, // gid 4
-        299, // gid 5
-        80u16   // gid 6
+        80,     // gid 2
+        81,     // gid 3
+        300u16  // gid 4
       ],
+      {299u16: "gid5_entry"},  // gid 5
+      {80u16:  "gid6_entry"},  // gid 6
 
       // ## Feature Map ##
       {3u16: "feature_map"}, // feature count

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -225,6 +225,7 @@ mod tests {
             TableKeyed {
                 fully_invalidating: false,
             },
+            Default::default(),
         )
         .into();
 
@@ -258,6 +259,7 @@ mod tests {
             TableKeyed {
                 fully_invalidating: false,
             },
+            Default::default(),
         )
         .into();
 
@@ -282,6 +284,7 @@ mod tests {
             IftTableTag::Ift(CompatibilityId::from_u32s([1, 2, 3, 4])),
             0,
             GlyphKeyed,
+            Default::default(),
         )
         .into();
 
@@ -309,6 +312,7 @@ mod tests {
             IftTableTag::Ift(CompatibilityId::from_u32s([6, 7, 9, 9])),
             0,
             GlyphKeyed,
+            Default::default(),
         )
         .into();
 

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -510,7 +510,15 @@ pub(crate) mod tests {
             b"IFTX" => IftTableTag::Iftx(CompatibilityId::from_u32s([0, 0, 0, 0])),
             _ => panic!("Unexpected tag value."),
         };
-        PatchUri::from_index("", 0, source, bit_index, PatchEncoding::GlyphKeyed).into()
+        PatchUri::from_index(
+            "",
+            0,
+            source,
+            bit_index,
+            PatchEncoding::GlyphKeyed,
+            Default::default(),
+        )
+        .into()
     }
 
     #[test]
@@ -925,4 +933,5 @@ pub(crate) mod tests {
     // - patch data offsets unordered.
     // - loca offset type switch required.
     // - glyph keyed test with large number of offsets to check type conversion on (glyphCount * tableCount)
+    // - test that glyph keyed patches are idempotent.
 }

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -1310,4 +1310,6 @@ mod tests {
             assert_eq!(ReadError::ValidationError, err);
         }
     }
+
+    // TODO(garretrieger): tests of selection order criteria for invalidating patches.
 }

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -277,7 +277,7 @@ impl<'a> PatchGroup<'a> {
         // Note:
         // - As mentioned in the spec we can find at least one entry matching that criteria by finding an entry with the
         //   largest intersection (since that can't be a strict subset of others).
-        // - Intesection size is tracked in intersection info.
+        // - Intersection size is tracked in intersection info.
         // - Ties are broken by entry order, which is also tracked in intersection info.
         // - So it's sufficient to just find a candidate patch with the largest intersection info, relying on it's
         //   Ord implementation.

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -311,7 +311,6 @@ pub(crate) struct PatchInfo {
     uri: String,
     source_table: IftTableTag,
     application_flag_bit_index: usize,
-    // TODO: Signals for heuristic patch selection:
 }
 
 impl PatchInfo {
@@ -453,6 +452,7 @@ mod tests {
             PatchEncoding::TableKeyed {
                 fully_invalidating: true,
             },
+            Default::default(),
         )
     }
 
@@ -465,6 +465,7 @@ mod tests {
             PatchEncoding::TableKeyed {
                 fully_invalidating: false,
             },
+            Default::default(),
         )
     }
 
@@ -477,6 +478,7 @@ mod tests {
             PatchEncoding::TableKeyed {
                 fully_invalidating: false,
             },
+            Default::default(),
         )
     }
 
@@ -487,6 +489,7 @@ mod tests {
             IftTableTag::Iftx(cid_2()),
             42,
             PatchEncoding::GlyphKeyed,
+            Default::default(),
         )
     }
 
@@ -499,6 +502,7 @@ mod tests {
             PatchEncoding::TableKeyed {
                 fully_invalidating: false,
             },
+            Default::default(),
         )
     }
 
@@ -511,6 +515,7 @@ mod tests {
             PatchEncoding::TableKeyed {
                 fully_invalidating: false,
             },
+            Default::default(),
         )
     }
 
@@ -521,6 +526,7 @@ mod tests {
             IftTableTag::Ift(cid_1()),
             42,
             PatchEncoding::GlyphKeyed,
+            Default::default(),
         )
     }
 
@@ -531,6 +537,7 @@ mod tests {
             IftTableTag::Ift(cid_1()),
             42,
             PatchEncoding::GlyphKeyed,
+            Default::default(),
         )
     }
 
@@ -541,6 +548,7 @@ mod tests {
             IftTableTag::Iftx(cid_2()),
             42,
             PatchEncoding::GlyphKeyed,
+            Default::default(),
         )
     }
 
@@ -551,6 +559,7 @@ mod tests {
             IftTableTag::Iftx(cid_2()),
             42,
             PatchEncoding::GlyphKeyed,
+            Default::default(),
         )
     }
 

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -269,7 +269,7 @@ impl<'a> PatchGroup<'a> {
 
     /// Select an entry from a list of candidate invalidating entries according to the specs selection criteria.
     ///
-    /// Context: https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection
+    /// Context: <https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection>
     fn select_invalidating_candidate<T>(candidates: T) -> Option<CandidatePatch>
     where
         T: Iterator<Item = CandidatePatch>,
@@ -1431,6 +1431,4 @@ mod tests {
             assert_eq!(ReadError::ValidationError, err);
         }
     }
-
-    // TODO(garretrieger): XXXXX tests of selection order criteria for invalidating patches.
 }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -704,7 +704,7 @@ pub struct PatchUri {
 /// Intersection details are used later on to choose a specific patch to apply next.
 /// See: https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct IntersectionInfo {
+pub(crate) struct IntersectionInfo {
     intersecting_codepoints: u64,
     intersecting_layout_tags: usize,
     // TODO(garretrieger): metric for design space intersection.
@@ -781,7 +781,7 @@ impl PatchUri {
         template.build()
     }
 
-    pub fn intersection_info(&self) -> IntersectionInfo {
+    pub(crate) fn intersection_info(&self) -> IntersectionInfo {
         self.intersection_info.clone()
     }
 
@@ -1015,10 +1015,10 @@ mod tests {
     use write_fonts::FontBuilder;
 
     impl IntersectionInfo {
-        fn new(num_codepoints: u64, num_features: usize, order: usize) -> Self {
+        pub(crate) fn new(codepoints: u64, features: usize, order: usize) -> Self {
             IntersectionInfo {
-                intersecting_codepoints: num_codepoints,
-                intersecting_layout_tags: num_features,
+                intersecting_codepoints: codepoints,
+                intersecting_layout_tags: features,
                 entry_order: order,
             }
         }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -702,7 +702,7 @@ pub struct PatchUri {
 /// Stores information on the intersection which lead to the selection of this patch.
 ///
 /// Intersection details are used later on to choose a specific patch to apply next.
-/// See: https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection
+/// See: <https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection>
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub(crate) struct IntersectionInfo {
     intersecting_codepoints: u64,


### PR DESCRIPTION
When multiple candidate invalidating patches match a target subset def the client must pick a specific one to proceed with. The specification provides specific criteria for making this selection: https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection

This adds an implementation of a spec compliant selection criteria. We track the size of the intersections of the subset definition sets and then use those to make the selection.