### PR TITLE
[skrifa] impl TableProvider -> FontRef in ctors (breaking)

### DIFF
--- a/skrifa/src/attribute.rs
+++ b/skrifa/src/attribute.rs
@@ -30,7 +30,7 @@ pub struct Attributes {
 impl Attributes {
     /// Extracts the stretch, style and weight attributes for the default
     /// instance of the given font.
-    pub fn new<'a>(font: &FontRef<'a>) -> Self {
+    pub fn new(font: &FontRef) -> Self {
         if let Ok(os2) = font.os2() {
             // Prefer values from the OS/2 table if it exists. We also use
             // the post table to extract the angle for oblique styles.

--- a/skrifa/src/attribute.rs
+++ b/skrifa/src/attribute.rs
@@ -6,7 +6,7 @@ use read_fonts::{
         os2::{Os2, SelectionFlags},
         post::Post,
     },
-    TableProvider,
+    FontRef, TableProvider,
 };
 
 /// Stretch, style and weight attributes of a font.
@@ -30,7 +30,7 @@ pub struct Attributes {
 impl Attributes {
     /// Extracts the stretch, style and weight attributes for the default
     /// instance of the given font.
-    pub fn new<'a>(font: &impl TableProvider<'a>) -> Self {
+    pub fn new<'a>(font: &FontRef<'a>) -> Self {
         if let Ok(os2) = font.os2() {
             // Prefer values from the OS/2 table if it exists. We also use
             // the post table to extract the angle for oblique styles.

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -42,7 +42,7 @@ mod traversal;
 #[cfg(test)]
 mod traversal_tests;
 
-use raw::tables::colr;
+use raw::{tables::colr, FontRef};
 #[cfg(test)]
 use serde::{Deserialize, Serialize};
 
@@ -388,7 +388,7 @@ pub struct ColorGlyphCollection<'a> {
 
 impl<'a> ColorGlyphCollection<'a> {
     /// Creates a new collection of paintable color glyphs for the given font.
-    pub fn new(font: &impl TableProvider<'a>) -> Self {
+    pub fn new(font: &FontRef<'a>) -> Self {
         let colr = font.colr().ok();
         let upem = font.head().map(|h| h.units_per_em());
 

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -27,7 +27,7 @@ use read_fonts::{
         glyf::Glyf, gvar::Gvar, hmtx::LongMetric, hvar::Hvar, loca::Loca, os2::SelectionFlags,
     },
     types::{BigEndian, Fixed, GlyphId},
-    TableProvider,
+    FontRef, TableProvider,
 };
 
 use super::instance::{LocationRef, NormalizedCoord, Size};
@@ -100,11 +100,7 @@ pub struct Metrics {
 impl Metrics {
     /// Creates new metrics for the given font, size, and location in
     /// normalized variation space.
-    pub fn new<'a>(
-        font: &impl TableProvider<'a>,
-        size: Size,
-        location: impl Into<LocationRef<'a>>,
-    ) -> Self {
+    pub fn new<'a>(font: &FontRef<'a>, size: Size, location: impl Into<LocationRef<'a>>) -> Self {
         let head = font.head();
         let mut metrics = Metrics {
             units_per_em: head.map(|head| head.units_per_em()).unwrap_or_default(),
@@ -231,11 +227,7 @@ pub struct GlyphMetrics<'a> {
 impl<'a> GlyphMetrics<'a> {
     /// Creates new glyph metrics from the given font, size, and location in
     /// normalized variation space.
-    pub fn new(
-        font: &impl TableProvider<'a>,
-        size: Size,
-        location: impl Into<LocationRef<'a>>,
-    ) -> Self {
+    pub fn new(font: &FontRef<'a>, size: Size, location: impl Into<LocationRef<'a>>) -> Self {
         let glyph_count = font
             .maxp()
             .map(|maxp| maxp.num_glyphs() as u32)

--- a/skrifa/src/string.rs
+++ b/skrifa/src/string.rs
@@ -25,7 +25,7 @@
 
 use read_fonts::{
     tables::name::{CharIter, Name, NameRecord, NameString},
-    TableProvider,
+    FontRef, TableProvider,
 };
 
 use core::fmt;
@@ -57,7 +57,7 @@ pub struct LocalizedStrings<'a> {
 
 impl<'a> LocalizedStrings<'a> {
     /// Creates a new localized string iterator from the given font and string identifier.
-    pub fn new(font: &impl TableProvider<'a>, id: StringId) -> Self {
+    pub fn new(font: &FontRef<'a>, id: StringId) -> Self {
         let name = font.name().ok();
         let records = name
             .as_ref()

--- a/skrifa/src/variation.rs
+++ b/skrifa/src/variation.rs
@@ -4,7 +4,7 @@ use read_fonts::{
     tables::avar::Avar,
     tables::fvar::{self, Fvar},
     types::{Fixed, Tag},
-    TableProvider,
+    FontRef, TableProvider,
 };
 
 use crate::{
@@ -90,7 +90,7 @@ pub struct AxisCollection<'a> {
 
 impl<'a> AxisCollection<'a> {
     /// Creates a new axis collection from the given font.
-    pub fn new(font: &impl TableProvider<'a>) -> Self {
+    pub fn new(font: &FontRef<'a>) -> Self {
         let fvar = font.fvar().ok();
         let avar = font.avar().ok();
         Self { fvar, avar }
@@ -349,7 +349,7 @@ pub struct NamedInstanceCollection<'a> {
 
 impl<'a> NamedInstanceCollection<'a> {
     /// Creates a new instance collection from the given font.
-    pub fn new(font: &impl TableProvider<'a>) -> Self {
+    pub fn new(font: &FontRef<'a>) -> Self {
         Self {
             axes: AxisCollection::new(font),
         }


### PR DESCRIPTION
We needed a full `FontRef` for outlines anyway so this changes all other constructors to take `FontRef` as well for consistency.

JMM