### PR TITLE
[IFT] switch to uri_template_system crate for URI template expansion.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -508,7 +508,9 @@ pub fn table_keyed_format2() -> BeBuffer {
       0u32,               // entry string data offset
 
       8u16, // uriTemplateLength
-      [b'f', b'o', b'o', b'/', b'{', b'i', b'd', b'}'],  // uriTemplate[8]
+      [b'f', b'o', b'o', b'/', b'{', b'i'],
+      {b'd': "uri_template_var_end"},
+      b'}', // uriTemplate[8]
 
       /* ### Entries Array ### */
       // Entry id = 1

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -24,7 +24,7 @@ write-fonts = { workspace = true }
 font-types = { workspace = true }
 skrifa = { workspace = true }
 shared-brotli-patch-decoder = { workspace = true }
-uritemplate = "0.1.2"
+uri-template-system = "0.1.5"
 data-encoding = "2.6.0"
 data-encoding-macro = "0.1.15"
 clap = { version = "4.5.4", features = ["derive"], optional = true }

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -225,7 +225,8 @@ mod tests {
             },
             Default::default(),
         )
-        .into();
+        .try_into()
+        .unwrap();
 
         let ift_table = codepoints_only_format2();
         let mut iftx_table = codepoints_only_format2();
@@ -259,7 +260,8 @@ mod tests {
             },
             Default::default(),
         )
-        .into();
+        .try_into()
+        .unwrap();
 
         let ift_table = codepoints_only_format2();
         let font = test_font_for_patching_with_loca_mod(
@@ -284,7 +286,8 @@ mod tests {
             GlyphKeyed,
             Default::default(),
         )
-        .into();
+        .try_into()
+        .unwrap();
 
         let ift_table = codepoints_only_format2();
         let font = test_font_for_patching_with_loca_mod(
@@ -312,7 +315,8 @@ mod tests {
             GlyphKeyed,
             Default::default(),
         )
-        .into();
+        .try_into()
+        .unwrap();
 
         let mut ift_table = codepoints_only_format2();
         ift_table.write_at("compat_id[0]", 6u32);

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -519,7 +519,8 @@ pub(crate) mod tests {
             PatchFormat::GlyphKeyed,
             Default::default(),
         )
-        .into()
+        .try_into()
+        .unwrap()
     }
 
     #[test]

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -736,7 +736,7 @@ impl Ord for IntersectionInfo {
 
 /// Indicates a malformed URI template was encountered.
 ///
-/// More info: https://datatracker.ietf.org/doc/html/rfc6570#section-3
+/// More info: <https://datatracker.ietf.org/doc/html/rfc6570#section-3>
 #[derive(Debug, PartialEq, Eq)]
 pub struct UriTemplateError;
 


### PR DESCRIPTION
The uri-template crate panics when encountering errors so switch to the uri-template-system crate which has error handling built into the API. Fixes fuzzer crashes from #1280.