### PR TITLE
[skrifa] use SmallVec for color stop resolution

### DIFF
--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -102,7 +102,7 @@ impl From<ReadError> for PaintError {
 ///
 /// All gradient callbacks of [`ColorPainter`] normalize color stops to be in the range of 0
 /// to 1.
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
 #[cfg_attr(test, derive(Serialize, Deserialize))]
 // This repr(C) is required so that C-side FFI's
 // are able to cast the ColorStop slice to a C-side array pointer.
@@ -350,6 +350,7 @@ impl<'a> ColorGlyph<'a> {
         painter: &mut impl ColorPainter,
     ) -> Result<(), PaintError> {
         let instance = instance::ColrInstance::new(self.colr.clone(), location.into().coords());
+        let mut stop_buffer = traversal::ColorStopVec::default();
         match &self.root_paint_ref {
             ColorGlyphRoot::V1Paint(paint, paint_id, glyph_id, _) => {
                 let clipbox = get_clipbox_font_units(&instance, *glyph_id);
@@ -365,6 +366,7 @@ impl<'a> ColorGlyph<'a> {
                     &instance,
                     painter,
                     &mut cycle_guard,
+                    &mut stop_buffer,
                     0,
                 )?;
 

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -350,7 +350,7 @@ impl<'a> ColorGlyph<'a> {
         painter: &mut impl ColorPainter,
     ) -> Result<(), PaintError> {
         let instance = instance::ColrInstance::new(self.colr.clone(), location.into().coords());
-        let mut stop_buffer = traversal::ColorStopVec::default();
+        let mut resolved_stops = traversal::ColorStopVec::default();
         match &self.root_paint_ref {
             ColorGlyphRoot::V1Paint(paint, paint_id, glyph_id, _) => {
                 let clipbox = get_clipbox_font_units(&instance, *glyph_id);
@@ -366,7 +366,7 @@ impl<'a> ColorGlyph<'a> {
                     &instance,
                     painter,
                     &mut cycle_guard,
-                    &mut stop_buffer,
+                    &mut resolved_stops,
                     0,
                 )?;
 

--- a/skrifa/src/color/traversal.rs
+++ b/skrifa/src/color/traversal.rs
@@ -26,6 +26,9 @@ pub(crate) type PaintDecycler = Decycler<usize, MAX_TRAVERSAL_DEPTH>;
 // The largest gradient in Noto Color Emoji has 13 stops.
 //
 // Only one ColorStopVec will be created per paint graph traversal.
+//
+// Usage of SmallVec as a response to Behdad's wonderful memory usage analysis:
+// <https://docs.google.com/document/d/1S47f3E--yqvFdG7lmmufxRoFi_wMzotC03v8UvS_p54/edit?tab=t.0#heading=h.bfj7urloz3oe>
 const MAX_INLINE_COLOR_STOPS: usize = 32;
 
 pub(crate) type ColorStopVec = crate::collections::SmallVec<ColorStop, MAX_INLINE_COLOR_STOPS>;
@@ -152,13 +155,12 @@ pub(crate) fn traverse_with_callbacks(
     instance: &ColrInstance,
     painter: &mut impl ColorPainter,
     decycler: &mut PaintDecycler,
-    stop_buffer: &mut ColorStopVec,
+    resolved_stops: &mut ColorStopVec,
     recurse_depth: usize,
 ) -> Result<(), PaintError> {
     if recurse_depth >= MAX_TRAVERSAL_DEPTH {
         return Err(PaintError::DepthLimitExceeded);
     }
-    let resolved_stops = stop_buffer;
     match paint {
         ResolvedPaint::ColrLayers { range } => {
             for layer_index in range.clone() {


### PR DESCRIPTION
We spill to the heap for more than 32 color stops, but will only use one allocation per glyph.