### PR TITLE
[read-fonts] CFF charsets

### DIFF
--- a/read-fonts/src/tables/postscript.rs
+++ b/read-fonts/src/tables/postscript.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 
 mod blend;
+mod charset;
 mod fd_select;
 mod index;
 mod stack;
@@ -14,6 +15,7 @@ pub mod dict;
 include!("../../generated/generated_postscript.rs");
 
 pub use blend::BlendState;
+pub use charset::{Charset, CharsetIter};
 pub use index::Index;
 pub use stack::{Number, Stack};
 pub use string::{Latin1String, StringId, STANDARD_STRINGS};

--- a/read-fonts/src/tables/postscript/charset.rs
+++ b/read-fonts/src/tables/postscript/charset.rs
@@ -318,7 +318,7 @@ mod tests {
     use font_test_data::bebuffer::BeBuffer;
 
     #[test]
-    fn iso_abode_charset() {
+    fn iso_adobe_charset() {
         // Offset of 0 signifies the ISOAdobe charset
         let charset_offset = 0;
         let num_glyphs = 64;

--- a/read-fonts/src/tables/postscript/charset.rs
+++ b/read-fonts/src/tables/postscript/charset.rs
@@ -1,0 +1,463 @@
+//! CFF charset support.
+
+use super::{
+    CharsetFormat0, CharsetFormat1, CharsetFormat2, CharsetRange1, CharsetRange2, CustomCharset,
+    FontData, FontRead, GlyphId, ReadError, StringId,
+};
+
+/// Character set for mapping from glyph to string identifiers.
+///
+/// See <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=21>
+#[derive(Clone)]
+pub struct Charset<'a> {
+    kind: CharsetKind<'a>,
+    num_glyphs: u32,
+}
+
+impl<'a> Charset<'a> {
+    pub fn new(
+        cff_data: FontData<'a>,
+        charset_offset: usize,
+        num_glyphs: u32,
+    ) -> Result<Self, ReadError> {
+        let kind = match charset_offset {
+            0 => CharsetKind::IsoAdobe,
+            1 => CharsetKind::Expert,
+            2 => CharsetKind::ExpertSubset,
+            _ => {
+                let data = cff_data
+                    .split_off(charset_offset)
+                    .ok_or(ReadError::OutOfBounds)?;
+                CharsetKind::Custom(CustomCharset::read(data)?)
+            }
+        };
+        Ok(Self { kind, num_glyphs })
+    }
+
+    pub fn kind(&self) -> &CharsetKind<'a> {
+        &self.kind
+    }
+
+    pub fn num_glyphs(&self) -> u32 {
+        self.num_glyphs
+    }
+
+    /// Returns the string identifier for the given glyph identifier.
+    pub fn string_id(&self, glyph_id: GlyphId) -> Result<StringId, ReadError> {
+        let gid = glyph_id.to_u32();
+        if gid >= self.num_glyphs {
+            return Err(ReadError::OutOfBounds);
+        }
+        match &self.kind {
+            CharsetKind::IsoAdobe => {
+                // The ISOAdobe charset is an identity mapping of gid->sid up
+                // to 228 entries
+                // <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=45>
+                if gid <= 228 {
+                    Ok(StringId::new(gid as u16))
+                } else {
+                    Err(ReadError::OutOfBounds)
+                }
+            }
+            CharsetKind::Expert => EXPERT_CHARSET
+                .get(gid as usize)
+                .copied()
+                .ok_or(ReadError::OutOfBounds)
+                .map(StringId::new),
+            CharsetKind::ExpertSubset => EXPERT_SUBSET_CHARSET
+                .get(gid as usize)
+                .copied()
+                .ok_or(ReadError::OutOfBounds)
+                .map(StringId::new),
+            CharsetKind::Custom(custom) => match custom {
+                CustomCharset::Format0(fmt) => fmt.string_id(glyph_id),
+                CustomCharset::Format1(fmt) => fmt.string_id(glyph_id),
+                CustomCharset::Format2(fmt) => fmt.string_id(glyph_id),
+            },
+        }
+    }
+
+    /// Returns an iterator over all of the glyph and string identifier
+    /// mappings.
+    pub fn iter(&self) -> CharsetIter<'a> {
+        match &self.kind {
+            CharsetKind::IsoAdobe
+            | CharsetKind::Expert
+            | CharsetKind::ExpertSubset
+            | CharsetKind::Custom(CustomCharset::Format0(_)) => {
+                CharsetIter(Iter::Simple(self.clone(), 0))
+            }
+            CharsetKind::Custom(CustomCharset::Format1(custom)) => CharsetIter(Iter::Custom1(
+                RangeIter::new(custom.ranges(), self.num_glyphs),
+            )),
+            CharsetKind::Custom(CustomCharset::Format2(custom)) => CharsetIter(Iter::Custom2(
+                RangeIter::new(custom.ranges(), self.num_glyphs),
+            )),
+        }
+    }
+}
+
+/// Predefined and custom character sets.
+#[derive(Clone)]
+pub enum CharsetKind<'a> {
+    IsoAdobe,
+    Expert,
+    ExpertSubset,
+    Custom(CustomCharset<'a>),
+}
+
+impl CharsetFormat0<'_> {
+    fn string_id(&self, glyph_id: GlyphId) -> Result<StringId, ReadError> {
+        let gid = glyph_id.to_u32() as usize;
+        if gid == 0 {
+            Ok(StringId::new(0))
+        } else {
+            self.glyph()
+                .get(gid - 1)
+                .map(|id| StringId::new(id.get()))
+                .ok_or(ReadError::OutOfBounds)
+        }
+    }
+}
+
+impl CharsetFormat1<'_> {
+    fn string_id(&self, glyph_id: GlyphId) -> Result<StringId, ReadError> {
+        string_id_from_ranges(self.ranges(), glyph_id)
+    }
+}
+
+impl CharsetFormat2<'_> {
+    fn string_id(&self, glyph_id: GlyphId) -> Result<StringId, ReadError> {
+        string_id_from_ranges(self.ranges(), glyph_id)
+    }
+}
+
+fn string_id_from_ranges<T: CharsetRange>(
+    ranges: &[T],
+    glyph_id: GlyphId,
+) -> Result<StringId, ReadError> {
+    let mut gid = glyph_id.to_u32();
+    // The notdef glyph isn't explicitly mapped so we need to special case
+    // it and add -1 and +1 at a few places when processing ranges
+    if gid == 0 {
+        return Ok(StringId::new(0));
+    }
+    gid -= 1;
+    let mut end = 0u32;
+    // Each range provides the string ids for `n_left + 1` glyphs with
+    // the sequence of string ids starting at `first`. Since the counts
+    // are cumulative, we must scan them all in order until we find
+    // the range that contains our requested glyph.
+    for range in ranges {
+        let next_end = end
+            .checked_add(range.n_left() + 1)
+            .ok_or(ReadError::OutOfBounds)?;
+        if gid < next_end {
+            return (gid - end)
+                .checked_add(range.first())
+                .and_then(|sid| sid.try_into().ok())
+                .ok_or(ReadError::OutOfBounds)
+                .map(StringId::new);
+        }
+        end = next_end;
+    }
+    Err(ReadError::OutOfBounds)
+}
+
+/// Trait that unifies ranges for formats 1 and 2 so that we can implement
+/// the tricky search logic once.
+trait CharsetRange {
+    fn first(&self) -> u32;
+    fn n_left(&self) -> u32;
+}
+
+impl CharsetRange for CharsetRange1 {
+    fn first(&self) -> u32 {
+        self.first.get() as u32
+    }
+
+    fn n_left(&self) -> u32 {
+        self.n_left as u32
+    }
+}
+
+impl CharsetRange for CharsetRange2 {
+    fn first(&self) -> u32 {
+        self.first.get() as u32
+    }
+
+    fn n_left(&self) -> u32 {
+        self.n_left.get() as u32
+    }
+}
+
+/// Iterator over the glyph and string identifier mappings in a character set.
+#[derive(Clone)]
+pub struct CharsetIter<'a>(Iter<'a>);
+
+impl Iterator for CharsetIter<'_> {
+    type Item = (GlyphId, StringId);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.0 {
+            Iter::Simple(charset, cur) => {
+                let gid = GlyphId::new(*cur);
+                let sid = charset.string_id(gid).ok()?;
+                *cur = cur.checked_add(1)?;
+                Some((gid, sid))
+            }
+            Iter::Custom1(custom) => custom.next(),
+            Iter::Custom2(custom) => custom.next(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum Iter<'a> {
+    /// Predefined sets and custom format 0 are just array lookups so we use
+    /// the builtin mapping function.
+    Simple(Charset<'a>, u32),
+    Custom1(RangeIter<'a, CharsetRange1>),
+    Custom2(RangeIter<'a, CharsetRange2>),
+}
+
+/// Custom iterator for range based formats.
+///
+/// Each individual lookup requires a linear scan through the ranges so this
+/// provides a more efficient code path for iteration.
+#[derive(Clone)]
+struct RangeIter<'a, T> {
+    ranges: std::slice::Iter<'a, T>,
+    num_glyphs: u32,
+    gid: u32,
+    first: u32,
+    end: u32,
+    prev_end: u32,
+}
+
+impl<'a, T> RangeIter<'a, T>
+where
+    T: CharsetRange,
+{
+    fn new(ranges: &'a [T], num_glyphs: u32) -> Self {
+        let mut ranges = ranges.iter();
+        let (first, end) = next_range(&mut ranges).unwrap_or_default();
+        Self {
+            ranges,
+            num_glyphs,
+            gid: 0,
+            first,
+            end,
+            prev_end: 0,
+        }
+    }
+
+    fn next(&mut self) -> Option<(GlyphId, StringId)> {
+        if self.gid >= self.num_glyphs {
+            return None;
+        }
+        // The notdef glyph isn't explicitly mapped so we need to special case
+        // it and add -1 and +1 at a few places when processing ranges
+        if self.gid == 0 {
+            self.gid += 1;
+            return Some((GlyphId::new(0), StringId::new(0)));
+        }
+        let gid = self.gid - 1;
+        self.gid = self.gid.checked_add(1)?;
+        while gid >= self.end {
+            let (first, end) = next_range(&mut self.ranges)?;
+            self.prev_end = self.end;
+            self.first = first;
+            self.end = self.prev_end.checked_add(end)?;
+        }
+        let sid = self
+            .first
+            .checked_add(gid.checked_sub(self.prev_end)?)?
+            .try_into()
+            .ok()?;
+        Some((GlyphId::new(gid + 1), StringId::new(sid)))
+    }
+}
+
+fn next_range<T: CharsetRange>(ranges: &mut std::slice::Iter<T>) -> Option<(u32, u32)> {
+    ranges
+        .next()
+        .map(|range| (range.first(), range.n_left() + 1))
+}
+
+/// See "Expert" charset at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=47>
+#[rustfmt::skip]
+const EXPERT_CHARSET: &[u16] = &[
+      0,    1,  229,  230,  231,  232,  233,  234,  235,  236,  237,  238,   13,   14,   15,   99,
+    239,  240,  241,  242,  243,  244,  245,  246,  247,  248,   27,   28,  249,  250,  251,  252,
+    253,  254,  255,  256,  257,  258,  259,  260,  261,  262,  263,  264,  265,  266,  109,  110,
+    267,  268,  269,  270,  271,  272,  273,  274,  275,  276,  277,  278,  279,  280,  281,  282,
+    283,  284,  285,  286,  287,  288,  289,  290,  291,  292,  293,  294,  295,  296,  297,  298,
+    299,  300,  301,  302,  303,  304,  305,  306,  307,  308,  309,  310,  311,  312,  313,  314,
+    315,  316,  317,  318,  158,  155,  163,  319,  320,  321,  322,  323,  324,  325,  326,  150,
+    164,  169,  327,  328,  329,  330,  331,  332,  333,  334,  335,  336,  337,  338,  339,  340,
+    341,  342,  343,  344,  345,  346,  347,  348,  349,  350,  351,  352,  353,  354,  355,  356,
+    357,  358,  359,  360,  361,  362,  363,  364,  365,  366,  367,  368,  369,  370,  371,  372,
+    373,  374,  375,  376,  377,  378,
+];
+
+/// See "Expert Subset" charset at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=49>
+#[rustfmt::skip]
+const EXPERT_SUBSET_CHARSET: &[u16] = &[
+      0,    1,  231,  232,  235,  236,  237,  238,   13,   14,   15,   99,  239,  240,  241,  242,
+    243,  244,  245,  246,  247,  248,   27,   28,  249,  250,  251,  253,  254,  255,  256,  257,
+    258,  259,  260,  261,  262,  263,  264,  265,  266,  109,  110,  267,  268,  269,  270,  272,
+    300,  301,  302,  305,  314,  315,  158,  155,  163,  320,  321,  322,  323,  324,  325,  326,
+    150,  164,  169,  327,  328,  329,  330,  331,  332,  333,  334,  335,  336,  337,  338,  339,
+    340,  341,  342,  343,  344,  345,  346
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use font_test_data::bebuffer::BeBuffer;
+
+    #[test]
+    fn iso_abode_charset() {
+        // Offset of 0 signifies the ISOAdobe charset
+        let charset_offset = 0;
+        let num_glyphs = 64;
+        // This is an identity mapping
+        let expected = |gid: GlyphId| Some(gid.to_u32());
+        test_simple_mapping(charset_offset, num_glyphs, expected);
+    }
+
+    #[test]
+    fn expert_charset() {
+        // Offset 1 signifies the expert charset
+        let charset_offset = 1;
+        let num_glyphs = 64;
+        // This is an array based mapping
+        let expected = |gid: GlyphId| {
+            EXPERT_CHARSET
+                .get(gid.to_u32() as usize)
+                .map(|id| *id as u32)
+        };
+        test_simple_mapping(charset_offset, num_glyphs, expected);
+    }
+
+    #[test]
+    fn expert_subset_charset() {
+        // Offset 2 signifies the expert subset charset
+        let charset_offset = 2;
+        let num_glyphs = 64;
+        // This is an array based mapping
+        let expected = |gid: GlyphId| {
+            EXPERT_SUBSET_CHARSET
+                .get(gid.to_u32() as usize)
+                .map(|id| *id as u32)
+        };
+        test_simple_mapping(charset_offset, num_glyphs, expected);
+    }
+
+    // Common test setup for identity or array based charset mappings
+    fn test_simple_mapping(
+        charset_offset: usize,
+        num_glyphs: u32,
+        expected: impl Fn(GlyphId) -> Option<u32>,
+    ) {
+        let charset = Charset::new(FontData::new(&[]), charset_offset, num_glyphs).unwrap();
+        for gid in 0..num_glyphs {
+            let gid = GlyphId::new(gid);
+            assert_eq!(
+                charset.string_id(gid).unwrap().to_u16() as u32,
+                expected(gid).unwrap()
+            )
+        }
+        // Don't map glyphs beyond num_glyphs
+        for gid in num_glyphs..u16::MAX as u32 {
+            assert_eq!(charset.string_id(GlyphId::new(gid)).ok(), None);
+        }
+    }
+
+    #[test]
+    fn custom_mapping_format0() {
+        let mut buf = BeBuffer::new();
+        let num_glyphs = 6;
+        // Add some padding so we can generate an offset greater than 2
+        buf = buf.extend([0u8; 4]);
+        // format 0
+        buf = buf.push(0u8);
+        // glyph array: each sid is gid * 2
+        buf = buf.extend([2u16, 4, 6, 8, 10]);
+        let charset = Charset::new(FontData::new(buf.data()), 4, num_glyphs).unwrap();
+        // Test lookup code path
+        for gid in 0..num_glyphs {
+            assert_eq!(
+                charset.string_id(GlyphId::new(gid)).unwrap().to_u16() as u32,
+                gid * 2
+            )
+        }
+        // Test iterator code path
+        for (gid, sid) in charset.iter() {
+            assert_eq!(sid.to_u16() as u32, gid.to_u32() * 2);
+        }
+        assert_eq!(charset.iter().count() as u32, num_glyphs);
+        // Test out of bounds glyphs
+        for gid in num_glyphs..u16::MAX as u32 {
+            assert_eq!(charset.string_id(GlyphId::new(gid)).ok(), None);
+        }
+    }
+
+    #[test]
+    fn custom_mapping_format1() {
+        let mut buf = BeBuffer::new();
+        let num_glyphs = 7;
+        // Add some padding so we can generate an offset greater than 2
+        buf = buf.extend([0u8; 4]);
+        // format 1
+        buf = buf.push(1u8);
+        // Three disjoint range mappings
+        buf = buf.push(8u16).push(2u8);
+        buf = buf.push(1200u16).push(0u8);
+        buf = buf.push(20u16).push(1u8);
+        let expected_sids = [0, 8, 9, 10, 1200, 20, 21];
+        test_range_mapping(buf.data(), num_glyphs, &expected_sids);
+    }
+
+    #[test]
+    fn custom_mapping_format2() {
+        let mut buf = BeBuffer::new();
+        // Add some padding so we can generate an offset greater than 2
+        buf = buf.extend([0u8; 4]);
+        // format 2
+        buf = buf.push(2u8);
+        // Three disjoint range mappings
+        buf = buf.push(8u16).push(2u16);
+        buf = buf.push(1200u16).push(0u16);
+        buf = buf.push(20u16).push(800u16);
+        let mut expected_sids = vec![0, 8, 9, 10, 1200];
+        for i in 0..=800 {
+            expected_sids.push(i + 20);
+        }
+        let num_glyphs = expected_sids.len() as u32;
+        test_range_mapping(buf.data(), num_glyphs, &expected_sids);
+    }
+
+    // Common code for testing range based mappings
+    fn test_range_mapping(data: &[u8], num_glyphs: u32, expected_sids: &[u32]) {
+        let charset = Charset::new(FontData::new(data), 4, num_glyphs).unwrap();
+        // Test lookup code path
+        for (gid, sid) in expected_sids.iter().enumerate() {
+            assert_eq!(
+                charset.string_id(GlyphId::new(gid as _)).unwrap().to_u16() as u32,
+                *sid
+            )
+        }
+        // Test iterator code path
+        assert!(charset.iter().eq(expected_sids
+            .iter()
+            .enumerate()
+            .map(|(gid, sid)| (GlyphId::new(gid as u32), StringId::new(*sid as u16)))));
+        assert_eq!(charset.iter().count() as u32, num_glyphs);
+        // Test out of bounds glyphs
+        for gid in num_glyphs..u16::MAX as u32 {
+            assert_eq!(charset.string_id(GlyphId::new(gid)).ok(), None);
+        }
+    }
+}

--- a/read-fonts/src/tables/postscript/string.rs
+++ b/read-fonts/src/tables/postscript/string.rs
@@ -67,6 +67,11 @@ impl<'a> Latin1String<'a> {
     pub fn chars(&self) -> impl Iterator<Item = char> + Clone + 'a {
         self.chars.iter().map(|b| *b as char)
     }
+
+    /// Returns the raw bytes of the string.
+    pub fn bytes(&self) -> &'a [u8] {
+        self.chars
+    }
 }
 
 impl PartialEq<&str> for Latin1String<'_> {

--- a/resources/codegen_inputs/postscript.rs
+++ b/resources/codegen_inputs/postscript.rs
@@ -90,3 +90,56 @@ record FdSelectRange4 {
     /// FD index for all glyphs in range.
     fd: u16,
 }
+
+/// Charset with custom glyph id to string id mappings.
+format u8 CustomCharset {
+    Format0(CharsetFormat0),
+    Format1(CharsetFormat1),
+    Format2(CharsetFormat2),
+}
+
+/// Charset format 0.
+table CharsetFormat0 {
+    /// Format; =0
+    #[format = 0]
+    format: u8,
+    /// Glyph name array.
+    #[count(..)]
+    glyph: [u16],
+}
+
+/// Charset format 1.
+table CharsetFormat1 {
+    /// Format; =1
+    #[format = 1]
+    format: u8,
+    /// Range1 array.
+    #[count(..)]
+    ranges: [CharsetRange1],
+}
+
+/// Range struct for Charset format 1.
+record CharsetRange1 {
+    /// First glyph in range.
+    first: u16,
+    /// Glyphs left in range (excluding first).
+    n_left: u8,
+}
+
+/// Charset format 2.
+table CharsetFormat2 {
+    /// Format; =2
+    #[format = 2]
+    format: u8,
+    /// Range2 array.
+    #[count(..)]
+    ranges: [CharsetRange2],
+}
+
+/// Range struct for Charset format 2.
+record CharsetRange2 {
+    /// First glyph in range.
+    first: u16,
+    /// Glyphs left in range (excluding first).
+    n_left: u16,
+}

--- a/write-fonts/generated/generated_postscript.rs
+++ b/write-fonts/generated/generated_postscript.rs
@@ -499,3 +499,345 @@ impl FromObjRef<read_fonts::tables::postscript::FdSelectRange4> for FdSelectRang
         }
     }
 }
+
+/// Charset with custom glyph id to string id mappings.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CustomCharset {
+    Format0(CharsetFormat0),
+    Format1(CharsetFormat1),
+    Format2(CharsetFormat2),
+}
+
+impl CustomCharset {
+    /// Construct a new `CharsetFormat0` subtable
+    pub fn format_0(glyph: Vec<u16>) -> Self {
+        Self::Format0(CharsetFormat0::new(glyph))
+    }
+
+    /// Construct a new `CharsetFormat1` subtable
+    pub fn format_1(ranges: Vec<CharsetRange1>) -> Self {
+        Self::Format1(CharsetFormat1::new(ranges))
+    }
+
+    /// Construct a new `CharsetFormat2` subtable
+    pub fn format_2(ranges: Vec<CharsetRange2>) -> Self {
+        Self::Format2(CharsetFormat2::new(ranges))
+    }
+}
+
+impl Default for CustomCharset {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
+}
+
+impl FontWrite for CustomCharset {
+    fn write_into(&self, writer: &mut TableWriter) {
+        match self {
+            Self::Format0(item) => item.write_into(writer),
+            Self::Format1(item) => item.write_into(writer),
+            Self::Format2(item) => item.write_into(writer),
+        }
+    }
+    fn table_type(&self) -> TableType {
+        match self {
+            Self::Format0(item) => item.table_type(),
+            Self::Format1(item) => item.table_type(),
+            Self::Format2(item) => item.table_type(),
+        }
+    }
+}
+
+impl Validate for CustomCharset {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        match self {
+            Self::Format0(item) => item.validate_impl(ctx),
+            Self::Format1(item) => item.validate_impl(ctx),
+            Self::Format2(item) => item.validate_impl(ctx),
+        }
+    }
+}
+
+impl FromObjRef<read_fonts::tables::postscript::CustomCharset<'_>> for CustomCharset {
+    fn from_obj_ref(obj: &read_fonts::tables::postscript::CustomCharset, _: FontData) -> Self {
+        use read_fonts::tables::postscript::CustomCharset as ObjRefType;
+        match obj {
+            ObjRefType::Format0(item) => CustomCharset::Format0(item.to_owned_table()),
+            ObjRefType::Format1(item) => CustomCharset::Format1(item.to_owned_table()),
+            ObjRefType::Format2(item) => CustomCharset::Format2(item.to_owned_table()),
+        }
+    }
+}
+
+impl FromTableRef<read_fonts::tables::postscript::CustomCharset<'_>> for CustomCharset {}
+
+impl<'a> FontRead<'a> for CustomCharset {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::postscript::CustomCharset as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
+impl From<CharsetFormat0> for CustomCharset {
+    fn from(src: CharsetFormat0) -> CustomCharset {
+        CustomCharset::Format0(src)
+    }
+}
+
+impl From<CharsetFormat1> for CustomCharset {
+    fn from(src: CharsetFormat1) -> CustomCharset {
+        CustomCharset::Format1(src)
+    }
+}
+
+impl From<CharsetFormat2> for CustomCharset {
+    fn from(src: CharsetFormat2) -> CustomCharset {
+        CustomCharset::Format2(src)
+    }
+}
+
+/// Charset format 0.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CharsetFormat0 {
+    /// Glyph name array.
+    pub glyph: Vec<u16>,
+}
+
+impl CharsetFormat0 {
+    /// Construct a new `CharsetFormat0`
+    pub fn new(glyph: Vec<u16>) -> Self {
+        Self {
+            glyph: glyph.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl FontWrite for CharsetFormat0 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (0 as u8).write_into(writer);
+        self.glyph.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CharsetFormat0")
+    }
+}
+
+impl Validate for CharsetFormat0 {
+    fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
+}
+
+impl<'a> FromObjRef<read_fonts::tables::postscript::CharsetFormat0<'a>> for CharsetFormat0 {
+    fn from_obj_ref(obj: &read_fonts::tables::postscript::CharsetFormat0<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        CharsetFormat0 {
+            glyph: obj.glyph().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::postscript::CharsetFormat0<'a>> for CharsetFormat0 {}
+
+impl<'a> FontRead<'a> for CharsetFormat0 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::postscript::CharsetFormat0 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
+/// Charset format 1.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CharsetFormat1 {
+    /// Range1 array.
+    pub ranges: Vec<CharsetRange1>,
+}
+
+impl CharsetFormat1 {
+    /// Construct a new `CharsetFormat1`
+    pub fn new(ranges: Vec<CharsetRange1>) -> Self {
+        Self {
+            ranges: ranges.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl FontWrite for CharsetFormat1 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (1 as u8).write_into(writer);
+        self.ranges.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CharsetFormat1")
+    }
+}
+
+impl Validate for CharsetFormat1 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("CharsetFormat1", |ctx| {
+            ctx.in_field("ranges", |ctx| {
+                self.ranges.validate_impl(ctx);
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::tables::postscript::CharsetFormat1<'a>> for CharsetFormat1 {
+    fn from_obj_ref(obj: &read_fonts::tables::postscript::CharsetFormat1<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        CharsetFormat1 {
+            ranges: obj.ranges().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::postscript::CharsetFormat1<'a>> for CharsetFormat1 {}
+
+impl<'a> FontRead<'a> for CharsetFormat1 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::postscript::CharsetFormat1 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
+/// Range struct for Charset format 1.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CharsetRange1 {
+    /// First glyph in range.
+    pub first: u16,
+    /// Glyphs left in range (excluding first).
+    pub n_left: u8,
+}
+
+impl CharsetRange1 {
+    /// Construct a new `CharsetRange1`
+    pub fn new(first: u16, n_left: u8) -> Self {
+        Self { first, n_left }
+    }
+}
+
+impl FontWrite for CharsetRange1 {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.first.write_into(writer);
+        self.n_left.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CharsetRange1")
+    }
+}
+
+impl Validate for CharsetRange1 {
+    fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
+}
+
+impl FromObjRef<read_fonts::tables::postscript::CharsetRange1> for CharsetRange1 {
+    fn from_obj_ref(obj: &read_fonts::tables::postscript::CharsetRange1, _: FontData) -> Self {
+        CharsetRange1 {
+            first: obj.first(),
+            n_left: obj.n_left(),
+        }
+    }
+}
+
+/// Charset format 2.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CharsetFormat2 {
+    /// Range2 array.
+    pub ranges: Vec<CharsetRange2>,
+}
+
+impl CharsetFormat2 {
+    /// Construct a new `CharsetFormat2`
+    pub fn new(ranges: Vec<CharsetRange2>) -> Self {
+        Self {
+            ranges: ranges.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl FontWrite for CharsetFormat2 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (2 as u8).write_into(writer);
+        self.ranges.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CharsetFormat2")
+    }
+}
+
+impl Validate for CharsetFormat2 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("CharsetFormat2", |ctx| {
+            ctx.in_field("ranges", |ctx| {
+                self.ranges.validate_impl(ctx);
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::tables::postscript::CharsetFormat2<'a>> for CharsetFormat2 {
+    fn from_obj_ref(obj: &read_fonts::tables::postscript::CharsetFormat2<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        CharsetFormat2 {
+            ranges: obj.ranges().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::postscript::CharsetFormat2<'a>> for CharsetFormat2 {}
+
+impl<'a> FontRead<'a> for CharsetFormat2 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::postscript::CharsetFormat2 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
+/// Range struct for Charset format 2.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CharsetRange2 {
+    /// First glyph in range.
+    pub first: u16,
+    /// Glyphs left in range (excluding first).
+    pub n_left: u16,
+}
+
+impl CharsetRange2 {
+    /// Construct a new `CharsetRange2`
+    pub fn new(first: u16, n_left: u16) -> Self {
+        Self { first, n_left }
+    }
+}
+
+impl FontWrite for CharsetRange2 {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.first.write_into(writer);
+        self.n_left.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CharsetRange2")
+    }
+}
+
+impl Validate for CharsetRange2 {
+    fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
+}
+
+impl FromObjRef<read_fonts::tables::postscript::CharsetRange2> for CharsetRange2 {
+    fn from_obj_ref(obj: &read_fonts::tables::postscript::CharsetRange2, _: FontData) -> Self {
+        CharsetRange2 {
+            first: obj.first(),
+            n_left: obj.n_left(),
+        }
+    }
+}


### PR DESCRIPTION
Lets us parse CFF charsets which enables support for reading glyph names from CFF fonts.

Makes some progress on #1261 and will soon be needed for harfruzz tests which depend on glyph names.