### PR TITLE
[write] Move over ClassDefBuilder from fea-rs

### DIFF
--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -391,7 +391,7 @@ impl FromIterator<GlyphId16> for CoverageTable {
 
 impl FromIterator<(GlyphId16, u16)> for ClassDef {
     fn from_iter<T: IntoIterator<Item = (GlyphId16, u16)>>(iter: T) -> Self {
-        builders::ClassDefBuilder::from_iter(iter).build()
+        builders::ClassDefBuilderImpl::from_iter(iter).build()
     }
 }
 


### PR DESCRIPTION
This will replace the previous, simpler ClassDef builder as the public API: the new builder includes a bit more opinionated logic, like sorting classes to match what fonttools does.


- this is a part of the larger program of moving a bunch of generally-useful builders out of fea-rs and into write-fonts.
- based on #1438 and #1440, (which were required in order for this to work)