### PR TITLE
Bump version numbers to release fix for autohint hanging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.8.3", path = "font-types" }
-read-fonts = { version = "0.27.1", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.27.2", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.28.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.36.0", path = "write-fonts" }
+skrifa = { version = "0.28.1", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.36.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder" }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.27.1"
+version = "0.27.2"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.28.0"
+version = "0.28.1"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.36.0"
+version = "0.36.1"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
Release tip of tree with fix for #1363 hang in gsub processing during autohinting of Noto Nastaliq.

Changes for read-fonts from read-fonts-v0.27.1 to 0.27.1
        5657ab8 [chore] Clippy day
        53407d0 [read-fonts] CFF charsets (#1361)
Changes for write-fonts from write-fonts-v0.36.0 to 0.36.0
        5657ab8 [chore] Clippy day
        029f62f [font_builder] provide more expository comment
        7f95b52 [font_builder] test recommended table order
        a49be74 [font_builder] test checksum_adjustment
        ffc69ee [font_builder] compute head.checksum_adjustment and sort table in recommended order
        53407d0 [read-fonts] CFF charsets (#1361)
Changes for skrifa from skrifa-v0.28.0 to 0.28.0
        e250138 [skrifa] autohint: use visited set when processing GSUB lookups (#1365)
        441a388 [skrifa] Remove unused write-fonts dev-dep
        652b3ca Apply limits to cmap12 iterator (#1352)
        24fb1c8 [skrifa] tthint: adjust DELTAP/DELTAC limits (#1353)