### PR TITLE
[IFT] divide loca offsets before casting down to u16 to avoid overflows.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -621,7 +621,7 @@ where
     // glyphs are padded to even number of bytes since loca format will be short.
     let glyf = if !short_loca {
         // Since we want a long loca artificially inflate glyf table to ensure long offsets are needed.
-        BeBuffer::new().extend(iter::repeat(0).take(70000))
+        BeBuffer::new().extend(iter::repeat(0).take(140000))
     } else {
         BeBuffer::new()
     };


### PR DESCRIPTION
additionally in long loca test since offsets are divided by 2 we actually need > 131072 bytes to trigger long loca.