### PR TITLE
Update copy indices implementation to match spec changes in https://github.com/w3c/IFT/pull/252

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -1087,7 +1087,7 @@ impl Field {
             let condition = condition.condition_tokens_for_read();
             if self.read_at_parse_time {
                 quote! {
-                    let #name = #condition.then(|| cursor.read::<#typ>()).transpose()?.unwrap_or(Default::default());
+                    let #name = #condition.then(|| cursor.read::<#typ>()).transpose()?.unwrap_or_default();
                 }
             } else {
                 quote! {

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -157,7 +157,7 @@ impl Fields {
             .find(|fld| &fld.name == name)
             .map(|fld| match &fld.typ {
                 FieldType::Scalar { typ } => typ,
-                _ => panic!("not a scalar field: {:?}", &fld.typ),
+                _ => panic!("not a scalar field"),
             })
             .or_else(|| {
                 self.read_args.as_ref().and_then(|args| {

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -157,7 +157,7 @@ impl Fields {
             .find(|fld| &fld.name == name)
             .map(|fld| match &fld.typ {
                 FieldType::Scalar { typ } => typ,
-                _ => panic!("not a scalar field"),
+                _ => panic!("not a scalar field: {:?}", &fld.typ),
             })
             .or_else(|| {
                 self.read_args.as_ref().and_then(|args| {
@@ -1087,7 +1087,7 @@ impl Field {
             let condition = condition.condition_tokens_for_read();
             if self.read_at_parse_time {
                 quote! {
-                    let #name = #condition.then(|| cursor.read::<#typ>()).transpose()?.unwrap_or(0);
+                    let #name = #condition.then(|| cursor.read::<#typ>()).transpose()?.unwrap_or(Default::default());
                 }
             } else {
                 quote! {

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -318,6 +318,8 @@ pub(crate) enum CountTransform {
     MaxValueBitmapLen,
     /// requires exactly two args, defined as $arg1 - $arg2 + 2
     SubAddTwo,
+    /// requires exactly one arg. Get the count from the $arg1.try_into::<usize>().
+    CustomCount,
 }
 
 /// Attributes for specifying how to compile a field
@@ -1468,6 +1470,7 @@ static TRANSFORM_IDENTS: &[(CountTransform, &str)] = &[
     (CountTransform::BitmapLen, "bitmap_len"),
     (CountTransform::MaxValueBitmapLen, "max_value_bitmap_len"),
     (CountTransform::SubAddTwo, "subtract_add_two"),
+    (CountTransform::CustomCount, "custom"),
 ];
 
 impl FromStr for CountTransform {
@@ -1505,6 +1508,7 @@ impl CountTransform {
             CountTransform::BitmapLen => 1,
             CountTransform::MaxValueBitmapLen => 1,
             CountTransform::SubAddTwo => 2,
+            CountTransform::CustomCount => 1,
         }
     }
 }
@@ -1661,6 +1665,9 @@ impl Count {
                 }
                 (CountTransform::SubAddTwo, [a, b]) => {
                     quote!(transforms::subtract_add_two(#a, #b))
+                }
+                (CountTransform::CustomCount, [a]) => {
+                    quote!(transforms::custom_count(#a))
                 }
                 _ => unreachable!("validated before now"),
             },

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -319,7 +319,7 @@ pub(crate) enum CountTransform {
     /// requires exactly two args, defined as $arg1 - $arg2 + 2
     SubAddTwo,
     /// requires exactly one arg. Get the count from the $arg1.try_into::<usize>().
-    CustomCount,
+    Custom,
 }
 
 /// Attributes for specifying how to compile a field
@@ -1470,7 +1470,7 @@ static TRANSFORM_IDENTS: &[(CountTransform, &str)] = &[
     (CountTransform::BitmapLen, "bitmap_len"),
     (CountTransform::MaxValueBitmapLen, "max_value_bitmap_len"),
     (CountTransform::SubAddTwo, "subtract_add_two"),
-    (CountTransform::CustomCount, "custom"),
+    (CountTransform::Custom, "custom"),
 ];
 
 impl FromStr for CountTransform {
@@ -1508,7 +1508,7 @@ impl CountTransform {
             CountTransform::BitmapLen => 1,
             CountTransform::MaxValueBitmapLen => 1,
             CountTransform::SubAddTwo => 2,
-            CountTransform::CustomCount => 1,
+            CountTransform::Custom => 1,
         }
     }
 }
@@ -1666,7 +1666,7 @@ impl Count {
                 (CountTransform::SubAddTwo, [a, b]) => {
                     quote!(transforms::subtract_add_two(#a, #b))
                 }
-                (CountTransform::CustomCount, [a]) => {
+                (CountTransform::Custom, [a]) => {
                     quote!(transforms::custom_count(#a))
                 }
                 _ => unreachable!("validated before now"),

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -319,7 +319,7 @@ pub(crate) enum CountTransform {
     /// requires exactly two args, defined as $arg1 - $arg2 + 2
     SubAddTwo,
     /// requires exactly one arg. Get the count from the $arg1.`try_into::<usize>`().
-    Custom,
+    TryInto,
 }
 
 /// Attributes for specifying how to compile a field
@@ -1470,7 +1470,7 @@ static TRANSFORM_IDENTS: &[(CountTransform, &str)] = &[
     (CountTransform::BitmapLen, "bitmap_len"),
     (CountTransform::MaxValueBitmapLen, "max_value_bitmap_len"),
     (CountTransform::SubAddTwo, "subtract_add_two"),
-    (CountTransform::Custom, "custom"),
+    (CountTransform::TryInto, "try_into"),
 ];
 
 impl FromStr for CountTransform {
@@ -1508,7 +1508,7 @@ impl CountTransform {
             CountTransform::BitmapLen => 1,
             CountTransform::MaxValueBitmapLen => 1,
             CountTransform::SubAddTwo => 2,
-            CountTransform::Custom => 1,
+            CountTransform::TryInto => 1,
         }
     }
 }
@@ -1666,8 +1666,8 @@ impl Count {
                 (CountTransform::SubAddTwo, [a, b]) => {
                     quote!(transforms::subtract_add_two(#a, #b))
                 }
-                (CountTransform::Custom, [a]) => {
-                    quote!(transforms::custom_count(#a))
+                (CountTransform::TryInto, [a]) => {
+                    quote!(usize::try_from(#a).unwrap_or_default())
                 }
                 _ => unreachable!("validated before now"),
             },

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -318,7 +318,7 @@ pub(crate) enum CountTransform {
     MaxValueBitmapLen,
     /// requires exactly two args, defined as $arg1 - $arg2 + 2
     SubAddTwo,
-    /// requires exactly one arg. Get the count from the $arg1.try_into::<usize>().
+    /// requires exactly one arg. Get the count from the $arg1.`try_into::<usize>`().
     Custom,
 }
 

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -296,7 +296,7 @@ pub fn features_and_design_space_format2() -> BeBuffer {
     buffer
 }
 
-pub fn copy_indices_format2() -> BeBuffer {
+pub fn child_indices_format2() -> BeBuffer {
     let mut buffer = be_buffer! {
       2u8,                      // format
 
@@ -347,33 +347,33 @@ pub fn copy_indices_format2() -> BeBuffer {
       0x0064_0000,                            // end = 100
 
       // Entry id = 5
-      {0b00000010u8: "entries[4]"},           // format = COPY_INDICES
-      1u8,                                    // copy count
-      (Uint24::new(0)),                       // copy
+      {0b00000010u8: "entries[4]"},           // format = CHILD_INDICES
+      1u8,                                    // child count
+      (Uint24::new(0)),                       // child[0] = 0
 
       // Entry id = 6
-      {0b00000010u8: "entries[5]"},           // format = COPY_INDICES
-      1u8,                                    // copy count
-      (Uint24::new(2)),                       // copy
+      {0b00000010u8: "entries[5]"},           // format = CHILD_INDICES
+      1u8,                                    // child count
+      (Uint24::new(2)),                       // child
 
       // Entry id = 7
-      {0b00000010u8: "entries[6]"},           // format = COPY_INDICES
-      4u8,                                    // copy count
-      (Uint24::new(3)),                       // copy[0]
-      (Uint24::new(2)),                       // copy[1]
-      (Uint24::new(1)),                       // copy[2]
-      (Uint24::new(0)),                       // copy[3]
+      {0b00000010u8: "entries[6]"},           // format = CHILD_INDICES
+      {4u8: "entries[6]_child_count"},        // child count
+      (Uint24::new(3)),                       // child[0] = 3
+      (Uint24::new(2)),                       // child[1] = 2
+      (Uint24::new(1)),                       // child[2] = 1
+      (Uint24::new(0)),                       // child[3] = 0
 
       // Entry id = 8
-      {0b00000010u8: "entries[7]"},           // format = COPY_INDICES
-      2u8,                                    // copy count
-      (Uint24::new(4)),                       // copy[0]
-      (Uint24::new(5)),                       // copy[1]
+      {0b00000010u8: "entries[7]"},           // format = CHILD_INDICES
+      2u8,                                    // child count
+      (Uint24::new(4)),                       // child[0] = 4
+      (Uint24::new(5)),                       // child[1] = 5
 
       // Entry id = 9
-      {0b00100010u8: "entries[8]"},           // format = CODEPOINT_BIT_2 | COPY_INDICES
-      1u8,                                    // copy count
-      (Uint24::new(0)),                       // copy[0]
+      {0b00100010u8: "entries[8]"},           // format = CODEPOINT_BIT_2 | CHILD_INDICES
+      1u8,                                    // child count
+      (Uint24::new(0)),                       // chil[0] = 0
       100u16,                                 // bias
       [0b00001101, 0b00000011, 0b00110001u8]  // codepoints = [100..117]
     };

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -360,7 +360,7 @@ pub fn child_indices_format2() -> BeBuffer {
       {0b00000010u8: "entries[6]"},           // format = CHILD_INDICES
       {4u8: "entries[6]_child_count"},        // child count
       (Uint24::new(3)),                       // child[0] = 3
-      (Uint24::new(2)),                       // child[1] = 2
+      {(Uint24::new(2)): "entries[6]_child"}, // child[1] = 2
       (Uint24::new(1)),                       // child[2] = 1
       (Uint24::new(0)),                       // child[3] = 0
 

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -1446,7 +1446,7 @@ mod tests {
         let s = SubsetDefinition::codepoints([5].into_iter().collect());
         let g = PatchGroup::select_next_patches(font.clone(), &s);
 
-        assert!(g.is_err());
+        assert!(g.is_err(), "did not fail as expected.");
         if let Err(err) = g {
             assert_eq!(ReadError::ValidationError, err);
         }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -392,19 +392,37 @@ impl EntryIntersectionCache<'_> {
             return true;
         }
 
-        let mut some_match = false;
-        let mut all_match = true;
-        for child_index in entry.child_indices.iter() {
-            let child_intersects = self.intersects(*child_index, subset_definition);
-            some_match = some_match || child_intersects;
-            all_match = all_match && child_intersects;
-        }
-
         if entry.conjunctive_child_match {
-            all_match
+            self.all_children_intersect(entry, subset_definition)
         } else {
-            some_match
+            self.some_children_intersect(entry, subset_definition)
         }
+    }
+
+    fn all_children_intersect(
+        &mut self,
+        entry: &Entry,
+        subset_definition: &SubsetDefinition,
+    ) -> bool {
+        for child_index in entry.child_indices.iter() {
+            if !self.intersects(*child_index, subset_definition) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn some_children_intersect(
+        &mut self,
+        entry: &Entry,
+        subset_definition: &SubsetDefinition,
+    ) -> bool {
+        for child_index in entry.child_indices.iter() {
+            if self.intersects(*child_index, subset_definition) {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -358,6 +358,56 @@ fn merge_intersecting_entries<const RECORD_INTERSECTION: bool>(
     }
 }
 
+struct EntryIntersectionCache<'a> {
+    entries: &'a [Entry],
+    cache: HashMap<usize, bool>,
+}
+
+impl<'a> EntryIntersectionCache<'a> {
+    fn intersects(&mut self, index: usize, subset_definition: &SubsetDefinition) -> bool {
+        if let Some(result) = self.cache.get(&index) {
+            return *result;
+        }
+
+        let Some(entry) = self.entries.get(index) else {
+            return false;
+        };
+
+        let result = self.compute_intersection(entry, subset_definition);
+        self.cache.insert(index, result);
+        result
+    }
+
+    fn compute_intersection(
+        &mut self,
+        entry: &Entry,
+        subset_definition: &SubsetDefinition,
+    ) -> bool {
+        // See: https://w3c.github.io/IFT/Overview.html#abstract-opdef-check-entry-intersection
+        if !entry.intersects(subset_definition) {
+            return false;
+        }
+
+        if entry.child_indices.is_empty() {
+            return true;
+        }
+
+        let mut some_match = false;
+        let mut all_match = true;
+        for child_index in entry.child_indices.iter() {
+            let child_intersects = self.intersects(*child_index, subset_definition);
+            some_match = some_match || child_intersects;
+            all_match = all_match && child_intersects;
+        }
+
+        if entry.conjunctive_child_match {
+            all_match
+        } else {
+            some_match
+        }
+    }
+}
+
 fn add_intersecting_format2_patches(
     source_table: &IftTableTag,
     map: &PatchMapFormat2,
@@ -366,25 +416,32 @@ fn add_intersecting_format2_patches(
 ) -> Result<(), ReadError> {
     let entries = decode_format2_entries(source_table, map)?;
 
-    for (order, mut e) in entries.into_iter().enumerate() {
+    // Caches the result of intersection check for an entry index.
+    let mut entry_intersection_cache = EntryIntersectionCache {
+        entries: &entries,
+        cache: Default::default(),
+    };
+
+    for (order, e) in entries.iter().enumerate() {
         if e.ignored {
             continue;
         }
 
-        if !e.intersects(subset_definition) {
+        if !entry_intersection_cache.intersects(order, subset_definition) {
             continue;
         }
 
-        if e.uri.encoding().is_invalidating() {
+        let mut uri = e.uri.clone();
+        if uri.encoding().is_invalidating() {
             // for invalidating keyed patches we need to record information about intersection size to use later
             // for patch selection.
-            e.uri.intersection_info = IntersectionInfo::from_subset(
+            uri.intersection_info = IntersectionInfo::from_subset(
                 e.subset_definition.intersection(subset_definition),
                 order,
             );
         }
 
-        patches.push(e.uri)
+        patches.push(uri)
     }
 
     Ok(())
@@ -460,8 +517,20 @@ fn decode_format2_entry<'a>(
     }
 
     // Copy indices
-    if let Some(copy_indices) = entry_data.copy_indices() {
-        // TODO XXXXXXX
+    if let (Some(child_indices), Some(match_mode)) = (
+        entry_data.child_indices(),
+        entry_data.match_mode_and_count(),
+    ) {
+        let max_index = entries.len();
+        for i in entry.child_indices.iter() {
+            if *i >= max_index {
+                return Err(ReadError::MalformedData(
+                    "Child index must refer to only prior entries.",
+                ));
+            }
+        }
+        entry.child_indices = child_indices.iter().map(|v| v.get().into()).collect();
+        entry.conjunctive_child_match = match_mode.conjunctive_match();
     }
 
     // Design space
@@ -481,19 +550,6 @@ fn decode_format2_entry<'a>(
         }
 
         entry.subset_definition.design_space = DesignSpace::Ranges(ranges);
-    }
-
-    // Copy Indices
-    if let Some(copy_indices) = entry_data.copy_indices() {
-        for index in copy_indices {
-            let entry_to_copy =
-                entries
-                    .get(index.get().to_u32() as usize)
-                    .ok_or(ReadError::MalformedData(
-                        "copy index can only refer to a previous entry.",
-                    ))?;
-            entry.union(entry_to_copy);
-        }
     }
 
     // Entry ID
@@ -1072,8 +1128,8 @@ impl SubsetDefinition {
 struct Entry {
     // Key
     subset_definition: SubsetDefinition,
-    copy_indices: Vec<usize>,
-    append_mode: bool,
+    child_indices: Vec<usize>,
+    conjunctive_child_match: bool,
     ignored: bool,
 
     // Value
@@ -1094,8 +1150,8 @@ impl Entry {
                 design_space: Default::default(),
             },
 
-            copy_indices: Default::default(),
-            append_mode: false,
+            child_indices: Default::default(),
+            conjunctive_child_match: false,
             ignored: false,
 
             uri: PatchUri::from_index(
@@ -1162,12 +1218,6 @@ impl Entry {
 
         false
     }
-
-    /// Union in the subset definition (codepoints, features, and design space segments)
-    /// from other.
-    fn union(&mut self, other: &Entry) {
-        self.subset_definition.union(&other.subset_definition);
-    }
 }
 
 #[cfg(test)]
@@ -1175,7 +1225,7 @@ mod tests {
     use super::*;
     use font_test_data as test_data;
     use font_test_data::ift::{
-        codepoints_only_format2, copy_indices_format2, custom_ids_format2, feature_map_format1,
+        child_indices_format2, codepoints_only_format2, custom_ids_format2, feature_map_format1,
         features_and_design_space_format2, simple_format1, string_ids_format2, u16_entries_format1,
     };
     use read_fonts::tables::ift::{IFTX_TAG, IFT_TAG};
@@ -2294,23 +2344,24 @@ mod tests {
     }
 
     #[test]
-    fn format_2_patch_map_copy_indices() {
+    fn format_2_patch_map_disjunctive_child_indices() {
         let font_bytes = create_ift_font(
             FontRef::new(test_data::ift::IFT_BASE).unwrap(),
-            Some(&copy_indices_format2()),
+            Some(&child_indices_format2()),
             None,
         );
         let font = FontRef::new(&font_bytes).unwrap();
 
-        let e3 = f2(3, copy_indices_format2().offset_for("entries[2]"));
-        let e5 = f2(5, copy_indices_format2().offset_for("entries[4]"));
-        let e6 = f2(6, copy_indices_format2().offset_for("entries[5]"));
-        let e7 = f2(7, copy_indices_format2().offset_for("entries[6]"));
-        let e8 = f2(8, copy_indices_format2().offset_for("entries[7]"));
-        let e9 = f2(9, copy_indices_format2().offset_for("entries[8]"));
+        let e3 = f2(3, child_indices_format2().offset_for("entries[2]"));
+        let e5 = f2(5, child_indices_format2().offset_for("entries[4]"));
+        let e6 = f2(6, child_indices_format2().offset_for("entries[5]"));
+        let e7 = f2(7, child_indices_format2().offset_for("entries[6]"));
+        let e8 = f2(8, child_indices_format2().offset_for("entries[7]"));
+        let e9 = f2(9, child_indices_format2().offset_for("entries[8]"));
         test_intersection(&font, [], [], []);
-        test_intersection(&font, [0x05], [], [e5, e9]);
-        test_intersection(&font, [0x65], [], [e9]);
+        test_intersection(&font, [0x05], [], [e5, e7, e8]);
+        test_intersection(&font, [0x65], [], []);
+        test_intersection(&font, [0x05, 0x65], [], [e5, e7, e8, e9]);
 
         test_design_space_intersection(
             &font,
@@ -2322,7 +2373,7 @@ mod tests {
                     .into_iter()
                     .collect(),
             )]),
-            [e3, e6],
+            [e3, e6, e7, e8],
         );
 
         test_design_space_intersection(
@@ -2335,7 +2386,44 @@ mod tests {
                     .into_iter()
                     .collect(),
             )]),
-            [e3, e5, e6, e7, e8, e9],
+            [e3, e5, e6, e7, e8],
+        );
+    }
+
+    #[test]
+    fn format_2_patch_map_conjunctive_child_indices() {
+        let mut builder = child_indices_format2();
+        builder.write_at("entries[6]_child_count", 0b10000000u8 | 4u8);
+
+        let font_bytes = create_ift_font(
+            FontRef::new(test_data::ift::IFT_BASE).unwrap(),
+            Some(&builder),
+            None,
+        );
+        let font = FontRef::new(&font_bytes).unwrap();
+
+        let e2 = f2(2, child_indices_format2().offset_for("entries[1]"));
+        let e3 = f2(3, child_indices_format2().offset_for("entries[2]"));
+        let e4 = f2(4, child_indices_format2().offset_for("entries[3]"));
+        let e5 = f2(5, child_indices_format2().offset_for("entries[4]"));
+        let e6 = f2(6, child_indices_format2().offset_for("entries[5]"));
+        let e7 = f2(7, child_indices_format2().offset_for("entries[6]"));
+        let e8 = f2(8, child_indices_format2().offset_for("entries[7]"));
+        test_intersection(&font, [0x05], [], [e5, e8]);
+        test_design_space_intersection(
+            &font,
+            [0x05, 51],
+            FeatureSet::from([Tag::new(b"liga"), Tag::new(b"rlig")]),
+            DesignSpace::from([(
+                Tag::new(b"wght"),
+                [
+                    Fixed::from_i32(75)..=Fixed::from_i32(75),
+                    Fixed::from_i32(500)..=Fixed::from_i32(500),
+                ]
+                .into_iter()
+                .collect(),
+            )]),
+            [e2, e3, e4, e5, e6, e7, e8],
         );
     }
 
@@ -2652,15 +2740,15 @@ mod tests {
             subset_definition: s1.clone(),
             uri: uri.clone(),
             ignored: false,
-            copy_indices: Default::default(),
-            append_mode: Default::default(),
+            child_indices: Default::default(),
+            conjunctive_child_match: Default::default(),
         };
         let e2 = Entry {
             subset_definition: Default::default(),
             uri: uri.clone(),
             ignored: false,
-            copy_indices: Default::default(),
-            append_mode: Default::default(),
+            child_indices: Default::default(),
+            conjunctive_child_match: Default::default(),
         };
 
         assert!(e1.intersects(&s1));
@@ -2768,15 +2856,15 @@ mod tests {
             subset_definition: s1.clone(),
             uri: uri.clone(),
             ignored: false,
-            copy_indices: Default::default(),
-            append_mode: Default::default(),
+            child_indices: Default::default(),
+            conjunctive_child_match: Default::default(),
         };
         let e2 = Entry {
             subset_definition: Default::default(),
             uri: uri.clone(),
             ignored: false,
-            copy_indices: Default::default(),
-            append_mode: Default::default(),
+            child_indices: Default::default(),
+            conjunctive_child_match: Default::default(),
         };
 
         assert!(e1.intersects(&s1));
@@ -2794,4 +2882,10 @@ mod tests {
             SubsetDefinition::default()
         );
     }
+
+    // TODO test for child indices:
+    // - detects invalid indices
+    // - conjunctive matching
+    // - disjunctive matching
+    // - multi level matching
 }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -363,7 +363,7 @@ struct EntryIntersectionCache<'a> {
     cache: HashMap<usize, bool>,
 }
 
-impl<'a> EntryIntersectionCache<'a> {
+impl EntryIntersectionCache<'_> {
     fn intersects(&mut self, index: usize, subset_definition: &SubsetDefinition) -> bool {
         if let Some(result) = self.cache.get(&index) {
             return *result;

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -459,6 +459,11 @@ fn decode_format2_entry<'a>(
             .extend(features.iter().map(|t| t.get()));
     }
 
+    // Copy indices
+    if let Some(copy_indices) = entry_data.copy_indices() {
+        // TODO XXXXXXX
+    }
+
     // Design space
     if let Some(design_space_segments) = entry_data.design_space_segments() {
         let mut ranges = HashMap::<Tag, RangeSet<Fixed>>::new();
@@ -1067,6 +1072,8 @@ impl SubsetDefinition {
 struct Entry {
     // Key
     subset_definition: SubsetDefinition,
+    copy_indices: Vec<usize>,
+    append_mode: bool,
     ignored: bool,
 
     // Value
@@ -1086,6 +1093,9 @@ impl Entry {
                 feature_tags: Default::default(),
                 design_space: Default::default(),
             },
+
+            copy_indices: Default::default(),
+            append_mode: false,
             ignored: false,
 
             uri: PatchUri::from_index(
@@ -2642,11 +2652,15 @@ mod tests {
             subset_definition: s1.clone(),
             uri: uri.clone(),
             ignored: false,
+            copy_indices: Default::default(),
+            append_mode: Default::default(),
         };
         let e2 = Entry {
             subset_definition: Default::default(),
             uri: uri.clone(),
             ignored: false,
+            copy_indices: Default::default(),
+            append_mode: Default::default(),
         };
 
         assert!(e1.intersects(&s1));
@@ -2754,11 +2768,15 @@ mod tests {
             subset_definition: s1.clone(),
             uri: uri.clone(),
             ignored: false,
+            copy_indices: Default::default(),
+            append_mode: Default::default(),
         };
         let e2 = Entry {
             subset_definition: Default::default(),
             uri: uri.clone(),
             ignored: false,
+            copy_indices: Default::default(),
+            append_mode: Default::default(),
         };
 
         assert!(e1.intersects(&s1));

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -1069,7 +1069,7 @@ impl<'a> FontReadWithArgs<'a> for EntryData<'a> {
             .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
             .then(|| cursor.read::<u8>())
             .transpose()?
-            .unwrap_or(Default::default());
+            .unwrap_or_default();
         let feature_tags_byte_start = format_flags
             .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
             .then(|| cursor.position())
@@ -1092,7 +1092,7 @@ impl<'a> FontReadWithArgs<'a> for EntryData<'a> {
             .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
             .then(|| cursor.read::<u16>())
             .transpose()?
-            .unwrap_or(Default::default());
+            .unwrap_or_default();
         let design_space_segments_byte_start = format_flags
             .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
             .then(|| cursor.position())
@@ -1115,7 +1115,7 @@ impl<'a> FontReadWithArgs<'a> for EntryData<'a> {
             .contains(EntryFormatFlags::CHILD_INDICES)
             .then(|| cursor.read::<MatchModeAndCount>())
             .transpose()?
-            .unwrap_or(Default::default());
+            .unwrap_or_default();
         let child_indices_byte_start = format_flags
             .contains(EntryFormatFlags::CHILD_INDICES)
             .then(|| cursor.position())
@@ -1123,7 +1123,7 @@ impl<'a> FontReadWithArgs<'a> for EntryData<'a> {
         let child_indices_byte_len = format_flags
             .contains(EntryFormatFlags::CHILD_INDICES)
             .then_some(
-                (transforms::custom_count(match_mode_and_count))
+                (usize::try_from(match_mode_and_count).unwrap_or_default())
                     .checked_mul(Uint24::RAW_BYTE_LEN)
                     .ok_or(ReadError::OutOfBounds)?,
             );

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -76,7 +76,7 @@ impl<'a> FontRead<'a> for Name<'a> {
             .compatible(1u16)
             .then(|| cursor.read::<u16>())
             .transpose()?
-            .unwrap_or(Default::default());
+            .unwrap_or_default();
         let lang_tag_record_byte_start = version
             .compatible(1u16)
             .then(|| cursor.position())

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -76,7 +76,7 @@ impl<'a> FontRead<'a> for Name<'a> {
             .compatible(1u16)
             .then(|| cursor.read::<u16>())
             .transpose()?
-            .unwrap_or(0);
+            .unwrap_or(Default::default());
         let lang_tag_record_byte_start = version
             .compatible(1u16)
             .then(|| cursor.position())

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -109,7 +109,7 @@ impl<'a> FontRead<'a> for Post<'a> {
             .compatible((2u16, 0u16))
             .then(|| cursor.read::<u16>())
             .transpose()?
-            .unwrap_or(Default::default());
+            .unwrap_or_default();
         let glyph_name_index_byte_start = version
             .compatible((2u16, 0u16))
             .then(|| cursor.position())

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -109,7 +109,7 @@ impl<'a> FontRead<'a> for Post<'a> {
             .compatible((2u16, 0u16))
             .then(|| cursor.read::<u16>())
             .transpose()?
-            .unwrap_or(0);
+            .unwrap_or(Default::default());
         let glyph_name_index_byte_start = version
             .compatible((2u16, 0u16))
             .then(|| cursor.position())

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -149,10 +149,6 @@ pub(crate) mod codegen_prelude {
             (count + 7) / 8
         }
 
-        pub fn custom_count<T: TryInto<usize>>(count: T) -> usize {
-            count.try_into().unwrap_or_default()
-        }
-
         pub fn add_multiply<T: TryInto<usize>, U: TryInto<usize>, V: TryInto<usize>>(
             a: T,
             b: U,

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -149,6 +149,10 @@ pub(crate) mod codegen_prelude {
             (count + 7) / 8
         }
 
+        pub fn custom_count<T: TryInto<usize>>(count: T) -> usize {
+            count.try_into().unwrap_or_default()
+        }
+
         pub fn add_multiply<T: TryInto<usize>, U: TryInto<usize>, V: TryInto<usize>>(
             a: T,
             b: U,

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -13,7 +13,7 @@ pub struct MatchModeAndCount(u8);
 impl MatchModeAndCount {
     /// Flag indicating that copy mode is append.
     ///
-    /// See: https://w3c.github.io/IFT/Overview.html#mapping-entry-copymodeandcount
+    /// See: <https://w3c.github.io/IFT/Overview.html#mapping-entry-copymodeandcount>
     pub const MATCH_MODE_MASK: u8 = 0b10000000;
 
     /// Mask for the low 7 bits to give the copy index count.

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -8,13 +8,13 @@ pub const IFT_TAG: types::Tag = Tag::new(b"IFT ");
 pub const IFTX_TAG: types::Tag = Tag::new(b"IFTX");
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CopyModeAndCount(u8);
+pub struct MatchModeAndCount(u8);
 
-impl CopyModeAndCount {
+impl MatchModeAndCount {
     /// Flag indicating that copy mode is append.
     ///
     /// See: https://w3c.github.io/IFT/Overview.html#mapping-entry-copymodeandcount
-    pub const APPEND_MODE_MASK: u8 = 0b10000000;
+    pub const MATCH_MODE_MASK: u8 = 0b10000000;
 
     /// Mask for the low 7 bits to give the copy index count.
     pub const COUNT_MASK: u8 = 0b01111111;
@@ -27,9 +27,9 @@ impl CopyModeAndCount {
         Self(bits)
     }
 
-    /// `true` if any tables reference a shared set of point numbers
-    pub fn append_mode(self) -> bool {
-        (self.0 & Self::APPEND_MODE_MASK) != 0
+    /// If true matching mode is conjunctive (... AND ...) otherwise disjunctive (... OR ...)
+    pub fn conjunctive_match(self) -> bool {
+        (self.0 & Self::MATCH_MODE_MASK) != 0
     }
 
     pub fn count(self) -> u8 {
@@ -37,7 +37,7 @@ impl CopyModeAndCount {
     }
 }
 
-impl TryInto<usize> for CopyModeAndCount {
+impl TryInto<usize> for MatchModeAndCount {
     type Error = ReadError;
 
     fn try_into(self) -> Result<usize, Self::Error> {
@@ -45,7 +45,7 @@ impl TryInto<usize> for CopyModeAndCount {
     }
 }
 
-impl types::Scalar for CopyModeAndCount {
+impl types::Scalar for MatchModeAndCount {
     type Raw = <u8 as types::Scalar>::Raw;
     fn to_raw(self) -> Self::Raw {
         self.0.to_raw()

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -7,6 +7,55 @@ use std::str;
 pub const IFT_TAG: types::Tag = Tag::new(b"IFT ");
 pub const IFTX_TAG: types::Tag = Tag::new(b"IFTX");
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CopyModeAndCount(u8);
+
+impl CopyModeAndCount {
+    /// Flag indicating that copy mode is append.
+    ///
+    /// See: https://w3c.github.io/IFT/Overview.html#mapping-entry-copymodeandcount
+    pub const APPEND_MODE_MASK: u8 = 0b10000000;
+
+    /// Mask for the low 7 bits to give the copy index count.
+    pub const COUNT_MASK: u8 = 0b01111111;
+
+    pub fn bits(self) -> u8 {
+        self.0
+    }
+
+    pub fn from_bits(bits: u8) -> Self {
+        Self(bits)
+    }
+
+    /// `true` if any tables reference a shared set of point numbers
+    pub fn append_mode(self) -> bool {
+        (self.0 & Self::APPEND_MODE_MASK) != 0
+    }
+
+    pub fn count(self) -> u8 {
+        self.0 & Self::COUNT_MASK
+    }
+}
+
+impl TryInto<usize> for CopyModeAndCount {
+    type Error = ReadError;
+
+    fn try_into(self) -> Result<usize, Self::Error> {
+        Ok(self.count() as usize)
+    }
+}
+
+impl types::Scalar for CopyModeAndCount {
+    type Raw = <u8 as types::Scalar>::Raw;
+    fn to_raw(self) -> Self::Raw {
+        self.0.to_raw()
+    }
+    fn from_raw(raw: Self::Raw) -> Self {
+        let t = <u8>::from_raw(raw);
+        Self(t)
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Default, Ord, PartialOrd, Hash)]
 pub struct CompatibilityId([u8; 16]);

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -7,6 +7,12 @@ use std::str;
 pub const IFT_TAG: types::Tag = Tag::new(b"IFT ");
 pub const IFTX_TAG: types::Tag = Tag::new(b"IFTX");
 
+/// Wrapper for the packed childEntryMatchModeAndCount field in IFT format 2 mapping table.
+///
+/// Reference: <https://w3c.github.io/IFT/Overview.html#mapping-entry-childentrymatchmodeandcount>
+///
+/// The MSB is a flag which indicates conjunctive (bit set) or disjunctive (bit cleared) matching.
+/// The remaining 7 bits are a count.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MatchModeAndCount(u8);
 
@@ -37,11 +43,11 @@ impl MatchModeAndCount {
     }
 }
 
-impl TryInto<usize> for MatchModeAndCount {
+impl TryFrom<MatchModeAndCount> for usize {
     type Error = ReadError;
 
-    fn try_into(self) -> Result<usize, Self::Error> {
-        Ok(self.count() as usize)
+    fn try_from(value: MatchModeAndCount) -> Result<Self, Self::Error> {
+        Ok(value.count() as usize)
     }
 }
 

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -1,5 +1,6 @@
 #![parse_module(read_fonts::tables::ift)]
 
+extern scalar CopyModeAndCount;
 extern record U8Or16;
 extern record U16Or24;
 extern record IdDeltaOrLength;
@@ -162,9 +163,11 @@ table EntryData {
 
   // COPY_INDICES
   #[if_flag($format_flags, EntryFormatFlags::COPY_INDICES)]
-  copy_count: u8,
+  #[traverse_with(skip)]
+  #[compile(skip)] // TODO remove this once write fonts side is implemented.]
+  copy_mode_and_count: CopyModeAndCount,
   #[if_flag($format_flags, EntryFormatFlags::COPY_INDICES)]
-  #[count($copy_count)]
+  #[count(custom($copy_mode_and_count))]
   copy_indices: [Uint24],
 
   // ENTRY_ID_DELTA

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -1,6 +1,6 @@
 #![parse_module(read_fonts::tables::ift)]
 
-extern scalar CopyModeAndCount;
+extern scalar MatchModeAndCount;
 extern record U8Or16;
 extern record U16Or24;
 extern record IdDeltaOrLength;
@@ -161,14 +161,14 @@ table EntryData {
   #[count($design_space_count)]
   design_space_segments: [DesignSpaceSegment],
 
-  // COPY_INDICES
-  #[if_flag($format_flags, EntryFormatFlags::COPY_INDICES)]
+  // CHILD_INDICES
+  #[if_flag($format_flags, EntryFormatFlags::CHILD_INDICES)]
   #[traverse_with(skip)]
   #[compile(skip)] // TODO remove this once write fonts side is implemented.]
-  copy_mode_and_count: CopyModeAndCount,
-  #[if_flag($format_flags, EntryFormatFlags::COPY_INDICES)]
-  #[count(custom($copy_mode_and_count))]
-  copy_indices: [Uint24],
+  match_mode_and_count: MatchModeAndCount,
+  #[if_flag($format_flags, EntryFormatFlags::CHILD_INDICES)]
+  #[count(custom($match_mode_and_count))]
+  child_indices: [Uint24],
 
   // ENTRY_ID_DELTA
   #[read_with($entry_id_string_data_offset)]
@@ -193,7 +193,7 @@ flags u8 EntryFormatFlags {
   FEATURES_AND_DESIGN_SPACE = 0b00000001,
 
   // Fields specifying copy indices are present.
-  COPY_INDICES = 0b00000010,
+  CHILD_INDICES = 0b00000010,
 
   // Fields specifying the entry ID delta are present.
   ENTRY_ID_DELTA = 0b00000100,

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -167,7 +167,7 @@ table EntryData {
   #[compile(skip)] // TODO remove this once write fonts side is implemented.]
   match_mode_and_count: MatchModeAndCount,
   #[if_flag($format_flags, EntryFormatFlags::CHILD_INDICES)]
-  #[count(custom($match_mode_and_count))]
+  #[count(try_into($match_mode_and_count))]
   child_indices: [Uint24],
 
   // ENTRY_ID_DELTA

--- a/write-fonts/generated/generated_ift.rs
+++ b/write-fonts/generated/generated_ift.rs
@@ -546,7 +546,7 @@ pub struct EntryData {
     pub feature_tags: Option<Vec<Tag>>,
     pub design_space_count: Option<u16>,
     pub design_space_segments: Option<Vec<DesignSpaceSegment>>,
-    pub copy_indices: Option<Vec<Uint24>>,
+    pub child_indices: Option<Vec<Uint24>>,
     pub patch_format: Option<u8>,
     pub codepoint_data: Vec<u8>,
 }
@@ -599,9 +599,9 @@ impl FontWrite for EntryData {
                     .write_into(writer)
             });
         self.format_flags
-            .contains(EntryFormatFlags::COPY_INDICES)
+            .contains(EntryFormatFlags::CHILD_INDICES)
             .then(|| {
-                self.copy_indices
+                self.child_indices
                     .as_ref()
                     .expect("missing conditional field should have failed validation")
                     .write_into(writer)
@@ -690,16 +690,16 @@ impl Validate for EntryData {
                 }
                 self.design_space_segments.validate_impl(ctx);
             });
-            ctx.in_field("copy_indices", |ctx| {
-                if !(format_flags.contains(EntryFormatFlags::COPY_INDICES))
-                    && self.copy_indices.is_some()
+            ctx.in_field("child_indices", |ctx| {
+                if !(format_flags.contains(EntryFormatFlags::CHILD_INDICES))
+                    && self.child_indices.is_some()
                 {
-                    ctx.report("'copy_indices' is present but COPY_INDICES not set")
+                    ctx.report("'child_indices' is present but CHILD_INDICES not set")
                 }
-                if (format_flags.contains(EntryFormatFlags::COPY_INDICES))
-                    && self.copy_indices.is_none()
+                if (format_flags.contains(EntryFormatFlags::CHILD_INDICES))
+                    && self.child_indices.is_none()
                 {
-                    ctx.report("COPY_INDICES is set but 'copy_indices' is None")
+                    ctx.report("CHILD_INDICES is set but 'child_indices' is None")
                 }
             });
             ctx.in_field("patch_format", |ctx| {
@@ -727,7 +727,7 @@ impl<'a> FromObjRef<read_fonts::tables::ift::EntryData<'a>> for EntryData {
             feature_tags: obj.feature_tags().to_owned_obj(offset_data),
             design_space_count: obj.design_space_count(),
             design_space_segments: obj.design_space_segments().to_owned_obj(offset_data),
-            copy_indices: obj.copy_indices().to_owned_obj(offset_data),
+            child_indices: obj.child_indices().to_owned_obj(offset_data),
             patch_format: obj.patch_format(),
             codepoint_data: obj.codepoint_data().to_owned_obj(offset_data),
         }


### PR DESCRIPTION
Copy indices becomes child indices. Intersection is now based on the intersection of the child entries instead of forming a union of the child entry subset definitions.