### PR TITLE
[skrifa] glyph names API

### DIFF
--- a/skrifa/src/glyph_name.rs
+++ b/skrifa/src/glyph_name.rs
@@ -20,7 +20,7 @@ const MAX_GLYPH_NAME_LEN: usize = 63;
 ///
 /// This sources glyph names from the `post` and `CFF` tables in that order.
 /// If glyph names are not available in either, then they are synthesized
-/// as `gidNNN` where `NNN` is the glyph identifier. Use the
+/// as `gidDDD` where `DDD` is the glyph identifier in decimal. Use the
 /// [`source`](Self::source) to determine which source was chosen.
 #[derive(Clone)]
 pub struct GlyphNames<'a> {
@@ -111,8 +111,8 @@ pub enum GlyphNameSource {
     Post,
     /// Glyph names are sourced from the `CFF` table.
     Cff,
-    /// Glyph names are synthesized in the format `gidNNN` where `NNN` is
-    /// the glyph identifier.
+    /// Glyph names are synthesized in the format `gidDDD` where `DDD` is
+    /// the glyph identifier in decimal.
     Synthesized,
 }
 

--- a/skrifa/src/glyph_names.rs
+++ b/skrifa/src/glyph_names.rs
@@ -1,0 +1,310 @@
+//! Support for accessing glyph names.
+
+use core::ops::Range;
+use raw::{
+    tables::{
+        cff::Cff,
+        post::Post,
+        postscript::{Charset, CharsetIter},
+    },
+    types::GlyphId,
+    FontRef, TableProvider,
+};
+
+/// "Names must be no longer than 63 characters; some older implementations
+/// can assume a length limit of 31 characters."
+/// See <https://learn.microsoft.com/en-us/typography/opentype/spec/post#version-20>
+const MAX_GLYPH_NAME_LEN: usize = 63;
+
+/// Mapping from glyph identifiers to names.
+///
+/// This sources glyph names from the `post` and `CFF` tables in that order.
+/// If glyph names are not available in either, then they are synthesized
+/// as `gidNNN` where `NNN` is the glyph identifier. Use the
+/// [`source`](Self::source) to determine which source was chosen.
+#[derive(Clone)]
+pub struct GlyphNames<'a> {
+    inner: Inner<'a>,
+}
+
+impl<'a> GlyphNames<'a> {
+    /// Creates a new object for accessing glyph names from the given font.
+    pub fn new(font: &FontRef<'a>) -> Self {
+        if let Ok(post) = font.post() {
+            if post.num_names() != 0 {
+                return Self {
+                    inner: Inner::Post(post),
+                };
+            }
+        }
+        if let Some((cff, charset)) = font
+            .cff()
+            .ok()
+            .and_then(|cff| Some((cff.clone(), cff.charset(0).ok()??)))
+        {
+            return Self {
+                inner: Inner::Cff(cff, charset),
+            };
+        }
+        let num_glyphs = font
+            .maxp()
+            .map(|maxp| maxp.num_glyphs() as u32)
+            .unwrap_or_default();
+        Self {
+            inner: Inner::Synthesized(num_glyphs),
+        }
+    }
+
+    /// Returns the chosen source for glyph names.
+    pub fn source(&self) -> GlyphNameSource {
+        match &self.inner {
+            Inner::Post(..) => GlyphNameSource::Post,
+            Inner::Cff(..) => GlyphNameSource::Cff,
+            Inner::Synthesized(..) => GlyphNameSource::Synthesized,
+        }
+    }
+
+    /// Returns the number of glyphs in the font.
+    pub fn num_glyphs(&self) -> u32 {
+        match &self.inner {
+            Inner::Post(post) => post.num_names() as u32,
+            Inner::Cff(_, charset) => charset.num_glyphs(),
+            Inner::Synthesized(n) => *n,
+        }
+    }
+
+    /// Returns the name for the given glyph identifier.
+    pub fn get(&self, glyph_id: GlyphId) -> Option<GlyphName> {
+        if glyph_id.to_u32() >= self.num_glyphs() {
+            return None;
+        }
+        match &self.inner {
+            Inner::Post(post) => {
+                let name = post.glyph_name(glyph_id.try_into().ok()?)?;
+                Some(GlyphName::from_bytes(name.as_bytes()))
+            }
+            Inner::Cff(cff, charset) => {
+                let sid = charset.string_id(glyph_id).ok()?;
+                let str = cff.string(sid)?;
+                let name = core::str::from_utf8(str.bytes()).ok()?;
+                Some(GlyphName::from_bytes(name.as_bytes()))
+            }
+            Inner::Synthesized(_) => Some(GlyphName::synthesize(glyph_id)),
+        }
+    }
+
+    /// Returns an iterator yielding the identifier and name for all glyphs in
+    /// the font.
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, GlyphName)> + 'a + Clone {
+        match &self.inner {
+            Inner::Post(post) => Iter::Post(0, post.clone()),
+            Inner::Cff(cff, charset) => Iter::Cff(cff.clone(), charset.iter()),
+            Inner::Synthesized(n) => Iter::Synthesized(0..*n),
+        }
+    }
+}
+
+/// Specifies the chosen source for glyph names.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum GlyphNameSource {
+    /// Glyph names are sourced from the `post` table.
+    Post,
+    /// Glyph names are sourced from the `CFF` table.
+    Cff,
+    /// Glyph names are synthesized in the format `gidNNN` where `NNN` is
+    /// the glyph identifier.
+    Synthesized,
+}
+
+/// The name of a glyph.
+#[derive(Clone)]
+pub struct GlyphName {
+    name: [u8; MAX_GLYPH_NAME_LEN],
+    len: u8,
+}
+
+impl GlyphName {
+    /// Returns the underlying name as a string.
+    pub fn as_str(&self) -> &str {
+        let bytes = &self.name[..self.len as usize];
+        core::str::from_utf8(bytes).unwrap_or_default()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let mut name = Self::default();
+        name.append(bytes);
+        name
+    }
+
+    fn synthesize(glyph_id: GlyphId) -> Self {
+        use core::fmt::Write;
+        let mut name = Self::default();
+        let _ = write!(GlyphNameWrite(&mut name), "gid{}", glyph_id.to_u32());
+        name
+    }
+
+    fn append(&mut self, bytes: &[u8]) {
+        // We simply truncate when length exceeds the max since glyph names
+        // are expected to be <= 63 chars
+        let start = self.len as usize;
+        let available = MAX_GLYPH_NAME_LEN - start;
+        let copy_len = available.min(bytes.len());
+        self.name[start..start + copy_len].copy_from_slice(&bytes[..copy_len]);
+        self.len = (start + copy_len) as u8;
+    }
+}
+
+impl Default for GlyphName {
+    fn default() -> Self {
+        Self {
+            name: [0; MAX_GLYPH_NAME_LEN],
+            len: 0,
+        }
+    }
+}
+
+impl core::fmt::Debug for GlyphName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self.as_str())
+    }
+}
+
+impl core::fmt::Display for GlyphName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl core::ops::Deref for GlyphName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl PartialEq<&str> for GlyphName {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+struct GlyphNameWrite<'a>(&'a mut GlyphName);
+
+impl core::fmt::Write for GlyphNameWrite<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.0.append(s.as_bytes());
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+enum Inner<'a> {
+    Post(Post<'a>),
+    Cff(Cff<'a>, Charset<'a>),
+    Synthesized(u32),
+}
+
+#[derive(Clone)]
+enum Iter<'a> {
+    Post(u32, Post<'a>),
+    Cff(Cff<'a>, CharsetIter<'a>),
+    Synthesized(Range<u32>),
+}
+
+impl Iterator for Iter<'_> {
+    type Item = (GlyphId, GlyphName);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Post(cur, post) => {
+                let gid = GlyphId::new(*cur);
+                *cur = cur.checked_add(1)?;
+                Some((
+                    gid,
+                    GlyphName::from_bytes(post.glyph_name(gid.try_into().ok()?)?.as_bytes()),
+                ))
+            }
+            Self::Cff(cff, iter) => {
+                let (gid, sid) = iter.next()?;
+                let str = cff.string(sid)?;
+                Some((gid, GlyphName::from_bytes(str.bytes())))
+            }
+            Self::Synthesized(range) => {
+                let gid = GlyphId::new(range.next()?);
+                Some((gid, GlyphName::synthesize(gid)))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthesized_glyph_names() {
+        let count = 58;
+        let names = GlyphNames {
+            inner: Inner::Synthesized(58),
+        };
+        let names_buf = (0..count).map(|i| format!("gid{i}")).collect::<Vec<_>>();
+        let expected_names = names_buf.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+        check_names(&names, &expected_names, GlyphNameSource::Synthesized);
+    }
+
+    #[test]
+    fn cff_glyph_names() {
+        let font = FontRef::new(font_test_data::NOTO_SERIF_DISPLAY_TRIMMED).unwrap();
+        let names = GlyphNames::new(&font);
+        assert_eq!(names.source(), GlyphNameSource::Cff);
+        let expected_names = [".notdef", "i", "j", "k", "l"];
+        check_names(&names, &expected_names, GlyphNameSource::Cff);
+    }
+
+    #[test]
+    fn post_glyph_names() {
+        let font = FontRef::new(font_test_data::HVAR_WITH_TRUNCATED_ADVANCE_INDEX_MAP).unwrap();
+        let names = GlyphNames::new(&font);
+        let expected_names = [
+            ".notdef",
+            "space",
+            "A",
+            "I",
+            "T",
+            "Aacute",
+            "Agrave",
+            "Iacute",
+            "Igrave",
+            "Amacron",
+            "Imacron",
+            "acutecomb",
+            "gravecomb",
+            "macroncomb",
+            "A.001",
+            "A.002",
+            "A.003",
+            "A.004",
+            "A.005",
+            "A.006",
+            "A.007",
+            "A.008",
+            "A.009",
+            "A.010",
+        ];
+        check_names(&names, &expected_names, GlyphNameSource::Post);
+    }
+
+    fn check_names(names: &GlyphNames, expected_names: &[&str], expected_source: GlyphNameSource) {
+        assert_eq!(names.source(), expected_source);
+        let iter_names = names.iter().collect::<Vec<_>>();
+        assert_eq!(iter_names.len(), expected_names.len());
+        for (i, expected) in expected_names.iter().enumerate() {
+            let gid = GlyphId::new(i as u32);
+            let name = names.get(gid).unwrap();
+            assert_eq!(name, expected);
+            assert_eq!(iter_names[i].0, gid);
+            assert_eq!(iter_names[i].1, expected);
+        }
+    }
+}

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -40,9 +40,11 @@ pub mod setting;
 pub mod string;
 
 mod collections;
+mod glyph_names;
 mod provider;
 mod variation;
 
+pub use glyph_names::{GlyphName, GlyphNameSource, GlyphNames};
 #[doc(inline)]
 pub use outline::{OutlineGlyph, OutlineGlyphCollection};
 pub use variation::{Axis, AxisCollection, NamedInstance, NamedInstanceCollection};

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -40,8 +40,8 @@ pub mod setting;
 pub mod string;
 
 mod collections;
-mod glyph_name;
 mod decycler;
+mod glyph_name;
 mod provider;
 mod variation;
 

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -40,11 +40,11 @@ pub mod setting;
 pub mod string;
 
 mod collections;
-mod glyph_names;
+mod glyph_name;
 mod provider;
 mod variation;
 
-pub use glyph_names::{GlyphName, GlyphNameSource, GlyphNames};
+pub use glyph_name::{GlyphName, GlyphNameSource, GlyphNames};
 #[doc(inline)]
 pub use outline::{OutlineGlyph, OutlineGlyphCollection};
 pub use variation::{Axis, AxisCollection, NamedInstance, NamedInstanceCollection};

--- a/skrifa/src/provider.rs
+++ b/skrifa/src/provider.rs
@@ -1,3 +1,5 @@
+use crate::GlyphNames;
+
 use super::{
     attribute::Attributes,
     charmap::Charmap,
@@ -25,6 +27,9 @@ pub trait MetadataProvider<'a>: Sized {
     /// Returns an iterator over the collection of localized strings for the
     /// given informational string identifier.
     fn localized_strings(&self, id: StringId) -> LocalizedStrings<'a>;
+
+    /// Returns the mapping from glyph identifiers to names.
+    fn glyph_names(&self) -> GlyphNames<'a>;
 
     /// Returns the global font metrics for the specified size and location in
     /// normalized variation space.
@@ -69,6 +74,11 @@ impl<'a> MetadataProvider<'a> for FontRef<'a> {
     /// given informational string identifier.
     fn localized_strings(&self, id: StringId) -> LocalizedStrings<'a> {
         LocalizedStrings::new(self, id)
+    }
+
+    /// Returns the mapping from glyph identifiers to names.
+    fn glyph_names(&self) -> GlyphNames<'a> {
+        GlyphNames::new(self)
     }
 
     /// Returns the global font metrics for the specified size and location in


### PR DESCRIPTION
Adds an API for accessing glyph names. Tries the `post` and `CFF` tables in that order. If neither are available or do not contain glyph names, then this generates synthesized names in the format `gidDDD` to match HarfBuzz.

Fixes #1261