### PR TITLE
[chore] bump read (patch), skrifa (minor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.8.3", path = "font-types" }
-read-fonts = { version = "0.27.2", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.27.3", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.28.1", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.29.0", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.36.4", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.27.2"
+version = "0.27.3"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.28.1"
+version = "0.29.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.27.2 to 0.27.3
             85352c0 Collection of glyf/gvar performance improvements (#1390)
             1bb6245 [read-fonts] fix slow cmap 12 test (#1383)
             dd282f7 Fix some typos, update `typos` check in CI
             6680a36 [klippa] subset HVAR/VVAR tables
     Changes for skrifa from skrifa-v0.28.1 to 0.29.0
             85352c0 Collection of glyf/gvar performance improvements (#1390)
             720f49d [skrifa] glyph names API (#1387)
             3baac34 [skrifa] malloc free cycle detection (#1388)
             53ccad4 clippy
             ab4680c [skrifa] impl TableProvider -> FontRef in ctors (breaking)