### PR TITLE
[IFT] Use stored charstring offsets to locate charstring tables

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -54,7 +54,8 @@ pub fn simple_format1_with_one_charstrings_offset() -> BeBuffer {
     let mut buffer = be_buffer! {
         /* ### Header ### */
         1u8,                    // format
-        0u32,                   // reserved
+        0u8, 0u8, 0u8,          // reserved
+        0b00000001u8,           // has charstrings offset
         [1u32, 2, 3, 4],        // compat id
         2u16,                   // max entry id
         {2u16: "max_glyph_map_entry_id"},
@@ -88,7 +89,8 @@ pub fn simple_format1_with_two_charstrings_offsets() -> BeBuffer {
     let mut buffer = be_buffer! {
         /* ### Header ### */
         1u8,                    // format
-        0u32,                   // reserved
+        0u8, 0u8, 0u8,          // reserved
+        0b00000011u8,           // has cff and cff2 charstrings offset
         [1u32, 2, 3, 4],        // compat id
         2u16,                   // max entry id
         {2u16: "max_glyph_map_entry_id"},
@@ -307,7 +309,8 @@ pub fn format2_with_one_charstrings_offset() -> BeBuffer {
     let mut buffer = be_buffer! {
       2u8,                // format
 
-      0u32,               // reserved
+      0u8, 0u8, 0u8,                 // reserved
+      {0b00000001u8: "field_flags"}, // has charstrings offset
 
       {1u32: "compat_id[0]"},
       {2u32: "compat_id[1]"},
@@ -340,7 +343,8 @@ pub fn format2_with_two_charstrings_offset() -> BeBuffer {
     let mut buffer = be_buffer! {
       2u8,                // format
 
-      0u32,               // reserved
+      0u8, 0u8, 0u8,          // reserved
+      0b00000011u8,           // has cff and cff2 charstrings offset
 
       {1u32: "compat_id[0]"},
       {2u32: "compat_id[1]"},
@@ -1255,7 +1259,7 @@ pub fn short_gvar_near_maximum_offset_size() -> BeBuffer {
     };
 
     // Glyph 0
-    let mut buffer = buffer.extend(iter::repeat(1u8).take(131065));
+    let mut buffer = buffer.extend(iter::repeat_n(1u8, 131065));
 
     let data_offset = buffer.offset_for("glyph_0");
     buffer.write_at("shared_tuples_offset", data_offset as u32);

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -231,6 +231,73 @@ pub fn codepoints_only_format2() -> BeBuffer {
     buffer
 }
 
+pub fn format2_with_one_charstrings_offset() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      2u8,                // format
+
+      0u32,               // reserved
+
+      {1u32: "compat_id[0]"},
+      {2u32: "compat_id[1]"},
+      {3u32: "compat_id[2]"},
+      {4u32: "compat_id[3]"},
+
+      3u8,                // default patch encoding
+      (Uint24::new(1)),   // entry count
+      {0u32: "entries_offset"},
+      0u32,               // entry string data offset
+
+      8u16, // uriTemplateLength
+      [b'A', b'B', b'C', b'D', b'E', b'F', 0xc9, 0xa4],  // uriTemplate[8]
+
+      456u32, // charstrings offset [0]
+
+      /* ### Entries Array ### */
+      // Entry id = 1
+      {0b00010000u8: "entries[0]"},           // format = CODEPOINT_BIT_1
+      [0b00001101, 0b00000011, 0b00110001u8]  // codepoints = [0..17]
+    };
+
+    let offset = buffer.offset_for("entries[0]") as u32;
+    buffer.write_at("entries_offset", offset);
+
+    buffer
+}
+
+pub fn format2_with_two_charstrings_offset() -> BeBuffer {
+    let mut buffer = be_buffer! {
+      2u8,                // format
+
+      0u32,               // reserved
+
+      {1u32: "compat_id[0]"},
+      {2u32: "compat_id[1]"},
+      {3u32: "compat_id[2]"},
+      {4u32: "compat_id[3]"},
+
+      3u8,                // default patch encoding
+      (Uint24::new(1)),   // entry count
+      {0u32: "entries_offset"},
+      0u32,               // entry string data offset
+
+      8u16, // uriTemplateLength
+      [b'A', b'B', b'C', b'D', b'E', b'F', 0xc9, 0xa4],  // uriTemplate[8]
+
+      456u32, // charstrings offset [0]
+      789u32, // charstrings offset [1]
+
+      /* ### Entries Array ### */
+      // Entry id = 1
+      {0b00010000u8: "entries[0]"},           // format = CODEPOINT_BIT_1
+      [0b00001101, 0b00000011, 0b00110001u8]  // codepoints = [0..17]
+    };
+
+    let offset = buffer.offset_for("entries[0]") as u32;
+    buffer.write_at("entries_offset", offset);
+
+    buffer
+}
+
 pub fn features_and_design_space_format2() -> BeBuffer {
     let mut buffer = be_buffer! {
       2u8, // format

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -50,6 +50,75 @@ pub fn simple_format1() -> BeBuffer {
     buffer
 }
 
+pub fn simple_format1_with_one_charstrings_offset() -> BeBuffer {
+    let mut buffer = be_buffer! {
+        /* ### Header ### */
+        1u8,                    // format
+        0u32,                   // reserved
+        [1u32, 2, 3, 4],        // compat id
+        2u16,                   // max entry id
+        {2u16: "max_glyph_map_entry_id"},
+        (Uint24::new(7)),       // glyph count
+        {0u32: "glyph_map_offset"},
+        0u32,                   // feature map offset
+        0b00000010u8,           // applied entry bitmap (entry 1)
+
+        8u16,                   // uri template length
+        {b'A': "uri_template[0]"},
+        {b'B': "uri_template[1]"},
+        [b'C', b'D', b'E', b'F', 0xc9, 0xa4], // uri_template[2..7]
+
+        {3u8: "patch_format"}, // = glyph keyed
+
+        456u32, // charstrings offset [0]
+
+        /* ### Glyph Map ### */
+        {1u16: "glyph_map"},     // first mapped glyph
+        {2u8: "entry_index[1]"},
+        [1u8, 0, 1, 0, 0]        // entry index[2..6]
+    };
+
+    let offset = buffer.offset_for("glyph_map") as u32;
+    buffer.write_at("glyph_map_offset", offset);
+
+    buffer
+}
+
+pub fn simple_format1_with_two_charstrings_offsets() -> BeBuffer {
+    let mut buffer = be_buffer! {
+        /* ### Header ### */
+        1u8,                    // format
+        0u32,                   // reserved
+        [1u32, 2, 3, 4],        // compat id
+        2u16,                   // max entry id
+        {2u16: "max_glyph_map_entry_id"},
+        (Uint24::new(7)),       // glyph count
+        {0u32: "glyph_map_offset"},
+        0u32,                   // feature map offset
+        0b00000010u8,           // applied entry bitmap (entry 1)
+
+        8u16,                   // uri template length
+        {b'A': "uri_template[0]"},
+        {b'B': "uri_template[1]"},
+        [b'C', b'D', b'E', b'F', 0xc9, 0xa4], // uri_template[2..7]
+
+        {3u8: "patch_format"}, // = glyph keyed
+
+        456u32, // charstrings offset [0]
+        789u32, // charstrings offset [1]
+
+        /* ### Glyph Map ### */
+        {1u16: "glyph_map"},     // first mapped glyph
+        {2u8: "entry_index[1]"},
+        [1u8, 0, 1, 0, 0]        // entry index[2..6]
+    };
+
+    let offset = buffer.offset_for("glyph_map") as u32;
+    buffer.write_at("glyph_map_offset", offset);
+
+    buffer
+}
+
 pub fn u16_entries_format1() -> BeBuffer {
     let mut buffer = be_buffer! {
       1u8,              // format

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -14,6 +14,9 @@ pub static IFT_BASE: &[u8] = include_bytes!("../test_data/ttf/ift_base.ttf");
 pub static CFF_FONT: &[u8] = include_bytes!("../test_data/ttf/NotoSansJP-Regular.subset.otf");
 pub static CFF2_FONT: &[u8] = include_bytes!("../test_data/ttf/NotoSansJP-VF.subset.otf");
 
+pub const CFF_FONT_CHARSTRINGS_OFFSET: u32 = 0x1b9;
+pub const CFF2_FONT_CHARSTRINGS_OFFSET: u32 = 0x8f;
+
 // Format specification: https://w3c.github.io/IFT/Overview.html#patch-map-format-1
 pub fn simple_format1() -> BeBuffer {
     let mut buffer = be_buffer! {
@@ -250,7 +253,7 @@ pub fn format2_with_one_charstrings_offset() -> BeBuffer {
       8u16, // uriTemplateLength
       [b'A', b'B', b'C', b'D', b'E', b'F', 0xc9, 0xa4],  // uriTemplate[8]
 
-      456u32, // charstrings offset [0]
+      {456u32: "charstrings_offset"}, // charstrings offset [0]
 
       /* ### Entries Array ### */
       // Entry id = 1

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -7,6 +7,19 @@ use std::str;
 pub const IFT_TAG: types::Tag = Tag::new(b"IFT ");
 pub const IFTX_TAG: types::Tag = Tag::new(b"IFTX");
 
+impl Ift<'_> {
+    pub fn get_charstring_offsets(
+        &self,
+        has_cff: bool,
+        has_cff2: bool,
+    ) -> (Option<u32>, Option<u32>) {
+        match self {
+            Ift::Format1(_) => todo!(),
+            Ift::Format2(f2) => f2.get_charstring_offsets(has_cff, has_cff2),
+        }
+    }
+}
+
 /// Wrapper for the packed childEntryMatchModeAndCount field in IFT format 2 mapping table.
 ///
 /// Reference: <https://w3c.github.io/IFT/Overview.html#mapping-entry-childentrymatchmodeandcount>

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -66,9 +66,11 @@ table PatchMapFormat1 {
   /// Patch format number for patches referenced by this mapping.
   patch_format: u8,
 
+  // Offset to the cff charstrings INDEX from the start of the CFF table.
   #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET)]
   cff_charstrings_offset: u32,
 
+  // Offset to the cff charstrings INDEX from the start of the CFF2 table.
   #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET)]
   cff2_charstrings_offset: u32,
 }
@@ -165,9 +167,11 @@ table PatchMapFormat2 {
   #[count($uri_template_length)]
   uri_template: [u8],
 
+  // Offset to the cff charstrings INDEX from the start of the CFF table.
   #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET)]
   cff_charstrings_offset: u32,
 
+  // Offset to the cff charstrings INDEX from the start of the CFF2 table.
   #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET)]
   cff2_charstrings_offset: u32,
 }

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -137,6 +137,9 @@ table PatchMapFormat2 {
   uri_template_length: u16,
   #[count($uri_template_length)]
   uri_template: [u8],
+
+  #[count(..)]
+  optional_charstring_offsets: [u8],
 }
 
 table MappingEntries {

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -52,6 +52,9 @@ table PatchMapFormat1 {
 
   /// Patch format number for patches referenced by this mapping.
   patch_format: u8,
+
+  #[count(..)]
+  optional_charstring_offsets: [u8],
 }
 
 #[read_args(glyph_count: Uint24, max_entry_index: u16)]

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -11,6 +11,11 @@ format u8 Ift {
   Format2(PatchMapFormat2),
 }
 
+flags u8 PatchMapFieldPresenceFlags {
+  CFF_CHARSTRINGS_OFFSET = 0b00000001,
+  CFF2_CHARSTRINGS_OFFSET = 0b00000010,
+}
+
 /// [Patch Map Format Format 1](https://w3c.github.io/IFT/Overview.html#patch-map-format-1)
 table PatchMapFormat1 {
   /// Format identifier: format = 1
@@ -19,7 +24,15 @@ table PatchMapFormat1 {
 
   #[skip_getter]
   #[compile(0)]
-  _reserved: u32,
+  _reserved_0: u8,
+  #[skip_getter]
+  #[compile(0)]
+  _reserved_1: u8,
+  #[skip_getter]
+  #[compile(0)]
+  _reserved_2: u8,
+
+  field_flags: PatchMapFieldPresenceFlags,
 
   /// Unique ID that identifies compatible patches.
   #[traverse_with(skip)]
@@ -53,8 +66,11 @@ table PatchMapFormat1 {
   /// Patch format number for patches referenced by this mapping.
   patch_format: u8,
 
-  #[count(..)]
-  optional_charstring_offsets: [u8],
+  #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET)]
+  cff_charstrings_offset: u32,
+
+  #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET)]
+  cff2_charstrings_offset: u32,
 }
 
 #[read_args(glyph_count: Uint24, max_entry_index: u16)]
@@ -120,7 +136,15 @@ table PatchMapFormat2 {
 
   #[skip_getter]
   #[compile(0)]
-  _reserved: u32,
+  _reserved_0: u8,
+  #[skip_getter]
+  #[compile(0)]
+  _reserved_1: u8,
+  #[skip_getter]
+  #[compile(0)]
+  _reserved_2: u8,
+
+  field_flags: PatchMapFieldPresenceFlags,
 
   /// Unique ID that identifies compatible patches.
   #[traverse_with(skip)]
@@ -141,8 +165,11 @@ table PatchMapFormat2 {
   #[count($uri_template_length)]
   uri_template: [u8],
 
-  #[count(..)]
-  optional_charstring_offsets: [u8],
+  #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET)]
+  cff_charstrings_offset: u32,
+
+  #[if_flag($field_flags, PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET)]
+  cff2_charstrings_offset: u32,
 }
 
 table MappingEntries {

--- a/write-fonts/generated/generated_ift.rs
+++ b/write-fonts/generated/generated_ift.rs
@@ -28,6 +28,7 @@ impl Ift {
         uri_template_length: u16,
         uri_template: Vec<u8>,
         patch_format: u8,
+        optional_charstring_offsets: Vec<u8>,
     ) -> Self {
         Self::Format1(PatchMapFormat1::new(
             compatibility_id,
@@ -40,6 +41,7 @@ impl Ift {
             uri_template_length,
             uri_template,
             patch_format,
+            optional_charstring_offsets,
         ))
     }
 
@@ -148,6 +150,7 @@ pub struct PatchMapFormat1 {
     pub uri_template: Vec<u8>,
     /// Patch format number for patches referenced by this mapping.
     pub patch_format: u8,
+    pub optional_charstring_offsets: Vec<u8>,
 }
 
 impl PatchMapFormat1 {
@@ -164,6 +167,7 @@ impl PatchMapFormat1 {
         uri_template_length: u16,
         uri_template: Vec<u8>,
         patch_format: u8,
+        optional_charstring_offsets: Vec<u8>,
     ) -> Self {
         Self {
             compatibility_id,
@@ -176,6 +180,7 @@ impl PatchMapFormat1 {
             uri_template_length,
             uri_template,
             patch_format,
+            optional_charstring_offsets,
         }
     }
 }
@@ -195,6 +200,7 @@ impl FontWrite for PatchMapFormat1 {
         self.uri_template_length.write_into(writer);
         self.uri_template.write_into(writer);
         self.patch_format.write_into(writer);
+        self.optional_charstring_offsets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
         TableType::Named("PatchMapFormat1")
@@ -233,6 +239,9 @@ impl<'a> FromObjRef<read_fonts::tables::ift::PatchMapFormat1<'a>> for PatchMapFo
             uri_template_length: obj.uri_template_length(),
             uri_template: obj.uri_template().to_owned_obj(offset_data),
             patch_format: obj.patch_format(),
+            optional_charstring_offsets: obj
+                .optional_charstring_offsets()
+                .to_owned_obj(offset_data),
         }
     }
 }

--- a/write-fonts/generated/generated_ift.rs
+++ b/write-fonts/generated/generated_ift.rs
@@ -44,6 +44,7 @@ impl Ift {
     }
 
     /// Construct a new `PatchMapFormat2` subtable
+    #[allow(clippy::too_many_arguments)]
     pub fn format_2(
         compatibility_id: CompatibilityId,
         default_patch_format: u8,
@@ -52,6 +53,7 @@ impl Ift {
         entry_id_string_data: Option<IdStringData>,
         uri_template_length: u16,
         uri_template: Vec<u8>,
+        optional_charstring_offsets: Vec<u8>,
     ) -> Self {
         Self::Format2(PatchMapFormat2::new(
             compatibility_id,
@@ -61,6 +63,7 @@ impl Ift {
             entry_id_string_data,
             uri_template_length,
             uri_template,
+            optional_charstring_offsets,
         ))
     }
 }
@@ -405,10 +408,12 @@ pub struct PatchMapFormat2 {
     pub entry_id_string_data: NullableOffsetMarker<IdStringData, WIDTH_32>,
     pub uri_template_length: u16,
     pub uri_template: Vec<u8>,
+    pub optional_charstring_offsets: Vec<u8>,
 }
 
 impl PatchMapFormat2 {
     /// Construct a new `PatchMapFormat2`
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         compatibility_id: CompatibilityId,
         default_patch_format: u8,
@@ -417,6 +422,7 @@ impl PatchMapFormat2 {
         entry_id_string_data: Option<IdStringData>,
         uri_template_length: u16,
         uri_template: Vec<u8>,
+        optional_charstring_offsets: Vec<u8>,
     ) -> Self {
         Self {
             compatibility_id,
@@ -426,6 +432,7 @@ impl PatchMapFormat2 {
             entry_id_string_data: entry_id_string_data.into(),
             uri_template_length,
             uri_template,
+            optional_charstring_offsets,
         }
     }
 }
@@ -442,6 +449,7 @@ impl FontWrite for PatchMapFormat2 {
         self.entry_id_string_data.write_into(writer);
         self.uri_template_length.write_into(writer);
         self.uri_template.write_into(writer);
+        self.optional_charstring_offsets.write_into(writer);
     }
     fn table_type(&self) -> TableType {
         TableType::Named("PatchMapFormat2")
@@ -477,6 +485,9 @@ impl<'a> FromObjRef<read_fonts::tables::ift::PatchMapFormat2<'a>> for PatchMapFo
             entry_id_string_data: obj.entry_id_string_data().to_owned_table(),
             uri_template_length: obj.uri_template_length(),
             uri_template: obj.uri_template().to_owned_obj(offset_data),
+            optional_charstring_offsets: obj
+                .optional_charstring_offsets()
+                .to_owned_obj(offset_data),
         }
     }
 }


### PR DESCRIPTION
Context: https://w3c.github.io/IFT/Overview.html#cff

In the IFT mapping tables of fonts with CFF or CFF2 tables the offsets to the charstrings INDEX structures are stored. Parse and utilize these to locate the charstring data structures during patch application instead of pulling the offsets out of the CFF tables.