### PR TITLE
[chore] bump patch for read-fonts/skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.8.3", path = "font-types" }
-read-fonts = { version = "0.27.4", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.27.5", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.29.1", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.29.2", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.36.5", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.27.4"
+version = "0.27.5"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.29.1"
+version = "0.29.2"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
Changes for read-fonts from read-fonts-v0.27.4 to 0.27.5
c32c0a6 Bypass variation processing for default location (#1423)

Changes for skrifa from skrifa-v0.29.1 to 0.29.2
3a6a9f2 [Skrifa/COLRv1] Add pop_layer_with_mode()
c32c0a6 Bypass variation processing for default location (#1423)
756d450 [skrifa] add 8k and 16k buckets to stack allocator
8209ac2 [skrifa] use SmallVec for color stop resolution (#1420)