### PR TITLE
[ivs_builder] match fonttools VarStore optimizer's stable ordering

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -38,6 +38,7 @@ read-fonts = { workspace = true, features = [
 ] }
 rstest = "0.18.0"
 bincode = "1.0"
+rand = "0.8.5"
 
 pretty_assertions.workspace = true
 env_logger.workspace = true

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -1521,8 +1521,8 @@ mod tests {
 
         let var_data = var_data_array.get(0).unwrap().unwrap();
         assert_eq!(var_data.region_indexes(), &[0, 1]);
-        assert_eq!(var_data.item_count(), 8); // not 7!
-        // [0, -1] should be in here
+        // count must be 8, not 7, because [0, -1] should be in here
+        assert_eq!(var_data.item_count(), 8);
         assert_eq!(var_data.delta_set(0).collect::<Vec<_>>(), vec![0, -1]);
         assert_eq!(var_data.delta_set(1).collect::<Vec<_>>(), vec![1, 2]);
         assert_eq!(var_data.delta_set(2).collect::<Vec<_>>(), vec![3, 4]);

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -1463,4 +1463,77 @@ mod tests {
         assert_eq!(var_data.region_indexes, vec![0, 1]); // not 1, 3
         assert_eq!(var_data.delta_sets, vec![50, 100]);
     }
+
+    #[test]
+    fn we_match_fonttools_stable_order() {
+        use rand::seq::SliceRandom;
+        use rand::thread_rng;
+
+        let mut builder = VariationStoreBuilder::new(1);
+        let r1 = VariationRegion::new(vec![reg_coords(-1.0, -1.0, 0.0)]);
+        let r2 = VariationRegion::new(vec![reg_coords(0.0, 1.0, 1.0)]);
+
+        let mut delta_sets = vec![
+            // 7 delta sets with row shape "BB"
+            vec![(r1.clone(), 1), (r2.clone(), 2)],
+            vec![(r1.clone(), 3), (r2.clone(), 4)],
+            vec![(r1.clone(), 5), (r2.clone(), 6)],
+            vec![(r1.clone(), 7), (r2.clone(), 8)],
+            vec![(r1.clone(), 9), (r2.clone(), 10)],
+            vec![(r1.clone(), 11), (r2.clone(), 12)],
+            vec![(r1.clone(), 13), (r2.clone(), 14)],
+            // 4 delta sets with row shape "-S"
+            vec![(r1.clone(), 0), (r2.clone(), -130)],
+            vec![(r1.clone(), 0), (r2.clone(), -129)],
+            vec![(r1.clone(), 0), (r2.clone(), 128)],
+            vec![(r1.clone(), 0), (r2.clone(), 129)],
+            // 1 delta set with row shape "-B".
+            // The gain from merging the following into either one of the previous
+            // encodings happens to be the same so the order in which the winning pair
+            // gets popped from the heap (sorted by relative gain) depends on the order
+            // in which the delta sets were pushed; the sort key that fonttools uses to
+            // sort the inputs (for stability) is such that the encoding with row shape
+            // "-B" will be merged with the first encoding with row shape "BB" and not
+            // with the second one with row shape "-S".
+            vec![(r1.clone(), 0), (r2.clone(), -1)],
+        ];
+
+        // Add delta sets in random order and test that the algorithm is stable
+        let mut rng = thread_rng();
+        delta_sets.shuffle(&mut rng);
+        for deltas in delta_sets {
+            builder.add_deltas(deltas);
+        }
+
+        let (store, _) = builder.build();
+
+        let bytes = crate::dump_table(&store).unwrap();
+        let data = FontData::new(&bytes);
+        let reloaded = read_fonts::tables::variations::ItemVariationStore::read(data).unwrap();
+
+        assert_eq!(reloaded.item_variation_data_count(), 2);
+        let var_data_array = reloaded.item_variation_data();
+
+        let var_data = var_data_array.get(0).unwrap().unwrap();
+        assert_eq!(var_data.region_indexes(), &[0, 1]);
+        assert_eq!(var_data.item_count(), 8); // not 7!
+        // [0, -1] should be in here
+        assert_eq!(var_data.delta_set(0).collect::<Vec<_>>(), vec![0, -1]);
+        assert_eq!(var_data.delta_set(1).collect::<Vec<_>>(), vec![1, 2]);
+        assert_eq!(var_data.delta_set(2).collect::<Vec<_>>(), vec![3, 4]);
+        assert_eq!(var_data.delta_set(3).collect::<Vec<_>>(), vec![5, 6]);
+        assert_eq!(var_data.delta_set(4).collect::<Vec<_>>(), vec![7, 8]);
+        assert_eq!(var_data.delta_set(5).collect::<Vec<_>>(), vec![9, 10]);
+        assert_eq!(var_data.delta_set(6).collect::<Vec<_>>(), vec![11, 12]);
+        assert_eq!(var_data.delta_set(7).collect::<Vec<_>>(), vec![13, 14]);
+
+        let var_data = var_data_array.get(1).unwrap().unwrap();
+        assert_eq!(var_data.region_indexes(), &[1]);
+        assert_eq!(var_data.item_count(), 4);
+        // ... and not in here
+        assert_eq!(var_data.delta_set(0).collect::<Vec<_>>(), vec![-130]);
+        assert_eq!(var_data.delta_set(1).collect::<Vec<_>>(), vec![-129]);
+        assert_eq!(var_data.delta_set(2).collect::<Vec<_>>(), vec![128]);
+        assert_eq!(var_data.delta_set(3).collect::<Vec<_>>(), vec![129]);
+    }
 }


### PR DESCRIPTION
the fonttools VarStore.optimize() algorithm performs a sorting step on the input encodings (i.e. groups of delta sets characterized by the same row shape) to be processed before the heap-based priority queue is populated. This is to make sure the optimizer's output is stable no matter the order in which delta sets are processed.
Our Rust port currently does not perform any such sorting on the inputs; these get stored in an IndexMap and thus their order is not random, but depends on the order in which delta sets are added to the builder (usually e.g. for HVAR this means the glyph order); we only sort the output matching fonttools sort key.

But since this is a greedy algorithm the order in which things are processed matters. 
Moreover, while the priority queue is sorted by decreasing gain in both implementations, there are situations when multiple pairs of encodings have the same gain, thus the order in which they were originally pushed onto the heap determines the order in which they get popped.

There is also an additional difference, if you like this is an implementation detail. Python heapq module used by fonttools is a "min heap" (where the smallest item gets popped first) whereas Rust's BinaryHeap is a "max heap". In fonttools the encoding pairs are pushed with a negative gain, but positive i and j indexes, i.e. `heappush(heap, (-gain, i, j))`, so items are correctly sorted by decreasing gain like in our Rust's max heap; but in case of identical gains, items with smaller indexes are popped first from python's min heap, while the opposite happens in rust's max heap.

So the lack of sorting of the inputs on the Rust end, and the different heap implementations, contribute to produce slightly different ItemVariationData subtables. Even though the difference in size of the VarStores compiled by fontc vs fontmake is negligible (in the order of bytes, mere luck), we can hold the temptation to normalize this away, as we can easily match fonttools here - and we should.

I'll first push a failing test case, then I will follow with the actual fix.

@cmyr run the crater locally and said that with this patch, we gain +20 identical fonts, including Google Sans Flex.


