### PR TITLE
Only write explicit tuple min/maxes if there is an intermediate tent

### DIFF
--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -358,7 +358,7 @@ impl Intermediate {
     }
 
     /// Derive intermediate coordinates from a peak position as OpenType would
-    /// do. For non-zero peak positions, this is equivalent to definining a
+    /// do. For non-zero peak positions, this is equivalent to defining a
     /// non-intermediate region. For zero peak positions, this is equivalent to
     /// specifying that the axis does not contribute.
     /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuple-variation-store-header>

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -704,7 +704,7 @@ mod tests {
             .into_iter()
             .map(|peak| AxisCoordinates {
                 peak,
-                intermediates: None,
+                intermediate: None,
             })
             .collect()
     }

--- a/write-fonts/src/tables/gvar.rs
+++ b/write-fonts/src/tables/gvar.rs
@@ -326,28 +326,43 @@ impl GlyphDelta {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Normalized coordinates representing the influence of a single axis on a
+/// region. This is an unzipped representation of the Tuples that will be
+/// serialised in a TupleVariationHeader.
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuple-variation-store-header>
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#variation-data>
 pub struct AxisCoordinates {
     peak: F2Dot14,
     intermediate: Option<Intermediate>,
 }
 
 impl AxisCoordinates {
+    /// Create coordinates from a peak position, and optionally an intermediate
+    /// value for when it cannot be implied from it.
     pub fn new(peak: F2Dot14, intermediate: Option<Intermediate>) -> Self {
         Self { peak, intermediate }
     }
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
+/// Intermediate normalized coordinates for a corresponding peak.
 pub struct Intermediate {
     minimum: F2Dot14,
     maximum: F2Dot14,
 }
 
 impl Intermediate {
+    /// Create intermediate coordinates based on explicitly known values.
     pub fn explicit(minimum: F2Dot14, maximum: F2Dot14) -> Self {
         Self { minimum, maximum }
     }
 
+    /// Derive intermediate coordinates from a peak position as OpenType would
+    /// do. For non-zero peak positions, this is equivalent to definining a
+    /// non-intermediate region. For zero peak positions, this is equivalent to
+    /// specifying that the axis does not contribute.
+    /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuple-variation-store-header>
+    /// <https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#variation-data>
     pub fn implied_by_peak(peak: F2Dot14) -> Self {
         Self {
             minimum: peak.min(F2Dot14::ZERO),


### PR DESCRIPTION
Moved from original implementation in googlefonts/fontc#1225.

Motivation for moving:

> I've hit a road block adding tests: fontations' `GlyphDeltas` is public but its fields are not, and so `intermediate_region` cannot be inspected after construction.
> 
> We could make this field public, but I am tempted to argue that we make the wider change of moving the abstraction boundary lower into fontations, and treat this as serialisation logic.
> 
> e.g. give `GlyphDeltas` a `Vec<(F2Dot14, F2Dot14, F2Dot14)>` (or custom struct equivalent) and determine whether explicit intermediate coordinates are needed to be written at serialisation time.
> 
> I think this optimisation is higher-level than delta set optimisation but lower-level than IUP optimisation -- it is lossless, ttx does not expose it, and there has never been motivation to toggle it -- and so it may be more ergonomic there. We could avoid unzipping until serialisation time, ditch the assert that the tuple lengths are the same, and gain a bit more immutability for example.

---

This PR roughly sketches how the optimisation could look in a new home here instead. In general I think it has reduced the complexity of the code in the original PR, at the cost of some additional `Vec`s that could be targeted later if we end up in the hot path, and some boilerplate when we already know we do not have intermediate regions in the test cases.

If we are happy with this direction then we can polish the types and tidy the PR, and I will look to furnish it with unit tests too.