### PR TITLE
Rename Hhea::number_of_long_metrics => ...h_metrics

### DIFF
--- a/fuzz/fuzz_targets/fuzz_basic_metadata.rs
+++ b/fuzz/fuzz_targets/fuzz_basic_metadata.rs
@@ -27,7 +27,7 @@ fn do_metadata_things(data: &[u8]) -> Result<(), Box<dyn Error>> {
     }
 
     if let Ok(hhea) = font.hhea() {
-        let _ = hhea.number_of_long_metrics();
+        let _ = hhea.number_of_h_metrics();
         if let Ok(hmtx) = font.hmtx() {
             let _ = hmtx.h_metrics().iter().count();
             let _ = hmtx.left_side_bearings().iter().count();

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -91,7 +91,7 @@ impl HheaMarker {
         start..start + i16::RAW_BYTE_LEN
     }
 
-    pub fn number_of_long_metrics_byte_range(&self) -> Range<usize> {
+    pub fn number_of_h_metrics_byte_range(&self) -> Range<usize> {
         let start = self.metric_data_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
@@ -99,7 +99,7 @@ impl HheaMarker {
 
 impl MinByteRange for HheaMarker {
     fn min_byte_range(&self) -> Range<usize> {
-        0..self.number_of_long_metrics_byte_range().end
+        0..self.number_of_h_metrics_byte_range().end
     }
 }
 
@@ -215,9 +215,9 @@ impl<'a> Hhea<'a> {
         self.data.read_at(range.start).unwrap()
     }
 
-    /// Number of LongMetric entries in 'hmtx'/'vmtx' table
-    pub fn number_of_long_metrics(&self) -> u16 {
-        let range = self.shape.number_of_long_metrics_byte_range();
+    /// Number of hMetric entries in 'hmtx' table
+    pub fn number_of_h_metrics(&self) -> u16 {
+        let range = self.shape.number_of_h_metrics_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -248,8 +248,8 @@ impl<'a> SomeTable<'a> for Hhea<'a> {
             10usize => Some(Field::new("caret_offset", self.caret_offset())),
             11usize => Some(Field::new("metric_data_format", self.metric_data_format())),
             12usize => Some(Field::new(
-                "number_of_long_metrics",
-                self.number_of_long_metrics(),
+                "number_of_h_metrics",
+                self.number_of_h_metrics(),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -214,7 +214,7 @@ impl<'a> Vhea<'a> {
         self.data.read_at(range.start).unwrap()
     }
 
-    /// Number of LongMetric entries in 'hmtx'/'vmtx' table
+    /// Number of advance heights in the vertical metrics (`vmtx`) table.
     pub fn number_of_long_ver_metrics(&self) -> u16 {
         let range = self.shape.number_of_long_ver_metrics_byte_range();
         self.data.read_at(range.start).unwrap()

--- a/read-fonts/src/table_provider.rs
+++ b/read-fonts/src/table_provider.rs
@@ -43,7 +43,7 @@ pub trait TableProvider<'a> {
     fn hmtx(&self) -> Result<tables::hmtx::Hmtx<'a>, ReadError> {
         //FIXME: should we make the user pass these in?
         let num_glyphs = self.maxp().map(|maxp| maxp.num_glyphs())?;
-        let number_of_h_metrics = self.hhea().map(|hhea| hhea.number_of_long_metrics())?;
+        let number_of_h_metrics = self.hhea().map(|hhea| hhea.number_of_h_metrics())?;
         let data = self.expect_data_for_tag(tables::hmtx::Hmtx::TAG)?;
         tables::hmtx::Hmtx::read(data, number_of_h_metrics, num_glyphs)
     }
@@ -271,7 +271,7 @@ mod tests {
             }
         }
 
-        let number_of_h_metrics = DummyProvider.hhea().unwrap().number_of_long_metrics();
+        let number_of_h_metrics = DummyProvider.hhea().unwrap().number_of_h_metrics();
         let num_glyphs = DummyProvider.maxp().unwrap().num_glyphs();
         let hmtx = DummyProvider.hmtx().unwrap();
 

--- a/read-fonts/src/tables/hhea.rs
+++ b/read-fonts/src/tables/hhea.rs
@@ -1,3 +1,10 @@
 //! the [hhea (Horizontal Header)](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) table
 
 include!("../../generated/generated_hhea.rs");
+
+impl Hhea<'_> {
+    #[deprecated(since = "0.25.3", note = "use number_of_h_metrics instead")]
+    pub fn number_of_long_metrics(&self) -> u16 {
+        self.number_of_h_metrics()
+    }
+}

--- a/resources/codegen_inputs/hhea.rs
+++ b/resources/codegen_inputs/hhea.rs
@@ -51,6 +51,6 @@ table Hhea {
     /// 0 for current format.
     #[compile(0)]
     metric_data_format: i16,
-    /// Number of LongMetric entries in 'hmtx'/'vmtx' table
-    number_of_long_metrics: u16,
+    /// Number of hMetric entries in 'hmtx' table
+    number_of_h_metrics: u16,
 }

--- a/resources/codegen_inputs/vhea.rs
+++ b/resources/codegen_inputs/vhea.rs
@@ -50,6 +50,6 @@ table Vhea {
     /// 0 for current format.
     #[compile(0)]
     metric_data_format: i16,
-    /// Number of LongMetric entries in 'hmtx'/'vmtx' table
+    /// Number of advance heights in the vertical metrics (`vmtx`) table.
     number_of_long_ver_metrics: u16,
 }

--- a/write-fonts/generated/generated_hhea.rs
+++ b/write-fonts/generated/generated_hhea.rs
@@ -35,8 +35,8 @@ pub struct Hhea {
     /// shifted to produce the best appearance. Set to 0 for
     /// non-slanted fonts
     pub caret_offset: i16,
-    /// Number of LongMetric entries in 'hmtx'/'vmtx' table
-    pub number_of_long_metrics: u16,
+    /// Number of hMetric entries in 'hmtx' table
+    pub number_of_h_metrics: u16,
 }
 
 impl Hhea {
@@ -53,7 +53,7 @@ impl Hhea {
         caret_slope_rise: i16,
         caret_slope_run: i16,
         caret_offset: i16,
-        number_of_long_metrics: u16,
+        number_of_h_metrics: u16,
     ) -> Self {
         Self {
             ascender,
@@ -66,7 +66,7 @@ impl Hhea {
             caret_slope_rise,
             caret_slope_run,
             caret_offset,
-            number_of_long_metrics,
+            number_of_h_metrics,
         }
     }
 }
@@ -90,7 +90,7 @@ impl FontWrite for Hhea {
         (0 as i16).write_into(writer);
         (0 as i16).write_into(writer);
         (0 as i16).write_into(writer);
-        self.number_of_long_metrics.write_into(writer);
+        self.number_of_h_metrics.write_into(writer);
     }
     fn table_type(&self) -> TableType {
         TableType::TopLevel(Hhea::TAG)
@@ -118,7 +118,7 @@ impl<'a> FromObjRef<read_fonts::tables::hhea::Hhea<'a>> for Hhea {
             caret_slope_rise: obj.caret_slope_rise(),
             caret_slope_run: obj.caret_slope_run(),
             caret_offset: obj.caret_offset(),
-            number_of_long_metrics: obj.number_of_long_metrics(),
+            number_of_h_metrics: obj.number_of_h_metrics(),
         }
     }
 }

--- a/write-fonts/generated/generated_vhea.rs
+++ b/write-fonts/generated/generated_vhea.rs
@@ -34,7 +34,7 @@ pub struct Vhea {
     /// shifted to produce the best appearance. Set to 0 for
     /// non-slanted fonts
     pub caret_offset: i16,
-    /// Number of LongMetric entries in 'hmtx'/'vmtx' table
+    /// Number of advance heights in the vertical metrics (`vmtx`) table.
     pub number_of_long_ver_metrics: u16,
 }
 

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -96,7 +96,7 @@
 //!     caret_slope_rise: 1,
 //!     caret_slope_run: 0,
 //!     caret_offset: 0,
-//!     number_of_long_metrics: 301,
+//!     number_of_h_metrics: 301,
 //! };
 //!
 //! let _bytes = write_fonts::dump_table(&my_table).expect("failed to write bytes");


### PR DESCRIPTION
This matches the spec; the old name was a relic of when we used a single common type to represent both vhea and hhea.

Also fixes the docs of both tables.

- closes #1213 