### PR TITLE
Prototype implementation of the IFT specific subset of URI templates.

### DIFF
--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -16,6 +16,7 @@ pub mod glyph_keyed;
 pub mod patch_group;
 pub mod patchmap;
 pub mod table_keyed;
+mod uri_templates;
 
 #[cfg(test)]
 mod testdata {

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -16,6 +16,8 @@ pub mod glyph_keyed;
 pub mod patch_group;
 pub mod patchmap;
 pub mod table_keyed;
+
+#[allow(dead_code)] // Not used by the main library yet
 mod uri_templates;
 
 #[cfg(test)]

--- a/incremental-font-transfer/src/uri_templates.rs
+++ b/incremental-font-transfer/src/uri_templates.rs
@@ -1,6 +1,6 @@
 //! Implementation of the specific variant of URI template expansion required by the IFT specification.
 //!
-//! Context: https://w3c.github.io/IFT/Overview.html#uri-templates
+//! Context: <https://w3c.github.io/IFT/Overview.html#uri-templates>
 //!
 //! In IFT RFC6570 style uri templates are used, however the IFT specification restricts template syntax
 //! to a subset (level 1 with a predefined set of variables) of the full RFC6570 syntax. This implements
@@ -58,9 +58,9 @@ impl std::error::Error for UriTemplateError {}
 
 /// Implements uri template expansion from incremental font transfer.
 ///
-/// Specification: https://w3c.github.io/IFT/Overview.html#uri-templates
+/// Specification: <https://w3c.github.io/IFT/Overview.html#uri-templates>
 ///
-/// IFT uri templates are a subset of the more general https://datatracker.ietf.org/doc/html/rfc6570
+/// IFT uri templates are a subset of the more general <https://datatracker.ietf.org/doc/html/rfc6570>
 /// uri templates. Notably, only level one substitution expressions are supported and there are a fixed
 /// set of variables used in the expansion (id, id64, d1, d2, d3, and d4).
 ///
@@ -74,7 +74,7 @@ pub(crate) fn expand_template(
     let mut output: OutputBuffer = Default::default();
 
     let mut state = ParseState::Literal;
-    let byte_info_map = byte_info();
+    let byte_info_map = byte_info_map();
 
     for byte in template_string.as_bytes() {
         let byte_info = &byte_info_map[*byte as usize];
@@ -147,7 +147,7 @@ impl OutputBuffer {
     ///
     /// - Value is substitued if one of the defined variable names are encountered.
     /// - Otherwise the variable name is undefined and the expression is replaced with an empty string.
-    /// - Also validates the variable name follows level 1 expression grammar (https://datatracker.ietf.org/doc/html/rfc6570#section-2.2)
+    /// - Also validates the variable name follows level 1 expression grammar (<https://datatracker.ietf.org/doc/html/rfc6570#section-2.2>)
     ///   and returns an error if it doesn't.
     fn handle_expression(
         &mut self,
@@ -226,9 +226,9 @@ impl OutputBuffer {
         }
     }
 
-    // Appends the expanded value of d1, d2, d3, or d4.
-    //
-    // See: https://w3c.github.io/IFT/Overview.html#uri-templates
+    /// Appends the expanded value of d1, d2, d3, or d4.
+    ///
+    /// See: <https://w3c.github.io/IFT/Overview.html#uri-templates>
     fn append_id_digit(&mut self, id_value: &str, digit: u8) {
         self.append(
             *id_value
@@ -288,14 +288,14 @@ impl ByteInfo {
 
     /// Returns true if byte is a hexdig.
     ///
-    /// As defined here: https://datatracker.ietf.org/doc/html/rfc6570#section-1.5
+    /// As defined here: <https://datatracker.ietf.org/doc/html/rfc6570#section-1.5>
     fn is_hexdig(byte: u8) -> bool {
         DIGIT.contains(&byte) || HEX_ALPHA_UPPER.contains(&byte) || HEX_ALPHA_LOWER.contains(&byte)
     }
 
     /// Returns true if byte is a varchar.
     ///
-    /// As defined here: https://datatracker.ietf.org/doc/html/rfc6570#section-2.3
+    /// As defined here: <https://datatracker.ietf.org/doc/html/rfc6570#section-2.3>
     fn is_varchar(byte: u8) -> bool {
         ALPHA_LOWER.contains(&byte)
             || ALPHA_UPPER.contains(&byte)
@@ -315,14 +315,14 @@ const CTL_AND_SPACE: RangeInclusive<u8> = 0x00..=0x20;
 const HEX_ALPHA_UPPER: RangeInclusive<u8> = 0x41..=0x46;
 const HEX_ALPHA_LOWER: RangeInclusive<u8> = 0x61..=0x66;
 
-static BYTE_CLASSIFICATION: OnceLock<[ByteInfo; NUM_U8S]> = OnceLock::new();
+static BYTE_INFO_MAP: OnceLock<[ByteInfo; NUM_U8S]> = OnceLock::new();
 
 /// Returns a map of information about each possible u8 byte value.
 ///
 /// See ByteInfo for more details.
-fn byte_info() -> &'static [ByteInfo; NUM_U8S] {
+fn byte_info_map() -> &'static [ByteInfo; NUM_U8S] {
     // See: https://datatracker.ietf.org/doc/html/rfc6570#section-2.1
-    BYTE_CLASSIFICATION.get_or_init(|| {
+    BYTE_INFO_MAP.get_or_init(|| {
         let mut info: [ByteInfo; NUM_U8S] = [ByteInfo::new(LiteralClass::Invalid, 0); NUM_U8S];
 
         // Start by assuming all values must be percent encoded, and then enumerate

--- a/incremental-font-transfer/src/uri_templates.rs
+++ b/incremental-font-transfer/src/uri_templates.rs
@@ -1,3 +1,13 @@
+//! Implementation of the specific variant of URI template expansion required by the IFT specification.
+//!
+//! Context: https://w3c.github.io/IFT/Overview.html#uri-templates
+//!
+//! In IFT RFC6570 style uri templates are used, however the IFT specification restricts template syntax
+//! to a subset (level 1 with a predefined set of variables) of the full RFC6570 syntax. This implements
+//! a URI template expander that adheres to the IFT specific requirements.
+//!
+//! By implementing our own we avoid pulling in a much larger general purpose template expansion library
+//! and improve performance versus a more general implementation.
 use std::{ops::RangeInclusive, sync::OnceLock};
 
 enum ParseState {

--- a/incremental-font-transfer/src/uri_templates.rs
+++ b/incremental-font-transfer/src/uri_templates.rs
@@ -1,0 +1,290 @@
+use std::sync::OnceLock;
+
+enum ParseState {
+    // Literal parsing
+    Literal,
+    LiteralPercentEncoded(PercentEncoded),
+
+    // Expression parsing,
+    Expression(Variable),
+    ExpressionPercentEncoded(PercentEncoded),
+}
+
+enum Variable {
+    Begin,
+    I,
+    ID,
+    ID6,
+    D,
+}
+
+enum PercentEncoded {
+    DigitOne,
+    DigitTwo,
+}
+
+#[derive(Default)]
+struct OutputBuffer(String);
+
+/// Indicates a malformed URI template was encountered.
+///
+/// More info: <https://datatracker.ietf.org/doc/html/rfc6570#section-3>
+#[derive(Debug, PartialEq, Eq)]
+pub struct UriTemplateError; // TODO(garretrieger): change patchmap to use this.
+
+impl std::fmt::Display for UriTemplateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Invalid URI template encountered.")
+    }
+}
+
+impl std::error::Error for UriTemplateError {}
+
+/// Implements uri template expansion from incremental font transfer.
+///
+/// Specification: https://w3c.github.io/IFT/Overview.html#uri-templates
+///
+/// IFT uri templates are a subset of the more general https://datatracker.ietf.org/doc/html/rfc6570
+/// uri templates. Notably, only level one substitution expressions are supported and there are a fixed
+/// set of variables used in the expansion (id, id64, d1, d2, d3, and d4).
+///
+/// All arguments are assumed to be utf8 encoded strings.
+pub(crate) fn expand_template(
+    template_string: &str,
+    id_value: &str,
+    id64_value: &str,
+) -> Result<String, UriTemplateError> {
+    let mut output: OutputBuffer = Default::default();
+
+    let mut state = ParseState::Literal;
+
+    for byte in template_string.as_bytes() {
+        state = match state {
+            ParseState::Literal => output.handle_literal(*byte)?,
+            ParseState::LiteralPercentEncoded(PercentEncoded::DigitOne) => {
+                if !is_hexdig(*byte) {
+                    return Err(UriTemplateError);
+                }
+                output.append(*byte);
+                ParseState::LiteralPercentEncoded(PercentEncoded::DigitTwo)
+            }
+            ParseState::LiteralPercentEncoded(PercentEncoded::DigitTwo) => {
+                if !is_hexdig(*byte) {
+                    return Err(UriTemplateError);
+                }
+                output.append(*byte);
+                ParseState::Literal
+            }
+            _ => todo!(),
+        }
+    }
+
+    if !matches!(state, ParseState::Literal) {
+        // Should always end back in the literal state otherwise we're in an incomplete expression
+        // or percent encoding.
+        return Err(UriTemplateError);
+    }
+
+    Ok(output.0)
+}
+
+impl OutputBuffer {
+    fn handle_literal(&mut self, byte: u8) -> Result<ParseState, UriTemplateError> {
+        let class: ByteClass = literal_byte_classification()[byte as usize];
+
+        match class {
+            ByteClass::Invalid | ByteClass::CloseBrace => Err(UriTemplateError),
+            ByteClass::Percent => {
+                self.append(byte);
+                Ok(ParseState::LiteralPercentEncoded(PercentEncoded::DigitOne))
+            }
+            ByteClass::OpenBrace => Ok(ParseState::Expression(Variable::Begin)),
+            ByteClass::LiteralCopied => {
+                self.append(byte);
+                Ok(ParseState::Literal)
+            }
+            ByteClass::LiteralPercentEncoded => {
+                self.append_percent_encoded(byte);
+                Ok(ParseState::Literal)
+            }
+        }
+    }
+
+    fn append(&mut self, byte: u8) {
+        self.0.push(byte.into());
+    }
+
+    fn append_percent_encoded(&mut self, byte: u8) {
+        self.0.push_str(&format!("%{:02X}", byte));
+    }
+}
+
+#[derive(Copy, Clone)]
+enum ByteClass {
+    Invalid,
+    Percent,
+    LiteralCopied,
+    LiteralPercentEncoded,
+    OpenBrace,
+    CloseBrace,
+}
+
+static BYTE_CLASSIFICATION: OnceLock<[ByteClass; 255]> = OnceLock::new();
+
+fn is_hexdig(byte: u8) -> bool {
+    (byte >= 0x41 && byte <= 0x46)
+        || (byte >= 0x61 && byte <= 0x66)
+        || (byte >= 0x30 && byte <= 0x39)
+}
+
+fn literal_byte_classification() -> &'static [ByteClass; 255] {
+    // See: https://datatracker.ietf.org/doc/html/rfc6570#section-2.1
+    BYTE_CLASSIFICATION.get_or_init(|| {
+        let mut classes: [ByteClass; 255] = [ByteClass::LiteralPercentEncoded; 255];
+
+        // ## URL Allowed ##
+
+        // Alpha
+        for i in 0x41..=0x5A {
+            classes[i] = ByteClass::LiteralCopied;
+        }
+        for i in 0x61..=0x7A {
+            classes[i] = ByteClass::LiteralCopied;
+        }
+
+        // Digit
+        for i in 0x30..=0x39 {
+            classes[i] = ByteClass::LiteralCopied;
+        }
+        classes['-' as usize] = ByteClass::LiteralCopied;
+        classes['.' as usize] = ByteClass::LiteralCopied;
+        classes['_' as usize] = ByteClass::LiteralCopied;
+        classes['~' as usize] = ByteClass::LiteralCopied;
+
+        // Reserved
+        for i in [
+            ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';',
+            '=',
+        ] {
+            classes[i as usize] = ByteClass::LiteralCopied;
+        }
+
+        // ## Template control characters ##
+        classes['{' as usize] = ByteClass::OpenBrace;
+        classes['}' as usize] = ByteClass::CloseBrace;
+        classes['%' as usize] = ByteClass::Percent;
+
+        // ## Invalid Characters ##
+
+        // CTL + Space
+        for i in 0..=0x20 {
+            classes[i] = ByteClass::Invalid;
+        }
+        classes[0x22] = ByteClass::Invalid;
+        classes[0x27] = ByteClass::Invalid;
+        classes[0x3C] = ByteClass::Invalid;
+        classes[0x3E] = ByteClass::Invalid;
+        classes[0x5C] = ByteClass::Invalid;
+        classes[0x5E] = ByteClass::Invalid;
+        classes[0x60] = ByteClass::Invalid;
+        classes[0x7C] = ByteClass::Invalid;
+
+        classes
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::uri_templates::UriTemplateError;
+
+    use super::expand_template;
+
+    #[test]
+    fn copied_literals_only() {
+        assert_eq!(
+            expand_template("foo/bar$", "abc", "def"),
+            Ok("foo/bar$".to_string())
+        );
+    }
+
+    #[test]
+    fn percent_encoding_copied() {
+        assert_eq!(
+            expand_template("%af%AF%09", "abc", "def"),
+            Ok("%af%AF%09".to_string())
+        );
+
+        assert_eq!(
+            expand_template("foo/b%a8", "abc", "def"),
+            Ok("foo/b%a8".to_string())
+        );
+
+        assert_eq!(
+            expand_template("foo/b%bFar", "abc", "def"),
+            Ok("foo/b%bFar".to_string())
+        );
+    }
+
+    #[test]
+    fn percent_encodes_literals() {
+        assert_eq!(
+            expand_template("foo/bàr", "abc", "def"),
+            Ok("foo/b%C3%A0r".to_string())
+        );
+    }
+
+    #[test]
+    fn invalid_percent_encoding() {
+        assert_eq!(
+            expand_template("foo/b%a/", "abc", "def"),
+            Err(UriTemplateError)
+        );
+
+        assert_eq!(
+            expand_template("foo/b%a", "abc", "def"),
+            Err(UriTemplateError)
+        );
+
+        assert_eq!(
+            expand_template("foo/b%a{id}", "abc", "def"),
+            Err(UriTemplateError)
+        );
+    }
+
+    #[test]
+    fn unexpected_close_brace() {
+        assert_eq!(
+            expand_template("foo/b}ar", "abc", "def"),
+            Err(UriTemplateError)
+        );
+    }
+
+    #[test]
+    fn invalid_characters() {
+        assert_eq!(
+            expand_template("foo/\"bar\"", "abc", "def"),
+            Err(UriTemplateError)
+        );
+
+        assert_eq!(
+            expand_template("foo bar", "abc", "def"),
+            Err(UriTemplateError)
+        );
+
+        let mut input: String = "foo".to_string();
+        input.push(0x00 as char);
+        assert_eq!(expand_template(&input, "abc", "def"), Err(UriTemplateError));
+
+        let mut input: String = "foo".to_string();
+        input.push(0x1F as char);
+        assert_eq!(expand_template(&input, "abc", "def"), Err(UriTemplateError));
+    }
+
+    // Valid cases:
+    // - variable expansion
+    // - undefined variables ignored
+
+    // Error cases for literals:
+    // - unsupported operators error
+    // - incomplete expression (no close brace)
+}

--- a/incremental-font-transfer/src/uri_templates.rs
+++ b/incremental-font-transfer/src/uri_templates.rs
@@ -326,11 +326,30 @@ impl ByteInfo {
             return true;
         }
 
-        match value {
-            b'-' | b'.' | b'_' | b'~' | b':' | b'/' | b'?' | b'#' | b'[' | b']' | b'@' | b'!'
-            | b'$' | b'&' | b'\'' | b'(' | b')' | b'*' | b'+' | b',' | b';' | b'=' => true,
-            _ => false,
-        }
+        matches!(
+            value,
+            b'-' | b'.'
+                | b'_'
+                | b'~'
+                | b':'
+                | b'/'
+                | b'?'
+                | b'#'
+                | b'['
+                | b']'
+                | b'@'
+                | b'!'
+                | b'$'
+                | b'&'
+                | b'\''
+                | b'('
+                | b')'
+                | b'*'
+                | b'+'
+                | b','
+                | b';'
+                | b'='
+        )
     }
 
     fn literal_class(value: u8) -> LiteralClass {


### PR DESCRIPTION
In the IFT spec we're restricting the URI template to a small subset of the general URI template syntax (see: https://github.com/w3c/IFT/pull/263). This makes it reasonable to write our own template expansion functionality instead of relying on a general parser implementation.

This takes a pass at implementing one (to see how it looks in practice), but does not yet hook it up to the rest of the IFT client. Ultimately it should allow us to drop the dependency on "uri-template-system".