### PR TITLE
[IFT] allow a custom brotli implementation to be provided for patch application.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,6 +21,7 @@ read-fonts = { workspace = true, default-features = true, features = ["ift"] }
 write-fonts = { workspace = true, default-features = true, features = ["ift"] }
 skrifa = { workspace = true }
 incremental-font-transfer = { workspace = true }
+shared-brotli-patch-decoder = { workspace = true }
 
 [[bin]]
 name = "fuzz_skrifa_charmap"

--- a/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
+++ b/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
@@ -13,6 +13,7 @@ use read_fonts::{
     collections::{IntSet, RangeSet},
     types::Tag,
 };
+use shared_brotli_patch_decoder::NoopBrotliDecoder;
 use skrifa::FontRef;
 use write_fonts::FontBuilder;
 
@@ -105,5 +106,9 @@ fuzz_target!(|input: FuzzInput| {
         uri_map.insert(uri.to_string(), UriStatus::Applied);
     }
 
-    let _ = black_box(group.apply_next_patches(&mut uri_map));
+    // When running under a fuzzer disable brotli decoding and instead just pass through the input data.
+    // This allows the fuzzer to more effectively explore code gated behind brotli decoding.
+    //
+    // TODO(garretrieger): In addition to the noop decoder, also have one that can return all of the possible errors.
+    let _ = black_box(group.apply_next_patches(&mut uri_map, Some(Box::new(NoopBrotliDecoder))));
 });

--- a/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
+++ b/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
@@ -110,5 +110,5 @@ fuzz_target!(|input: FuzzInput| {
     // This allows the fuzzer to more effectively explore code gated behind brotli decoding.
     //
     // TODO(garretrieger): In addition to the noop decoder, also have one that can return all of the possible errors.
-    let _ = black_box(group.apply_next_patches(&mut uri_map, Some(Box::new(NoopBrotliDecoder))));
+    let _ = black_box(group.apply_next_patches_with_decoder(&mut uri_map, &NoopBrotliDecoder));
 });

--- a/incremental-font-transfer/src/bin/ift_extend.rs
+++ b/incremental-font-transfer/src/bin/ift_extend.rs
@@ -110,7 +110,7 @@ fn main() {
 
         println!("  Applying patches");
         font_bytes = next_patches
-            .apply_next_patches(&mut patch_data)
+            .apply_next_patches(&mut patch_data, None)
             .expect("Patch application failed.");
     }
 

--- a/incremental-font-transfer/src/bin/ift_extend.rs
+++ b/incremental-font-transfer/src/bin/ift_extend.rs
@@ -110,7 +110,7 @@ fn main() {
 
         println!("  Applying patches");
         font_bytes = next_patches
-            .apply_next_patches(&mut patch_data, None)
+            .apply_next_patches(&mut patch_data)
             .expect("Patch application failed.");
     }
 

--- a/incremental-font-transfer/src/bin/ift_graph.rs
+++ b/incremental-font-transfer/src/bin/ift_graph.rs
@@ -16,6 +16,7 @@ use incremental_font_transfer::{
     uri_templates::UriTemplateError,
 };
 use read_fonts::{ReadError, TableProvider};
+use shared_brotli_patch_decoder::BuiltInBrotliDecoder;
 use skrifa::{FontRef, MetadataProvider};
 
 #[derive(Parser, Debug)]
@@ -200,7 +201,7 @@ fn to_next_font(
     let patch_info: PatchInfo = patch_uri.try_into()?;
 
     Ok(font
-        .apply_table_keyed_patch(&patch_info, &patch_bytes)
+        .apply_table_keyed_patch(&patch_info, &patch_bytes, &BuiltInBrotliDecoder)
         .expect("Patch application failed."))
 }
 

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -245,18 +245,14 @@ impl PatchGroup<'_> {
     pub fn apply_next_patches(
         self,
         patch_data: &mut HashMap<String, UriStatus>,
-        override_brotli_decoder: Option<Box<dyn SharedBrotliDecoder>>,
     ) -> Result<Vec<u8>, PatchingError> {
-        match override_brotli_decoder {
-            None => self.apply_next_patches_with_decoder(patch_data, &BuiltInBrotliDecoder),
-            Some(decoder) => self.apply_next_patches_with_decoder(patch_data, &decoder),
-        }
+        self.apply_next_patches_with_decoder(patch_data, &BuiltInBrotliDecoder)
     }
 
     /// Attempt to apply the next patch (or patches if non-invalidating) listed in this group.
     ///
     /// Returns the bytes of the updated font.
-    fn apply_next_patches_with_decoder<D: SharedBrotliDecoder>(
+    pub fn apply_next_patches_with_decoder<D: SharedBrotliDecoder>(
         self,
         patch_data: &mut HashMap<String, UriStatus>,
         brotli_decoder: &D,
@@ -1148,7 +1144,7 @@ mod tests {
         assert_eq!(g.uris().collect::<Vec<&str>>(), Vec::<&str>::default());
 
         assert_eq!(
-            g.apply_next_patches(&mut Default::default(), None),
+            g.apply_next_patches(&mut Default::default()),
             Err(PatchingError::EmptyPatchList)
         );
     }
@@ -1173,7 +1169,7 @@ mod tests {
             ),
         ]);
 
-        let new_font = g.apply_next_patches(&mut patch_data, None).unwrap();
+        let new_font = g.apply_next_patches(&mut patch_data).unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
         assert_eq!(
@@ -1231,7 +1227,7 @@ mod tests {
         ]);
 
         let new_font = g
-            .apply_next_patches(&mut patch_data, Some(Box::new(CustomBrotliDecoder)))
+            .apply_next_patches_with_decoder(&mut patch_data, &CustomBrotliDecoder)
             .unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
@@ -1273,7 +1269,7 @@ mod tests {
             UriStatus::Pending(table_keyed_patch().as_slice().to_vec()),
         )]);
 
-        let new_font = g.apply_next_patches(&mut patch_data, None).unwrap();
+        let new_font = g.apply_next_patches(&mut patch_data).unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
         assert_eq!(
@@ -1302,7 +1298,7 @@ mod tests {
             UriStatus::Pending(table_keyed_patch().as_slice().to_vec()),
         )]);
 
-        let new_font = g.apply_next_patches(&mut patch_data, None).unwrap();
+        let new_font = g.apply_next_patches(&mut patch_data).unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
         assert_eq!(
@@ -1352,7 +1348,7 @@ mod tests {
             ),
         ]);
 
-        let new_font = g.apply_next_patches(&mut patch_data, None).unwrap();
+        let new_font = g.apply_next_patches(&mut patch_data).unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
         assert_eq!(
@@ -1417,7 +1413,7 @@ mod tests {
             ),
         ]);
 
-        let new_font = g.apply_next_patches(&mut patch_data, None).unwrap();
+        let new_font = g.apply_next_patches(&mut patch_data).unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
         assert_eq!(
@@ -1483,7 +1479,7 @@ mod tests {
             ),
         ]);
 
-        let new_font = g.apply_next_patches(&mut patch_data, None).unwrap();
+        let new_font = g.apply_next_patches(&mut patch_data).unwrap();
         let new_font = FontRef::new(&new_font).unwrap();
 
         let new_glyf: &[u8] = new_font.table_data(Tag::new(b"glyf")).unwrap().as_bytes();


### PR DESCRIPTION
This is needed to support a WASM version of the rust IFT client which can't use the c brotli used by default. As an added bonus this opens the door for increasing fuzzing coverage by allowing the fuzzer to provide a custom implementation that can generate errors.