### PR TITLE
Set MSRV for font-types, read-fonts, write-fonts and skrifa to 1.71

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,6 +129,29 @@ jobs:
       - name: cargo build skrifa
         run: cargo build -p skrifa --target thumbv7em-none-eabihf --no-default-features --features=libm
 
+  check-msrv:
+    name: cargo check msrv (Rust 1.71)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install msrv toolchain (1.71)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.0
+
+      - name: cargo build font-types
+        run: cargo build -p font-types --all-targets --all-features
+
+      - name: cargo build read-fonts
+        run: cargo build -p read-fonts --all-targets --all-features
+
+      - name: cargo build write-fonts
+        run: cargo build -p read-fonts --all-targets --all-features
+
+      - name: cargo build skrifa
+        run: cargo build -p skrifa --all-targets --all-features
+
   # We use `cargo build` here because `cargo check` doesn't pick up all
   # warnings / errors. Notably, it misses `arithmetic_overflow`.
   check-wasm:

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.3"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]
+rust-version = "1.71"
 
 edition.workspace = true
 license.workspace = true

--- a/fuzz/fuzz_targets/int_set_op_processor.rs
+++ b/fuzz/fuzz_targets/int_set_op_processor.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::io::Cursor;
 use std::io::Read;
+use std::iter::Map;
 use std::ops::Bound::Excluded;
 use std::ops::Bound::Included;
 use std::ops::RangeInclusive;
@@ -132,6 +133,8 @@ impl SetMember for SmallInt {
 }
 
 impl Domain for SmallInt {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         self.0
     }
@@ -148,13 +151,11 @@ impl Domain for SmallInt {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         0..=Self::MAX_VALUE
     }
 
-    fn ordered_values_range(
-        range: RangeInclusive<SmallInt>,
-    ) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<SmallInt>) -> Self::OrderedValues {
         assert!(
             range.start().0 <= Self::MAX_VALUE && range.end().0 <= Self::MAX_VALUE,
             "Invalid range of the SmallInt set."
@@ -205,7 +206,11 @@ impl SetMember for SmallEvenInt {
     }
 }
 
+
+
 impl Domain for SmallEvenInt {
+    type OrderedValues = Map<RangeInclusive<u32>, fn(u32) -> u32>;
+
     fn to_u32(&self) -> u32 {
         self.0
     }
@@ -222,13 +227,14 @@ impl Domain for SmallEvenInt {
         false
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
-        (0..=(Self::MAX_VALUE / 2)).map(|ord| ord * 2)
+    fn ordered_values() -> Self::OrderedValues {
+        fn double(input: u32) -> u32 {
+            input * 2
+        }
+        (0..=(Self::MAX_VALUE / 2)).map(double)
     }
 
-    fn ordered_values_range(
-        range: RangeInclusive<SmallEvenInt>,
-    ) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<SmallEvenInt>) -> Self::OrderedValues {
         assert!(
             range.start().0 <= Self::MAX_VALUE && range.end().0 <= Self::MAX_VALUE,
             "Invalid range of the SmallInt set."

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.27.5"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+rust-version = "1.71"
 
 edition.workspace = true
 license.workspace = true

--- a/read-fonts/src/collections/int_set/mod.rs
+++ b/read-fonts/src/collections/int_set/mod.rs
@@ -53,6 +53,8 @@ pub struct IntSet<T>(Membership, PhantomData<T>);
 /// by an implementation of this trait. So it doesn't need to correctly handle values
 /// that are outside the domain of `T`.
 pub trait Domain: Sized {
+    type OrderedValues: DoubleEndedIterator<Item = u32>;
+
     /// Converts this value of `T` to a value in u32.
     ///
     /// The mapped value must maintain the same ordering as `T`.
@@ -73,13 +75,13 @@ pub trait Domain: Sized {
     ///
     /// Values should be converted to `u32`'s according to the mapping defined in
     /// `to_u32`/`from_u32`.
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32>;
+    fn ordered_values() -> Self::OrderedValues;
 
     /// Return an iterator which iterates over all values of T in the given range.
     ///
     /// Values should be converted to `u32`'s according to the mapping defined in
     /// `to_u32`/`from_u32`.
-    fn ordered_values_range(range: RangeInclusive<Self>) -> impl DoubleEndedIterator<Item = u32>;
+    fn ordered_values_range(range: RangeInclusive<Self>) -> Self::OrderedValues;
 
     /// Returns the number of members in the domain.
     fn count() -> u64;
@@ -1002,6 +1004,8 @@ where
 }
 
 impl Domain for u32 {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         *self
     }
@@ -1018,11 +1022,11 @@ impl Domain for u32 {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         u32::MIN..=u32::MAX
     }
 
-    fn ordered_values_range(range: RangeInclusive<u32>) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<u32>) -> Self::OrderedValues {
         range
     }
 
@@ -1032,6 +1036,8 @@ impl Domain for u32 {
 }
 
 impl Domain for u16 {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         *self as u32
     }
@@ -1048,11 +1054,11 @@ impl Domain for u16 {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         (u16::MIN as u32)..=(u16::MAX as u32)
     }
 
-    fn ordered_values_range(range: RangeInclusive<u16>) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<u16>) -> Self::OrderedValues {
         (*range.start() as u32)..=(*range.end() as u32)
     }
 
@@ -1062,6 +1068,8 @@ impl Domain for u16 {
 }
 
 impl Domain for u8 {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         *self as u32
     }
@@ -1078,11 +1086,11 @@ impl Domain for u8 {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         (u8::MIN as u32)..=(u8::MAX as u32)
     }
 
-    fn ordered_values_range(range: RangeInclusive<u8>) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<u8>) -> Self::OrderedValues {
         (*range.start() as u32)..=(*range.end() as u32)
     }
 
@@ -1092,6 +1100,8 @@ impl Domain for u8 {
 }
 
 impl Domain for GlyphId16 {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         self.to_u16() as u32
     }
@@ -1108,13 +1118,11 @@ impl Domain for GlyphId16 {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         (u16::MIN as u32)..=(u16::MAX as u32)
     }
 
-    fn ordered_values_range(
-        range: RangeInclusive<GlyphId16>,
-    ) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<GlyphId16>) -> Self::OrderedValues {
         range.start().to_u32()..=range.end().to_u32()
     }
 
@@ -1124,6 +1132,8 @@ impl Domain for GlyphId16 {
 }
 
 impl Domain for GlyphId {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         GlyphId::to_u32(*self)
     }
@@ -1140,13 +1150,11 @@ impl Domain for GlyphId {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         u32::MIN..=u32::MAX
     }
 
-    fn ordered_values_range(
-        range: RangeInclusive<GlyphId>,
-    ) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<GlyphId>) -> Self::OrderedValues {
         range.start().to_u32()..=range.end().to_u32()
     }
 
@@ -1156,6 +1164,8 @@ impl Domain for GlyphId {
 }
 
 impl Domain for Tag {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         u32::from_be_bytes(self.to_be_bytes())
     }
@@ -1172,11 +1182,11 @@ impl Domain for Tag {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         u32::MIN..=u32::MAX
     }
 
-    fn ordered_values_range(range: RangeInclusive<Tag>) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<Tag>) -> Self::OrderedValues {
         range.start().to_u32()..=range.end().to_u32()
     }
 
@@ -1186,6 +1196,8 @@ impl Domain for Tag {
 }
 
 impl Domain for NameId {
+    type OrderedValues = RangeInclusive<u32>;
+
     fn to_u32(&self) -> u32 {
         self.to_u16() as u32
     }
@@ -1202,11 +1214,11 @@ impl Domain for NameId {
         true
     }
 
-    fn ordered_values() -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values() -> Self::OrderedValues {
         (u16::MIN as u32)..=(u16::MAX as u32)
     }
 
-    fn ordered_values_range(range: RangeInclusive<NameId>) -> impl DoubleEndedIterator<Item = u32> {
+    fn ordered_values_range(range: RangeInclusive<NameId>) -> Self::OrderedValues {
         (range.start().to_u16() as u32)..=(range.end().to_u16() as u32)
     }
 

--- a/read-fonts/src/collections/int_set/mod.rs
+++ b/read-fonts/src/collections/int_set/mod.rs
@@ -1271,7 +1271,7 @@ mod test {
         }
 
         fn count() -> u64 {
-            ((u32::MAX as u64) - (u32::MIN as u64)).div_ceil(2)
+            ((u32::MAX as u64) - (u32::MIN as u64) + 1) / 2
         }
     }
 

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -141,13 +141,13 @@ pub(crate) mod codegen_prelude {
 
         #[allow(dead_code)]
         pub fn bitmap_len<T: TryInto<usize>>(count: T) -> usize {
-            count.try_into().unwrap_or_default().div_ceil(8)
+            (count.try_into().unwrap_or_default() + 7) / 8
         }
 
         #[cfg(feature = "ift")]
         pub fn max_value_bitmap_len<T: TryInto<usize>>(count: T) -> usize {
             let count: usize = count.try_into().unwrap_or_default() + 1usize;
-            count.div_ceil(8)
+            (count + 7) / 8
         }
 
         pub fn add_multiply<T: TryInto<usize>, U: TryInto<usize>, V: TryInto<usize>>(

--- a/read-fonts/src/tables/bitmap.rs
+++ b/read-fonts/src/tables/bitmap.rs
@@ -199,7 +199,7 @@ pub(crate) fn bitmap_data<'a>(
         1 => {
             let metrics = read_small_metrics(&mut image_data)?;
             // The data for each row is padded to a byte boundary
-            let pitch = (metrics.width as usize * location.bit_depth as usize).div_ceil(8);
+            let pitch = (metrics.width as usize * location.bit_depth as usize + 7) / 8;
             let height = metrics.height as usize;
             let data = image_data.read_array::<u8>(pitch * height)?;
             Ok(BitmapData {
@@ -214,7 +214,7 @@ pub(crate) fn bitmap_data<'a>(
             let width = metrics.width as usize * location.bit_depth as usize;
             let height = metrics.height as usize;
             // The data is tightly packed
-            let data = image_data.read_array::<u8>((width * height).div_ceil(8))?;
+            let data = image_data.read_array::<u8>((width * height + 7) / 8)?;
             Ok(BitmapData {
                 metrics: BitmapMetrics::Small(metrics),
                 content: BitmapContent::Data(BitmapDataFormat::BitAligned, data),
@@ -234,7 +234,7 @@ pub(crate) fn bitmap_data<'a>(
             let width = metrics.width as usize * location.bit_depth as usize;
             let height = metrics.height as usize;
             // The data is tightly packed
-            let data = image_data.read_array::<u8>((width * height).div_ceil(8))?;
+            let data = image_data.read_array::<u8>((width * height + 7) / 8)?;
             Ok(BitmapData {
                 metrics: BitmapMetrics::Big(metrics),
                 content: BitmapContent::Data(BitmapDataFormat::BitAligned, data),
@@ -245,7 +245,7 @@ pub(crate) fn bitmap_data<'a>(
         6 => {
             let metrics = read_big_metrics(&mut image_data)?;
             // The data for each row is padded to a byte boundary
-            let pitch = (metrics.width as usize * location.bit_depth as usize).div_ceil(8);
+            let pitch = (metrics.width as usize * location.bit_depth as usize + 7) / 8;
             let height = metrics.height as usize;
             let data = image_data.read_array::<u8>(pitch * height)?;
             Ok(BitmapData {
@@ -260,7 +260,7 @@ pub(crate) fn bitmap_data<'a>(
             let width = metrics.width as usize * location.bit_depth as usize;
             let height = metrics.height as usize;
             // The data is tightly packed
-            let data = image_data.read_array::<u8>((width * height).div_ceil(8))?;
+            let data = image_data.read_array::<u8>((width * height + 7) / 8)?;
             Ok(BitmapData {
                 metrics: BitmapMetrics::Big(metrics),
                 content: BitmapContent::Data(BitmapDataFormat::BitAligned, data),

--- a/read-fonts/src/tables/meta.rs
+++ b/read-fonts/src/tables/meta.rs
@@ -73,7 +73,7 @@ impl<'a> FontRead<'a> for ScriptLangTag<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         std::str::from_utf8(data.as_bytes())
             .map_err(|_| ReadError::MalformedData("LangScriptTag must be utf8"))
-            .map(|s| ScriptLangTag(s.trim_matches([' ', ','])))
+            .map(|s| ScriptLangTag(s.trim_matches(|c| c == ' ' || c == ',')))
     }
 }
 

--- a/read-fonts/src/tables/postscript/charstring.rs
+++ b/read-fonts/src/tables/postscript/charstring.rs
@@ -266,7 +266,7 @@ where
                     i += 2;
                 }
                 self.stem_count += len / 2;
-                let count = self.stem_count.div_ceil(8);
+                let count = (self.stem_count + 7) / 8;
                 let mask = cursor.read_array::<u8>(count)?;
                 if operator == HintMask {
                     self.sink.hint_mask(mask);

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.29.2"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+rust-version = "1.71"
 
 edition.workspace = true
 license.workspace = true

--- a/skrifa/src/glyph_name.rs
+++ b/skrifa/src/glyph_name.rs
@@ -94,7 +94,7 @@ impl<'a> GlyphNames<'a> {
             _ => None,
         };
         // If name is empty string, synthesize it
-        if name.as_ref().is_none_or(|s| s.is_empty()) {
+        if !name.as_ref().is_some_and(|s| !s.is_empty()) {
             return Some(GlyphName::synthesize(glyph_id));
         }
         Some(name.unwrap_or_else(|| GlyphName::synthesize(glyph_id)))

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -87,7 +87,7 @@ pub(crate) enum Orientation {
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L239>
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-pub(super) struct Point {
+pub(crate) struct Point {
     /// Describes the type and hinting state of the point.
     pub flags: PointFlags,
     /// X coordinate in font units.
@@ -148,7 +148,7 @@ const MAX_INLINE_POINTS: usize = 96;
 const MAX_INLINE_CONTOURS: usize = 8;
 
 #[derive(Default)]
-pub(super) struct Outline {
+pub(crate) struct Outline {
     pub units_per_em: i32,
     pub orientation: Option<Orientation>,
     pub points: SmallVec<Point, MAX_INLINE_POINTS>,
@@ -465,7 +465,7 @@ fn is_corner_flat(in_x: i32, in_y: i32, out_x: i32, out_y: i32) -> bool {
 }
 
 #[derive(Copy, Clone, Default, Debug)]
-pub(super) struct Contour {
+pub(crate) struct Contour {
     first_ix: u16,
     last_ix: u16,
 }

--- a/skrifa/src/outline/autohint/shape.rs
+++ b/skrifa/src/outline/autohint/shape.rs
@@ -792,7 +792,7 @@ mod tests {
     #[test]
     fn visited_set() {
         let count = 2341u16;
-        let n_bytes = (count as usize).div_ceil(8);
+        let n_bytes = (count as usize + 7) / 8;
         let mut set_buf = vec![0u8; n_bytes];
         let mut set = VisitedLookupSet::new(&mut set_buf);
         for i in 0..count {

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -126,7 +126,7 @@ impl GlyphStyleMap {
         if lookup_count > 0 {
             // If we're processing lookups, allocate some temporary memory to
             // store the visited set
-            let lookup_set_byte_size = lookup_count.div_ceil(8);
+            let lookup_set_byte_size = (lookup_count + 7) / 8;
             super::super::memory::with_temporary_memory(lookup_set_byte_size, |bytes| {
                 Self::new_inner(glyph_count, shaper, VisitedLookupSet::new(bytes))
             })

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -8,7 +8,7 @@ use raw::types::{GlyphId, Tag};
 /// Defines the script and style associated with a single glyph.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(transparent)]
-pub(super) struct GlyphStyle(pub(super) u16);
+pub(crate) struct GlyphStyle(pub(super) u16);
 
 impl GlyphStyle {
     // The following flags roughly correspond to those defined in FreeType

--- a/skrifa/src/outline/autohint/topo/mod.rs
+++ b/skrifa/src/outline/autohint/topo/mod.rs
@@ -27,7 +27,7 @@ pub type Dimension = usize;
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L309>
 #[derive(Clone, Default, Debug)]
-pub struct Axis {
+pub(crate) struct Axis {
     /// Either horizontal or vertical.
     pub dim: Dimension,
     /// Depends on dimension and outline orientation.

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -20,7 +20,7 @@ const MAX_HINTS: usize = 96;
 
 // One bit per stem hint
 // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/psaux/pshints.h#L80>
-const HINT_MASK_SIZE: usize = MAX_HINTS.div_ceil(8);
+const HINT_MASK_SIZE: usize = (MAX_HINTS + 7) / 8;
 
 // Constant for hint adjustment and em box hint placement.
 // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/psaux/psblues.h#L114>

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.36.5"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+rust-version = "1.71"
 
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
As foundational crates in the ecosystem (that will sit low down in dependency trees), it would be helpful if these crates could be relatively conservative with MSRV unless there is a good reason not to. So I went through to see how low I could get it without excessive effort.

The result was Rust 1.71. Lower than that runs into issues with lack of support for `dep:` syntax in `Cargo.toml` files.

### Changes made
- Replace `is_none_or` with negated `is_some_and`
- Use predicate matcher instead of array matcher with `trim_matches`
- Use associated type instead of "impl trait in trait" in intset Domain trait
- Fix some item visibility inconsitencies
- Set `rust-version` key in Cargo.toml
- Add CI check for Rust 1.71