### PR TITLE
[types] Add Tag::NULL associated constant

### DIFF
--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -23,6 +23,15 @@ use std::{
 pub struct Tag([u8; 4]);
 
 impl Tag {
+    /// A 'null' tag consists of four spaces.
+    ///
+    /// This tag is not a valid identifier, but can be used to represent the
+    /// absence of a tag. See the comments on the [OS/2 `achVendID`][achVendID]
+    /// field.
+    ///
+    /// [achVendID]: https://learn.microsoft.com/en-us/typography/opentype/spec/os2#achvendid
+    pub const NULL: Self = Tag::new(&[0x20; 4]);
+
     /// Construct a `Tag` from raw bytes.
     ///
     /// This does not perform any validation; use [`Tag::new_checked`] for a
@@ -234,10 +243,9 @@ impl Debug for Tag {
     }
 }
 
-// a meaningless placeholder value.
 impl Default for Tag {
     fn default() -> Self {
-        Tag([b' '; 4])
+        Tag::NULL
     }
 }
 


### PR DESCRIPTION
We'd already decided to use this value (four spaces) as the value of Tag::default(), and it turns out that it is also allowed in OS/2, so exposing it as a constant seems useful.