### PR TITLE
Reduce typo count

### DIFF
--- a/incremental-font-transfer/src/bin/ift_extend.rs
+++ b/incremental-font-transfer/src/bin/ift_extend.rs
@@ -35,9 +35,9 @@ struct Args {
     #[arg(short, long)]
     text: Option<String>,
 
-    /// Comma separate list of unicode codepoint values (base 10) to extend the font to cover.
+    /// Comma separated list of Unicode codepoint values (base 10) to extend the font to cover.
     ///
-    /// * indicates to include all unicode code points.
+    /// * indicates to include all Unicode codepoints.
     #[arg(short, long, value_delimiter = ',', num_args = 1..)]
     unicodes: Vec<String>,
 
@@ -227,7 +227,7 @@ impl std::fmt::Display for ParsingError {
                 )
             }
             ParsingError::UnicodeCodepointParsingFailed(value) => {
-                write!(f, "Invalid unicode code point value: {}", value,)
+                write!(f, "Invalid unicode codepoint value: {}", value,)
             }
             ParsingError::FeatureTagParsingFailed(value) => {
                 write!(f, "Invalid feature tag value: {value}")

--- a/klippa/src/main.rs
+++ b/klippa/src/main.rs
@@ -30,7 +30,7 @@ struct Args {
     #[arg(short, long)]
     gids: Option<String>,
 
-    /// List of unicode codepoints
+    /// List of Unicode codepoints
     #[arg(short, long)]
     unicodes: Option<String>,
 

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -925,14 +925,14 @@ impl<'a> Os2<'a> {
         Some(self.data.read_at(range.start).unwrap())
     }
 
-    /// This is the Unicode code point, in UTF-16 encoding, of a character that
+    /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used for a default glyph.
     pub fn us_default_char(&self) -> Option<u16> {
         let range = self.shape.us_default_char_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
-    /// his is the Unicode code point, in UTF-16 encoding, of a character that
+    /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used as a default break character.
     pub fn us_break_char(&self) -> Option<u16> {
         let range = self.shape.us_break_char_byte_range()?;

--- a/read-fonts/src/tables/name.rs
+++ b/read-fonts/src/tables/name.rs
@@ -230,8 +230,8 @@ impl MacRomanMapping {
     }
 }
 
-/// a lookup table for the Mac Moman encoding. this matches the values 128..=255
-/// to specific unicode values.
+/// A lookup table for the Mac Roman encoding. This matches the values `128..=255`
+/// to specific Unicode values.
 #[rustfmt::skip]
 static MAC_ROMAN_DECODE: [u16; 128] = [
     196, 197, 199, 201, 209, 214, 220, 225, 224, 226, 228, 227, 229, 231, 233,
@@ -246,7 +246,7 @@ static MAC_ROMAN_DECODE: [u16; 128] = [
     731, 711,
 ];
 
-/// A lookup pairing (sorted) unicode values to Mac Roman values
+/// A lookup pairing (sorted) Unicode values to Mac Roman values
 #[rustfmt::skip]
 static MAC_ROMAN_ENCODE: [(u16, u8); 128] = [
     (160, 202), (161, 193), (162, 162), (163, 163),

--- a/resources/codegen_inputs/os2.rs
+++ b/resources/codegen_inputs/os2.rs
@@ -152,11 +152,11 @@ table Os2 {
     /// approximate height of uppercase letters measured in FUnits.
     #[since_version(2)]
     s_cap_height: i16,
-    /// This is the Unicode code point, in UTF-16 encoding, of a character that
+    /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used for a default glyph.
     #[since_version(2)]
     us_default_char: u16,
-    /// his is the Unicode code point, in UTF-16 encoding, of a character that
+    /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used as a default break character.
     #[since_version(2)]
     us_break_char: u16,

--- a/resources/raw_tables/head.txt
+++ b/resources/raw_tables/head.txt
@@ -41,7 +41,7 @@
 
 # Bit 13: Font optimized for ClearType™. Note, fonts that rely on embedded bitmaps (EBDT) for rendering should not be considered optimized for ClearType, and therefore should keep this bit cleared.
 
-# Bit 14: Last Resort font. If set, indicates that the glyphs encoded in the 'cmap' subtables are simply generic symbolic representations of code point ranges and don’t truly represent support for those code points. If unset, indicates that the glyphs encoded in the 'cmap' subtables represent proper support for those code points.
+# Bit 14: Last Resort font. If set, indicates that the glyphs encoded in the 'cmap' subtables are simply generic symbolic representations of codepoint ranges and don’t truly represent support for those codepoints. If unset, indicates that the glyphs encoded in the 'cmap' subtables represent proper support for those codepoints.
 
 # Bit 15: Reserved, set to 0.
 

--- a/write-fonts/generated/generated_os2.rs
+++ b/write-fonts/generated/generated_os2.rs
@@ -122,10 +122,10 @@ pub struct Os2 {
     /// This metric specifies the distance between the baseline and the
     /// approximate height of uppercase letters measured in FUnits.
     pub s_cap_height: Option<i16>,
-    /// This is the Unicode code point, in UTF-16 encoding, of a character that
+    /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used for a default glyph.
     pub us_default_char: Option<u16>,
-    /// his is the Unicode code point, in UTF-16 encoding, of a character that
+    /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used as a default break character.
     pub us_break_char: Option<u16>,
     /// This field is used for fonts with multiple optical styles.


### PR DESCRIPTION
This includes changes to use "Unicode" as a proper noun more often as well as to use the term "codepoint" rather than the occasional usage of "code points".