### PR TITLE
[IFT] Add support for applying glyph keyed patches to gvar tables.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ skrifa = { version = "0.26.4", path = "skrifa", default-features = false, featur
 write-fonts = { version = "0.33.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder" }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
+klippa = { version = "0.1.0", path = "klippa" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -904,7 +904,6 @@ pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
     buffer
 }
 
-// TODO XXXX gvar without shared tuples
 // TODO XXXX gvar with overlapping glyph data and shared tuples
 // TODO XXXX long offset gvar
 
@@ -955,6 +954,71 @@ pub fn short_gvar_with_shared_tuples() -> BeBuffer {
     buffer.write_at("shared_tuples_offset", offset);
 
     let data_offset = buffer.offset_for("glyph_0");
+    buffer.write_at("glyph_variation_data_offset", data_offset as u32);
+
+    let glyph0_offset = ((buffer.offset_for("glyph_0") - data_offset) / 2) as u16;
+    let glyph8_offset = ((buffer.offset_for("glyph_8") - data_offset) / 2) as u16;
+    let end_offset = ((buffer.offset_for("end") + 1 - data_offset) / 2) as u16;
+
+    buffer.write_at("glyph_offset[0]", glyph0_offset);
+    buffer.write_at("glyph_offset[1]", glyph8_offset);
+    buffer.write_at("glyph_offset[2]", glyph8_offset);
+    buffer.write_at("glyph_offset[3]", glyph8_offset);
+    buffer.write_at("glyph_offset[4]", glyph8_offset);
+    buffer.write_at("glyph_offset[5]", glyph8_offset);
+    buffer.write_at("glyph_offset[6]", glyph8_offset);
+    buffer.write_at("glyph_offset[7]", glyph8_offset);
+    buffer.write_at("glyph_offset[8]", glyph8_offset);
+    buffer.write_at("glyph_offset[9]", end_offset);
+    buffer.write_at("glyph_offset[10]", end_offset);
+    buffer.write_at("glyph_offset[11]", end_offset);
+    buffer.write_at("glyph_offset[12]", end_offset);
+    buffer.write_at("glyph_offset[13]", end_offset);
+    buffer.write_at("glyph_offset[14]", end_offset);
+    buffer.write_at("glyph_offset[15]", end_offset);
+
+    buffer
+}
+
+pub fn short_gvar_with_no_shared_tuples() -> BeBuffer {
+    // This gvar has the correct header and tuple structure but the per glyph variation data is not valid.
+    // Meant for testing with IFT glyph keyed patching which treats the per glyph data as opaque blobs.
+    let mut buffer = be_buffer! {
+      // HEADER
+      1u16,  // major version
+      0u16,  // minor version
+      1u16,  // axis count
+      0u16,  // sharedTupleCount
+      {0u32: "shared_tuples_offset"},
+      15u16, // glyph count
+      0u16,  // flags
+      {0u32: "glyph_variation_data_offset"},
+
+      // OFFSETS
+      {0u16: "glyph_offset[0]"},
+      {0u16: "glyph_offset[1]"},
+      {0u16: "glyph_offset[2]"},
+      {0u16: "glyph_offset[3]"},
+      {0u16: "glyph_offset[4]"},
+      {0u16: "glyph_offset[5]"},
+      {0u16: "glyph_offset[6]"},
+      {0u16: "glyph_offset[7]"},
+      {0u16: "glyph_offset[8]"},
+      {0u16: "glyph_offset[9]"},
+      {0u16: "glyph_offset[10]"},
+      {0u16: "glyph_offset[11]"},
+      {0u16: "glyph_offset[12]"},
+      {0u16: "glyph_offset[13]"},
+      {0u16: "glyph_offset[14]"},
+      {0u16: "glyph_offset[15]"},
+
+      // GLYPH VARIATION DATA
+      {1u8: "glyph_0"}, [2, 3, 4u8],
+      {5u8: "glyph_8"}, [6, 7, 8, 9u8], {10u8: "end"}
+    };
+
+    let data_offset = buffer.offset_for("glyph_0");
+    buffer.write_at("shared_tuples_offset", data_offset as u32);
     buffer.write_at("glyph_variation_data_offset", data_offset as u32);
 
     let glyph0_offset = ((buffer.offset_for("glyph_0") - data_offset) / 2) as u16;

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -904,7 +904,7 @@ pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
     buffer
 }
 
-/// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/gvar>
 pub fn short_gvar_with_shared_tuples() -> BeBuffer {
     // This gvar has the correct header and tuple structure but the per glyph variation data is not valid.
     // Meant for testing with IFT glyph keyed patching which treats the per glyph data as opaque blobs.
@@ -977,7 +977,7 @@ pub fn short_gvar_with_shared_tuples() -> BeBuffer {
     buffer
 }
 
-/// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/gvar>
 pub fn long_gvar_with_shared_tuples() -> BeBuffer {
     // This gvar has the correct header and tuple structure but the per glyph variation data is not valid.
     // Meant for testing with IFT glyph keyed patching which treats the per glyph data as opaque blobs.
@@ -1115,7 +1115,7 @@ pub fn short_gvar_with_no_shared_tuples() -> BeBuffer {
     buffer
 }
 
-/// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/gvar>
 pub fn out_of_order_gvar_with_shared_tuples() -> BeBuffer {
     let mut buffer = be_buffer! {
       // HEADER

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -905,7 +905,6 @@ pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
 }
 
 // TODO XXXX gvar without shared tuples
-// TODO XXXX gvar with out of order glyph data and shared tuples
 // TODO XXXX gvar with overlapping glyph data and shared tuples
 // TODO XXXX long offset gvar
 
@@ -950,6 +949,77 @@ pub fn short_gvar_with_shared_tuples() -> BeBuffer {
       // GLYPH VARIATION DATA
       {1u8: "glyph_0"}, [2, 3, 4u8],
       {5u8: "glyph_8"}, [6, 7, 8, 9u8], {10u8: "end"}
+    };
+
+    let offset = buffer.offset_for("sharedTuples[0]") as u32;
+    buffer.write_at("shared_tuples_offset", offset);
+
+    let data_offset = buffer.offset_for("glyph_0");
+    buffer.write_at("glyph_variation_data_offset", data_offset as u32);
+
+    let glyph0_offset = ((buffer.offset_for("glyph_0") - data_offset) / 2) as u16;
+    let glyph8_offset = ((buffer.offset_for("glyph_8") - data_offset) / 2) as u16;
+    let end_offset = ((buffer.offset_for("end") + 1 - data_offset) / 2) as u16;
+
+    buffer.write_at("glyph_offset[0]", glyph0_offset);
+    buffer.write_at("glyph_offset[1]", glyph8_offset);
+    buffer.write_at("glyph_offset[2]", glyph8_offset);
+    buffer.write_at("glyph_offset[3]", glyph8_offset);
+    buffer.write_at("glyph_offset[4]", glyph8_offset);
+    buffer.write_at("glyph_offset[5]", glyph8_offset);
+    buffer.write_at("glyph_offset[6]", glyph8_offset);
+    buffer.write_at("glyph_offset[7]", glyph8_offset);
+    buffer.write_at("glyph_offset[8]", glyph8_offset);
+    buffer.write_at("glyph_offset[9]", end_offset);
+    buffer.write_at("glyph_offset[10]", end_offset);
+    buffer.write_at("glyph_offset[11]", end_offset);
+    buffer.write_at("glyph_offset[12]", end_offset);
+    buffer.write_at("glyph_offset[13]", end_offset);
+    buffer.write_at("glyph_offset[14]", end_offset);
+    buffer.write_at("glyph_offset[15]", end_offset);
+
+    buffer
+}
+
+/// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+pub fn out_of_order_gvar_with_shared_tuples() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      // HEADER
+      1u16, // major version
+      0u16, // minor version
+      1u16, // axis count
+      3u16, // sharedTupleCount
+      {0u32: "shared_tuples_offset"},
+      15u16, // glyph count
+      0u16,  // flags
+      {0u32: "glyph_variation_data_offset"},
+
+      // OFFSETS
+      {0u16: "glyph_offset[0]"},
+      {0u16: "glyph_offset[1]"},
+      {0u16: "glyph_offset[2]"},
+      {0u16: "glyph_offset[3]"},
+      {0u16: "glyph_offset[4]"},
+      {0u16: "glyph_offset[5]"},
+      {0u16: "glyph_offset[6]"},
+      {0u16: "glyph_offset[7]"},
+      {0u16: "glyph_offset[8]"},
+      {0u16: "glyph_offset[9]"},
+      {0u16: "glyph_offset[10]"},
+      {0u16: "glyph_offset[11]"},
+      {0u16: "glyph_offset[12]"},
+      {0u16: "glyph_offset[13]"},
+      {0u16: "glyph_offset[14]"},
+      {0u16: "glyph_offset[15]"},
+
+      // GLYPH VARIATION DATA
+      {1u8: "glyph_0"}, [2, 3, 4u8],
+      {5u8: "glyph_8"}, [6, 7, 8, 9u8], {10u8: "end"},
+
+      // SHARED TUPLES
+      {42u16: "sharedTuples[0]"},
+      13u16,
+      25u16
     };
 
     let offset = buffer.offset_for("sharedTuples[0]") as u32;

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -905,7 +905,6 @@ pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
 }
 
 // TODO XXXX gvar with overlapping glyph data and shared tuples
-// TODO XXXX long offset gvar
 
 /// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
 pub fn short_gvar_with_shared_tuples() -> BeBuffer {
@@ -959,6 +958,79 @@ pub fn short_gvar_with_shared_tuples() -> BeBuffer {
     let glyph0_offset = ((buffer.offset_for("glyph_0") - data_offset) / 2) as u16;
     let glyph8_offset = ((buffer.offset_for("glyph_8") - data_offset) / 2) as u16;
     let end_offset = ((buffer.offset_for("end") + 1 - data_offset) / 2) as u16;
+
+    buffer.write_at("glyph_offset[0]", glyph0_offset);
+    buffer.write_at("glyph_offset[1]", glyph8_offset);
+    buffer.write_at("glyph_offset[2]", glyph8_offset);
+    buffer.write_at("glyph_offset[3]", glyph8_offset);
+    buffer.write_at("glyph_offset[4]", glyph8_offset);
+    buffer.write_at("glyph_offset[5]", glyph8_offset);
+    buffer.write_at("glyph_offset[6]", glyph8_offset);
+    buffer.write_at("glyph_offset[7]", glyph8_offset);
+    buffer.write_at("glyph_offset[8]", glyph8_offset);
+    buffer.write_at("glyph_offset[9]", end_offset);
+    buffer.write_at("glyph_offset[10]", end_offset);
+    buffer.write_at("glyph_offset[11]", end_offset);
+    buffer.write_at("glyph_offset[12]", end_offset);
+    buffer.write_at("glyph_offset[13]", end_offset);
+    buffer.write_at("glyph_offset[14]", end_offset);
+    buffer.write_at("glyph_offset[15]", end_offset);
+
+    buffer
+}
+
+/// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
+pub fn long_gvar_with_shared_tuples() -> BeBuffer {
+    // This gvar has the correct header and tuple structure but the per glyph variation data is not valid.
+    // Meant for testing with IFT glyph keyed patching which treats the per glyph data as opaque blobs.
+    let mut buffer = be_buffer! {
+      // HEADER
+      1u16, // major version
+      0u16, // minor version
+      1u16, // axis count
+      3u16, // sharedTupleCount
+      {0u32: "shared_tuples_offset"},
+      15u16, // glyph count
+      0b00000000_00000001u16,  // flags
+      {0u32: "glyph_variation_data_offset"},
+
+      // OFFSETS
+      {0u32: "glyph_offset[0]"},
+      {0u32: "glyph_offset[1]"},
+      {0u32: "glyph_offset[2]"},
+      {0u32: "glyph_offset[3]"},
+      {0u32: "glyph_offset[4]"},
+      {0u32: "glyph_offset[5]"},
+      {0u32: "glyph_offset[6]"},
+      {0u32: "glyph_offset[7]"},
+      {0u32: "glyph_offset[8]"},
+      {0u32: "glyph_offset[9]"},
+      {0u32: "glyph_offset[10]"},
+      {0u32: "glyph_offset[11]"},
+      {0u32: "glyph_offset[12]"},
+      {0u32: "glyph_offset[13]"},
+      {0u32: "glyph_offset[14]"},
+      {0u32: "glyph_offset[15]"},
+
+      // SHARED TUPLES
+      {42u16: "sharedTuples[0]"},
+      13u16,
+      25u16,
+
+      // GLYPH VARIATION DATA
+      {1u8: "glyph_0"}, [2, 3, 4u8],
+      {5u8: "glyph_8"}, [6, 7, 8, 9u8], {10u8: "end"}
+    };
+
+    let offset = buffer.offset_for("sharedTuples[0]") as u32;
+    buffer.write_at("shared_tuples_offset", offset);
+
+    let data_offset = buffer.offset_for("glyph_0");
+    buffer.write_at("glyph_variation_data_offset", data_offset as u32);
+
+    let glyph0_offset = (buffer.offset_for("glyph_0") - data_offset) as u32;
+    let glyph8_offset = (buffer.offset_for("glyph_8") - data_offset) as u32;
+    let end_offset = (buffer.offset_for("end") + 1 - data_offset) as u32;
 
     buffer.write_at("glyph_offset[0]", glyph0_offset);
     buffer.write_at("glyph_offset[1]", glyph8_offset);

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -904,8 +904,6 @@ pub fn glyf_and_gvar_u16_glyph_patches() -> BeBuffer {
     buffer
 }
 
-// TODO XXXX gvar with overlapping glyph data and shared tuples
-
 /// https://learn.microsoft.com/en-us/typography/opentype/spec/gvar
 pub fn short_gvar_with_shared_tuples() -> BeBuffer {
     // This gvar has the correct header and tuple structure but the per glyph variation data is not valid.
@@ -1060,7 +1058,7 @@ pub fn short_gvar_with_no_shared_tuples() -> BeBuffer {
       1u16,  // major version
       0u16,  // minor version
       1u16,  // axis count
-      0u16,  // sharedTupleCount
+      {0u16: "shared_tuple_count"},
       {0u32: "shared_tuples_offset"},
       15u16, // glyph count
       0u16,  // flags

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -23,6 +23,7 @@ read-fonts = { workspace = true }
 write-fonts = { workspace = true }
 font-types = { workspace = true }
 skrifa = { workspace = true }
+klippa = { workspace = true }
 shared-brotli-patch-decoder = { workspace = true }
 uri-template-system = "0.1.5"
 data-encoding = "2.6.0"

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -103,11 +103,7 @@ impl std::fmt::Display for PatchingError {
                 write!(f, "Failed to parse font file: {}", err)
             }
             PatchingError::SerializationError(err) => {
-                write!(
-                    f,
-                    "serialization failure constructing patched table: {}",
-                    err
-                )
+                write!(f, "serialization failure constructing patched table: {err}")
             }
             PatchingError::IncompatiblePatch => {
                 write!(f, "Compatibility ID of the patch does not match the font.")

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -259,20 +259,23 @@ fn retained_glyphs_total_size<T: GlyphDataOffsetArray>(
     Ok(total_size)
 }
 
-trait WritableOffset<const DIV: usize> {
+/// Objects with this trait can be written to bytes.
+///
+/// The offset value will be divided by DIVISOR prior to conversion to bytes.
+trait WritableOffset<const DIVISOR: usize> {
     fn write_to(self, dest: &mut [u8]);
 }
 
-impl<const DIV: usize> WritableOffset<DIV> for u32 {
+impl<const DIVISOR: usize> WritableOffset<DIVISOR> for u32 {
     fn write_to(self, dest: &mut [u8]) {
-        let data: [u8; 4] = (self / DIV as u32).to_raw();
+        let data: [u8; 4] = (self / DIVISOR as u32).to_raw();
         dest[..4].copy_from_slice(&data);
     }
 }
 
-impl<const DIV: usize> WritableOffset<DIV> for u16 {
+impl<const DIVISOR: usize> WritableOffset<DIVISOR> for u16 {
     fn write_to(self, dest: &mut [u8]) {
-        let data: [u8; 2] = (self / DIV as u16).to_raw();
+        let data: [u8; 2] = (self / DIVISOR as u16).to_raw();
         dest[..2].copy_from_slice(&data);
     }
 }

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -614,7 +614,7 @@ impl GlyphDataOffsetArray for Gvar<'_> {
 
         // part 1 and 2 - write gvar header and offsets
         serializer
-            .push()
+            .start_serialize()
             .and(serializer.embed_bytes(part1_header))
             .and(serializer.embed_bytes(&part2_offsets))
             .map_err(PatchingError::from)?;

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -96,7 +96,7 @@ pub(crate) fn apply_glyph_keyed_patches(
             // glyf patch application also generates a loca table.
             processed_tables.insert(table_tag);
             processed_tables.insert(Loca::TAG);
-        } else if table_tag == Tag::new(b"gvar") {
+        } else if table_tag == Gvar::TAG {
             let Ok(gvar) = font.gvar() else {
                 return Err(PatchingError::InvalidPatch(
                     "Trying to patch gvar but base font doesn't have them.",

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -638,18 +638,24 @@ impl GlyphDataOffsetArray for Gvar<'_> {
             .get(shared_tuples.shape().tuples_byte_range())
             .ok_or_else(|| PatchingError::SerializationError(serializer.error()))?;
 
-        serializer
-            .push()
-            .and(serializer.embed_bytes(shared_tuples_bytes))
-            .map_err(PatchingError::from)?;
+        let shared_tuples_obj = if shared_tuples_bytes.len() > 0 {
+            serializer
+                .push()
+                .and(serializer.embed_bytes(shared_tuples_bytes))
+                .map_err(PatchingError::from)?;
 
-        // The spec says that shared tuple data should come before glyph variation data so use a virtual link to ensure correct
-        // ordering.
-        serializer.add_virtual_link(glyph_data_obj);
+            // The spec says that shared tuple data should come before glyph variation data so use a virtual link to ensure correct
+            // ordering.
+            serializer.add_virtual_link(glyph_data_obj);
 
-        let shared_tuples_obj = serializer
-            .pop_pack(false)
-            .ok_or_else(|| PatchingError::SerializationError(serializer.error()))?;
+            serializer
+                .pop_pack(false)
+                .ok_or_else(|| PatchingError::SerializationError(serializer.error()))?
+        } else {
+            // If there's no shared tuples just point the shared tuples offset to the start of glyph_data_obj
+            // (since it can't be null).
+            glyph_data_obj
+        };
 
         // Set up offsets to shared tuples and glyph data.
         serializer
@@ -699,7 +705,7 @@ pub(crate) mod tests {
     use font_test_data::ift::{
         glyf_and_gvar_u16_glyph_patches, glyf_u16_glyph_patches, glyf_u16_glyph_patches_2,
         glyph_keyed_patch_header, noop_glyf_glyph_patches, out_of_order_gvar_with_shared_tuples,
-        short_gvar_with_shared_tuples, test_font_for_patching,
+        short_gvar_with_no_shared_tuples, short_gvar_with_shared_tuples, test_font_for_patching,
         test_font_for_patching_with_loca_mod,
     };
     use skrifa::{FontRef, Tag};
@@ -1040,6 +1046,64 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn glyph_keyed_glyf_and_gvar_no_shared_tuples() {
+        let patch = assemble_glyph_keyed_patch(
+            glyph_keyed_patch_header(),
+            glyf_and_gvar_u16_glyph_patches(),
+        );
+        let patch: &[u8] = &patch;
+        let patch = GlyphKeyedPatch::read(FontData::new(patch)).unwrap();
+        let patch_info = patch_info(IFT_TAG, 0);
+
+        let gvar = short_gvar_with_no_shared_tuples();
+
+        let font = test_font_for_patching_with_loca_mod(
+            true,
+            |_| {},
+            HashMap::from([
+                (Gvar::TAG, gvar.as_slice()),
+                (Tag::new(b"IFT "), vec![0, 0, 0, 0].as_slice()),
+            ]),
+        );
+        let font = FontRef::new(&font).unwrap();
+
+        let patched = apply_glyph_keyed_patches(&[(&patch_info, patch)], &font).unwrap();
+        let patched = FontRef::new(&patched).unwrap();
+
+        let new_gvar: &[u8] = patched.table_data(Gvar::TAG).unwrap().as_bytes();
+
+        let mut expected_gvar: Vec<u8> = vec![];
+
+        let change_start = gvar.offset_for("glyph_offset[3]");
+
+        expected_gvar.extend_from_slice(gvar.get(0..change_start).unwrap());
+        // Offsets
+        expected_gvar.extend_from_slice(&[
+            0x00, 0x03, // gid 3
+            0x00, 0x03, // gid 4
+            0x00, 0x03, // gid 5
+            0x00, 0x03, // gid 6
+            0x00, 0x03, // gid 7
+            0x00, 0x05, // gid 8
+            0x00, 0x06, // gid 9
+            0x00, 0x06, // gid 10
+            0x00, 0x06, // gid 11
+            0x00, 0x06, // gid 12
+            0x00, 0x06, // gid 13
+            0x00, 0x06, // gid 14
+            0x00, 0x06u8, // trailing
+        ]);
+        // Data
+        expected_gvar.extend_from_slice(&[
+            1, 2, 3, 4, // gid 0
+            b'm', b'n', // gid 2
+            b'o', b'p', b'q', 0, // gid 7
+            b'r', 0u8, // gid 8
+        ]);
+        assert_eq!(&expected_gvar, new_gvar);
+    }
+
+    #[test]
     fn glyph_keyed_out_of_order_gvar() {
         let patch = assemble_glyph_keyed_patch(
             glyph_keyed_patch_header(),
@@ -1350,7 +1414,6 @@ pub(crate) mod tests {
     // - loca offset type switch required.
     // - glyph keyed test with large number of offsets to check type conversion on (glyphCount * tableCount)
     // - test that glyph keyed patches are idempotent.
-    // TODO XXXX gvar without shared tuples
     // TODO XXXX gvar with overlapping glyph data and shared tuples
     // TODO XXXX long offset gvar
 }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -1443,6 +1443,7 @@ mod tests {
             "//foo.bar/O/O/4/OEG64OO",
         );
 
+        check_uri_template_substitution("//foo.bar/{id64}", 0, "//foo.bar/AA%3D%3D");
         check_uri_template_substitution("//foo.bar/{id64}", 14_000_000, "//foo.bar/1Z-A");
         check_uri_template_substitution("//foo.bar/{id64}", 17_000_000, "//foo.bar/AQNmQA%3D%3D");
 

--- a/klippa/src/lib.rs
+++ b/klippa/src/lib.rs
@@ -16,7 +16,7 @@ mod name;
 mod os2;
 mod parsing_util;
 mod post;
-mod serialize;
+pub mod serialize;
 mod stat;
 pub use parsing_util::{
     parse_drop_tables, parse_name_ids, parse_name_languages, parse_unicodes, populate_gids,
@@ -638,7 +638,7 @@ fn subset<'a>(
     table_len: u32,
 ) -> Result<(), SubsetError> {
     let buf_size = estimate_subset_table_size(font, table_tag, plan);
-    let mut s = Serializer::new(buf_size as u32);
+    let mut s = Serializer::new(buf_size);
     let needed = try_subset(table_tag, font, plan, builder, &mut s, table_len);
     if s.in_error() && !s.only_offset_overflow() {
         return Err(SubsetError::SubsetTableError(table_tag));

--- a/klippa/src/serialize.rs
+++ b/klippa/src/serialize.rs
@@ -14,6 +14,12 @@ use write_fonts::types::{FixedSize, Scalar, Uint24};
 #[allow(dead_code)]
 pub struct SerializeErrorFlags(u16);
 
+impl std::fmt::Display for SerializeErrorFlags {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Error during serialization, error flags: {}", self.0)
+    }
+}
+
 #[allow(dead_code)]
 impl SerializeErrorFlags {
     pub const SERIALIZE_ERROR_NONE: Self = Self(0x0000);
@@ -54,7 +60,7 @@ impl std::ops::Not for SerializeErrorFlags {
 #[derive(Default, Eq, PartialEq, Hash)]
 // Offset relative to the current object head (default)/tail or
 // Absolute: from the start of the serialize buffer
-pub(crate) enum OffsetWhence {
+pub enum OffsetWhence {
     #[default]
     Head,
     Tail,
@@ -304,7 +310,7 @@ impl Serializer {
         self.errors
     }
 
-    pub(crate) fn error(&self) -> SerializeErrorFlags {
+    pub fn error(&self) -> SerializeErrorFlags {
         self.errors
     }
 
@@ -360,7 +366,7 @@ impl Serializer {
         s
     }
 
-    pub(crate) fn push(&mut self) -> Result<(), SerializeErrorFlags> {
+    pub fn push(&mut self) -> Result<(), SerializeErrorFlags> {
         if self.in_error() {
             return Err(self.errors);
         }
@@ -378,7 +384,7 @@ impl Serializer {
         Ok(())
     }
 
-    pub(crate) fn pop_pack(&mut self, share: bool) -> Option<ObjIdx> {
+    pub fn pop_pack(&mut self, share: bool) -> Option<ObjIdx> {
         self.current?;
 
         // Allow cleanup when we've error'd out on int overflows which don't compromise the serializer state
@@ -543,7 +549,7 @@ impl Serializer {
         }
     }
 
-    pub(crate) fn add_link(
+    pub fn add_link(
         &mut self,
         offset_byte_range: Range<usize>,
         obj_idx: ObjIdx,
@@ -582,7 +588,7 @@ impl Serializer {
         Ok(())
     }
 
-    pub(crate) fn add_virtual_link(&mut self, obj_idx: ObjIdx) -> bool {
+    pub fn add_virtual_link(&mut self, obj_idx: ObjIdx) -> bool {
         if self.current.is_none() {
             return false;
         }
@@ -738,7 +744,7 @@ impl Serializer {
         self.push()
     }
 
-    pub(crate) fn end_serialize(&mut self) {
+    pub fn end_serialize(&mut self) {
         if self.current.is_none() {
             return;
         }

--- a/klippa/src/serialize.rs
+++ b/klippa/src/serialize.rs
@@ -405,7 +405,7 @@ impl Serializer {
     ///
     /// On success returns an index identifying the packed object.
     ///
-    /// If share is true and there is an existing packed object which is identical this will not pack the ojbect and
+    /// If share is true and there is an existing packed object which is identical this will not pack the object and
     /// instead return the index of the existing object.
     pub fn pop_pack(&mut self, share: bool) -> Option<ObjIdx> {
         self.current?;

--- a/klippa/src/serialize.rs
+++ b/klippa/src/serialize.rs
@@ -17,7 +17,11 @@ pub struct SerializeErrorFlags(u16);
 
 impl std::fmt::Display for SerializeErrorFlags {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Error during serialization, error flags: {}", self.0)
+        write!(
+            f,
+            "Error during serialization, error flags: {:016b}",
+            self.0
+        )
     }
 }
 
@@ -154,7 +158,7 @@ pub(crate) struct Snapshot {
     errors: SerializeErrorFlags,
 }
 
-/// Constructs a sequential stream of bytes from one or more sub sequences of bytes/objects.
+/// Constructs a sequential stream of bytes from one or more subsequences of bytes/objects.
 ///
 /// Notably this allows construction of open type tables that make use of offsets (eg. GSUB, GPOS) to form
 /// graphs of sub tables. The serializer is capable of automatically placing object data in a topological sorting

--- a/klippa/src/serialize.rs
+++ b/klippa/src/serialize.rs
@@ -12,7 +12,7 @@ use write_fonts::types::{FixedSize, Scalar, Uint24};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(dead_code)]
-pub(crate) struct SerializeErrorFlags(u16);
+pub struct SerializeErrorFlags(u16);
 
 #[allow(dead_code)]
 impl SerializeErrorFlags {
@@ -168,12 +168,11 @@ pub struct Serializer {
 
 #[allow(dead_code)]
 impl Serializer {
-    pub(crate) fn new(size: u32) -> Self {
-        let buf_size = size as usize;
+    pub fn new(size: usize) -> Self {
         Serializer {
-            data: vec![0; buf_size],
-            end: buf_size,
-            tail: buf_size,
+            data: vec![0; size],
+            end: size,
+            tail: size,
             packed: Vec::new(),
             ..Default::default()
         }
@@ -191,7 +190,7 @@ impl Serializer {
     }
 
     /// Embed bytes
-    pub(crate) fn embed_bytes(&mut self, bytes: &[u8]) -> Result<usize, SerializeErrorFlags> {
+    pub fn embed_bytes(&mut self, bytes: &[u8]) -> Result<usize, SerializeErrorFlags> {
         let len = bytes.len();
         let ret = self.allocate_size(len, false)?;
         self.data[ret..ret + len].copy_from_slice(bytes);
@@ -695,7 +694,7 @@ impl Serializer {
         }
     }
 
-    pub(crate) fn copy_bytes(mut self) -> Vec<u8> {
+    pub fn copy_bytes(mut self) -> Vec<u8> {
         if !self.successful() {
             return Vec::new();
         }

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -62,6 +62,24 @@ impl<'a> Gvar<'a> {
         self.data.slice(range).ok_or(ReadError::OutOfBounds)
     }
 
+    pub fn glyph_variation_data_for_range(
+        &self,
+        offset_range: Range<usize>,
+    ) -> Result<FontData<'a>, ReadError> {
+        let base = self.glyph_variation_data_array_offset() as usize;
+        let start = base
+            .checked_add(offset_range.start)
+            .ok_or(ReadError::OutOfBounds)?;
+        let end = base
+            .checked_add(offset_range.end)
+            .ok_or(ReadError::OutOfBounds)?;
+        self.data.slice(start..end).ok_or(ReadError::OutOfBounds)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data.as_bytes()
+    }
+
     fn data_range_for_gid(&self, gid: GlyphId) -> Result<Range<usize>, ReadError> {
         let start_idx = gid.to_u32() as usize;
         let end_idx = start_idx + 1;


### PR DESCRIPTION
Glyph keyed format: https://w3c.github.io/IFT/Overview.html#glyph-keyed

Due to the nature of gvar, complex serialization with offset calculation was needed so I made the klippa Serializer public and used it here as it is designed specifically to handle this type of situation.

Also added a method to read_fonts::Gvar to provide more direct access to underlying bytes.