### PR TITLE
Gvar delta getters return Result<Option<_>,_>>

### DIFF
--- a/klippa/src/gvar.rs
+++ b/klippa/src/gvar.rs
@@ -40,7 +40,10 @@ impl Subset for Gvar<'_> {
                 {
                     return None;
                 }
-                self.data_for_gid(x.0).ok().map(|data| data.len() as u32)
+                self.data_for_gid(x.0)
+                    .ok()
+                    .flatten()
+                    .map(|data| data.len() as u32)
             })
             .sum();
 
@@ -132,7 +135,7 @@ fn subset_with_offset_type<OffsetType: GvarOffset>(
             last += 1;
         }
 
-        if let Ok(glyph_var_data) = gvar.data_for_gid(*old_gid) {
+        if let Ok(Some(glyph_var_data)) = gvar.data_for_gid(*old_gid) {
             s.embed_bytes(glyph_var_data.as_bytes())
                 .map_err(|_| SubsetError::SubsetTableError(Gvar::TAG))?;
             glyph_offset += glyph_var_data.len() as u32;

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -373,7 +373,8 @@ impl GlyphMetrics<'_> {
             .gvar
             .as_ref()?
             .phantom_point_deltas(glyf, loca, self.coords, glyph_id)
-            .ok()?;
+            .ok()
+            .flatten()?;
         deltas[1] -= deltas[0];
         Some([deltas[0], deltas[1]].map(|delta| delta.x.to_i32()))
     }

--- a/skrifa/src/outline/glyf/deltas.rs
+++ b/skrifa/src/outline/glyf/deltas.rs
@@ -139,7 +139,7 @@ where
     for delta in deltas.iter_mut() {
         *delta = Default::default();
     }
-    let Ok(var_data) = gvar.glyph_variation_data(glyph_id) else {
+    let Ok(Some(var_data)) = gvar.glyph_variation_data(glyph_id) else {
         // Empty variation data for a glyph is not an error.
         return Ok(());
     };

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -520,7 +520,7 @@ impl Scaler for FreeTypeScaler<'_> {
             && self.outlines.gvar.is_some()
             && !self.coords.is_empty()
         {
-            if let Ok(deltas) = self.outlines.gvar.as_ref().unwrap().phantom_point_deltas(
+            if let Ok(Some(deltas)) = self.outlines.gvar.as_ref().unwrap().phantom_point_deltas(
                 &self.outlines.glyf,
                 &self.outlines.loca,
                 self.coords,
@@ -1044,7 +1044,7 @@ impl Scaler for HarfBuzzScaler<'_> {
             && self.outlines.gvar.is_some()
             && !self.coords.is_empty()
         {
-            if let Ok(deltas) = self.outlines.gvar.as_ref().unwrap().phantom_point_deltas(
+            if let Ok(Some(deltas)) = self.outlines.gvar.as_ref().unwrap().phantom_point_deltas(
                 &self.outlines.glyf,
                 &self.outlines.loca,
                 self.coords,

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -721,7 +721,7 @@ mod tests {
         assert_eq!(gvar.shared_tuple_count(), 1);
         assert_eq!(gvar.glyph_count(), 3);
 
-        let g1 = gvar.glyph_variation_data(GlyphId::new(1)).unwrap();
+        let g1 = gvar.glyph_variation_data(GlyphId::new(1)).unwrap().unwrap();
         let g1tup = g1.tuples().collect::<Vec<_>>();
         assert_eq!(g1tup.len(), 1);
 
@@ -729,7 +729,7 @@ mod tests {
         assert_eq!(x, vec![30, 40, -50, 101, 10]);
         assert_eq!(y, vec![31, 41, -49, 102, 11]);
 
-        let g2 = gvar.glyph_variation_data(GlyphId::new(2)).unwrap();
+        let g2 = gvar.glyph_variation_data(GlyphId::new(2)).unwrap().unwrap();
         let g2tup = g2.tuples().collect::<Vec<_>>();
         assert_eq!(g2tup.len(), 2);
 
@@ -774,7 +774,7 @@ mod tests {
         assert_eq!(gvar.shared_tuple_count(), 0);
         assert_eq!(gvar.glyph_count(), 1);
 
-        let g1 = gvar.glyph_variation_data(gid).unwrap();
+        let g1 = gvar.glyph_variation_data(gid).unwrap().unwrap();
         let g1tup = g1.tuples().collect::<Vec<_>>();
         assert_eq!(g1tup.len(), 1);
         let tuple_variation = &g1tup[0];
@@ -822,7 +822,7 @@ mod tests {
         assert_eq!(gvar.shared_tuple_count(), 0);
         assert_eq!(gvar.glyph_count(), 1);
 
-        let g1 = gvar.glyph_variation_data(gid).unwrap();
+        let g1 = gvar.glyph_variation_data(gid).unwrap().unwrap();
         let g1tup = g1.tuples().collect::<Vec<_>>();
         assert_eq!(g1tup.len(), 1);
         let tuple_variation = &g1tup[0];


### PR DESCRIPTION
Instead of just Result<_,_>. This better represents the underlying semantics, where there is a potentially important distinction between deltas that do not exist at all and deltas that are expected to exist but cannot be read.

- closes #1277 