### PR TITLE
Drop uri-template-system and instead use our own template expander in IFT client.

### DIFF
--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -27,7 +27,6 @@ font-types = { workspace = true }
 skrifa = { workspace = true }
 klippa = { workspace = true }
 shared-brotli-patch-decoder = { workspace = true, default-features = false }
-uri-template-system = "0.1.5"
 data-encoding = "2.6.0"
 data-encoding-macro = "0.1.15"
 clap = { version = "4.5.4", features = ["derive"], optional = true }

--- a/incremental-font-transfer/src/bin/ift_graph.rs
+++ b/incremental-font-transfer/src/bin/ift_graph.rs
@@ -12,7 +12,8 @@ use font_types::Tag;
 use incremental_font_transfer::{
     font_patch::IncrementalFontPatchBase,
     patch_group::PatchInfo,
-    patchmap::{intersecting_patches, PatchFormat, PatchUri, SubsetDefinition, UriTemplateError},
+    patchmap::{intersecting_patches, PatchFormat, PatchUri, SubsetDefinition},
+    uri_templates::UriTemplateError,
 };
 use read_fonts::{ReadError, TableProvider};
 use skrifa::{FontRef, MetadataProvider};

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -16,9 +16,7 @@ pub mod glyph_keyed;
 pub mod patch_group;
 pub mod patchmap;
 pub mod table_keyed;
-
-#[allow(dead_code)] // Not used by the main library yet
-mod uri_templates;
+pub mod uri_templates;
 
 #[cfg(test)]
 mod testdata {

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -10,8 +10,9 @@ use crate::{
     font_patch::{IncrementalFontPatchBase, PatchingError},
     patchmap::{
         intersecting_patches, IftTableTag, IntersectionInfo, PatchFormat, PatchUri,
-        SubsetDefinition, UriTemplateError,
+        SubsetDefinition,
     },
+    uri_templates::UriTemplateError,
 };
 
 /// A group of patches derived from a single IFT font.

--- a/incremental-font-transfer/src/uri_templates.rs
+++ b/incremental-font-transfer/src/uri_templates.rs
@@ -65,8 +65,6 @@ impl std::error::Error for UriTemplateError {}
 /// IFT uri templates are a subset of the more general <https://datatracker.ietf.org/doc/html/rfc6570>
 /// uri templates. Notably, only level one substitution expressions are supported and there are a fixed
 /// set of variables used in the expansion (id, id64, d1, d2, d3, and d4).
-///
-/// template_string is assumed to be a utf8 encoded string.
 pub(crate) fn expand_template(
     template_string: &str,
     patch_id: &PatchId,
@@ -102,15 +100,7 @@ const BASE32HEX_NO_PADDING: data_encoding::Encoding = new_encoding! {
 };
 
 fn count_leading_zeroes(id: &[u8]) -> usize {
-    let mut leading_bytes = 0;
-    for b in id {
-        if *b != 0 {
-            break;
-        }
-        leading_bytes += 1;
-    }
-    // Always keep at least one digit.
-    leading_bytes.min(id.len() - 1)
+    id.iter().take_while(|b| **b == 0).count().min(id.len() - 1)
 }
 
 /// Expands template string with the provided id and id64 string values.


### PR DESCRIPTION
- Also syncs up to some recent spec changes with regards to handling undefined expansion variables.