### PR TITLE
[chore] Clippy day

### DIFF
--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -291,13 +291,13 @@ pub(crate) fn generate_compile_impl(
     let constructor_field_inits = constructor_args_raw.iter().map(
         |FieldConstructorInfo {
              name,
-             is_offset,
              is_array,
+             needs_into,
              ..
          }| {
-            if *is_array {
+            if *is_array && *needs_into {
                 quote!(#name: #name.into_iter().map(Into::into).collect())
-            } else if *is_offset {
+            } else if *needs_into {
                 quote!( #name: #name.into())
             } else {
                 name.into_token_stream()

--- a/read-fonts/src/tables/aat.rs
+++ b/read-fonts/src/tables/aat.rs
@@ -30,7 +30,7 @@ impl Lookup0<'_> {
 
 /// Lookup segment for format 2.
 #[derive(Copy, Clone, bytemuck::AnyBitPattern)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct LookupSegment2<T>
 where
     T: LookupValue,
@@ -93,7 +93,7 @@ impl Lookup4<'_> {
 
 /// Lookup single record for format 6.
 #[derive(Copy, Clone, bytemuck::AnyBitPattern)]
-#[repr(packed)]
+#[repr(C, packed)]
 pub struct LookupSingle<T>
 where
     T: LookupValue,
@@ -661,7 +661,7 @@ mod tests {
     }
 
     #[derive(Copy, Clone, Debug, bytemuck::AnyBitPattern)]
-    #[repr(packed)]
+    #[repr(C, packed)]
     struct ContextualData {
         _mark_index: BigEndian<u16>,
         current_index: BigEndian<u16>,

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -105,9 +105,7 @@ pub struct SegmentMaps {
 impl SegmentMaps {
     /// Construct a new `SegmentMaps`
     pub fn new(axis_value_maps: Vec<AxisValueMap>) -> Self {
-        Self {
-            axis_value_maps: axis_value_maps.into_iter().map(Into::into).collect(),
-        }
+        Self { axis_value_maps }
     }
 }
 

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -157,9 +157,7 @@ pub struct BaseTagList {
 impl BaseTagList {
     /// Construct a new `BaseTagList`
     pub fn new(baseline_tags: Vec<Tag>) -> Self {
-        Self {
-            baseline_tags: baseline_tags.into_iter().map(Into::into).collect(),
-        }
+        Self { baseline_tags }
     }
 }
 
@@ -217,7 +215,7 @@ impl BaseScriptList {
     /// Construct a new `BaseScriptList`
     pub fn new(base_script_records: Vec<BaseScriptRecord>) -> Self {
         Self {
-            base_script_records: base_script_records.into_iter().map(Into::into).collect(),
+            base_script_records,
         }
     }
 }
@@ -340,7 +338,7 @@ impl BaseScript {
         Self {
             base_values: base_values.into(),
             default_min_max: default_min_max.into(),
-            base_lang_sys_records: base_lang_sys_records.into_iter().map(Into::into).collect(),
+            base_lang_sys_records,
         }
     }
 }
@@ -541,7 +539,7 @@ impl MinMax {
         Self {
             min_coord: min_coord.into(),
             max_coord: max_coord.into(),
-            feat_min_max_records: feat_min_max_records.into_iter().map(Into::into).collect(),
+            feat_min_max_records,
         }
     }
 }

--- a/write-fonts/generated/generated_cff.rs
+++ b/write-fonts/generated/generated_cff.rs
@@ -25,8 +25,8 @@ impl CffHeader {
         Self {
             hdr_size,
             off_size,
-            _padding: _padding.into_iter().map(Into::into).collect(),
-            trailing_data: trailing_data.into_iter().map(Into::into).collect(),
+            _padding,
+            trailing_data,
         }
     }
 }

--- a/write-fonts/generated/generated_cff2.rs
+++ b/write-fonts/generated/generated_cff2.rs
@@ -33,9 +33,9 @@ impl Cff2Header {
         Self {
             header_size,
             top_dict_length,
-            _padding: _padding.into_iter().map(Into::into).collect(),
-            top_dict_data: top_dict_data.into_iter().map(Into::into).collect(),
-            trailing_data: trailing_data.into_iter().map(Into::into).collect(),
+            _padding,
+            top_dict_data,
+            trailing_data,
         }
     }
 }

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -17,9 +17,7 @@ pub struct Cmap {
 impl Cmap {
     /// Construct a new `Cmap`
     pub fn new(encoding_records: Vec<EncodingRecord>) -> Self {
-        Self {
-            encoding_records: encoding_records.into_iter().map(Into::into).collect(),
-        }
+        Self { encoding_records }
     }
 }
 
@@ -393,7 +391,7 @@ impl Cmap0 {
     pub fn new(language: u16, glyph_id_array: Vec<u8>) -> Self {
         Self {
             language,
-            glyph_id_array: glyph_id_array.into_iter().map(Into::into).collect(),
+            glyph_id_array,
         }
     }
 }
@@ -454,7 +452,7 @@ impl Cmap2 {
         Self {
             length,
             language,
-            sub_header_keys: sub_header_keys.into_iter().map(Into::into).collect(),
+            sub_header_keys,
         }
     }
 }
@@ -580,11 +578,11 @@ impl Cmap4 {
     ) -> Self {
         Self {
             language,
-            end_code: end_code.into_iter().map(Into::into).collect(),
-            start_code: start_code.into_iter().map(Into::into).collect(),
-            id_delta: id_delta.into_iter().map(Into::into).collect(),
-            id_range_offsets: id_range_offsets.into_iter().map(Into::into).collect(),
-            glyph_id_array: glyph_id_array.into_iter().map(Into::into).collect(),
+            end_code,
+            start_code,
+            id_delta,
+            id_range_offsets,
+            glyph_id_array,
         }
     }
 }
@@ -669,7 +667,7 @@ impl Cmap6 {
             language,
             first_code,
             entry_count,
-            glyph_id_array: glyph_id_array.into_iter().map(Into::into).collect(),
+            glyph_id_array,
         }
     }
 }
@@ -754,9 +752,9 @@ impl Cmap8 {
         Self {
             length,
             language,
-            is32: is32.into_iter().map(Into::into).collect(),
+            is32,
             num_groups,
-            groups: groups.into_iter().map(Into::into).collect(),
+            groups,
         }
     }
 }
@@ -895,7 +893,7 @@ impl Cmap10 {
             language,
             start_char_code,
             num_chars,
-            glyph_id_array: glyph_id_array.into_iter().map(Into::into).collect(),
+            glyph_id_array,
         }
     }
 }
@@ -956,10 +954,7 @@ pub struct Cmap12 {
 impl Cmap12 {
     /// Construct a new `Cmap12`
     pub fn new(language: u32, groups: Vec<SequentialMapGroup>) -> Self {
-        Self {
-            language,
-            groups: groups.into_iter().map(Into::into).collect(),
-        }
+        Self { language, groups }
     }
 }
 
@@ -1032,7 +1027,7 @@ impl Cmap13 {
             length,
             language,
             num_groups,
-            groups: groups.into_iter().map(Into::into).collect(),
+            groups,
         }
     }
 }
@@ -1157,7 +1152,7 @@ impl Cmap14 {
         Self {
             length,
             num_var_selector_records,
-            var_selector: var_selector.into_iter().map(Into::into).collect(),
+            var_selector,
         }
     }
 }
@@ -1289,7 +1284,7 @@ impl DefaultUvs {
     pub fn new(num_unicode_value_ranges: u32, ranges: Vec<UnicodeRange>) -> Self {
         Self {
             num_unicode_value_ranges,
-            ranges: ranges.into_iter().map(Into::into).collect(),
+            ranges,
         }
     }
 }
@@ -1349,7 +1344,7 @@ impl NonDefaultUvs {
     pub fn new(num_uvs_mappings: u32, uvs_mapping: Vec<UvsMapping>) -> Self {
         Self {
             num_uvs_mappings,
-            uvs_mapping: uvs_mapping.into_iter().map(Into::into).collect(),
+            uvs_mapping,
         }
     }
 }

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -63,7 +63,7 @@ impl Cpal {
             num_palettes,
             num_color_records,
             color_records_array: color_records_array.into(),
-            color_record_indices: color_record_indices.into_iter().map(Into::into).collect(),
+            color_record_indices,
             ..Default::default()
         }
     }

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -32,7 +32,7 @@ impl TableDirectory {
             search_range,
             entry_selector,
             range_shift,
-            table_records: table_records.into_iter().map(Into::into).collect(),
+            table_records,
         }
     }
 }

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -84,10 +84,7 @@ pub struct AxisInstanceArrays {
 impl AxisInstanceArrays {
     /// Construct a new `AxisInstanceArrays`
     pub fn new(axes: Vec<VariationAxisRecord>, instances: Vec<InstanceRecord>) -> Self {
-        Self {
-            axes: axes.into_iter().map(Into::into).collect(),
-            instances,
-        }
+        Self { axes, instances }
     }
 }
 

--- a/write-fonts/generated/generated_gasp.rs
+++ b/write-fonts/generated/generated_gasp.rs
@@ -25,7 +25,7 @@ impl Gasp {
         Self {
             version,
             num_ranges,
-            gasp_ranges: gasp_ranges.into_iter().map(Into::into).collect(),
+            gasp_ranges,
         }
     }
 }

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -206,9 +206,7 @@ pub struct AttachPoint {
 impl AttachPoint {
     /// Construct a new `AttachPoint`
     pub fn new(point_indices: Vec<u16>) -> Self {
-        Self {
-            point_indices: point_indices.into_iter().map(Into::into).collect(),
-        }
+        Self { point_indices }
     }
 }
 

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -576,9 +576,7 @@ pub struct MarkArray {
 impl MarkArray {
     /// Construct a new `MarkArray`
     pub fn new(mark_records: Vec<MarkRecord>) -> Self {
-        Self {
-            mark_records: mark_records.into_iter().map(Into::into).collect(),
-        }
+        Self { mark_records }
     }
 }
 
@@ -1371,7 +1369,7 @@ impl CursivePosFormat1 {
     pub fn new(coverage: CoverageTable, entry_exit_record: Vec<EntryExitRecord>) -> Self {
         Self {
             coverage: coverage.into(),
-            entry_exit_record: entry_exit_record.into_iter().map(Into::into).collect(),
+            entry_exit_record,
         }
     }
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -400,7 +400,7 @@ impl SingleSubstFormat2 {
     pub fn new(coverage: CoverageTable, substitute_glyph_ids: Vec<GlyphId16>) -> Self {
         Self {
             coverage: coverage.into(),
-            substitute_glyph_ids: substitute_glyph_ids.into_iter().map(Into::into).collect(),
+            substitute_glyph_ids,
         }
     }
 }
@@ -535,7 +535,7 @@ impl Sequence {
     /// Construct a new `Sequence`
     pub fn new(substitute_glyph_ids: Vec<GlyphId16>) -> Self {
         Self {
-            substitute_glyph_ids: substitute_glyph_ids.into_iter().map(Into::into).collect(),
+            substitute_glyph_ids,
         }
     }
 }
@@ -669,7 +669,7 @@ impl AlternateSet {
     /// Construct a new `AlternateSet`
     pub fn new(alternate_glyph_ids: Vec<GlyphId16>) -> Self {
         Self {
-            alternate_glyph_ids: alternate_glyph_ids.into_iter().map(Into::into).collect(),
+            alternate_glyph_ids,
         }
     }
 }
@@ -860,7 +860,7 @@ impl Ligature {
     pub fn new(ligature_glyph: GlyphId16, component_glyph_ids: Vec<GlyphId16>) -> Self {
         Self {
             ligature_glyph,
-            component_glyph_ids: component_glyph_ids.into_iter().map(Into::into).collect(),
+            component_glyph_ids,
         }
     }
 }
@@ -1121,7 +1121,7 @@ impl ReverseChainSingleSubstFormat1 {
             coverage: coverage.into(),
             backtrack_coverages: backtrack_coverages.into_iter().map(Into::into).collect(),
             lookahead_coverages: lookahead_coverages.into_iter().map(Into::into).collect(),
-            substitute_glyph_ids: substitute_glyph_ids.into_iter().map(Into::into).collect(),
+            substitute_glyph_ids,
         }
     }
 }

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -21,8 +21,8 @@ impl Hmtx {
     /// Construct a new `Hmtx`
     pub fn new(h_metrics: Vec<LongMetric>, left_side_bearings: Vec<i16>) -> Self {
         Self {
-            h_metrics: h_metrics.into_iter().map(Into::into).collect(),
-            left_side_bearings: left_side_bearings.into_iter().map(Into::into).collect(),
+            h_metrics,
+            left_side_bearings,
         }
     }
 }

--- a/write-fonts/generated/generated_ift.rs
+++ b/write-fonts/generated/generated_ift.rs
@@ -169,9 +169,9 @@ impl PatchMapFormat1 {
             glyph_count,
             glyph_map: glyph_map.into(),
             feature_map: feature_map.into(),
-            applied_entries_bitmap: applied_entries_bitmap.into_iter().map(Into::into).collect(),
+            applied_entries_bitmap,
             uri_template_length,
-            uri_template: uri_template.into_iter().map(Into::into).collect(),
+            uri_template,
             patch_format,
         }
     }
@@ -295,7 +295,7 @@ impl FeatureMap {
     pub fn new(feature_count: u16, entry_map_data: Vec<u8>) -> Self {
         Self {
             feature_count,
-            entry_map_data: entry_map_data.into_iter().map(Into::into).collect(),
+            entry_map_data,
         }
     }
 }
@@ -425,7 +425,7 @@ impl PatchMapFormat2 {
             entries: entries.into(),
             entry_id_string_data: entry_id_string_data.into(),
             uri_template_length,
-            uri_template: uri_template.into_iter().map(Into::into).collect(),
+            uri_template,
         }
     }
 }
@@ -500,9 +500,7 @@ pub struct MappingEntries {
 impl MappingEntries {
     /// Construct a new `MappingEntries`
     pub fn new(entry_data: Vec<u8>) -> Self {
-        Self {
-            entry_data: entry_data.into_iter().map(Into::into).collect(),
-        }
+        Self { entry_data }
     }
 }
 
@@ -556,7 +554,7 @@ impl EntryData {
     pub fn new(format_flags: EntryFormatFlags, codepoint_data: Vec<u8>) -> Self {
         Self {
             format_flags,
-            codepoint_data: codepoint_data.into_iter().map(Into::into).collect(),
+            codepoint_data,
             ..Default::default()
         }
     }
@@ -796,9 +794,7 @@ pub struct IdStringData {
 impl IdStringData {
     /// Construct a new `IdStringData`
     pub fn new(id_data: Vec<u8>) -> Self {
-        Self {
-            id_data: id_data.into_iter().map(Into::into).collect(),
-        }
+        Self { id_data }
     }
 }
 
@@ -928,7 +924,7 @@ impl TablePatch {
             tag,
             flags,
             max_uncompressed_length,
-            brotli_stream: brotli_stream.into_iter().map(Into::into).collect(),
+            brotli_stream,
         }
     }
 }
@@ -1001,7 +997,7 @@ impl GlyphKeyedPatch {
             flags,
             compatibility_id,
             max_uncompressed_length,
-            brotli_stream: brotli_stream.into_iter().map(Into::into).collect(),
+            brotli_stream,
         }
     }
 }
@@ -1075,7 +1071,7 @@ impl GlyphPatches {
         Self {
             glyph_count,
             table_count,
-            tables: tables.into_iter().map(Into::into).collect(),
+            tables,
             glyph_data: glyph_data.into_iter().map(Into::into).collect(),
         }
     }
@@ -1133,9 +1129,7 @@ pub struct GlyphData {
 impl GlyphData {
     /// Construct a new `GlyphData`
     pub fn new(data: Vec<u8>) -> Self {
-        Self {
-            data: data.into_iter().map(Into::into).collect(),
-        }
+        Self { data }
     }
 }
 

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -18,9 +18,7 @@ pub struct ScriptList {
 impl ScriptList {
     /// Construct a new `ScriptList`
     pub fn new(script_records: Vec<ScriptRecord>) -> Self {
-        Self {
-            script_records: script_records.into_iter().map(Into::into).collect(),
-        }
+        Self { script_records }
     }
 }
 
@@ -131,7 +129,7 @@ impl Script {
     pub fn new(default_lang_sys: Option<LangSys>, lang_sys_records: Vec<LangSysRecord>) -> Self {
         Self {
             default_lang_sys: default_lang_sys.into(),
-            lang_sys_records: lang_sys_records.into_iter().map(Into::into).collect(),
+            lang_sys_records,
         }
     }
 }
@@ -258,7 +256,7 @@ impl LangSys {
     /// Construct a new `LangSys`
     pub fn new(feature_indices: Vec<u16>) -> Self {
         Self {
-            feature_indices: feature_indices.into_iter().map(Into::into).collect(),
+            feature_indices,
             ..Default::default()
         }
     }
@@ -320,9 +318,7 @@ pub struct FeatureList {
 impl FeatureList {
     /// Construct a new `FeatureList`
     pub fn new(feature_records: Vec<FeatureRecord>) -> Self {
-        Self {
-            feature_records: feature_records.into_iter().map(Into::into).collect(),
-        }
+        Self { feature_records }
     }
 }
 
@@ -437,7 +433,7 @@ impl Feature {
     pub fn new(feature_params: Option<FeatureParams>, lookup_list_indices: Vec<u16>) -> Self {
         Self {
             feature_params: feature_params.into(),
-            lookup_list_indices: lookup_list_indices.into_iter().map(Into::into).collect(),
+            lookup_list_indices,
         }
     }
 }
@@ -629,9 +625,7 @@ pub struct CoverageFormat1 {
 impl CoverageFormat1 {
     /// Construct a new `CoverageFormat1`
     pub fn new(glyph_array: Vec<GlyphId16>) -> Self {
-        Self {
-            glyph_array: glyph_array.into_iter().map(Into::into).collect(),
-        }
+        Self { glyph_array }
     }
 }
 
@@ -689,9 +683,7 @@ pub struct CoverageFormat2 {
 impl CoverageFormat2 {
     /// Construct a new `CoverageFormat2`
     pub fn new(range_records: Vec<RangeRecord>) -> Self {
-        Self {
-            range_records: range_records.into_iter().map(Into::into).collect(),
-        }
+        Self { range_records }
     }
 }
 
@@ -887,7 +879,7 @@ impl ClassDefFormat1 {
     pub fn new(start_glyph_id: GlyphId16, class_value_array: Vec<u16>) -> Self {
         Self {
             start_glyph_id,
-            class_value_array: class_value_array.into_iter().map(Into::into).collect(),
+            class_value_array,
         }
     }
 }
@@ -949,7 +941,7 @@ impl ClassDefFormat2 {
     /// Construct a new `ClassDefFormat2`
     pub fn new(class_range_records: Vec<ClassRangeRecord>) -> Self {
         Self {
-            class_range_records: class_range_records.into_iter().map(Into::into).collect(),
+            class_range_records,
         }
     }
 }
@@ -1330,8 +1322,8 @@ impl SequenceRule {
         seq_lookup_records: Vec<SequenceLookupRecord>,
     ) -> Self {
         Self {
-            input_sequence: input_sequence.into_iter().map(Into::into).collect(),
-            seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
+            input_sequence,
+            seq_lookup_records,
         }
     }
 }
@@ -1554,8 +1546,8 @@ impl ClassSequenceRule {
     /// Construct a new `ClassSequenceRule`
     pub fn new(input_sequence: Vec<u16>, seq_lookup_records: Vec<SequenceLookupRecord>) -> Self {
         Self {
-            input_sequence: input_sequence.into_iter().map(Into::into).collect(),
-            seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
+            input_sequence,
+            seq_lookup_records,
         }
     }
 }
@@ -1625,7 +1617,7 @@ impl SequenceContextFormat3 {
     ) -> Self {
         Self {
             coverages: coverages.into_iter().map(Into::into).collect(),
-            seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
+            seq_lookup_records,
         }
     }
 }
@@ -1970,10 +1962,10 @@ impl ChainedSequenceRule {
         seq_lookup_records: Vec<SequenceLookupRecord>,
     ) -> Self {
         Self {
-            backtrack_sequence: backtrack_sequence.into_iter().map(Into::into).collect(),
-            input_sequence: input_sequence.into_iter().map(Into::into).collect(),
-            lookahead_sequence: lookahead_sequence.into_iter().map(Into::into).collect(),
-            seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
+            backtrack_sequence,
+            input_sequence,
+            lookahead_sequence,
+            seq_lookup_records,
         }
     }
 }
@@ -2252,10 +2244,10 @@ impl ChainedClassSequenceRule {
         seq_lookup_records: Vec<SequenceLookupRecord>,
     ) -> Self {
         Self {
-            backtrack_sequence: backtrack_sequence.into_iter().map(Into::into).collect(),
-            input_sequence: input_sequence.into_iter().map(Into::into).collect(),
-            lookahead_sequence: lookahead_sequence.into_iter().map(Into::into).collect(),
-            seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
+            backtrack_sequence,
+            input_sequence,
+            lookahead_sequence,
+            seq_lookup_records,
         }
     }
 }
@@ -2356,7 +2348,7 @@ impl ChainedSequenceContextFormat3 {
             backtrack_coverages: backtrack_coverages.into_iter().map(Into::into).collect(),
             input_coverages: input_coverages.into_iter().map(Into::into).collect(),
             lookahead_coverages: lookahead_coverages.into_iter().map(Into::into).collect(),
-            seq_lookup_records: seq_lookup_records.into_iter().map(Into::into).collect(),
+            seq_lookup_records,
         }
     }
 }
@@ -2821,10 +2813,7 @@ impl FeatureVariations {
     /// Construct a new `FeatureVariations`
     pub fn new(feature_variation_records: Vec<FeatureVariationRecord>) -> Self {
         Self {
-            feature_variation_records: feature_variation_records
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            feature_variation_records,
         }
     }
 }
@@ -3455,9 +3444,7 @@ pub struct FeatureTableSubstitution {
 impl FeatureTableSubstitution {
     /// Construct a new `FeatureTableSubstitution`
     pub fn new(substitutions: Vec<FeatureTableSubstitutionRecord>) -> Self {
-        Self {
-            substitutions: substitutions.into_iter().map(Into::into).collect(),
-        }
+        Self { substitutions }
     }
 }
 
@@ -3757,7 +3744,7 @@ impl CharacterVariantParams {
             sample_text_name_id,
             num_named_parameters,
             first_param_ui_label_name_id,
-            character: character.into_iter().map(Into::into).collect(),
+            character,
         }
     }
 }

--- a/write-fonts/generated/generated_meta.rs
+++ b/write-fonts/generated/generated_meta.rs
@@ -16,9 +16,7 @@ pub struct Meta {
 impl Meta {
     /// Construct a new `Meta`
     pub fn new(data_maps: Vec<DataMapRecord>) -> Self {
-        Self {
-            data_maps: data_maps.into_iter().map(Into::into).collect(),
-        }
+        Self { data_maps }
     }
 }
 

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -19,7 +19,7 @@ impl Name {
     /// Construct a new `Name`
     pub fn new(name_record: Vec<NameRecord>) -> Self {
         Self {
-            name_record: name_record.into_iter().map(Into::into).collect(),
+            name_record,
             ..Default::default()
         }
     }

--- a/write-fonts/generated/generated_postscript.rs
+++ b/write-fonts/generated/generated_postscript.rs
@@ -25,8 +25,8 @@ impl Index1 {
         Self {
             count,
             off_size,
-            offsets: offsets.into_iter().map(Into::into).collect(),
-            data: data.into_iter().map(Into::into).collect(),
+            offsets,
+            data,
         }
     }
 }
@@ -88,8 +88,8 @@ impl Index2 {
         Self {
             count,
             off_size,
-            offsets: offsets.into_iter().map(Into::into).collect(),
-            data: data.into_iter().map(Into::into).collect(),
+            offsets,
+            data,
         }
     }
 }
@@ -239,9 +239,7 @@ pub struct FdSelectFormat0 {
 impl FdSelectFormat0 {
     /// Construct a new `FdSelectFormat0`
     pub fn new(fds: Vec<u8>) -> Self {
-        Self {
-            fds: fds.into_iter().map(Into::into).collect(),
-        }
+        Self { fds }
     }
 }
 
@@ -295,10 +293,7 @@ pub struct FdSelectFormat3 {
 impl FdSelectFormat3 {
     /// Construct a new `FdSelectFormat3`
     pub fn new(ranges: Vec<FdSelectRange3>, sentinel: u16) -> Self {
-        Self {
-            ranges: ranges.into_iter().map(Into::into).collect(),
-            sentinel,
-        }
+        Self { ranges, sentinel }
     }
 }
 
@@ -404,10 +399,7 @@ pub struct FdSelectFormat4 {
 impl FdSelectFormat4 {
     /// Construct a new `FdSelectFormat4`
     pub fn new(ranges: Vec<FdSelectRange4>, sentinel: u32) -> Self {
-        Self {
-            ranges: ranges.into_iter().map(Into::into).collect(),
-            sentinel,
-        }
+        Self { ranges, sentinel }
     }
 }
 
@@ -608,9 +600,7 @@ pub struct CharsetFormat0 {
 impl CharsetFormat0 {
     /// Construct a new `CharsetFormat0`
     pub fn new(glyph: Vec<u16>) -> Self {
-        Self {
-            glyph: glyph.into_iter().map(Into::into).collect(),
-        }
+        Self { glyph }
     }
 }
 
@@ -659,9 +649,7 @@ pub struct CharsetFormat1 {
 impl CharsetFormat1 {
     /// Construct a new `CharsetFormat1`
     pub fn new(ranges: Vec<CharsetRange1>) -> Self {
-        Self {
-            ranges: ranges.into_iter().map(Into::into).collect(),
-        }
+        Self { ranges }
     }
 }
 
@@ -756,9 +744,7 @@ pub struct CharsetFormat2 {
 impl CharsetFormat2 {
     /// Construct a new `CharsetFormat2`
     pub fn new(ranges: Vec<CharsetRange2>) -> Self {
-        Self {
-            ranges: ranges.into_iter().map(Into::into).collect(),
-        }
+        Self { ranges }
     }
 }
 

--- a/write-fonts/generated/generated_sbix.rs
+++ b/write-fonts/generated/generated_sbix.rs
@@ -95,7 +95,7 @@ impl Strike {
         Self {
             ppem,
             ppi,
-            glyph_data_offsets: glyph_data_offsets.into_iter().map(Into::into).collect(),
+            glyph_data_offsets,
         }
     }
 }
@@ -155,7 +155,7 @@ impl GlyphData {
             origin_offset_x,
             origin_offset_y,
             graphic_type,
-            data: data.into_iter().map(Into::into).collect(),
+            data,
         }
     }
 }

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -609,7 +609,7 @@ impl AxisValueFormat4 {
         Self {
             flags,
             value_name_id,
-            axis_values: axis_values.into_iter().map(Into::into).collect(),
+            axis_values,
         }
     }
 }

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -63,9 +63,7 @@ pub struct Table2 {
 impl Table2 {
     /// Construct a new `Table2`
     pub fn new(values: Vec<u16>) -> Self {
-        Self {
-            values: values.into_iter().map(Into::into).collect(),
-        }
+        Self { values }
     }
 }
 

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -16,7 +16,7 @@ impl BasicTable {
     /// Construct a new `BasicTable`
     pub fn new(simple_records: Vec<SimpleRecord>, array_records: Vec<ContainsArrays>) -> Self {
         Self {
-            simple_records: simple_records.into_iter().map(Into::into).collect(),
+            simple_records,
             array_records,
         }
     }
@@ -127,10 +127,7 @@ pub struct ContainsArrays {
 impl ContainsArrays {
     /// Construct a new `ContainsArrays`
     pub fn new(scalars: Vec<u16>, records: Vec<SimpleRecord>) -> Self {
-        Self {
-            scalars: scalars.into_iter().map(Into::into).collect(),
-            records: records.into_iter().map(Into::into).collect(),
-        }
+        Self { scalars, records }
     }
 }
 

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -88,9 +88,7 @@ pub struct Tuple {
 impl Tuple {
     /// Construct a new `Tuple`
     pub fn new(values: Vec<F2Dot14>) -> Self {
-        Self {
-            values: values.into_iter().map(Into::into).collect(),
-        }
+        Self { values }
     }
 }
 
@@ -142,7 +140,7 @@ impl DeltaSetIndexMapFormat0 {
         Self {
             entry_format,
             map_count,
-            map_data: map_data.into_iter().map(Into::into).collect(),
+            map_data,
         }
     }
 }
@@ -212,7 +210,7 @@ impl DeltaSetIndexMapFormat1 {
         Self {
             entry_format,
             map_count,
-            map_data: map_data.into_iter().map(Into::into).collect(),
+            map_data,
         }
     }
 }
@@ -448,9 +446,7 @@ pub struct VariationRegion {
 impl VariationRegion {
     /// Construct a new `VariationRegion`
     pub fn new(region_axes: Vec<RegionAxisCoordinates>) -> Self {
-        Self {
-            region_axes: region_axes.into_iter().map(Into::into).collect(),
-        }
+        Self { region_axes }
     }
 }
 
@@ -643,8 +639,8 @@ impl ItemVariationData {
         Self {
             item_count,
             word_delta_count,
-            region_indexes: region_indexes.into_iter().map(Into::into).collect(),
-            delta_sets: delta_sets.into_iter().map(Into::into).collect(),
+            region_indexes,
+            delta_sets,
         }
     }
 }

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -20,8 +20,8 @@ impl Vmtx {
     /// Construct a new `Vmtx`
     pub fn new(v_metrics: Vec<LongMetric>, top_side_bearings: Vec<i16>) -> Self {
         Self {
-            v_metrics: v_metrics.into_iter().map(Into::into).collect(),
-            top_side_bearings: top_side_bearings.into_iter().map(Into::into).collect(),
+            v_metrics,
+            top_side_bearings,
         }
     }
 }

--- a/write-fonts/generated/generated_vorg.rs
+++ b/write-fonts/generated/generated_vorg.rs
@@ -22,7 +22,7 @@ impl Vorg {
     pub fn new(default_vert_origin_y: i16, vert_origin_y_metrics: Vec<VertOriginYMetrics>) -> Self {
         Self {
             default_vert_origin_y,
-            vert_origin_y_metrics: vert_origin_y_metrics.into_iter().map(Into::into).collect(),
+            vert_origin_y_metrics,
         }
     }
 }

--- a/write-fonts/src/tables/mvar.rs
+++ b/write-fonts/src/tables/mvar.rs
@@ -17,7 +17,7 @@ impl Mvar {
             value_record_size: size_of::<ValueRecord>() as u16,
             value_record_count: value_records.len() as u16,
             item_variation_store: item_variation_store.into(),
-            value_records: value_records.into_iter().map(Into::into).collect(),
+            value_records,
         }
     }
 }


### PR DESCRIPTION
- clarifies some #[repr(packed)] to #[repr(C, packed)]
- updates codegen to generate fewer useless `Into` conversions in constructor methods