### PR TITLE
[ift] Put ift-related code behind a feature

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,8 +17,8 @@ release = false
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 font-types = { workspace = true }
-read-fonts = { workspace = true, default-features = true }
-write-fonts = { workspace = true, default-features = true }
+read-fonts = { workspace = true, default-features = true, features = ["ift"] }
+write-fonts = { workspace = true, default-features = true, features = ["ift"] }
 skrifa = { workspace = true }
 incremental-font-transfer = { workspace = true }
 

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -19,8 +19,8 @@ default = ["read-fonts/std"]
 cli = ["clap", "regex"]
 
 [dependencies]
-read-fonts = { workspace = true }
-write-fonts = { workspace = true }
+read-fonts = { workspace = true, features = ["ift"] }
+write-fonts = { workspace = true, features = ["ift"] }
 font-types = { workspace = true }
 skrifa = { workspace = true }
 klippa = { workspace = true }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -18,6 +18,9 @@ features = ["libm", "serde", "std"]
 std = ["font-types/std"]
 codegen_test = []
 scaler_test = []
+# experimental support for incremental font transfer (https://www.w3.org/TR/IFT/)
+# code behind this feature does not honor semver and may break at any time.
+ift = []
 # this feature is not stable, but provides untyped traversal of font tables.
 # we do not consider this feature public API for the purposes of semver.
 experimental_traverse = ["std"]

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -144,6 +144,7 @@ pub(crate) mod codegen_prelude {
             (count.try_into().unwrap_or_default() + 7) / 8
         }
 
+        #[cfg(feature = "ift")]
         pub fn max_value_bitmap_len<T: TryInto<usize>>(count: T) -> usize {
             let count: usize = count.try_into().unwrap_or_default() + 1usize;
             (count + 7) / 8
@@ -160,6 +161,7 @@ pub(crate) mod codegen_prelude {
                 .saturating_mul(c.try_into().unwrap_or_default())
         }
 
+        #[cfg(feature = "ift")]
         pub fn multiply_add<T: TryInto<usize>, U: TryInto<usize>, V: TryInto<usize>>(
             a: T,
             b: U,

--- a/read-fonts/src/table_provider.rs
+++ b/read-fonts/src/table_provider.rs
@@ -210,11 +210,13 @@ pub trait TableProvider<'a> {
         self.expect_table()
     }
 
+    #[cfg(feature = "ift")]
     fn ift(&self) -> Result<tables::ift::Ift<'a>, ReadError> {
         self.expect_data_for_tag(tables::ift::IFT_TAG)
             .and_then(FontRead::read)
     }
 
+    #[cfg(feature = "ift")]
     fn iftx(&self) -> Result<tables::ift::Ift<'a>, ReadError> {
         self.expect_data_for_tag(tables::ift::IFTX_TAG)
             .and_then(FontRead::read)

--- a/read-fonts/src/tables.rs
+++ b/read-fonts/src/tables.rs
@@ -28,7 +28,6 @@ pub mod head;
 pub mod hhea;
 pub mod hmtx;
 pub mod hvar;
-pub mod ift;
 pub mod layout;
 pub mod loca;
 pub mod ltag;
@@ -48,6 +47,9 @@ pub mod vhea;
 pub mod vmtx;
 pub mod vorg;
 pub mod vvar;
+
+#[cfg(feature = "ift")]
+pub mod ift;
 
 /// Computes the table checksum for the given data.
 ///

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 read = []
 dot2 = ["dep:dot2"]
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
+ift = ["read-fonts/ift"]
 
 [dependencies]
 font-types = { workspace = true }

--- a/write-fonts/src/tables.rs
+++ b/write-fonts/src/tables.rs
@@ -17,7 +17,6 @@ pub mod head;
 pub mod hhea;
 pub mod hmtx;
 pub mod hvar;
-pub mod ift;
 pub mod layout;
 pub mod loca;
 pub mod maxp;
@@ -31,6 +30,9 @@ pub mod stat;
 pub mod variations;
 pub mod vhea;
 pub mod vmtx;
+
+#[cfg(feature = "ift")]
+pub mod ift;
 
 // ensure that all of our types implement the serde traits
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This ensures that changes in ift don't need to be breaking changes in read-fonts.