### PR TITLE
[int-set] Remove use of Cell

### DIFF
--- a/read-fonts/src/collections/int_set/bitpage.rs
+++ b/read-fonts/src/collections/int_set/bitpage.rs
@@ -94,10 +94,12 @@ impl BitPage {
 
     /// Marks `(val % page width)` a member of this set and returns `true` if it is newly added.
     pub(crate) fn insert(&mut self, val: u32) -> bool {
-        let ret = !self.contains(val);
-        *self.element_mut(val) |= elem_index_bit_mask(val);
-        self.length += ret as u32;
-        ret
+        let el_mut = self.element_mut(val);
+        let mask = elem_index_bit_mask(val);
+        let is_new = (*el_mut & mask) == 0;
+        *el_mut |= mask;
+        self.length += is_new as u32;
+        is_new
     }
 
     /// Marks all values `[first, last]` as members of this set.

--- a/read-fonts/src/collections/int_set/bitpage.rs
+++ b/read-fonts/src/collections/int_set/bitpage.rs
@@ -100,21 +100,6 @@ impl BitPage {
         ret
     }
 
-    /// Blindly marks `(val % page width)` a member of this set.
-    ///
-    /// This is used to maximize performance in cases where the return value
-    /// on [`insert()`] is not needed (such as for batching).
-    ///
-    /// # WARNING:
-    /// After calling this method, the `length` value for this page is no longer
-    /// valid. The caller is responsible for ensuring that the
-    /// `recalculate_length` method is called when they're finished adding items.
-    ///
-    /// [`insert()`]: Self::insert
-    pub(crate) fn insert_no_return_and_promise_to_do_your_own_bookkeeping(&mut self, val: u32) {
-        *self.element_mut(val) |= elem_index_bit_mask(val);
-    }
-
     /// Marks all values `[first, last]` as members of this set.
     pub(crate) fn insert_range(&mut self, first: u32, last: u32) {
         let first = first & PAGE_MASK;

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -611,16 +611,13 @@ impl<'a> BitSetBuilder<'a> {
             self.last_major_value = major_value;
         };
         if let Some(page) = self.set.pages.get_mut(self.last_page_index) {
-            page.insert_no_return_and_promise_to_do_your_own_bookkeeping(val);
+            self.set.length += page.insert(val) as u64;
         }
     }
 
     pub(crate) fn finish(&mut self) {
-        self.set
-            .pages
-            .iter_mut()
-            .for_each(BitPage::recompute_length);
-        self.set.recompute_length()
+        // we used to do some finalization and bookkeeping here, and we will
+        // want to again if we optimize the impl more.
     }
 }
 


### PR DESCRIPTION
This was something we'd wanted to do a while ago but now I'm motivated by clippy not liking `Cell` to be used in any type that could be stored in a {hash,btree}set.