### PR TITLE
[IFT] Update ift_extend to support design space

### DIFF
--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 
 [features]
 default = ["read-fonts/std"]
-cli = ["clap"]
+cli = ["clap", "regex"]
 
 [dependencies]
 read-fonts = { workspace = true }
@@ -28,6 +28,7 @@ uri-template-system = "0.1.5"
 data-encoding = "2.6.0"
 data-encoding-macro = "0.1.15"
 clap = { version = "4.5.4", features = ["derive"], optional = true }
+regex = { version = "1.11.1", optional = true }
 
 [dev-dependencies]
 font-test-data = { workspace = true }

--- a/incremental-font-transfer/src/bin/ift_extend.rs
+++ b/incremental-font-transfer/src/bin/ift_extend.rs
@@ -110,6 +110,10 @@ fn main() {
 
 fn parse_unicodes(args: Vec<String>, codepoints: &mut IntSet<u32>) -> Result<(), ParsingError> {
     for unicode_string in args {
+        if unicode_string == "" {
+            continue;
+        }
+
         if unicode_string == "*" {
             let all = IntSet::<u32>::all();
             codepoints.union(&all);
@@ -137,6 +141,10 @@ fn parse_design_space(args: Vec<String>) -> Result<DesignSpace, ParsingError> {
 
     let mut result = HashMap::<Tag, RangeSet<Fixed>>::default();
     for arg in args {
+        if arg == "" {
+            continue;
+        }
+
         if arg == "*" {
             return Ok(DesignSpace::All);
         }

--- a/incremental-font-transfer/src/bin/ift_extend.rs
+++ b/incremental-font-transfer/src/bin/ift_extend.rs
@@ -110,7 +110,7 @@ fn main() {
 
 fn parse_unicodes(args: Vec<String>, codepoints: &mut IntSet<u32>) -> Result<(), ParsingError> {
     for unicode_string in args {
-        if unicode_string == "" {
+        if unicode_string.is_empty() {
             continue;
         }
 
@@ -141,7 +141,7 @@ fn parse_design_space(args: Vec<String>) -> Result<DesignSpace, ParsingError> {
 
     let mut result = HashMap::<Tag, RangeSet<Fixed>>::default();
     for arg in args {
-        if arg == "" {
+        if arg.is_empty() {
             continue;
         }
 

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -233,6 +233,7 @@ mod tests {
         iftx_table.write_at("compat_id[0]", 2u32);
 
         let font = test_font_for_patching_with_loca_mod(
+            true,
             |_| {},
             HashMap::from([
                 (IFT_TAG, ift_table.as_slice()),
@@ -265,6 +266,7 @@ mod tests {
 
         let ift_table = codepoints_only_format2();
         let font = test_font_for_patching_with_loca_mod(
+            true,
             |_| {},
             HashMap::from([(IFT_TAG, ift_table.as_slice())]),
         );
@@ -291,6 +293,7 @@ mod tests {
 
         let ift_table = codepoints_only_format2();
         let font = test_font_for_patching_with_loca_mod(
+            true,
             |_| {},
             HashMap::from([(IFT_TAG, ift_table.as_slice())]),
         );
@@ -325,6 +328,7 @@ mod tests {
         ift_table.write_at("compat_id[3]", 9u32);
 
         let font = test_font_for_patching_with_loca_mod(
+            true,
             |_| {},
             HashMap::from([(IFT_TAG, ift_table.as_slice())]),
         );

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -1306,6 +1306,7 @@ mod tests {
         iftx_builder.write_at("id_delta", Int24::new(1));
 
         let font = test_font_for_patching_with_loca_mod(
+            true,
             |_| {},
             HashMap::from([
                 (IFT_TAG, ift_builder.as_slice()),
@@ -1366,6 +1367,7 @@ mod tests {
         iftx_builder.write_at("id_delta", Int24::new(1));
 
         let font = test_font_for_patching_with_loca_mod(
+            true,
             |_| {},
             HashMap::from([
                 (IFT_TAG, ift_builder.as_slice()),


### PR DESCRIPTION
Adds --design-space flag to ift_extend to specify design space as part of the target subset definition.

Also fix a bug in glyph keyed patch application on long loca tables.