### PR TITLE
Declare 1.0 for libraries actively used by Chrome

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ core_maths = "0.1"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.8.2", path = "font-types" }
-read-fonts = { version = "0.25.3", path = "read-fonts", default-features = false }
+font-types = { version = "1.0.0", path = "font-types" }
+read-fonts = { version = "1.0.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.26.5", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "1.0.0", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.33.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder" }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.2.1"
+version = "1.0.0"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.8.2"
+version = "1.0.0"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.25.3"
+version = "1.0.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.26.5"
+version = "1.0.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
We are LIVE from the sold out Chrome stable user base. Declare 1.0 for relevant libraries.

