### PR TITLE
[read-fonts] no glyph names for CID-keyed CFF fonts

### DIFF
--- a/read-fonts/src/tables/cff.rs
+++ b/read-fonts/src/tables/cff.rs
@@ -104,6 +104,13 @@ impl<'a> Cff<'a> {
                         .count() as u32,
                     );
                 }
+                // The ROS operator signifies a CID-keyed font and the charset
+                // maps to CIDs rather than SIDs which we don't parse for
+                // glyph names.
+                // <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=28>
+                Ok(dict::Entry::Ros { .. }) => {
+                    return Ok(None);
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
We were treating CIDs as SIDs for CID-keyed fonts leading to incorrect glyph names.

Fixes #1404 