### PR TITLE
[write] Enable traversal when using 'read' feature

### DIFF
--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 
 [features]
 default = []
-read = []
+read = ["read-fonts/experimental_traverse"]
 dot2 = ["dep:dot2"]
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
 ift = ["read-fonts/ift"]


### PR DESCRIPTION
This is the feature of write-fonts that reexports read-fonts as public API; in this case being able to debug the read-fonts items makes sense.