### PR TITLE
impl Error for DrawError

### DIFF
--- a/skrifa/src/outline/error.rs
+++ b/skrifa/src/outline/error.rs
@@ -84,3 +84,6 @@ impl fmt::Display for DrawError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for DrawError {}


### PR DESCRIPTION
Helps with error composition & handling (e.g. using `anyhow`)