### PR TITLE
Update CFF hinting to match FreeType

### DIFF
--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 skrifa = { workspace = true }
-freetype-rs = "0.38.0"
+freetype-rs = { version = "0.38.0", features = ["bundled"] }
 memmap2 = "0.5.10"
 rayon = "1.8.0"
 clap = { version = "4.4.7", features = ["derive"] }

--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 skrifa = { workspace = true }
-freetype-rs = "0.32.0"
+freetype-rs = "0.38.0"
 memmap2 = "0.5.10"
 rayon = "1.8.0"
 clap = { version = "4.4.7", features = ["derive"] }

--- a/read-fonts/src/tables/postscript/stack.rs
+++ b/read-fonts/src/tables/postscript/stack.rs
@@ -216,14 +216,7 @@ impl Stack {
                 .zip(&mut self.value_is_fixed)
             {
                 let fixed_value = if *is_fixed {
-                    // FreeType reads delta values using cff_parse_num which
-                    // which truncates the fractional parts of 16.16 values
-                    // See delta parsing:
-                    // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/cff/cffparse.c#L1427>
-                    // See cff_parse_num "binary-coded decimal is truncated to
-                    // integer":
-                    // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/cff/cffparse.c#L463>
-                    Fixed::from_bits(*value).floor()
+                    Fixed::from_bits(*value)
                 } else {
                     Fixed::from_i32(*value)
                 };
@@ -431,9 +424,9 @@ mod tests {
         assert!(stack.len_is_odd());
         let values: Vec<_> = stack.fixed_values().collect();
         let expected = &[
-            Fixed::from_f64(1.0),
-            Fixed::from_f64(43.0),
-            Fixed::from_f64(47.0),
+            Fixed::from_f64(1.5),
+            Fixed::from_f64(43.5),
+            Fixed::from_f64(47.69999694824219),
         ];
         assert_eq!(&values, expected);
     }

--- a/skrifa/src/outline/cff/hint.rs
+++ b/skrifa/src/outline/cff/hint.rs
@@ -143,12 +143,7 @@ impl HintState {
         let mut zone_ix = 0usize;
         // Copy blues and other blues to a combined array of top and bottom zones.
         for blue in params.blues.values().iter().take(MAX_BLUES) {
-            // FreeType loads blues as integers and then expands to 16.16
-            // at initialization. We load them as 16.16 so floor them here
-            // to ensure we match.
-            // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/psaux/psblues.c#L190>
-            let bottom = blue.0.floor();
-            let top = blue.1.floor();
+            let (bottom, top) = *blue;
             let zone_height = top - bottom;
             if zone_height < Fixed::ZERO {
                 // Reject zones with negative height
@@ -173,8 +168,7 @@ impl HintState {
             zone_ix += 1;
         }
         for blue in params.other_blues.values().iter().take(MAX_OTHER_BLUES) {
-            let bottom = blue.0.floor();
-            let top = blue.1.floor();
+            let (bottom, top) = *blue;
             let zone_height = top - bottom;
             if zone_height < Fixed::ZERO {
                 // Reject zones with negative height

--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -317,7 +317,7 @@ impl PrivateDict {
                 BlueValues(values) => dict.hint_params.blues = values,
                 FamilyBlues(values) => dict.hint_params.family_blues = values,
                 OtherBlues(values) => dict.hint_params.other_blues = values,
-                FamilyOtherBlues(values) => dict.hint_params.family_blues = values,
+                FamilyOtherBlues(values) => dict.hint_params.family_other_blues = values,
                 BlueScale(value) => dict.hint_params.blue_scale = value,
                 BlueShift(value) => dict.hint_params.blue_shift = value,
                 BlueFuzz(value) => dict.hint_params.blue_fuzz = value,
@@ -621,6 +621,7 @@ mod tests {
         prelude::{LocationRef, Size},
         MetadataProvider,
     };
+    use dict::Blues;
     use font_test_data::bebuffer::BeBuffer;
     use raw::tables::cff2::Cff2;
     use read_fonts::FontRef;
@@ -849,5 +850,25 @@ mod tests {
                 );
             }
         }
+    }
+
+    // We were overwriting family_other_blues with family_blues.
+    #[test]
+    fn capture_family_other_blues() {
+        let private_dict_data = &font_test_data::cff2::EXAMPLE[0x4f..=0xc0];
+        let store =
+            ItemVariationStore::read(FontData::new(&font_test_data::cff2::EXAMPLE[18..])).unwrap();
+        let coords = &[F2Dot14::from_f32(0.0)];
+        let blend_state = BlendState::new(store, coords, 0).unwrap();
+        let private_dict = PrivateDict::new(
+            FontData::new(private_dict_data),
+            0..private_dict_data.len(),
+            Some(blend_state),
+        )
+        .unwrap();
+        assert_eq!(
+            private_dict.hint_params.family_other_blues,
+            Blues::new([-249.0, -239.0].map(Fixed::from_f64).into_iter())
+        )
     }
 }


### PR DESCRIPTION
* Don't truncate fixed values when parsing (blue zones, scale, shift, fuzz, etc)
* Match FreeType's parsing of binary coded decimal numbers
* Fix bug where we were overwriting "family blues" with "family other blues"
* Update fauntlet to latest available FreeType via freetype-rs (2.13.2)

Basically follows FreeType fix https://gitlab.freedesktop.org/freetype/freetype/-/commit/8eab511017a65026985523cab14aff07f1bb9746