### PR TITLE
[skrifa] autohint: use visited set when processing GSUB lookups

### DIFF
--- a/skrifa/src/outline/memory.rs
+++ b/skrifa/src/outline/memory.rs
@@ -1,0 +1,25 @@
+//! Support for temporary memory allocation, making use of the stack for
+//! small sizes.
+
+/// Invokes the callback with a memory buffer of the requested size.
+pub(super) fn with_temporary_memory<R>(size: usize, mut f: impl FnMut(&mut [u8]) -> R) -> R {
+    // Wrap in a function and prevent inlining to avoid stack allocation
+    // and zeroing if we don't take this code path.
+    #[inline(never)]
+    fn stack_mem<const STACK_SIZE: usize, R>(size: usize, mut f: impl FnMut(&mut [u8]) -> R) -> R {
+        f(&mut [0u8; STACK_SIZE][..size])
+    }
+    // Use bucketed stack allocations to prevent excessive zeroing of
+    // memory
+    if size <= 512 {
+        stack_mem::<512, _>(size, f)
+    } else if size <= 1024 {
+        stack_mem::<1024, _>(size, f)
+    } else if size <= 2048 {
+        stack_mem::<2048, _>(size, f)
+    } else if size <= 4096 {
+        stack_mem::<4096, _>(size, f)
+    } else {
+        f(&mut vec![0u8; size])
+    }
+}


### PR DESCRIPTION
Adds a visited set to GSUB traversal for autohinting to prevent redundant processing of lookups. This can cause a perceived hang on fonts with large complex lookup graphs (like Noto Nastaliq Urdu) even when there are no cycles.

Also removes the existing cycle detection code since it is no longer needed.

Fixes #1363