### PR TITLE
Bypass variation processing for default location

### DIFF
--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -1240,6 +1240,9 @@ impl ItemVariationStore<'_> {
         index: DeltaSetIndex,
         coords: &[F2Dot14],
     ) -> Result<i32, ReadError> {
+        if coords.is_empty() {
+            return Ok(0);
+        }
         let data = match self.item_variation_data().get(index.outer as usize) {
             Some(data) => data?,
             None => return Ok(0),
@@ -1270,6 +1273,9 @@ impl ItemVariationStore<'_> {
         index: DeltaSetIndex,
         coords: &[F2Dot14],
     ) -> Result<FloatItemDelta, ReadError> {
+        if coords.is_empty() {
+            return Ok(FloatItemDelta::ZERO);
+        }
         let data = match self.item_variation_data().get(index.outer as usize) {
             Some(data) => data?,
             None => return Ok(FloatItemDelta::ZERO),
@@ -1468,6 +1474,9 @@ pub(crate) fn advance_delta(
     glyph_id: GlyphId,
     coords: &[F2Dot14],
 ) -> Result<Fixed, ReadError> {
+    if coords.is_empty() {
+        return Ok(Fixed::ZERO);
+    }
     let gid = glyph_id.to_u32();
     let ix = match dsim {
         Some(Ok(dsim)) => dsim.get(gid)?,
@@ -1485,6 +1494,9 @@ pub(crate) fn item_delta(
     glyph_id: GlyphId,
     coords: &[F2Dot14],
 ) -> Result<Fixed, ReadError> {
+    if coords.is_empty() {
+        return Ok(Fixed::ZERO);
+    }
     let gid = glyph_id.to_u32();
     let ix = match dsim {
         Some(Ok(dsim)) => dsim.get(gid)?,

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -349,7 +349,8 @@ impl<'a> ColorGlyph<'a> {
         location: impl Into<LocationRef<'a>>,
         painter: &mut impl ColorPainter,
     ) -> Result<(), PaintError> {
-        let instance = instance::ColrInstance::new(self.colr.clone(), location.into().coords());
+        let instance =
+            instance::ColrInstance::new(self.colr.clone(), location.into().effective_coords());
         let mut resolved_stops = traversal::ColorStopVec::default();
         match &self.root_paint_ref {
             ColorGlyphRoot::V1Paint(paint, paint_id, glyph_id, _) => {

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -106,7 +106,7 @@ impl Metrics {
             units_per_em: head.map(|head| head.units_per_em()).unwrap_or_default(),
             ..Default::default()
         };
-        let coords = location.into().coords();
+        let coords = location.into().effective_coords();
         let scale = size.linear_scale(metrics.units_per_em);
         if let Ok(head) = font.head() {
             metrics.bounds = Some(BoundingBox {
@@ -237,7 +237,7 @@ impl<'a> GlyphMetrics<'a> {
             .map(|head| head.units_per_em())
             .unwrap_or_default();
         let fixed_scale = FixedScaleFactor(size.fixed_linear_scale(upem));
-        let coords = location.into().coords();
+        let coords = location.into().effective_coords();
         let (h_metrics, default_advance_width, lsbs) = font
             .hmtx()
             .map(|hmtx| {

--- a/skrifa/src/outline/hint.rs
+++ b/skrifa/src/outline/hint.rs
@@ -329,7 +329,8 @@ impl HintingInstance {
     ) -> Result<(), DrawError> {
         self.size = size;
         self.coords.clear();
-        self.coords.extend_from_slice(location.into().coords());
+        self.coords
+            .extend_from_slice(location.into().effective_coords());
         let options = options.into();
         self.target = options.target;
         let engine = options.engine.resolve_auto_fallback(outlines);

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -395,7 +395,7 @@ impl<'a> OutlineGlyph<'a> {
         pen: &mut impl OutlinePen,
     ) -> Result<AdjustedMetrics, DrawError> {
         let ppem = size.ppem();
-        let coords = location.into().coords();
+        let coords = location.into().effective_coords();
         match &self.kind {
             OutlineKind::Glyf(glyf, outline) => {
                 with_glyf_memory(outline, Hinting::None, user_memory, |buf| {
@@ -446,7 +446,7 @@ impl<'a> OutlineGlyph<'a> {
         user_memory: Option<&mut [u8]>,
         sink: &mut impl unscaled::UnscaledOutlineSink,
     ) -> Result<i32, DrawError> {
-        let coords = location.into().coords();
+        let coords = location.into().effective_coords();
         let ppem = None;
         match &self.kind {
             OutlineKind::Glyf(glyf, outline) => {


### PR DESCRIPTION
Adds an internal `LocationRef::effective_coords()` method that returns an empty slice when all coordinates are 0. This allows us to check for `coords.is_empty()` to skip processing variations in many places.

This is potentially a nice performance boost when calling `font.axes().location(...)` with default settings.