### PR TITLE
Remove is_none_or call for compatibility with older Rust.

### DIFF
--- a/skrifa/src/glyph_name.rs
+++ b/skrifa/src/glyph_name.rs
@@ -94,7 +94,11 @@ impl<'a> GlyphNames<'a> {
             _ => None,
         };
         // If name is empty string, synthesize it
-        if name.as_ref().is_none_or(|s| s.is_empty()) {
+        let no_name: bool = match name {
+           None => true,
+           Some(ref x) => x.is_empty(),
+        };
+        if no_name {
             return Some(GlyphName::synthesize(glyph_id));
         }
         Some(name.unwrap_or_else(|| GlyphName::synthesize(glyph_id)))


### PR DESCRIPTION
The function is only only available for Rust >= 1.82, which causes builds to [fail](https://launchpadlibrarian.net/786378027/buildlog_snap_ubuntu_jammy_amd64_chromium-snap-from-source-beta_BUILDING.txt.gz) in e.g. Ubuntu 24.04 and 22.04 which only have 1.80.

```
:: error[E0599]: no method named `is_none_or` found for enum `Option` in the current scope
::   --> ../../third_party/rust/chromium_crates_io/vendor/skrifa-v0_29/src/glyph_name.rs:97:26
::    |
:: 97 |         if name.as_ref().is_none_or(|s| s.is_empty()) {
::    |                          ^^^^^^^^^^
::    |
:: help: there is a method `is_none` with a similar name, but with different arguments
::   --> /build/rustc-1.80-osjZwj/rustc-1.80-1.80.1+dfsg0ubuntu1/library/core/src/option.rs:653:5
```

We applied this patch downstream, which allowed our Chromium builds to complete, so I'm forwarding it here in case you have interest in pulling it in.