### PR TITLE
[int-set] Impl Serialize, Deserialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ env_logger = "0.11"
 pretty_assertions = "1.3.0"
 
 kurbo = "0.11.0"
-
+serde_json = "1.0"
 core_maths = "0.1"
 
 # These allow using the workspace library crates without having to

--- a/fuzz/fuzz_targets/int_set_op_processor.rs
+++ b/fuzz/fuzz_targets/int_set_op_processor.rs
@@ -140,6 +140,10 @@ impl Domain for SmallInt {
         SmallInt::new(member.value())
     }
 
+    fn contains(value: u32) -> bool {
+        value <= Self::MAX_VALUE
+    }
+
     fn is_continuous() -> bool {
         true
     }
@@ -208,6 +212,10 @@ impl Domain for SmallEvenInt {
 
     fn from_u32(member: InDomain) -> SmallEvenInt {
         SmallEvenInt::new(member.value())
+    }
+
+    fn contains(value: u32) -> bool {
+        (value % 2) == 0 && value <= Self::MAX_VALUE
     }
 
     fn is_continuous() -> bool {

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -41,6 +41,7 @@ bytemuck = { workspace = true }
 font-test-data = { workspace = true }
 criterion = "0.5.1"
 rand = "0.8.5"
+serde_json = { workspace = true }
 
 [[bench]]
 name = "int_set_benchmark"

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -86,7 +86,7 @@ pub mod offsets_arrays {
             .iter()
             .map(|x| x.unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(kids[0].bytes, &[]);
+        assert!(kids[0].bytes.is_empty());
         assert_eq!(kids[1].bytes, &[1, 1]);
         assert_eq!(kids[2].bytes, &[7, 7, 7, 7, 7]);
         assert_eq!(table.other_field(), 0xdeadbeef)

--- a/read-fonts/src/collections/int_set/bitpage.rs
+++ b/read-fonts/src/collections/int_set/bitpage.rs
@@ -20,6 +20,7 @@ const PAGE_MASK: u32 = PAGE_BITS - 1;
 
 /// A fixed size (512 bits wide) page of bits that records integer set membership from `[0, 511]`.
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct BitPage {
     storage: [Element; PAGE_SIZE as usize],
     len: Cell<u32>,
@@ -408,7 +409,7 @@ mod test {
     #[test]
     fn test_iter_bit_indices() {
         let items: Vec<_> = Iter::new(0).collect();
-        assert_eq!(items, vec![]);
+        assert_eq!(items.len(), 0);
 
         let items: Vec<_> = Iter::new(1).collect();
         assert_eq!(items, vec![0]);
@@ -642,9 +643,9 @@ mod test {
     fn page_iter_after() {
         let mut page = BitPage::new_zeroes();
         let items: Vec<_> = page.iter_after(0).collect();
-        assert_eq!(items, vec![]);
+        assert!(items.is_empty());
         let items: Vec<_> = page.iter_after(256).collect();
-        assert_eq!(items, vec![]);
+        assert!(items.is_empty());
 
         page.insert(1);
         page.insert(12);
@@ -673,7 +674,7 @@ mod test {
         assert_eq!(items, vec![400, 511]);
 
         let items: Vec<_> = page.iter_after(511).collect();
-        assert_eq!(items, vec![]);
+        assert!(items.is_empty());
 
         let items: Vec<_> = page.iter_after(390).collect();
         assert_eq!(items, vec![400, 511]);
@@ -686,9 +687,9 @@ mod test {
     fn page_iter_after_rev() {
         let mut page = BitPage::new_zeroes();
         let items: Vec<_> = page.iter_after(0).collect();
-        assert_eq!(items, vec![]);
+        assert!(items.is_empty());
         let items: Vec<_> = page.iter_after(256).collect();
-        assert_eq!(items, vec![]);
+        assert!(items.is_empty());
 
         page.insert(1);
         page.insert(12);
@@ -717,7 +718,7 @@ mod test {
         assert_eq!(items, vec![511, 400]);
 
         let items: Vec<_> = page.iter_after(511).rev().collect();
-        assert_eq!(items, vec![]);
+        assert!(items.is_empty());
 
         let items: Vec<_> = page.iter_after(390).rev().collect();
         assert_eq!(items, vec![511, 400]);

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -14,6 +14,7 @@ const PAGE_BITS_LOG_2: u32 = PAGE_BITS.ilog2();
 
 /// An ordered integer (u32) set.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct BitSet {
     // TODO(garretrieger): consider a "small array" type instead of Vec.
     pages: Vec<BitPage>,
@@ -625,6 +626,7 @@ impl<'a> BitSetBuilder<'a> {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct PageInfo {
     // index into pages vector of this page
     index: u32,
@@ -914,13 +916,13 @@ mod test {
         );
 
         assert_eq!(bitset.iter_after(3000).collect::<Vec<u32>>(), vec![3001]);
-        assert_eq!(bitset.iter_after(3001).collect::<Vec<u32>>(), vec![]);
-        assert_eq!(bitset.iter_after(3002).collect::<Vec<u32>>(), vec![]);
-        assert_eq!(bitset.iter_after(5000).collect::<Vec<u32>>(), vec![]);
-        assert_eq!(bitset.iter_after(u32::MAX).collect::<Vec<u32>>(), vec![]);
+        assert_eq!(bitset.iter_after(3001).count(), 0);
+        assert_eq!(bitset.iter_after(3002).count(), 0);
+        assert_eq!(bitset.iter_after(5000).count(), 0);
+        assert_eq!(bitset.iter_after(u32::MAX).count(), 0);
 
         bitset.insert(u32::MAX);
-        assert_eq!(bitset.iter_after(u32::MAX).collect::<Vec<u32>>(), vec![]);
+        assert_eq!(bitset.iter_after(u32::MAX).count(), 0);
         assert_eq!(
             bitset.iter_after(u32::MAX - 1).collect::<Vec<u32>>(),
             vec![u32::MAX]
@@ -931,7 +933,7 @@ mod test {
 
         assert_eq!(bitset.iter_after(510).collect::<Vec<u32>>(), vec![511, 512]);
         assert_eq!(bitset.iter_after(511).collect::<Vec<u32>>(), vec![512]);
-        assert_eq!(bitset.iter_after(512).collect::<Vec<u32>>(), vec![]);
+        assert!(bitset.iter_after(512).collect::<Vec<u32>>().is_empty());
     }
 
     #[test]

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -1657,7 +1657,7 @@ mod tests {
         static ALL_POINTS: FontData = FontData::new(&[0]);
         let (all_points, _) = PackedPointNumbers::split_off_front(ALL_POINTS);
         // in which case the iterator just keeps incrementing until u16::MAX
-        assert_eq!(all_points.iter().count(), u16::MAX as _);
+        assert_eq!(all_points.iter().count(), u16::MAX as usize);
     }
 
     /// Test that we split properly when the coordinate boundary doesn't align


### PR DESCRIPTION
This is slightly tricky because we need to ensure on deserialization that the data is valid for the given domain.

We need these impls in order to be able to use int set more broadly.

Also: adding serde_json as a dev dependency to read-fonts caused a bunch of existing code to stop compiling in a way that really looks like a rustc bug; I've changed the offenders here but it makes this a noisier patch than I'd hoped.