### PR TITLE
Shuffle things to avoid circular dep

### DIFF
--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -8,8 +8,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
-
+# do NOT create circular deps, even with dev-dependencies. It messes with google3 import.
 [dependencies]
-read-fonts = { workspace = true }
-write-fonts = { workspace = true }
+font-types = { workspace = true }
 

--- a/font-test-data/src/bebuffer.rs
+++ b/font-test-data/src/bebuffer.rs
@@ -1,6 +1,6 @@
 //! small utilities used in tests
 
-use crate::{FontData, Scalar};
+use font_types::Scalar;
 use std::collections::HashMap;
 
 /// A convenience type for generating a buffer of big-endian bytes.
@@ -75,8 +75,8 @@ impl BeBuffer {
         }
     }
 
-    pub fn font_data(&self) -> FontData {
-        FontData::new(&self.data)
+    pub fn data(&self) -> &[u8] {
+        &self.data
     }
 }
 
@@ -125,7 +125,7 @@ macro_rules! be_buffer {
         {
             let builder = BeBuffer::new();
             $(
-                be_buffer_add!(builder, $x);
+                $crate::be_buffer_add!(builder, $x);
             )*
             builder
         }

--- a/font-test-data/src/cmap.rs
+++ b/font-test-data/src/cmap.rs
@@ -1,6 +1,6 @@
 //! cmap test data for scenarios not readily produced with ttx
 
-use read_fonts::{be_buffer, be_buffer_add, test_helpers::BeBuffer};
+use crate::{be_buffer, bebuffer::BeBuffer};
 
 /// Contains two codepoint ranges, both [6, 64]. Surely you don't duplicate them?
 pub fn repetitive_cmap4() -> BeBuffer {

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -3,15 +3,9 @@
 //! Used for incremental font transfer. Specification:
 //! <https://w3c.github.io/IFT/Overview.html>
 
-use std::collections::HashMap;
-use std::iter;
+use font_types::{Int24, Tag, Uint24};
 
-use read_fonts::types::Tag;
-use read_fonts::{be_buffer, be_buffer_add, test_helpers::BeBuffer, types::Int24, types::Uint24};
-use write_fonts::{
-    tables::{head::Head, loca::Loca, maxp::Maxp},
-    FontBuilder,
-};
+use crate::{be_buffer, bebuffer::BeBuffer};
 
 pub static IFT_BASE: &[u8] = include_bytes!("../test_data/ttf/ift_base.ttf");
 
@@ -589,93 +583,6 @@ pub fn noop_table_keyed_patch() -> BeBuffer {
         // patch_offsets[1]
         {0u32: "patch_off[0]"}
     }
-}
-
-pub fn test_font_for_patching_with_loca_mod<F>(
-    short_loca: bool,
-    loca_mod: F,
-    additional_tables: HashMap<Tag, &[u8]>,
-) -> Vec<u8>
-where
-    F: Fn(&mut Vec<u32>),
-{
-    let mut font_builder = FontBuilder::new();
-
-    for (tag, data) in additional_tables {
-        font_builder.add_raw(tag, data);
-    }
-
-    let maxp = Maxp {
-        num_glyphs: 15,
-        ..Default::default()
-    };
-    font_builder.add_table(&maxp).unwrap();
-
-    let head = Head {
-        index_to_loc_format: if short_loca { 0 } else { 1 },
-        ..Default::default()
-    };
-    font_builder.add_table(&head).unwrap();
-
-    // ## glyf ##
-    // glyphs are padded to even number of bytes since loca format will be short.
-    let glyf = if !short_loca {
-        // Since we want a long loca artificially inflate glyf table to ensure long offsets are needed.
-        BeBuffer::new().extend(iter::repeat(0).take(140000))
-    } else {
-        BeBuffer::new()
-    };
-
-    let glyf = glyf
-        .push_with_tag(1u8, "gid_0")
-        .extend([2, 3, 4, 5u8, 0u8])
-        .push_with_tag(6u8, "gid_1")
-        .extend([7, 8u8, 0u8])
-        .push_with_tag(9u8, "gid_8")
-        .extend([10, 11, 12u8]);
-
-    // ## loca ##
-    let gid_0 = glyf.offset_for("gid_0") as u32;
-    let gid_1 = glyf.offset_for("gid_1") as u32;
-    let gid_8 = glyf.offset_for("gid_8") as u32;
-    let end = gid_8 + 4;
-
-    let mut loca = vec![
-        gid_0, // gid 0
-        gid_1, // gid 1
-        gid_8, // gid 2
-        gid_8, // gid 3
-        gid_8, // gid 4
-        gid_8, // gid 5
-        gid_8, // gid 6
-        gid_8, // gid 7
-        gid_8, // gid 8
-        end,   // gid 9
-        end,   // gid 10
-        end,   // gid 11
-        end,   // gid 12
-        end,   // gid 13
-        end,   // gid 14
-        end,   // end
-    ];
-
-    loca_mod(&mut loca);
-
-    let loca = Loca::new(loca);
-    font_builder.add_table(&loca).unwrap();
-
-    let glyf: &[u8] = &glyf;
-    font_builder.add_raw(Tag::new(b"glyf"), glyf);
-
-    font_builder.build()
-}
-
-pub fn test_font_for_patching() -> Vec<u8> {
-    test_font_for_patching_with_loca_mod(
-        true,
-        |_| {},
-        HashMap::from([(Tag::new(b"IFT "), vec![0, 0, 0, 0].as_slice())]),
-    )
 }
 
 // Format specification: https://w3c.github.io/IFT/Overview.html#glyph-keyed

--- a/font-test-data/src/lib.rs
+++ b/font-test-data/src/lib.rs
@@ -1,5 +1,6 @@
 //! test data shared between various fontations crates.
 
+pub mod bebuffer;
 pub mod cmap;
 pub mod gdef;
 pub mod gpos;

--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -216,14 +216,19 @@ mod tests {
 
     use font_test_data::ift::{
         codepoints_only_format2, glyf_u16_glyph_patches, glyph_keyed_patch_header,
-        table_keyed_patch, test_font_for_patching_with_loca_mod,
+        table_keyed_patch,
     };
     use read_fonts::tables::ift::{CompatibilityId, IFTX_TAG, IFT_TAG};
 
     use crate::{
         font_patch::PatchingError,
         glyph_keyed::tests::assemble_glyph_keyed_patch,
-        patchmap::{IftTableTag, PatchFormat::GlyphKeyed, PatchFormat::TableKeyed, PatchUri},
+        patchmap::{
+            IftTableTag,
+            PatchFormat::{GlyphKeyed, TableKeyed},
+            PatchUri,
+        },
+        testdata::test_font_for_patching_with_loca_mod,
     };
 
     use super::{IncrementalFontPatchBase, PatchInfo};

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -703,16 +703,17 @@ pub(crate) mod tests {
             ift::{CompatibilityId, GlyphKeyedPatch, IFTX_TAG, IFT_TAG},
             loca::Loca,
         },
-        test_helpers::BeBuffer,
         FontData, FontRead, ReadError, TableProvider, TopLevelTable,
     };
 
-    use font_test_data::ift::{
-        glyf_and_gvar_u16_glyph_patches, glyf_u16_glyph_patches, glyf_u16_glyph_patches_2,
-        glyph_keyed_patch_header, long_gvar_with_shared_tuples, noop_glyf_glyph_patches,
-        out_of_order_gvar_with_shared_tuples, short_gvar_with_no_shared_tuples,
-        short_gvar_with_shared_tuples, test_font_for_patching,
-        test_font_for_patching_with_loca_mod,
+    use font_test_data::{
+        bebuffer::BeBuffer,
+        ift::{
+            glyf_and_gvar_u16_glyph_patches, glyf_u16_glyph_patches, glyf_u16_glyph_patches_2,
+            glyph_keyed_patch_header, long_gvar_with_shared_tuples, noop_glyf_glyph_patches,
+            out_of_order_gvar_with_shared_tuples, short_gvar_with_no_shared_tuples,
+            short_gvar_with_shared_tuples,
+        },
     };
     use skrifa::{FontRef, Tag};
 
@@ -720,6 +721,7 @@ pub(crate) mod tests {
         font_patch::PatchingError,
         glyph_keyed::apply_glyph_keyed_patches,
         patchmap::{PatchFormat, PatchUri},
+        testdata::{test_font_for_patching, test_font_for_patching_with_loca_mod},
     };
 
     use super::{IftTableTag, PatchInfo};

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -16,3 +16,102 @@ pub mod glyph_keyed;
 pub mod patch_group;
 pub mod patchmap;
 pub mod table_keyed;
+
+#[cfg(test)]
+mod testdata {
+    use std::{collections::HashMap, iter};
+
+    use font_test_data::bebuffer::BeBuffer;
+    use skrifa::Tag;
+    use write_fonts::{
+        tables::{head::Head, loca::Loca, maxp::Maxp},
+        FontBuilder,
+    };
+
+    pub fn test_font_for_patching_with_loca_mod<F>(
+        short_loca: bool,
+        loca_mod: F,
+        additional_tables: HashMap<Tag, &[u8]>,
+    ) -> Vec<u8>
+    where
+        F: Fn(&mut Vec<u32>),
+    {
+        let mut font_builder = FontBuilder::new();
+
+        for (tag, data) in additional_tables {
+            font_builder.add_raw(tag, data);
+        }
+
+        let maxp = Maxp {
+            num_glyphs: 15,
+            ..Default::default()
+        };
+        font_builder.add_table(&maxp).unwrap();
+
+        let head = Head {
+            index_to_loc_format: if short_loca { 0 } else { 1 },
+            ..Default::default()
+        };
+        font_builder.add_table(&head).unwrap();
+
+        // ## glyf ##
+        // glyphs are padded to even number of bytes since loca format will be short.
+        let glyf = if !short_loca {
+            // Since we want a long loca artificially inflate glyf table to ensure long offsets are needed.
+            BeBuffer::new().extend(iter::repeat(0).take(140000))
+        } else {
+            BeBuffer::new()
+        };
+
+        let glyf = glyf
+            .push_with_tag(1u8, "gid_0")
+            .extend([2, 3, 4, 5u8, 0u8])
+            .push_with_tag(6u8, "gid_1")
+            .extend([7, 8u8, 0u8])
+            .push_with_tag(9u8, "gid_8")
+            .extend([10, 11, 12u8]);
+
+        // ## loca ##
+        let gid_0 = glyf.offset_for("gid_0") as u32;
+        let gid_1 = glyf.offset_for("gid_1") as u32;
+        let gid_8 = glyf.offset_for("gid_8") as u32;
+        let end = gid_8 + 4;
+
+        let mut loca = vec![
+            gid_0, // gid 0
+            gid_1, // gid 1
+            gid_8, // gid 2
+            gid_8, // gid 3
+            gid_8, // gid 4
+            gid_8, // gid 5
+            gid_8, // gid 6
+            gid_8, // gid 7
+            gid_8, // gid 8
+            end,   // gid 9
+            end,   // gid 10
+            end,   // gid 11
+            end,   // gid 12
+            end,   // gid 13
+            end,   // gid 14
+            end,   // end
+        ];
+
+        loca_mod(&mut loca);
+
+        let loca = Loca::new(loca);
+        font_builder.add_table(&loca).unwrap();
+
+        let glyf: &[u8] = &glyf;
+        font_builder.add_raw(Tag::new(b"glyf"), glyf);
+
+        font_builder.build()
+    }
+
+    pub fn test_font_for_patching() -> Vec<u8> {
+        test_font_for_patching_with_loca_mod(
+            true,
+            |_| {},
+            HashMap::from([(Tag::new(b"IFT "), vec![0, 0, 0, 0].as_slice())]),
+        )
+    }
+}

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -480,17 +480,22 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::glyph_keyed::tests::assemble_glyph_keyed_patch;
-    use font_test_data::ift::{
-        glyf_u16_glyph_patches, glyph_keyed_patch_header, table_keyed_format2, table_keyed_patch,
-        test_font_for_patching_with_loca_mod,
+    use crate::{
+        glyph_keyed::tests::assemble_glyph_keyed_patch,
+        testdata::test_font_for_patching_with_loca_mod,
+    };
+    use font_test_data::{
+        bebuffer::BeBuffer,
+        ift::{
+            glyf_u16_glyph_patches, glyph_keyed_patch_header, table_keyed_format2,
+            table_keyed_patch,
+        },
     };
 
     use font_types::{Int24, Tag};
 
     use read_fonts::{
         tables::ift::{IFTX_TAG, IFT_TAG},
-        test_helpers::BeBuffer,
         FontRef,
     };
 

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -85,11 +85,6 @@ pub mod traversal;
 #[cfg(any(test, feature = "codegen_test"))]
 pub mod codegen_test;
 
-#[path = "tests/test_helpers.rs"]
-#[doc(hidden)]
-#[cfg(feature = "std")]
-pub mod test_helpers;
-
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
 pub use offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};

--- a/read-fonts/src/tables/aat.rs
+++ b/read-fonts/src/tables/aat.rs
@@ -437,7 +437,7 @@ pub type ExtendedStateTableU16<'a> = ExtendedStateTable<'a, u16>;
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::BeBuffer;
+    use font_test_data::bebuffer::BeBuffer;
 
     use super::*;
 
@@ -450,7 +450,7 @@ mod tests {
         ];
         let mut buf = BeBuffer::new();
         buf = buf.extend(words);
-        let lookup = LookupU16::read(buf.font_data()).unwrap();
+        let lookup = LookupU16::read(buf.data().into()).unwrap();
         for gid in 0..=8 {
             assert_eq!(lookup.value(gid).unwrap(), gid * 2);
         }
@@ -474,7 +474,7 @@ mod tests {
         ];
         let mut buf = BeBuffer::new();
         buf = buf.extend(words);
-        let lookup = LookupU16::read(buf.font_data()).unwrap();
+        let lookup = LookupU16::read(buf.data().into()).unwrap();
         let expected = [(20..=22, 4), (23..=24, 5), (25..=28, 6)];
         for (range, class) in expected {
             for gid in range {
@@ -506,7 +506,7 @@ mod tests {
         ];
         let mut buf = BeBuffer::new();
         buf = buf.extend(words);
-        let lookup = LookupU16::read(buf.font_data()).unwrap();
+        let lookup = LookupU16::read(buf.data().into()).unwrap();
         let expected = [
             (20, 3),
             (21, 2),
@@ -544,7 +544,7 @@ mod tests {
         ];
         let mut buf = BeBuffer::new();
         buf = buf.extend(words);
-        let lookup = LookupU16::read(buf.font_data()).unwrap();
+        let lookup = LookupU16::read(buf.data().into()).unwrap();
         let expected = [(50, 600), (51, 601), (201, 602), (202, 900)];
         for (in_glyph, out_glyph) in expected {
             assert_eq!(lookup.value(in_glyph).unwrap(), out_glyph);
@@ -565,7 +565,7 @@ mod tests {
         ];
         let mut buf = BeBuffer::new();
         buf = buf.extend(words);
-        let lookup = LookupU16::read(buf.font_data()).unwrap();
+        let lookup = LookupU16::read(buf.data().into()).unwrap();
         let expected = &words[3..];
         for (gid, expected) in (201..209).zip(expected) {
             assert_eq!(lookup.value(gid).unwrap(), *expected);
@@ -588,7 +588,7 @@ mod tests {
         let mapped = [3_u32, 8, 2902384, 9, 1, u32::MAX, 60];
         let mut buf = BeBuffer::new();
         buf = buf.extend(words).extend(mapped);
-        let lookup = LookupU32::read(buf.font_data()).unwrap();
+        let lookup = LookupU32::read(buf.data().into()).unwrap();
         for (gid, expected) in (201..209).zip(mapped) {
             assert_eq!(lookup.value(gid).unwrap(), expected);
         }
@@ -639,7 +639,7 @@ mod tests {
             .extend(class_table)
             .extend(state_array)
             .extend(entry_table);
-        let table = ExtendedStateTable::<ContextualData>::read(buf.font_data()).unwrap();
+        let table = ExtendedStateTable::<ContextualData>::read(buf.data().into()).unwrap();
         // check class lookups
         let [class_50, class_80, class_201] =
             [50, 80, 201].map(|gid| table.class(GlyphId16::from(gid)).unwrap());
@@ -712,7 +712,7 @@ mod tests {
             .extend(classes)
             .extend(state_array)
             .extend(entry_table);
-        let table = StateTable::read(buf.font_data()).unwrap();
+        let table = StateTable::read(buf.data().into()).unwrap();
         // check class lookups
         for i in 0..4u8 {
             assert_eq!(table.class(GlyphId16::from(i as u16 + 3)).unwrap(), i + 1);

--- a/read-fonts/src/tables/ankr.rs
+++ b/read-fonts/src/tables/ankr.rs
@@ -22,8 +22,9 @@ impl<'a> Ankr<'a> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn anchor_points() {
@@ -51,7 +52,7 @@ mod tests {
                 .push(entry.len() as u32)
                 .extend(entry.iter().flat_map(|x| [x.0, x.1]));
         }
-        let ankr = Ankr::read(buf.font_data()).unwrap();
+        let ankr = Ankr::read(buf.data().into()).unwrap();
         let anchor_points = (0..4)
             .map(|gid| {
                 let points = ankr.anchor_points(GlyphId::new(gid)).unwrap();

--- a/read-fonts/src/tables/avar.rs
+++ b/read-fonts/src/tables/avar.rs
@@ -59,8 +59,10 @@ impl<'a> FontRead<'a> for SegmentMaps<'a> {
 #[cfg(test)]
 mod tests {
 
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::{test_helpers, FontRef, TableProvider};
+    use crate::{FontRef, TableProvider};
 
     fn value_map(from: f32, to: f32) -> [F2Dot14; 2] {
         [F2Dot14::from_f32(from), F2Dot14::from_f32(to)]
@@ -100,8 +102,6 @@ mod tests {
 
     #[test]
     fn segment_maps_multi_axis() {
-        use test_helpers::BeBuffer;
-
         let segment_one_maps = [
             value_map(-1.0, -1.0),
             value_map(-0.6667, -0.5),
@@ -123,7 +123,7 @@ mod tests {
             .extend(segment_two_maps[0])
             .extend(segment_two_maps[1]);
 
-        let avar = super::Avar::read(data.font_data()).unwrap();
+        let avar = super::Avar::read(data.data().into()).unwrap();
         assert_eq!(avar.axis_segment_maps().iter().count(), 2);
         assert_eq!(
             avar.axis_segment_maps()

--- a/read-fonts/src/tables/base.rs
+++ b/read-fonts/src/tables/base.rs
@@ -6,10 +6,10 @@ include!("../../generated/generated_base.rs");
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
     use font_types::MajorMinor;
 
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     /// https://learn.microsoft.com/en-us/typography/opentype/spec/base#base-table-examples
@@ -37,7 +37,7 @@ mod tests {
             .push(Tag::new(b"latn"))
             .push(0xb4_u16);
 
-        let base = Base::read(data.font_data()).unwrap();
+        let base = Base::read(data.data().into()).unwrap();
         assert_eq!(base.version(), MajorMinor::VERSION_1_0);
         let horiz = base.horiz_axis().unwrap().unwrap();
         let base_tag = horiz.base_tag_list().unwrap().unwrap();

--- a/read-fonts/src/tables/cmap.rs
+++ b/read-fonts/src/tables/cmap.rs
@@ -541,10 +541,10 @@ impl Iterator for NonDefaultUvsIter<'_> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::{be_buffer, bebuffer::BeBuffer};
+
     use super::*;
-    use crate::{
-        be_buffer, be_buffer_add, test_helpers::BeBuffer, FontRef, GlyphId, TableProvider,
-    };
+    use crate::{FontRef, GlyphId, TableProvider};
 
     #[test]
     fn map_codepoints() {
@@ -690,7 +690,7 @@ mod tests {
     #[test]
     fn cmap12_iter_avoid_overflow() {
         let data = cmap12_overflow_data();
-        let cmap12 = Cmap12::read(data.font_data()).unwrap();
+        let cmap12 = Cmap12::read(data.data().into()).unwrap();
         let _ = cmap12.iter().count();
     }
 
@@ -709,14 +709,14 @@ mod tests {
             // groups: [startCode, endCode, startGlyphID]
             [170u32, 1330926671, 328960] // group 0
         };
-        let cmap12 = Cmap12::read(cmap12_data.font_data()).unwrap();
+        let cmap12 = Cmap12::read(cmap12_data.data().into()).unwrap();
         assert!(cmap12.iter().count() <= char::MAX as usize + 1);
     }
 
     #[test]
     fn cmap12_iter_range_clamping() {
         let data = cmap12_overflow_data();
-        let cmap12 = Cmap12::read(data.font_data()).unwrap();
+        let cmap12 = Cmap12::read(data.data().into()).unwrap();
         let ranges = cmap12
             .groups()
             .iter()

--- a/read-fonts/src/tables/feat.rs
+++ b/read-fonts/src/tables/feat.rs
@@ -33,13 +33,14 @@ impl FeatureName {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn feat_example() {
         let feat_data = build_feat_example();
-        let feat = Feat::read(feat_data.font_data()).unwrap();
+        let feat = Feat::read(feat_data.data().into()).unwrap();
         let names = feat.names();
         #[rustfmt::skip]
         let expected_name_fields = [
@@ -87,7 +88,7 @@ mod tests {
     #[test]
     fn feat_find() {
         let feat_data = build_feat_example();
-        let feat = Feat::read(feat_data.font_data()).unwrap();
+        let feat = Feat::read(feat_data.data().into()).unwrap();
         // List of available feature types
         let valid_features = [0, 1, 3, 6];
         for i in 0..10 {

--- a/read-fonts/src/tables/gasp.rs
+++ b/read-fonts/src/tables/gasp.rs
@@ -4,8 +4,9 @@ include!("../../generated/generated_gasp.rs");
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn smoke_test() {
@@ -20,7 +21,7 @@ mod tests {
                     | GaspRangeBehavior::GASP_SYMMETRIC_SMOOTHING,
             );
 
-        let gasp = Gasp::read(buf.font_data()).unwrap();
+        let gasp = Gasp::read(buf.data().into()).unwrap();
         assert_eq!(gasp.version(), 1);
         assert_eq!(
             gasp.gasp_ranges()[0],

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -267,8 +267,10 @@ fn find_glyph_and_point_count(
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::{test_helpers::BeBuffer, FontRef, TableProvider};
+    use crate::{FontRef, TableProvider};
 
     // Shared tuples in the 'gvar' table of the Skia font, as printed
     // in Apple's TrueType specification.
@@ -547,7 +549,7 @@ mod tests {
         buf = buf.push(u32::MAX - 10);
         // two 32-bit entries that overflow when added to the above offset
         buf = buf.push(0u32).push(11u32);
-        let gvar = Gvar::read(buf.font_data()).unwrap();
+        let gvar = Gvar::read(buf.data().into()).unwrap();
         // don't panic with overflow!
         let _ = gvar.data_range_for_gid(GlyphId::new(0));
     }

--- a/read-fonts/src/tables/hdmx.rs
+++ b/read-fonts/src/tables/hdmx.rs
@@ -112,12 +112,12 @@ impl<'a> SomeRecord<'a> for DeviceRecord<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{be_buffer, be_buffer_add, test_helpers::BeBuffer};
+    use font_test_data::{be_buffer, bebuffer::BeBuffer};
 
     #[test]
     fn read_hdmx() {
         let buf = make_hdmx();
-        let hdmx = Hdmx::read(buf.font_data(), 3).unwrap();
+        let hdmx = Hdmx::read(buf.data().into(), 3).unwrap();
         assert_eq!(hdmx.version(), 0);
         assert_eq!(hdmx.num_records(), 3);
         // Note: this table has sizes for 3 glyphs making each device
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn find_by_size() {
         let buf = make_hdmx();
-        let hdmx = Hdmx::read(buf.font_data(), 3).unwrap();
+        let hdmx = Hdmx::read(buf.data().into(), 3).unwrap();
         assert_eq!(hdmx.record_for_size(8).unwrap().pixel_size, 8);
         assert_eq!(hdmx.record_for_size(16).unwrap().pixel_size, 16);
         assert_eq!(hdmx.record_for_size(32).unwrap().pixel_size, 32);

--- a/read-fonts/src/tables/head.rs
+++ b/read-fonts/src/tables/head.rs
@@ -4,8 +4,9 @@ include!("../../generated/generated_head.rs");
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn smoke_text() {
@@ -19,7 +20,7 @@ mod tests {
             .extend([0u16, 12]) // mac_style / ppem
             .extend([2i16, 1, 0]);
 
-        let head = super::Head::read(buf.font_data()).unwrap();
+        let head = super::Head::read(buf.data().into()).unwrap();
         assert_eq!(head.version(), MajorMinor::VERSION_1_0);
         assert_eq!(head.font_revision(), Fixed::from_f64(2.8));
         assert_eq!(head.units_per_em(), 4096);

--- a/read-fonts/src/tables/loca.rs
+++ b/read-fonts/src/tables/loca.rs
@@ -137,9 +137,8 @@ impl<'a> std::fmt::Debug for Loca<'a> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
     use types::Scalar;
-
-    use crate::test_helpers::BeBuffer;
 
     use super::Loca;
 
@@ -163,12 +162,12 @@ mod tests {
 
     fn check_loca_sorting(values: &[u16], is_sorted: bool) {
         let (bytes, is_long) = to_loca_bytes(values);
-        let loca = Loca::read(bytes.font_data(), is_long).unwrap();
+        let loca = Loca::read(bytes.data().into(), is_long).unwrap();
         assert_eq!(loca.all_offsets_are_ascending(), is_sorted);
 
         let u32_values: Vec<u32> = values.iter().map(|v| *v as u32).collect();
         let (bytes, is_long) = to_loca_bytes(&u32_values);
-        let loca = Loca::read(bytes.font_data(), is_long).unwrap();
+        let loca = Loca::read(bytes.data().into(), is_long).unwrap();
         assert_eq!(loca.all_offsets_are_ascending(), is_sorted);
     }
 

--- a/read-fonts/src/tables/ltag.rs
+++ b/read-fonts/src/tables/ltag.rs
@@ -28,8 +28,9 @@ impl<'a> Ltag<'a> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn tags() {
@@ -42,7 +43,7 @@ mod tests {
         // string data
         buf = buf.extend("enspsr".as_bytes().iter().copied());
         let expected_tags = [(0, "en"), (1, "sp"), (2, "sr")];
-        let ltag = Ltag::read(buf.font_data()).unwrap();
+        let ltag = Ltag::read(buf.data().into()).unwrap();
         let tags = ltag.tag_indices().collect::<Vec<_>>();
         assert_eq!(tags, expected_tags);
         assert_eq!(ltag.index_for_tag("en"), Some(0));

--- a/read-fonts/src/tables/post.rs
+++ b/read-fonts/src/tables/post.rs
@@ -122,10 +122,8 @@ pub static DEFAULT_GLYPH_NAMES: [&str; 258] = [
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helpers::BeBuffer;
-
     use super::*;
-    use font_test_data::post as test_data;
+    use font_test_data::{bebuffer::BeBuffer, post as test_data};
 
     #[test]
     fn test_post() {
@@ -152,10 +150,10 @@ mod tests {
 
         // basic table should not parse in v2.0, because that adds another field:
         let buf = make_basic_post(Version16Dot16::VERSION_2_0);
-        assert!(Post::read(buf.font_data()).is_err());
+        assert!(Post::read(buf.data().into()).is_err());
 
         // but it should be fine on version 3.0, which does not require any extra fields:
         let buf = make_basic_post(Version16Dot16::VERSION_3_0);
-        assert!(Post::read(buf.font_data()).is_ok());
+        assert!(Post::read(buf.data().into()).is_ok());
     }
 }

--- a/read-fonts/src/tables/postscript/dict.rs
+++ b/read-fonts/src/tables/postscript/dict.rs
@@ -554,10 +554,12 @@ fn parse_bcd(cursor: &mut Cursor) -> Result<Fixed, Error> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
     use crate::{
-        tables::variations::ItemVariationStore, test_helpers::BeBuffer, types::F2Dot14, FontData,
-        FontRead, FontRef, TableProvider,
+        tables::variations::ItemVariationStore, types::F2Dot14, FontData, FontRead, FontRef,
+        TableProvider,
     };
 
     #[test]

--- a/read-fonts/src/tables/postscript/fd_select.rs
+++ b/read-fonts/src/tables/postscript/fd_select.rs
@@ -39,8 +39,9 @@ impl FdSelect<'_> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::{FdSelect, GlyphId};
-    use crate::test_helpers::BeBuffer;
     use crate::FontRead;
     use std::ops::Range;
 
@@ -54,7 +55,7 @@ mod tests {
             (128..1024, 2),
         ];
         for data in make_fd_selects(map) {
-            let fd_select = FdSelect::read(data.font_data()).unwrap();
+            let fd_select = FdSelect::read(data.data().into()).unwrap();
             for (range, font_index) in map {
                 for gid in range.clone() {
                     assert_eq!(

--- a/read-fonts/src/tables/postscript/index.rs
+++ b/read-fonts/src/tables/postscript/index.rs
@@ -203,8 +203,9 @@ fn read_offset(
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     enum IndexParams {
         Format1 { off_size: u8, count: usize },
@@ -281,7 +282,7 @@ mod tests {
             IndexParams::Format2 { off_size, count } => (2, off_size, count),
         };
         let buf = make_index(fmt, off_size, count);
-        let index = Index::new(buf.font_data().as_bytes(), fmt == 2).unwrap();
+        let index = Index::new(buf.data(), fmt == 2).unwrap();
         let built_off_size = match &index {
             Index::Empty => 0,
             Index::Format1(v1) => v1.off_size(),

--- a/read-fonts/src/tables/sbix.rs
+++ b/read-fonts/src/tables/sbix.rs
@@ -25,8 +25,9 @@ impl<'a> Strike<'a> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use crate::tables::sbix::Sbix;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn sbix_strikes_count_overflow_table() {
@@ -39,7 +40,7 @@ mod tests {
             .push(0u16) // flags
             .push(u32::MAX); // num_strikes
 
-        let table = Sbix::read(sbix.font_data(), 5);
+        let table = Sbix::read(sbix.data().into(), 5);
         // Must not panic with "attempt to multiply with overflow".
         assert!(table.is_err());
     }

--- a/read-fonts/src/tables/svg.rs
+++ b/read-fonts/src/tables/svg.rs
@@ -35,8 +35,9 @@ impl<'a> Svg<'a> {
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::test_helpers::BeBuffer;
 
     #[test]
     fn read_dummy_svg_file() {
@@ -71,7 +72,7 @@ mod tests {
         let mut buf = BeBuffer::new();
         buf = buf.extend(data);
 
-        let table = Svg::read(buf.font_data()).unwrap();
+        let table = Svg::read(buf.data().into()).unwrap();
 
         let first_document = &[0, 1, 0, 0, 0, 0, 0, 0, 0, 1][..];
         let second_document = &[0, 2, 0, 0, 0, 0][..];

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -1233,8 +1233,10 @@ pub(crate) fn item_delta(
 
 #[cfg(test)]
 mod tests {
+    use font_test_data::bebuffer::BeBuffer;
+
     use super::*;
-    use crate::{test_helpers::BeBuffer, FontRef, TableProvider};
+    use crate::{FontRef, TableProvider};
 
     #[test]
     fn ivs_regions() {
@@ -1471,7 +1473,7 @@ mod tests {
             .extend([0u16, 1, 2, 3, 4]) // region_indices
             .extend([1u8; 128]); // this is much more data than we need!
 
-        let ivs = ItemVariationData::read(data.font_data()).unwrap();
+        let ivs = ItemVariationData::read(data.data().into()).unwrap();
         let row_len = (3 * u16::RAW_BYTE_LEN) + (2 * u8::RAW_BYTE_LEN); // 3 word deltas, 2 byte deltas
         let expected_len = 2 * row_len;
         assert_eq!(ivs.delta_sets().len(), expected_len);
@@ -1486,7 +1488,7 @@ mod tests {
             .extend([0u16, 1, 2]) // region_indices
             .extend([1u8; 128]); // this is much more data than we need!
 
-        let ivs = ItemVariationData::read(data.font_data()).unwrap();
+        let ivs = ItemVariationData::read(data.data().into()).unwrap();
         let row_len = (2 * u32::RAW_BYTE_LEN) + (2 * u16::RAW_BYTE_LEN); // 1 word (4-byte) delta, 2 short (2-byte)
         let expected_len = 2 * row_len;
         assert_eq!(ivs.delta_sets().len(), expected_len);

--- a/skrifa/src/outline/autohint/shape.rs
+++ b/skrifa/src/outline/autohint/shape.rs
@@ -669,7 +669,8 @@ enum ProcessLookupError {
 #[cfg(test)]
 mod tests {
     use super::{super::style, *};
-    use raw::{test_helpers::BeBuffer, FontData, FontRead};
+    use font_test_data::bebuffer::BeBuffer;
+    use raw::{FontData, FontRead};
 
     #[test]
     fn small_caps_subst() {

--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -621,8 +621,9 @@ mod tests {
         prelude::{LocationRef, Size},
         MetadataProvider,
     };
+    use font_test_data::bebuffer::BeBuffer;
     use raw::tables::cff2::Cff2;
-    use read_fonts::{test_helpers::BeBuffer, FontRef};
+    use read_fonts::FontRef;
 
     #[test]
     fn unscaled_scaling_sink_produces_integers() {

--- a/write-fonts/src/codegen_test.rs
+++ b/write-fonts/src/codegen_test.rs
@@ -113,7 +113,7 @@ mod enums {
 
 pub mod conditions {
     #[cfg(test)]
-    use read_fonts::test_helpers::BeBuffer;
+    use font_test_data::bebuffer::BeBuffer;
 
     include!("../generated/generated_test_conditions.rs");
 


### PR DESCRIPTION
`font-test-data/Cargo.toml` no longer depends on read/write fonts, meaning there isn't a cycle formed by a regular dependency from font-test-data => read/write-fonts and the dev-dependency from read/write-fonts to font-test-data. Despite being theoretically OK this was confusing things during import into other enviornments.

Meant to unblock #1329 , if this looks ok please mark that approved as well.