### PR TITLE
[skrifa] avoid timeout in DELTA instructions

### DIFF
--- a/skrifa/src/outline/glyf/hint/value_stack.rs
+++ b/skrifa/src/outline/glyf/hint/value_stack.rs
@@ -118,15 +118,10 @@ impl<'a> ValueStack<'a> {
     /// or 0 otherwise.
     pub fn pop_count_checked(&mut self) -> Result<usize, HintErrorKind> {
         let value = self.pop()?;
-        if value < 0 {
-            if self.is_pedantic {
-                Err(HintErrorKind::InvalidStackValue(value))
-            } else {
-                Ok(0)
-            }
+        if value < 0 && self.is_pedantic {
+            Err(HintErrorKind::InvalidStackValue(value))
         } else {
-            // Positive i32 always fits into usize
-            Ok(value as usize)
+            Ok(value.max(0) as usize)
         }
     }
 


### PR DESCRIPTION
Adds a new `ValueStack::pop_count_checked()` method that checks for negative stack values when we're popping a value intended for a count. Changing `ValueStack::pop_usize()` directly could affect our compatibility with FreeType when dealing with other instructions so that one is left unchanged.

Additionally limits the counts for DELTAP and DELTAC to point count and cvt size respectively since we don't expect those instructions to modify the same value more than once.

ref https://issues.oss-fuzz.com/issues/42538387

Fixes #1290