### PR TITLE
Set up shared-brotli-patch-decoder to be able to utilize a rust or c brotli decoder implementation.

### DIFF
--- a/incremental-font-transfer/src/font_patch.rs
+++ b/incremental-font-transfer/src/font_patch.rs
@@ -23,7 +23,7 @@ use read_fonts::tables::ift::{CompatibilityId, GlyphKeyedPatch, TableKeyedPatch}
 
 use read_fonts::{FontData, FontRead, FontRef, ReadError};
 
-use shared_brotli_patch_decoder::DecodeError;
+use shared_brotli_patch_decoder::decode_error::DecodeError;
 
 /// A trait for types to which an incremental font transfer patch can be applied.
 ///
@@ -88,6 +88,9 @@ impl From<DecodeError> for PatchingError {
             DecodeError::MaxSizeExceeded => PatchingError::InvalidPatch("Max size exceeded."),
             DecodeError::ExcessInputData => {
                 PatchingError::InvalidPatch("Input brotli stream has excess bytes.")
+            }
+            DecodeError::IoError(_) => {
+                PatchingError::InvalidPatch("IO error decoding input brotli stream.")
             }
         }
     }

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -11,8 +11,16 @@ repository.workspace = true
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
 all-features = true
 
+[features]
+default = ["c-brotli"]
+c-brotli = ["dep:brotlic-sys"]
+rust-brotli = ["dep:brotli-decompressor"]
+
+
 [dependencies]
-brotlic-sys = {version = "0.2.2"}
+brotlic-sys = {version = "0.2.2", optional = true}
+brotli-decompressor = {version = "4.0.2", optional = true}
+cfg-if = "0.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/shared-brotli-patch-decoder/src/c_brotli.rs
+++ b/shared-brotli-patch-decoder/src/c_brotli.rs
@@ -1,0 +1,100 @@
+use crate::decode_error::DecodeError;
+use brotlic_sys::{
+    BrotliDecoderAttachDictionary, BrotliDecoderCreateInstance, BrotliDecoderDecompressStream,
+    BrotliDecoderDestroyInstance, BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR,
+    BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT,
+    BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT,
+    BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS,
+    BrotliSharedDictionaryType_BROTLI_SHARED_DICTIONARY_RAW, BROTLI_FALSE,
+};
+use core::ptr;
+
+pub fn shared_brotli_decode_c(
+    encoded: &[u8],
+    shared_dictionary: Option<&[u8]>,
+    max_uncompressed_length: usize,
+) -> Result<Vec<u8>, DecodeError> {
+    let decoder = unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) };
+    if decoder.is_null() {
+        return Err(DecodeError::InitFailure);
+    }
+
+    if let Some(shared_dictionary) = shared_dictionary {
+        if unsafe {
+            BrotliDecoderAttachDictionary(
+                decoder,
+                BrotliSharedDictionaryType_BROTLI_SHARED_DICTIONARY_RAW,
+                shared_dictionary.len(),
+                shared_dictionary.as_ptr(),
+            )
+        } == BROTLI_FALSE
+        {
+            unsafe {
+                BrotliDecoderDestroyInstance(decoder);
+            }
+            return Err(DecodeError::InvalidDictionary);
+        }
+    }
+
+    let mut sink = vec![0u8; max_uncompressed_length];
+
+    let mut next_in = encoded.as_ptr();
+    let mut available_in = encoded.len();
+    let mut next_out = sink.as_mut_ptr();
+    let mut available_out = sink.len();
+    let mut total_out = 0;
+
+    let mut error: Option<DecodeError> = None;
+    loop {
+        let result = unsafe {
+            BrotliDecoderDecompressStream(
+                decoder,
+                &mut available_in,
+                &mut next_in,
+                &mut available_out,
+                &mut next_out,
+                &mut total_out,
+            )
+        };
+
+        #[allow(non_upper_case_globals)]
+        match result {
+            BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS => break,
+            BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR => {
+                error = Some(DecodeError::InvalidStream);
+                break;
+            }
+            BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT if available_in == 0 => {
+                // Needs more input and none is available.
+                error = Some(DecodeError::InvalidStream);
+                break;
+            }
+            BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT if available_out == 0 => {
+                // Needs more output space, but none is available.
+                error = Some(DecodeError::MaxSizeExceeded);
+                break;
+            }
+            _ => continue,
+        }
+    }
+
+    unsafe {
+        BrotliDecoderDestroyInstance(decoder);
+    }
+    if let Some(error) = error {
+        return Err(error);
+    }
+
+    if available_in > 0 {
+        // There's is data left in the input stream, which is not allowed
+        return Err(DecodeError::ExcessInputData);
+    }
+
+    if total_out > sink.len() {
+        return Err(DecodeError::MaxSizeExceeded);
+    }
+
+    sink.resize(total_out, 0);
+
+    Ok(sink)
+}

--- a/shared-brotli-patch-decoder/src/decode_error.rs
+++ b/shared-brotli-patch-decoder/src/decode_error.rs
@@ -1,0 +1,41 @@
+use std::io::{self, ErrorKind};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DecodeError {
+    InitFailure,
+    InvalidStream,
+    InvalidDictionary,
+    MaxSizeExceeded,
+    ExcessInputData,
+    IoError(io::ErrorKind),
+}
+
+impl DecodeError {
+    pub fn from_io_error(err: io::Error) -> Self {
+        match err.kind() {
+            ErrorKind::OutOfMemory => DecodeError::MaxSizeExceeded,
+            ErrorKind::UnexpectedEof => DecodeError::InvalidStream,
+            _ => DecodeError::IoError(err.kind()),
+        }
+    }
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DecodeError::InitFailure => write!(f, "Failed to initialize the brotli decoder."),
+            DecodeError::InvalidStream => {
+                write!(f, "Brotli compressed stream is invalid, decoding failed.")
+            }
+            DecodeError::InvalidDictionary => write!(f, "Shared dictionary format is invalid."),
+            DecodeError::MaxSizeExceeded => write!(f, "Decompressed size greater than maximum."),
+            DecodeError::ExcessInputData => write!(
+                f,
+                "There is unconsumed data in the input stream after decoding."
+            ),
+            DecodeError::IoError(kind) => write!(f, "Generic IO error: {}", kind),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}

--- a/shared-brotli-patch-decoder/src/rust_brotli.rs
+++ b/shared-brotli-patch-decoder/src/rust_brotli.rs
@@ -1,0 +1,59 @@
+use std::io::{self, Cursor, Write};
+
+use crate::decode_error::DecodeError;
+use brotli_decompressor::BrotliDecompressCustomDict;
+
+#[allow(dead_code)]
+pub fn shared_brotli_decode_rust(
+    encoded: &[u8],
+    shared_dictionary: Option<&[u8]>,
+    max_uncompressed_length: usize,
+) -> Result<Vec<u8>, DecodeError> {
+    let mut input_buffer: [u8; 4096] = [0; 4096];
+    let mut output_buffer: [u8; 4096] = [0; 4096];
+
+    let mut cursor = Cursor::new(encoded);
+    let mut output = BoundedOutput(Default::default(), max_uncompressed_length);
+
+    let mut dict: Vec<u8> = Default::default();
+    if let Some(dict_data) = shared_dictionary {
+        dict.extend_from_slice(dict_data);
+    }
+
+    BrotliDecompressCustomDict(
+        &mut cursor,
+        &mut output,
+        &mut input_buffer,
+        &mut output_buffer,
+        dict,
+    )
+    .map_err(DecodeError::from_io_error)?;
+
+    if cursor.get_ref().len() as u64 > cursor.position() {
+        return Err(DecodeError::ExcessInputData);
+    }
+
+    Ok(output.0)
+}
+
+#[allow(dead_code)]
+struct BoundedOutput(Vec<u8>, usize);
+
+#[allow(dead_code)]
+impl Write for BoundedOutput {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.1 < buf.len() {
+            // hit the write bound, return an error.
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "Max output size reached.",
+            ));
+        }
+        self.1 -= buf.len();
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}


### PR DESCRIPTION
The pure rust decoder implementation is needed when compiling to WASM which can't easily work with the c version.