### PR TITLE
[write] Split ligature subtables during compilation

### DIFF
--- a/write-fonts/src/tables/gsub/builders.rs
+++ b/write-fonts/src/tables/gsub/builders.rs
@@ -2,10 +2,94 @@
 
 use std::{collections::BTreeMap, convert::TryFrom};
 
-use types::GlyphId16;
+use types::{FixedSize, GlyphId16, Offset16};
 
-use crate::tables::{layout::builders::Builder, variations::ivs_builder::VariationStoreBuilder};
+use crate::{
+    tables::{
+        layout::{builders::Builder, CoverageTable},
+        variations::ivs_builder::VariationStoreBuilder,
+    },
+    FontWrite,
+};
 
+/// Helper type for splitting layout subtables
+// NOTE: currently just used for ligature substitution, but hopefully can be
+// reused for other lookups as needed?
+#[derive(Clone, Debug)]
+struct TableSplitter<T: SplitTable> {
+    finished: Vec<T>,
+    current_coverage: Vec<GlyphId16>,
+    current_items: Vec<T::Component>,
+    current_size: usize,
+}
+
+/// A trait for splitting layout subtables.
+trait SplitTable {
+    /// The component item of this table.
+    type Component;
+
+    /// The (maximum) number of bytes required to store this item.
+    ///
+    /// This should include only the costs of the item, not the cost of adding
+    /// to the coverage table.
+    ///
+    /// 'Maximum' because this does not account for possible size savings from
+    /// deduplication of identical objects, for instance.
+    fn size_for_item(item: &Self::Component) -> usize;
+    /// The starting size of a new table that will contain this item.
+    ///
+    /// This does not include the size of the item itself! The item is provided
+    /// because sometimes the table contains fields derived from its members.
+    fn initial_size_for_item(item: &Self::Component) -> usize;
+    fn instantiate(coverage: CoverageTable, items: Vec<Self::Component>) -> Self;
+}
+
+impl<T: SplitTable + FontWrite> TableSplitter<T> {
+    const MAX_TABLE_SIZE: usize = u16::MAX as usize;
+
+    fn new() -> Self {
+        Self {
+            finished: Vec::new(),
+            current_coverage: Vec::new(),
+            current_items: Vec::new(),
+            current_size: 0,
+        }
+    }
+
+    fn add(&mut self, gid: GlyphId16, item: T::Component) {
+        let item_size = T::size_for_item(&item);
+        if item_size + self.current_size > Self::MAX_TABLE_SIZE {
+            let current_len = self.current_coverage.len();
+            self.finish_current();
+            let type_ = self.finished.last().unwrap().table_type();
+            log::info!("adding split in {type_} at {current_len}");
+        }
+
+        if self.current_size == 0 {
+            self.current_size = T::initial_size_for_item(&item);
+        }
+        self.current_coverage.push(gid);
+        self.current_items.push(item);
+        // item size + a glyph in the coverage table (worst case)
+        self.current_size += item_size + GlyphId16::RAW_BYTE_LEN;
+    }
+
+    fn finish_current(&mut self) {
+        if !self.current_coverage.is_empty() {
+            let coverage = std::mem::take(&mut self.current_coverage).into();
+            self.finished.push(T::instantiate(
+                coverage,
+                std::mem::take(&mut self.current_items),
+            ));
+            self.current_size = 0;
+        }
+    }
+
+    fn finish(mut self) -> Vec<T> {
+        self.finish_current();
+        self.finished
+    }
+}
 /// A builder for [`SingleSubst`](super::SingleSubst) subtables.
 #[derive(Clone, Debug, Default)]
 pub struct SingleSubBuilder {
@@ -196,22 +280,110 @@ impl Builder for LigatureSubBuilder {
     type Output = Vec<super::LigatureSubstFormat1>;
 
     fn build(self, _: &mut VariationStoreBuilder) -> Self::Output {
-        let coverage = self.items.keys().copied().collect();
-        let lig_sets = self
-            .items
-            .into_values()
-            .map(|mut ligs| {
-                // we want to sort longer items first, but otherwise preserve
-                // the order provided by the user.
-                ligs.sort_by_key(|(lig, _)| std::cmp::Reverse(lig.len()));
-                super::LigatureSet::new(
-                    ligs.into_iter()
-                        .map(|(components, lig_glyph)| super::Ligature::new(lig_glyph, components))
-                        .collect(),
-                )
-            })
-            .collect();
+        let mut splitter = TableSplitter::<super::LigatureSubstFormat1>::new();
+        for (gid, mut ligs) in self.items.into_iter() {
+            // we want to sort longer items first, but otherwise preserve
+            // the order provided by the user.
+            ligs.sort_by_key(|(lig, _)| std::cmp::Reverse(lig.len()));
+            let lig_set = super::LigatureSet::new(
+                ligs.into_iter()
+                    .map(|(components, replacement)| super::Ligature::new(replacement, components))
+                    .collect(),
+            );
+            splitter.add(gid, lig_set);
+        }
+        splitter.finish()
+    }
+}
 
-        vec![super::LigatureSubstFormat1::new(coverage, lig_sets)]
+impl SplitTable for super::LigatureSubstFormat1 {
+    type Component = super::LigatureSet;
+
+    fn size_for_item(item: &Self::Component) -> usize {
+        item.compute_size()
+    }
+
+    fn initial_size_for_item(_item: &Self::Component) -> usize {
+        // format, coverage offset, set count, sets offset
+        u16::RAW_BYTE_LEN * 4
+    }
+
+    fn instantiate(coverage: CoverageTable, items: Vec<Self::Component>) -> Self {
+        Self::new(coverage, items)
+    }
+}
+
+impl super::LigatureSet {
+    fn compute_size(&self) -> usize {
+        // ligatureCount
+        u16::RAW_BYTE_LEN
+            // ligatureOffsets
+            + Offset16::RAW_BYTE_LEN * self.ligatures.len()
+            // size of each referenced ligature table
+            + self
+                .ligatures
+                .iter()
+                .map(|lig| lig.compute_size())
+                .sum::<usize>()
+    }
+}
+
+impl super::Ligature {
+    fn compute_size(&self) -> usize {
+        // ligatureGlyph
+        u16::RAW_BYTE_LEN
+            // componentCount
+            + u16::RAW_BYTE_LEN
+            // componentGlyphIDs
+            + u16::RAW_BYTE_LEN * self.component_glyph_ids.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tables::gsub::LigatureSubstFormat1;
+
+    use super::*;
+
+    fn make_lig_table(n_bytes: u16, first: u16) -> super::super::Ligature {
+        assert!(n_bytes >= 6, "minimum table size");
+        assert!(n_bytes % 2 == 0, "can only generate even sizes: {n_bytes}");
+        // 6 bytes per Ligature (header, including offset)
+        let n_glyphs = (n_bytes - 6) / 2;
+        let components = (first..=first + n_glyphs).map(GlyphId16::new).collect();
+        super::super::Ligature::new(GlyphId16::new(first), components)
+    }
+    fn make_2048_bytes_of_ligature() -> super::super::LigatureSet {
+        // 4 bytes for header
+        // 2048 - 4 = 2044
+        // 2044 / 2 = 1022
+        let lig1 = make_lig_table(1022, 1);
+        let lig2 = make_lig_table(1022, 3);
+        super::super::LigatureSet::new(vec![lig1, lig2])
+    }
+
+    #[test]
+    fn who_tests_the_testers1() {
+        for size in [6, 12, 144, 2046, u16::MAX - 1] {
+            let table = make_lig_table(size, 1);
+            let bytes = crate::dump_table(&table).unwrap();
+            assert_eq!(bytes.len(), size as usize);
+        }
+    }
+
+    #[test]
+    fn splitting_ligature_subs() {
+        let mut splitter = TableSplitter::<LigatureSubstFormat1>::new();
+        let ligset = make_2048_bytes_of_ligature();
+        for gid in 0u16..31 {
+            // in real packing these would be deduplicated but we can't now that here
+            splitter.add(GlyphId16::new(gid), ligset.clone());
+        }
+
+        // 31 * 2048 < u16::MAX
+        assert_eq!(splitter.clone().finish().len(), 1);
+        splitter.add(GlyphId16::new(32), ligset);
+        // 32 * 2048 < u16::MAX
+        assert_eq!(splitter.finish().len(), 2)
     }
 }

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -389,6 +389,12 @@ impl FromIterator<GlyphId16> for CoverageTable {
     }
 }
 
+impl From<Vec<GlyphId16>> for CoverageTable {
+    fn from(value: Vec<GlyphId16>) -> Self {
+        builders::CoverageTableBuilder::from_glyphs(value).build()
+    }
+}
+
 impl FromIterator<(GlyphId16, u16)> for ClassDef {
     fn from_iter<T: IntoIterator<Item = (GlyphId16, u16)>>(iter: T) -> Self {
         builders::ClassDefBuilderImpl::from_iter(iter).build()


### PR DESCRIPTION
This is much easier than splitting them during packing.

This fixes at least one crater crash, and also resolves an error that we encounter when compiling a brand font (although, unfortunately, we seem to hit another unrelated error afterwards)
