### PR TITLE
[skrifa] add 8k and 16k buckets to stack allocator

### DIFF
--- a/skrifa/src/outline/memory.rs
+++ b/skrifa/src/outline/memory.rs
@@ -9,8 +9,8 @@ pub(super) fn with_temporary_memory<R>(size: usize, mut f: impl FnMut(&mut [u8])
     fn stack_mem<const STACK_SIZE: usize, R>(size: usize, mut f: impl FnMut(&mut [u8]) -> R) -> R {
         f(&mut [0u8; STACK_SIZE][..size])
     }
-    // Use bucketed stack allocations to prevent excessive zeroing of
-    // memory
+    // Use bucketed stack allocations (up to 16k) to prevent excessive zeroing
+    // of memory
     if size <= 512 {
         stack_mem::<512, _>(size, f)
     } else if size <= 1024 {
@@ -19,6 +19,10 @@ pub(super) fn with_temporary_memory<R>(size: usize, mut f: impl FnMut(&mut [u8])
         stack_mem::<2048, _>(size, f)
     } else if size <= 4096 {
         stack_mem::<4096, _>(size, f)
+    } else if size <= 8192 {
+        stack_mem::<8192, _>(size, f)
+    } else if size <= 16384 {
+        stack_mem::<16384, _>(size, f)
     } else {
         f(&mut vec![0u8; size])
     }


### PR DESCRIPTION
Let's try to keep some more work off the heap.

Motivated by our excessive allocations for NotoSansCJK-VF as documented by @behdad here: https://docs.google.com/document/d/1S47f3E--yqvFdG7lmmufxRoFi_wMzotC03v8UvS_p54/edit?tab=t.0#heading=h.bfj7urloz3oe

JMM