### PR TITLE
[codegen] Add OffsetSource trait

### DIFF
--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -188,6 +188,7 @@ pub(crate) struct FieldAttrs {
     /// optionally a method on the parent type used to generate the offset data
     /// source for this item.
     pub(crate) offset_data: Option<Attr<syn::Ident>>,
+    pub(crate) offset_from: Option<Attr<syn::Ident>>,
     /// If present, argument is an expression that evaluates to a u32, and is
     /// used to adjust the write position of offsets.
     //TODO: this could maybe be combined with offset_data?
@@ -1048,6 +1049,7 @@ static FORMAT: &str = "format";
 static VERSION: &str = "version";
 static OFFSET_GETTER: &str = "offset_getter";
 static OFFSET_DATA: &str = "offset_data_method";
+static OFFSET_FROM: &str = "offset_from";
 static OFFSET_ADJUSTMENT: &str = "offset_adjustment";
 static COMPILE: &str = "compile";
 static COMPILE_WITH: &str = "compile_with";
@@ -1082,6 +1084,8 @@ impl Parse for FieldAttrs {
                 this.offset_getter = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == OFFSET_DATA {
                 this.offset_data = Some(Attr::new(ident.clone(), attr.parse_args()?));
+            } else if ident == OFFSET_FROM {
+                this.offset_from = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == OFFSET_ADJUSTMENT {
                 this.offset_adjustment = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == VERSION {

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -377,7 +377,7 @@ fn generate_from_obj_impl(item: &Record, parse_module: &syn::Path) -> syn::Resul
 
 impl Record {
     pub(crate) fn sanity_check(&self, phase: Phase) -> syn::Result<()> {
-        self.fields.sanity_check(phase)?;
+        self.fields.sanity_check(phase, true)?;
         let field_needs_lifetime = self
             .fields
             .iter()

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -138,6 +138,13 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
         }
 
         #debug
+
+        impl<'a, #generic> OffsetSource<'a, #raw_name<'a, #generic>> for &#raw_name<'a, #generic> {
+            fn offset_source(&self) -> FontData<'a> {
+                self.offset_data()
+            }
+
+        }
     })
 }
 
@@ -907,7 +914,7 @@ pub(crate) fn generate_format_group(item: &TableFormat, items: &Items) -> syn::R
 
 impl Table {
     pub(crate) fn sanity_check(&self, phase: Phase) -> syn::Result<()> {
-        self.fields.sanity_check(phase)
+        self.fields.sanity_check(phase, false)
     }
 
     fn marker_name(&self) -> syn::Ident {

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -140,6 +140,12 @@ impl<'a> std::fmt::Debug for TableDirectory<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, TableDirectory<'a>> for &TableDirectory<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Record for a table in a font.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -374,5 +380,11 @@ impl<'a> SomeTable<'a> for TTCHeader<'a> {
 impl<'a> std::fmt::Debug for TTCHeader<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, TTCHeader<'a>> for &TTCHeader<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -185,6 +185,12 @@ impl<'a> std::fmt::Debug for Lookup0<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Lookup0<'a>> for &Lookup0<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Lookup2Marker {
     const FORMAT: u16 = 2;
 }
@@ -334,6 +340,12 @@ impl<'a> SomeTable<'a> for Lookup2<'a> {
 impl<'a> std::fmt::Debug for Lookup2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Lookup2<'a>> for &Lookup2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -491,6 +503,12 @@ impl<'a> SomeTable<'a> for Lookup4<'a> {
 impl<'a> std::fmt::Debug for Lookup4<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Lookup4<'a>> for &Lookup4<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -694,6 +712,12 @@ impl<'a> std::fmt::Debug for Lookup6<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Lookup6<'a>> for &Lookup6<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Lookup8Marker {
     const FORMAT: u16 = 8;
 }
@@ -802,6 +826,12 @@ impl<'a> SomeTable<'a> for Lookup8<'a> {
 impl<'a> std::fmt::Debug for Lookup8<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Lookup8<'a>> for &Lookup8<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -927,6 +957,12 @@ impl<'a> SomeTable<'a> for Lookup10<'a> {
 impl<'a> std::fmt::Debug for Lookup10<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Lookup10<'a>> for &Lookup10<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1056,6 +1092,12 @@ impl<'a> std::fmt::Debug for StateHeader<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, StateHeader<'a>> for &StateHeader<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Maps the glyph indexes of your font into classes.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1149,6 +1191,12 @@ impl<'a> std::fmt::Debug for ClassSubtable<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ClassSubtable<'a>> for &ClassSubtable<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Used for the `state_array` and `entry_table` fields in [`StateHeader`].
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1207,6 +1255,12 @@ impl<'a> SomeTable<'a> for RawBytes<'a> {
 impl<'a> std::fmt::Debug for RawBytes<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, RawBytes<'a>> for &RawBytes<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1335,6 +1389,12 @@ impl<'a> std::fmt::Debug for StxHeader<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, StxHeader<'a>> for &StxHeader<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Used for the `state_array` in [`StxHeader`].
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1393,5 +1453,11 @@ impl<'a> SomeTable<'a> for RawWords<'a> {
 impl<'a> std::fmt::Debug for RawWords<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, RawWords<'a>> for &RawWords<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -122,6 +122,12 @@ impl<'a> std::fmt::Debug for Ankr<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Ankr<'a>> for &Ankr<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct GlyphDataEntryMarker {
@@ -203,6 +209,12 @@ impl<'a> SomeTable<'a> for GlyphDataEntry<'a> {
 impl<'a> std::fmt::Debug for GlyphDataEntry<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, GlyphDataEntry<'a>> for &GlyphDataEntry<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -178,6 +178,12 @@ impl<'a> std::fmt::Debug for Avar<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Avar<'a>> for &Avar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [SegmentMaps](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SegmentMaps<'a> {

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -146,6 +146,12 @@ impl<'a> std::fmt::Debug for Base<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Base<'a>> for &Base<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Axis Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#axis-tables-horizaxis-and-vertaxis)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -237,6 +243,12 @@ impl<'a> std::fmt::Debug for Axis<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Axis<'a>> for &Axis<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [BaseTagList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basetaglist-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -315,6 +327,12 @@ impl<'a> SomeTable<'a> for BaseTagList<'a> {
 impl<'a> std::fmt::Debug for BaseTagList<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, BaseTagList<'a>> for &BaseTagList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -405,6 +423,12 @@ impl<'a> std::fmt::Debug for BaseScriptList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseScriptList<'a>> for &BaseScriptList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [BaseScriptRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptrecord)
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -431,7 +455,11 @@ impl BaseScriptRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn base_script<'a>(&self, data: FontData<'a>) -> Result<BaseScript<'a>, ReadError> {
+    pub fn base_script<'a>(
+        &self,
+        data: impl OffsetSource<'a, BaseScriptList<'a>>,
+    ) -> Result<BaseScript<'a>, ReadError> {
+        let data = data.offset_source();
         self.base_script_offset().resolve(data)
     }
 }
@@ -592,6 +620,12 @@ impl<'a> std::fmt::Debug for BaseScript<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseScript<'a>> for &BaseScript<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [BaseLangSysRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -618,7 +652,11 @@ impl BaseLangSysRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn min_max<'a>(&self, data: FontData<'a>) -> Result<MinMax<'a>, ReadError> {
+    pub fn min_max<'a>(
+        &self,
+        data: impl OffsetSource<'a, BaseScript<'a>>,
+    ) -> Result<MinMax<'a>, ReadError> {
+        let data = data.offset_source();
         self.min_max_offset().resolve(data)
     }
 }
@@ -765,6 +803,12 @@ impl<'a> std::fmt::Debug for BaseValues<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseValues<'a>> for &BaseValues<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [MinMax](https://learn.microsoft.com/en-us/typography/opentype/spec/base#minmax-table) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -898,6 +942,12 @@ impl<'a> std::fmt::Debug for MinMax<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MinMax<'a>> for &MinMax<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [FeatMinMaxRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -932,7 +982,11 @@ impl FeatMinMaxRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn min_coord<'a>(&self, data: FontData<'a>) -> Option<Result<MinMax<'a>, ReadError>> {
+    pub fn min_coord<'a>(
+        &self,
+        data: impl OffsetSource<'a, MinMax<'a>>,
+    ) -> Option<Result<MinMax<'a>, ReadError>> {
+        let data = data.offset_source();
         self.min_coord_offset().resolve(data)
     }
 
@@ -947,7 +1001,11 @@ impl FeatMinMaxRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn max_coord<'a>(&self, data: FontData<'a>) -> Option<Result<MinMax<'a>, ReadError>> {
+    pub fn max_coord<'a>(
+        &self,
+        data: impl OffsetSource<'a, MinMax<'a>>,
+    ) -> Option<Result<MinMax<'a>, ReadError>> {
+        let data = data.offset_source();
         self.max_coord_offset().resolve(data)
     }
 }
@@ -1140,6 +1198,12 @@ impl<'a> std::fmt::Debug for BaseCoordFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseCoordFormat1<'a>> for &BaseCoordFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for BaseCoordFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -1242,6 +1306,12 @@ impl<'a> std::fmt::Debug for BaseCoordFormat2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseCoordFormat2<'a>> for &BaseCoordFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for BaseCoordFormat3Marker {
     const FORMAT: u16 = 3;
 }
@@ -1339,5 +1409,11 @@ impl<'a> SomeTable<'a> for BaseCoordFormat3<'a> {
 impl<'a> std::fmt::Debug for BaseCoordFormat3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, BaseCoordFormat3<'a>> for &BaseCoordFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -828,6 +828,12 @@ impl<'a> std::fmt::Debug for IndexSubtableList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, IndexSubtableList<'a>> for &IndexSubtableList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
@@ -860,7 +866,11 @@ impl IndexSubtableRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn index_subtable<'a>(&self, data: FontData<'a>) -> Result<IndexSubtable<'a>, ReadError> {
+    pub fn index_subtable<'a>(
+        &self,
+        data: impl OffsetSource<'a, IndexSubtableList<'a>>,
+    ) -> Result<IndexSubtable<'a>, ReadError> {
+        let data = data.offset_source();
         let args = (self.last_glyph_index(), self.first_glyph_index());
         self.index_subtable_offset().resolve_with_args(data, &args)
     }
@@ -1022,6 +1032,12 @@ impl<'a> std::fmt::Debug for IndexSubtable1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, IndexSubtable1<'a>> for &IndexSubtable1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for IndexSubtable2Marker {
     const FORMAT: u16 = 2;
 }
@@ -1146,6 +1162,12 @@ impl<'a> SomeTable<'a> for IndexSubtable2<'a> {
 impl<'a> std::fmt::Debug for IndexSubtable2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, IndexSubtable2<'a>> for &IndexSubtable2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1281,6 +1303,12 @@ impl<'a> std::fmt::Debug for IndexSubtable3<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, IndexSubtable3<'a>> for &IndexSubtable3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for IndexSubtable4Marker {
     const FORMAT: u16 = 4;
 }
@@ -1407,6 +1435,12 @@ impl<'a> SomeTable<'a> for IndexSubtable4<'a> {
 impl<'a> std::fmt::Debug for IndexSubtable4<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, IndexSubtable4<'a>> for &IndexSubtable4<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1607,6 +1641,12 @@ impl<'a> SomeTable<'a> for IndexSubtable5<'a> {
 impl<'a> std::fmt::Debug for IndexSubtable5<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, IndexSubtable5<'a>> for &IndexSubtable5<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -81,3 +81,9 @@ impl<'a> std::fmt::Debug for Cbdt<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Cbdt<'a>> for &Cbdt<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -121,3 +121,9 @@ impl<'a> std::fmt::Debug for Cblc<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Cblc<'a>> for &Cblc<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -138,3 +138,9 @@ impl<'a> std::fmt::Debug for CffHeader<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, CffHeader<'a>> for &CffHeader<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -156,3 +156,9 @@ impl<'a> std::fmt::Debug for Cff2Header<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Cff2Header<'a>> for &Cff2Header<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -108,6 +108,12 @@ impl<'a> std::fmt::Debug for Cmap<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cmap<'a>> for &Cmap<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Encoding Record](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings)
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -144,7 +150,11 @@ impl EncodingRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn subtable<'a>(&self, data: FontData<'a>) -> Result<CmapSubtable<'a>, ReadError> {
+    pub fn subtable<'a>(
+        &self,
+        data: impl OffsetSource<'a, Cmap<'a>>,
+    ) -> Result<CmapSubtable<'a>, ReadError> {
+        let data = data.offset_source();
         self.subtable_offset().resolve(data)
     }
 }
@@ -448,6 +458,12 @@ impl<'a> std::fmt::Debug for Cmap0<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cmap0<'a>> for &Cmap0<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Cmap2Marker {
     const FORMAT: u16 = 2;
 }
@@ -556,6 +572,12 @@ impl<'a> SomeTable<'a> for Cmap2<'a> {
 impl<'a> std::fmt::Debug for Cmap2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Cmap2<'a>> for &Cmap2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -861,6 +883,12 @@ impl<'a> std::fmt::Debug for Cmap4<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cmap4<'a>> for &Cmap4<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Cmap6Marker {
     const FORMAT: u16 = 6;
 }
@@ -994,6 +1022,12 @@ impl<'a> SomeTable<'a> for Cmap6<'a> {
 impl<'a> std::fmt::Debug for Cmap6<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Cmap6<'a>> for &Cmap6<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1150,6 +1184,12 @@ impl<'a> SomeTable<'a> for Cmap8<'a> {
 impl<'a> std::fmt::Debug for Cmap8<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Cmap8<'a>> for &Cmap8<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1352,6 +1392,12 @@ impl<'a> std::fmt::Debug for Cmap10<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cmap10<'a>> for &Cmap10<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Cmap12Marker {
     const FORMAT: u16 = 12;
 }
@@ -1486,6 +1532,12 @@ impl<'a> std::fmt::Debug for Cmap12<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cmap12<'a>> for &Cmap12<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Cmap13Marker {
     const FORMAT: u16 = 13;
 }
@@ -1617,6 +1669,12 @@ impl<'a> SomeTable<'a> for Cmap13<'a> {
 impl<'a> std::fmt::Debug for Cmap13<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Cmap13<'a>> for &Cmap13<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1791,6 +1849,12 @@ impl<'a> std::fmt::Debug for Cmap14<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cmap14<'a>> for &Cmap14<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [Cmap14]
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -1823,7 +1887,11 @@ impl VariationSelector {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn default_uvs<'a>(&self, data: FontData<'a>) -> Option<Result<DefaultUvs<'a>, ReadError>> {
+    pub fn default_uvs<'a>(
+        &self,
+        data: impl OffsetSource<'a, Cmap14<'a>>,
+    ) -> Option<Result<DefaultUvs<'a>, ReadError>> {
+        let data = data.offset_source();
         self.default_uvs_offset().resolve(data)
     }
 
@@ -1840,8 +1908,9 @@ impl VariationSelector {
     /// By calling its `offset_data` method.
     pub fn non_default_uvs<'a>(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, Cmap14<'a>>,
     ) -> Option<Result<NonDefaultUvs<'a>, ReadError>> {
+        let data = data.offset_source();
         self.non_default_uvs_offset().resolve(data)
     }
 }
@@ -1960,6 +2029,12 @@ impl<'a> std::fmt::Debug for DefaultUvs<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, DefaultUvs<'a>> for &DefaultUvs<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2041,6 +2116,12 @@ impl<'a> SomeTable<'a> for NonDefaultUvs<'a> {
 impl<'a> std::fmt::Debug for NonDefaultUvs<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, NonDefaultUvs<'a>> for &NonDefaultUvs<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -315,6 +315,12 @@ impl<'a> std::fmt::Debug for Colr<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Colr<'a>> for &Colr<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [BaseGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -494,6 +500,12 @@ impl<'a> std::fmt::Debug for BaseGlyphList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseGlyphList<'a>> for &BaseGlyphList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [BaseGlyphPaint](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -520,7 +532,11 @@ impl BaseGlyphPaint {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn paint<'a>(&self, data: FontData<'a>) -> Result<Paint<'a>, ReadError> {
+    pub fn paint<'a>(
+        &self,
+        data: impl OffsetSource<'a, BaseGlyphList<'a>>,
+    ) -> Result<Paint<'a>, ReadError> {
+        let data = data.offset_source();
         self.paint_offset().resolve(data)
     }
 }
@@ -645,6 +661,12 @@ impl<'a> std::fmt::Debug for LayerList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LayerList<'a>> for &LayerList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [ClipList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -742,6 +764,12 @@ impl<'a> std::fmt::Debug for ClipList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ClipList<'a>> for &ClipList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Clip](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -775,7 +803,11 @@ impl Clip {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn clip_box<'a>(&self, data: FontData<'a>) -> Result<ClipBox<'a>, ReadError> {
+    pub fn clip_box<'a>(
+        &self,
+        data: impl OffsetSource<'a, ClipList<'a>>,
+    ) -> Result<ClipBox<'a>, ReadError> {
+        let data = data.offset_source();
         self.clip_box_offset().resolve(data)
     }
 }
@@ -1023,6 +1055,12 @@ impl<'a> std::fmt::Debug for ClipBoxFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ClipBoxFormat1<'a>> for &ClipBoxFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for ClipBoxFormat2Marker {
     const FORMAT: u8 = 2;
 }
@@ -1148,6 +1186,12 @@ impl<'a> SomeTable<'a> for ClipBoxFormat2<'a> {
 impl<'a> std::fmt::Debug for ClipBoxFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ClipBoxFormat2<'a>> for &ClipBoxFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1450,6 +1494,12 @@ impl<'a> std::fmt::Debug for ColorLine<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ColorLine<'a>> for &ColorLine<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [VarColorLine](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1546,6 +1596,12 @@ impl<'a> SomeTable<'a> for VarColorLine<'a> {
 impl<'a> std::fmt::Debug for VarColorLine<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, VarColorLine<'a>> for &VarColorLine<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1959,6 +2015,12 @@ impl<'a> std::fmt::Debug for PaintColrLayers<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintColrLayers<'a>> for &PaintColrLayers<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintSolidMarker {
     const FORMAT: u8 = 2;
 }
@@ -2045,6 +2107,12 @@ impl<'a> SomeTable<'a> for PaintSolid<'a> {
 impl<'a> std::fmt::Debug for PaintSolid<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintSolid<'a>> for &PaintSolid<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2147,6 +2215,12 @@ impl<'a> SomeTable<'a> for PaintVarSolid<'a> {
 impl<'a> std::fmt::Debug for PaintVarSolid<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintVarSolid<'a>> for &PaintVarSolid<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2310,6 +2384,12 @@ impl<'a> SomeTable<'a> for PaintLinearGradient<'a> {
 impl<'a> std::fmt::Debug for PaintLinearGradient<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintLinearGradient<'a>> for &PaintLinearGradient<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2495,6 +2575,12 @@ impl<'a> std::fmt::Debug for PaintVarLinearGradient<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarLinearGradient<'a>> for &PaintVarLinearGradient<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintRadialGradientMarker {
     const FORMAT: u8 = 6;
 }
@@ -2655,6 +2741,12 @@ impl<'a> SomeTable<'a> for PaintRadialGradient<'a> {
 impl<'a> std::fmt::Debug for PaintRadialGradient<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintRadialGradient<'a>> for &PaintRadialGradient<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2838,6 +2930,12 @@ impl<'a> std::fmt::Debug for PaintVarRadialGradient<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarRadialGradient<'a>> for &PaintVarRadialGradient<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintSweepGradientMarker {
     const FORMAT: u8 = 8;
 }
@@ -2974,6 +3072,12 @@ impl<'a> SomeTable<'a> for PaintSweepGradient<'a> {
 impl<'a> std::fmt::Debug for PaintSweepGradient<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintSweepGradient<'a>> for &PaintSweepGradient<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3131,6 +3235,12 @@ impl<'a> std::fmt::Debug for PaintVarSweepGradient<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarSweepGradient<'a>> for &PaintVarSweepGradient<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintGlyphMarker {
     const FORMAT: u8 = 10;
 }
@@ -3229,6 +3339,12 @@ impl<'a> std::fmt::Debug for PaintGlyph<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintGlyph<'a>> for &PaintGlyph<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintColrGlyphMarker {
     const FORMAT: u8 = 11;
 }
@@ -3302,6 +3418,12 @@ impl<'a> SomeTable<'a> for PaintColrGlyph<'a> {
 impl<'a> std::fmt::Debug for PaintColrGlyph<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintColrGlyph<'a>> for &PaintColrGlyph<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3412,6 +3534,12 @@ impl<'a> std::fmt::Debug for PaintTransform<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintTransform<'a>> for &PaintTransform<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintVarTransformMarker {
     const FORMAT: u8 = 13;
 }
@@ -3516,6 +3644,12 @@ impl<'a> SomeTable<'a> for PaintVarTransform<'a> {
 impl<'a> std::fmt::Debug for PaintVarTransform<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintVarTransform<'a>> for &PaintVarTransform<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3640,6 +3774,12 @@ impl<'a> SomeTable<'a> for Affine2x3<'a> {
 impl<'a> std::fmt::Debug for Affine2x3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Affine2x3<'a>> for &Affine2x3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3784,6 +3924,12 @@ impl<'a> std::fmt::Debug for VarAffine2x3<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, VarAffine2x3<'a>> for &VarAffine2x3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintTranslateMarker {
     const FORMAT: u8 = 14;
 }
@@ -3892,6 +4038,12 @@ impl<'a> SomeTable<'a> for PaintTranslate<'a> {
 impl<'a> std::fmt::Debug for PaintTranslate<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintTranslate<'a>> for &PaintTranslate<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4019,6 +4171,12 @@ impl<'a> std::fmt::Debug for PaintVarTranslate<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarTranslate<'a>> for &PaintVarTranslate<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintScaleMarker {
     const FORMAT: u8 = 16;
 }
@@ -4127,6 +4285,12 @@ impl<'a> SomeTable<'a> for PaintScale<'a> {
 impl<'a> std::fmt::Debug for PaintScale<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintScale<'a>> for &PaintScale<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4253,6 +4417,12 @@ impl<'a> SomeTable<'a> for PaintVarScale<'a> {
 impl<'a> std::fmt::Debug for PaintVarScale<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintVarScale<'a>> for &PaintVarScale<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4390,6 +4560,12 @@ impl<'a> SomeTable<'a> for PaintScaleAroundCenter<'a> {
 impl<'a> std::fmt::Debug for PaintScaleAroundCenter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintScaleAroundCenter<'a>> for &PaintScaleAroundCenter<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4547,6 +4723,12 @@ impl<'a> std::fmt::Debug for PaintVarScaleAroundCenter<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarScaleAroundCenter<'a>> for &PaintVarScaleAroundCenter<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintScaleUniformMarker {
     const FORMAT: u8 = 20;
 }
@@ -4642,6 +4824,12 @@ impl<'a> SomeTable<'a> for PaintScaleUniform<'a> {
 impl<'a> std::fmt::Debug for PaintScaleUniform<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintScaleUniform<'a>> for &PaintScaleUniform<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4754,6 +4942,12 @@ impl<'a> SomeTable<'a> for PaintVarScaleUniform<'a> {
 impl<'a> std::fmt::Debug for PaintVarScaleUniform<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintVarScaleUniform<'a>> for &PaintVarScaleUniform<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4878,6 +5072,14 @@ impl<'a> SomeTable<'a> for PaintScaleUniformAroundCenter<'a> {
 impl<'a> std::fmt::Debug for PaintScaleUniformAroundCenter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintScaleUniformAroundCenter<'a>>
+    for &PaintScaleUniformAroundCenter<'a>
+{
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5022,6 +5224,14 @@ impl<'a> std::fmt::Debug for PaintVarScaleUniformAroundCenter<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarScaleUniformAroundCenter<'a>>
+    for &PaintVarScaleUniformAroundCenter<'a>
+{
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintRotateMarker {
     const FORMAT: u8 = 24;
 }
@@ -5118,6 +5328,12 @@ impl<'a> SomeTable<'a> for PaintRotate<'a> {
 impl<'a> std::fmt::Debug for PaintRotate<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintRotate<'a>> for &PaintRotate<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5230,6 +5446,12 @@ impl<'a> SomeTable<'a> for PaintVarRotate<'a> {
 impl<'a> std::fmt::Debug for PaintVarRotate<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintVarRotate<'a>> for &PaintVarRotate<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5355,6 +5577,12 @@ impl<'a> SomeTable<'a> for PaintRotateAroundCenter<'a> {
 impl<'a> std::fmt::Debug for PaintRotateAroundCenter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintRotateAroundCenter<'a>> for &PaintRotateAroundCenter<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5498,6 +5726,12 @@ impl<'a> std::fmt::Debug for PaintVarRotateAroundCenter<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarRotateAroundCenter<'a>> for &PaintVarRotateAroundCenter<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintSkewMarker {
     const FORMAT: u8 = 28;
 }
@@ -5608,6 +5842,12 @@ impl<'a> SomeTable<'a> for PaintSkew<'a> {
 impl<'a> std::fmt::Debug for PaintSkew<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintSkew<'a>> for &PaintSkew<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5736,6 +5976,12 @@ impl<'a> SomeTable<'a> for PaintVarSkew<'a> {
 impl<'a> std::fmt::Debug for PaintVarSkew<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintVarSkew<'a>> for &PaintVarSkew<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5875,6 +6121,12 @@ impl<'a> SomeTable<'a> for PaintSkewAroundCenter<'a> {
 impl<'a> std::fmt::Debug for PaintSkewAroundCenter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintSkewAroundCenter<'a>> for &PaintSkewAroundCenter<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -6034,6 +6286,12 @@ impl<'a> std::fmt::Debug for PaintVarSkewAroundCenter<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PaintVarSkewAroundCenter<'a>> for &PaintVarSkewAroundCenter<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for PaintCompositeMarker {
     const FORMAT: u8 = 32;
 }
@@ -6151,6 +6409,12 @@ impl<'a> SomeTable<'a> for PaintComposite<'a> {
 impl<'a> std::fmt::Debug for PaintComposite<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PaintComposite<'a>> for &PaintComposite<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -289,6 +289,12 @@ impl<'a> std::fmt::Debug for Cpal<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Cpal<'a>> for &Cpal<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// The [PaletteType](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-type-array) flags.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -127,3 +127,9 @@ impl<'a> std::fmt::Debug for Cvar<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Cvar<'a>> for &Cvar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -81,3 +81,9 @@ impl<'a> std::fmt::Debug for Ebdt<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Ebdt<'a>> for &Ebdt<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -121,3 +121,9 @@ impl<'a> std::fmt::Debug for Eblc<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Eblc<'a>> for &Eblc<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -120,6 +120,12 @@ impl<'a> std::fmt::Debug for Feat<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Feat<'a>> for &Feat<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Type, flags and names for a feature.
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -163,7 +169,11 @@ impl FeatureName {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn setting_table<'a>(&self, data: FontData<'a>) -> Result<SettingNameArray<'a>, ReadError> {
+    pub fn setting_table<'a>(
+        &self,
+        data: impl OffsetSource<'a, Feat<'a>>,
+    ) -> Result<SettingNameArray<'a>, ReadError> {
+        let data = data.offset_source();
         let args = self.n_settings();
         self.setting_table_offset().resolve_with_args(data, &args)
     }
@@ -290,6 +300,12 @@ impl<'a> SomeTable<'a> for SettingNameArray<'a> {
 impl<'a> std::fmt::Debug for SettingNameArray<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SettingNameArray<'a>> for &SettingNameArray<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -160,6 +160,12 @@ impl<'a> std::fmt::Debug for Fvar<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Fvar<'a>> for &Fvar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Shim table to handle combined axis and instance arrays.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -293,6 +299,12 @@ impl<'a> SomeTable<'a> for AxisInstanceArrays<'a> {
 impl<'a> std::fmt::Debug for AxisInstanceArrays<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AxisInstanceArrays<'a>> for &AxisInstanceArrays<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -109,6 +109,12 @@ impl<'a> std::fmt::Debug for Gasp<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Gasp<'a>> for &Gasp<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -232,6 +232,12 @@ impl<'a> std::fmt::Debug for Gdef<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Gdef<'a>> for &Gdef<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Used in the [Glyph Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table)
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -403,6 +409,12 @@ impl<'a> std::fmt::Debug for AttachList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, AttachList<'a>> for &AttachList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [AttachList]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -479,6 +491,12 @@ impl<'a> SomeTable<'a> for AttachPoint<'a> {
 impl<'a> std::fmt::Debug for AttachPoint<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AttachPoint<'a>> for &AttachPoint<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -604,6 +622,12 @@ impl<'a> std::fmt::Debug for LigCaretList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LigCaretList<'a>> for &LigCaretList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Ligature Glyph Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-glyph-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -701,6 +725,12 @@ impl<'a> SomeTable<'a> for LigGlyph<'a> {
 impl<'a> std::fmt::Debug for LigGlyph<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, LigGlyph<'a>> for &LigGlyph<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -858,6 +888,12 @@ impl<'a> std::fmt::Debug for CaretValueFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, CaretValueFormat1<'a>> for &CaretValueFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for CaretValueFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -934,6 +970,12 @@ impl<'a> SomeTable<'a> for CaretValueFormat2<'a> {
 impl<'a> std::fmt::Debug for CaretValueFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CaretValueFormat2<'a>> for &CaretValueFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1034,6 +1076,12 @@ impl<'a> SomeTable<'a> for CaretValueFormat3<'a> {
 impl<'a> std::fmt::Debug for CaretValueFormat3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CaretValueFormat3<'a>> for &CaretValueFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1154,5 +1202,11 @@ impl<'a> SomeTable<'a> for MarkGlyphSets<'a> {
 impl<'a> std::fmt::Debug for MarkGlyphSets<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, MarkGlyphSets<'a>> for &MarkGlyphSets<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -53,6 +53,12 @@ impl<'a> std::fmt::Debug for Glyf<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Glyf<'a>> for &Glyf<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -236,6 +242,12 @@ impl<'a> SomeTable<'a> for SimpleGlyph<'a> {
 impl<'a> std::fmt::Debug for SimpleGlyph<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SimpleGlyph<'a>> for &SimpleGlyph<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -767,6 +779,12 @@ impl<'a> SomeTable<'a> for CompositeGlyph<'a> {
 impl<'a> std::fmt::Debug for CompositeGlyph<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CompositeGlyph<'a>> for &CompositeGlyph<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -172,6 +172,12 @@ impl<'a> std::fmt::Debug for Gpos<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Gpos<'a>> for &Gpos<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// A [GPOS Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#gsubLookupTypeEnum) subtable.
 pub enum PositionLookup<'a> {
     Single(Lookup<'a, SinglePos<'a>>),
@@ -786,6 +792,12 @@ impl<'a> std::fmt::Debug for AnchorFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, AnchorFormat1<'a>> for &AnchorFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for AnchorFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -885,6 +897,12 @@ impl<'a> SomeTable<'a> for AnchorFormat2<'a> {
 impl<'a> std::fmt::Debug for AnchorFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AnchorFormat2<'a>> for &AnchorFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1025,6 +1043,12 @@ impl<'a> std::fmt::Debug for AnchorFormat3<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, AnchorFormat3<'a>> for &AnchorFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1112,6 +1136,12 @@ impl<'a> std::fmt::Debug for MarkArray<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MarkArray<'a>> for &MarkArray<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkArray]
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -1138,7 +1168,11 @@ impl MarkRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn mark_anchor<'a>(&self, data: FontData<'a>) -> Result<AnchorTable<'a>, ReadError> {
+    pub fn mark_anchor<'a>(
+        &self,
+        data: impl OffsetSource<'a, MarkArray<'a>>,
+    ) -> Result<AnchorTable<'a>, ReadError> {
+        let data = data.offset_source();
         self.mark_anchor_offset().resolve(data)
     }
 }
@@ -1375,6 +1409,12 @@ impl<'a> std::fmt::Debug for SinglePosFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SinglePosFormat1<'a>> for &SinglePosFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for SinglePosFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -1513,6 +1553,12 @@ impl<'a> SomeTable<'a> for SinglePosFormat2<'a> {
 impl<'a> std::fmt::Debug for SinglePosFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SinglePosFormat2<'a>> for &SinglePosFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1783,6 +1829,12 @@ impl<'a> std::fmt::Debug for PairPosFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PairPosFormat1<'a>> for &PairPosFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [PairPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1907,6 +1959,12 @@ impl<'a> SomeTable<'a> for PairSet<'a> {
 impl<'a> std::fmt::Debug for PairSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, PairSet<'a>> for &PairSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2240,6 +2298,12 @@ impl<'a> std::fmt::Debug for PairPosFormat2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PairPosFormat2<'a>> for &PairPosFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [PairPosFormat2]
 #[derive(Clone, Debug)]
 pub struct Class1Record<'a> {
@@ -2539,6 +2603,12 @@ impl<'a> std::fmt::Debug for CursivePosFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, CursivePosFormat1<'a>> for &CursivePosFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [CursivePosFormat1]
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -2566,8 +2636,9 @@ impl EntryExitRecord {
     /// By calling its `offset_data` method.
     pub fn entry_anchor<'a>(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, CursivePosFormat1<'a>>,
     ) -> Option<Result<AnchorTable<'a>, ReadError>> {
+        let data = data.offset_source();
         self.entry_anchor_offset().resolve(data)
     }
 
@@ -2584,8 +2655,9 @@ impl EntryExitRecord {
     /// By calling its `offset_data` method.
     pub fn exit_anchor<'a>(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, CursivePosFormat1<'a>>,
     ) -> Option<Result<AnchorTable<'a>, ReadError>> {
+        let data = data.offset_source();
         self.exit_anchor_offset().resolve(data)
     }
 }
@@ -2784,6 +2856,12 @@ impl<'a> std::fmt::Debug for MarkBasePosFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MarkBasePosFormat1<'a>> for &MarkBasePosFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkBasePosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2896,6 +2974,12 @@ impl<'a> std::fmt::Debug for BaseArray<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BaseArray<'a>> for &BaseArray<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [BaseArray]
 #[derive(Clone, Debug)]
 pub struct BaseRecord<'a> {
@@ -2921,8 +3005,9 @@ impl<'a> BaseRecord<'a> {
     /// By calling its `offset_data` method.
     pub fn base_anchors(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, BaseArray<'a>>,
     ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
+        let data = data.offset_source();
         let offsets = self.base_anchor_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
     }
@@ -3159,6 +3244,12 @@ impl<'a> std::fmt::Debug for MarkLigPosFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MarkLigPosFormat1<'a>> for &MarkLigPosFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkLigPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3284,6 +3375,12 @@ impl<'a> std::fmt::Debug for LigatureArray<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LigatureArray<'a>> for &LigatureArray<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkLigPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3396,6 +3493,12 @@ impl<'a> std::fmt::Debug for LigatureAttach<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LigatureAttach<'a>> for &LigatureAttach<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkLigPosFormat1]
 #[derive(Clone, Debug)]
 pub struct ComponentRecord<'a> {
@@ -3421,8 +3524,9 @@ impl<'a> ComponentRecord<'a> {
     /// By calling its `offset_data` method.
     pub fn ligature_anchors(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, LigatureAttach<'a>>,
     ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
+        let data = data.offset_source();
         let offsets = self.ligature_anchor_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
     }
@@ -3659,6 +3763,12 @@ impl<'a> std::fmt::Debug for MarkMarkPosFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MarkMarkPosFormat1<'a>> for &MarkMarkPosFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkMarkPosFormat1]Class2Record
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3771,6 +3881,12 @@ impl<'a> std::fmt::Debug for Mark2Array<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Mark2Array<'a>> for &Mark2Array<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MarkMarkPosFormat1]
 #[derive(Clone, Debug)]
 pub struct Mark2Record<'a> {
@@ -3796,8 +3912,9 @@ impl<'a> Mark2Record<'a> {
     /// By calling its `offset_data` method.
     pub fn mark2_anchors(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, Mark2Array<'a>>,
     ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
+        let data = data.offset_source();
         let offsets = self.mark2_anchor_offsets();
         ArrayOfNullableOffsets::new(offsets, data, ())
     }
@@ -4008,6 +4125,12 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for ExtensionPosFor
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for ExtensionPosFormat1<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a, T> OffsetSource<'a, ExtensionPosFormat1<'a, T>> for &ExtensionPosFormat1<'a, T> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -172,6 +172,12 @@ impl<'a> std::fmt::Debug for Gsub<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Gsub<'a>> for &Gsub<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// A [GSUB Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsubLookupTypeEnum) subtable.
 pub enum SubstitutionLookup<'a> {
     Single(Lookup<'a, SingleSubst<'a>>),
@@ -433,6 +439,12 @@ impl<'a> std::fmt::Debug for SingleSubstFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SingleSubstFormat1<'a>> for &SingleSubstFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for SingleSubstFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -552,6 +564,12 @@ impl<'a> SomeTable<'a> for SingleSubstFormat2<'a> {
 impl<'a> std::fmt::Debug for SingleSubstFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SingleSubstFormat2<'a>> for &SingleSubstFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -695,6 +713,12 @@ impl<'a> std::fmt::Debug for MultipleSubstFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MultipleSubstFormat1<'a>> for &MultipleSubstFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [MultipleSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -775,6 +799,12 @@ impl<'a> SomeTable<'a> for Sequence<'a> {
 impl<'a> std::fmt::Debug for Sequence<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Sequence<'a>> for &Sequence<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -921,6 +951,12 @@ impl<'a> std::fmt::Debug for AlternateSubstFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, AlternateSubstFormat1<'a>> for &AlternateSubstFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [AlternateSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1000,6 +1036,12 @@ impl<'a> SomeTable<'a> for AlternateSet<'a> {
 impl<'a> std::fmt::Debug for AlternateSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AlternateSet<'a>> for &AlternateSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1143,6 +1185,12 @@ impl<'a> std::fmt::Debug for LigatureSubstFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LigatureSubstFormat1<'a>> for &LigatureSubstFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [LigatureSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1243,6 +1291,12 @@ impl<'a> std::fmt::Debug for LigatureSet<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LigatureSet<'a>> for &LigatureSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [LigatureSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1336,6 +1390,12 @@ impl<'a> SomeTable<'a> for Ligature<'a> {
 impl<'a> std::fmt::Debug for Ligature<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Ligature<'a>> for &Ligature<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1482,6 +1542,12 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for ExtensionSubstF
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for ExtensionSubstFormat1<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a, T> OffsetSource<'a, ExtensionSubstFormat1<'a, T>> for &ExtensionSubstFormat1<'a, T> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1791,5 +1857,13 @@ impl<'a> SomeTable<'a> for ReverseChainSingleSubstFormat1<'a> {
 impl<'a> std::fmt::Debug for ReverseChainSingleSubstFormat1<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ReverseChainSingleSubstFormat1<'a>>
+    for &ReverseChainSingleSubstFormat1<'a>
+{
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -192,6 +192,12 @@ impl<'a> std::fmt::Debug for Gvar<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Gvar<'a>> for &Gvar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
@@ -587,6 +593,12 @@ impl<'a> std::fmt::Debug for SharedTuples<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SharedTuples<'a>> for &SharedTuples<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// The [GlyphVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#the-glyphvariationdata-table-array) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -693,5 +705,11 @@ impl<'a> SomeTable<'a> for GlyphVariationDataHeader<'a> {
 impl<'a> std::fmt::Debug for GlyphVariationDataHeader<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, GlyphVariationDataHeader<'a>> for &GlyphVariationDataHeader<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -148,3 +148,9 @@ impl<'a> std::fmt::Debug for Hdmx<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Hdmx<'a>> for &Hdmx<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -630,3 +630,9 @@ impl<'a> std::fmt::Debug for Head<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Head<'a>> for &Head<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -263,3 +263,9 @@ impl<'a> std::fmt::Debug for Hhea<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Hhea<'a>> for &Hhea<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -123,6 +123,12 @@ impl<'a> std::fmt::Debug for Hmtx<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Hmtx<'a>> for &Hmtx<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -163,3 +163,9 @@ impl<'a> std::fmt::Debug for Hvar<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Hvar<'a>> for &Hvar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -740,6 +740,12 @@ impl<'a> std::fmt::Debug for PatchMapFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PatchMapFormat1<'a>> for &PatchMapFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct GlyphMapMarker {
@@ -840,6 +846,12 @@ impl<'a> SomeTable<'a> for GlyphMap<'a> {
 impl<'a> std::fmt::Debug for GlyphMap<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, GlyphMap<'a>> for &GlyphMap<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -957,6 +969,12 @@ impl<'a> SomeTable<'a> for FeatureMap<'a> {
 impl<'a> std::fmt::Debug for FeatureMap<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, FeatureMap<'a>> for &FeatureMap<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1394,6 +1412,12 @@ impl<'a> std::fmt::Debug for PatchMapFormat2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, PatchMapFormat2<'a>> for &PatchMapFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct MappingEntriesMarker {
@@ -1452,6 +1476,12 @@ impl<'a> SomeTable<'a> for MappingEntries<'a> {
 impl<'a> std::fmt::Debug for MappingEntries<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, MappingEntries<'a>> for &MappingEntries<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1780,6 +1810,12 @@ impl<'a> SomeTable<'a> for EntryData<'a> {
 impl<'a> std::fmt::Debug for EntryData<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, EntryData<'a>> for &EntryData<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2215,6 +2251,12 @@ impl<'a> std::fmt::Debug for IdStringData<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, IdStringData<'a>> for &IdStringData<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Table Keyed Patch](https://w3c.github.io/IFT/Overview.html#table-keyed)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2346,6 +2388,12 @@ impl<'a> std::fmt::Debug for TableKeyedPatch<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, TableKeyedPatch<'a>> for &TableKeyedPatch<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [TablePatch](https://w3c.github.io/IFT/Overview.html#tablepatch)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2445,6 +2493,12 @@ impl<'a> SomeTable<'a> for TablePatch<'a> {
 impl<'a> std::fmt::Debug for TablePatch<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, TablePatch<'a>> for &TablePatch<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2873,6 +2927,12 @@ impl<'a> SomeTable<'a> for GlyphKeyedPatch<'a> {
 impl<'a> std::fmt::Debug for GlyphKeyedPatch<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, GlyphKeyedPatch<'a>> for &GlyphKeyedPatch<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3347,6 +3407,12 @@ impl<'a> std::fmt::Debug for GlyphPatches<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, GlyphPatches<'a>> for &GlyphPatches<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct GlyphDataMarker {
@@ -3403,5 +3469,11 @@ impl<'a> SomeTable<'a> for GlyphData<'a> {
 impl<'a> std::fmt::Debug for GlyphData<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, GlyphData<'a>> for &GlyphData<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -91,6 +91,12 @@ impl<'a> std::fmt::Debug for ScriptList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ScriptList<'a>> for &ScriptList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -117,7 +123,11 @@ impl ScriptRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn script<'a>(&self, data: FontData<'a>) -> Result<Script<'a>, ReadError> {
+    pub fn script<'a>(
+        &self,
+        data: impl OffsetSource<'a, ScriptList<'a>>,
+    ) -> Result<Script<'a>, ReadError> {
+        let data = data.offset_source();
         self.script_offset().resolve(data)
     }
 }
@@ -254,6 +264,12 @@ impl<'a> std::fmt::Debug for Script<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Script<'a>> for &Script<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
@@ -279,7 +295,11 @@ impl LangSysRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn lang_sys<'a>(&self, data: FontData<'a>) -> Result<LangSys<'a>, ReadError> {
+    pub fn lang_sys<'a>(
+        &self,
+        data: impl OffsetSource<'a, Script<'a>>,
+    ) -> Result<LangSys<'a>, ReadError> {
+        let data = data.offset_source();
         self.lang_sys_offset().resolve(data)
     }
 }
@@ -412,6 +432,12 @@ impl<'a> std::fmt::Debug for LangSys<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, LangSys<'a>> for &LangSys<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -499,6 +525,12 @@ impl<'a> std::fmt::Debug for FeatureList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, FeatureList<'a>> for &FeatureList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [FeatureList]
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -525,7 +557,11 @@ impl FeatureRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
+    pub fn feature<'a>(
+        &self,
+        data: impl OffsetSource<'a, FeatureList<'a>>,
+    ) -> Result<Feature<'a>, ReadError> {
+        let data = data.offset_source();
         let args = self.feature_tag();
         self.feature_offset().resolve_with_args(data, &args)
     }
@@ -681,6 +717,12 @@ impl<'a> std::fmt::Debug for Feature<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Feature<'a>> for &Feature<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
 #[derive(Debug)]
 #[doc(hidden)]
@@ -820,6 +862,12 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, 
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for LookupList<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a, T> OffsetSource<'a, LookupList<'a, T>> for &LookupList<'a, T> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1020,6 +1068,12 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for Lookup<'a, T>
     }
 }
 
+impl<'a, T> OffsetSource<'a, Lookup<'a, T>> for &Lookup<'a, T> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for CoverageFormat1Marker {
     const FORMAT: u16 = 1;
 }
@@ -1113,6 +1167,12 @@ impl<'a> SomeTable<'a> for CoverageFormat1<'a> {
 impl<'a> std::fmt::Debug for CoverageFormat1<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CoverageFormat1<'a>> for &CoverageFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1216,6 +1276,12 @@ impl<'a> SomeTable<'a> for CoverageFormat2<'a> {
 impl<'a> std::fmt::Debug for CoverageFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CoverageFormat2<'a>> for &CoverageFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1454,6 +1520,12 @@ impl<'a> std::fmt::Debug for ClassDefFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ClassDefFormat1<'a>> for &ClassDefFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for ClassDefFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -1554,6 +1626,12 @@ impl<'a> SomeTable<'a> for ClassDefFormat2<'a> {
 impl<'a> std::fmt::Debug for ClassDefFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ClassDefFormat2<'a>> for &ClassDefFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1862,6 +1940,12 @@ impl<'a> std::fmt::Debug for SequenceContextFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SequenceContextFormat1<'a>> for &SequenceContextFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [SequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1959,6 +2043,12 @@ impl<'a> SomeTable<'a> for SequenceRuleSet<'a> {
 impl<'a> std::fmt::Debug for SequenceRuleSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SequenceRuleSet<'a>> for &SequenceRuleSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2076,6 +2166,12 @@ impl<'a> SomeTable<'a> for SequenceRule<'a> {
 impl<'a> std::fmt::Debug for SequenceRule<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SequenceRule<'a>> for &SequenceRule<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2247,6 +2343,12 @@ impl<'a> std::fmt::Debug for SequenceContextFormat2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SequenceContextFormat2<'a>> for &SequenceContextFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [SequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2347,6 +2449,12 @@ impl<'a> SomeTable<'a> for ClassSequenceRuleSet<'a> {
 impl<'a> std::fmt::Debug for ClassSequenceRuleSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ClassSequenceRuleSet<'a>> for &ClassSequenceRuleSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2465,6 +2573,12 @@ impl<'a> SomeTable<'a> for ClassSequenceRule<'a> {
 impl<'a> std::fmt::Debug for ClassSequenceRule<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ClassSequenceRule<'a>> for &ClassSequenceRule<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2620,6 +2734,12 @@ impl<'a> SomeTable<'a> for SequenceContextFormat3<'a> {
 impl<'a> std::fmt::Debug for SequenceContextFormat3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SequenceContextFormat3<'a>> for &SequenceContextFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -2845,6 +2965,14 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ChainedSequenceContextFormat1<'a>>
+    for &ChainedSequenceContextFormat1<'a>
+{
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2945,6 +3073,12 @@ impl<'a> SomeTable<'a> for ChainedSequenceRuleSet<'a> {
 impl<'a> std::fmt::Debug for ChainedSequenceRuleSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ChainedSequenceRuleSet<'a>> for &ChainedSequenceRuleSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3130,6 +3264,12 @@ impl<'a> SomeTable<'a> for ChainedSequenceRule<'a> {
 impl<'a> std::fmt::Debug for ChainedSequenceRule<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ChainedSequenceRule<'a>> for &ChainedSequenceRule<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3354,6 +3494,14 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ChainedSequenceContextFormat2<'a>>
+    for &ChainedSequenceContextFormat2<'a>
+{
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3456,6 +3604,12 @@ impl<'a> SomeTable<'a> for ChainedClassSequenceRuleSet<'a> {
 impl<'a> std::fmt::Debug for ChainedClassSequenceRuleSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ChainedClassSequenceRuleSet<'a>> for &ChainedClassSequenceRuleSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3642,6 +3796,12 @@ impl<'a> SomeTable<'a> for ChainedClassSequenceRule<'a> {
 impl<'a> std::fmt::Debug for ChainedClassSequenceRule<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ChainedClassSequenceRule<'a>> for &ChainedClassSequenceRule<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -3907,6 +4067,14 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat3<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ChainedSequenceContextFormat3<'a>>
+    for &ChainedSequenceContextFormat3<'a>
+{
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone)]
 pub enum ChainedSequenceContext<'a> {
     Format1(ChainedSequenceContextFormat1<'a>),
@@ -4143,6 +4311,12 @@ impl<'a> std::fmt::Debug for Device<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Device<'a>> for &Device<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Variation index table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -4233,6 +4407,12 @@ impl<'a> SomeTable<'a> for VariationIndex<'a> {
 impl<'a> std::fmt::Debug for VariationIndex<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, VariationIndex<'a>> for &VariationIndex<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4407,6 +4587,12 @@ impl<'a> std::fmt::Debug for FeatureVariations<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, FeatureVariations<'a>> for &FeatureVariations<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [FeatureVariations]
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -4434,8 +4620,9 @@ impl FeatureVariationRecord {
     /// By calling its `offset_data` method.
     pub fn condition_set<'a>(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, FeatureVariations<'a>>,
     ) -> Option<Result<ConditionSet<'a>, ReadError>> {
+        let data = data.offset_source();
         self.condition_set_offset().resolve(data)
     }
 
@@ -4452,8 +4639,9 @@ impl FeatureVariationRecord {
     /// By calling its `offset_data` method.
     pub fn feature_table_substitution<'a>(
         &self,
-        data: FontData<'a>,
+        data: impl OffsetSource<'a, FeatureVariations<'a>>,
     ) -> Option<Result<FeatureTableSubstitution<'a>, ReadError>> {
+        let data = data.offset_source();
         self.feature_table_substitution_offset().resolve(data)
     }
 }
@@ -4583,6 +4771,12 @@ impl<'a> SomeTable<'a> for ConditionSet<'a> {
 impl<'a> std::fmt::Debug for ConditionSet<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ConditionSet<'a>> for &ConditionSet<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4790,6 +4984,12 @@ impl<'a> std::fmt::Debug for ConditionFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ConditionFormat1<'a>> for &ConditionFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for ConditionFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -4876,6 +5076,12 @@ impl<'a> SomeTable<'a> for ConditionFormat2<'a> {
 impl<'a> std::fmt::Debug for ConditionFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ConditionFormat2<'a>> for &ConditionFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -4995,6 +5201,12 @@ impl<'a> std::fmt::Debug for ConditionFormat3<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ConditionFormat3<'a>> for &ConditionFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for ConditionFormat4Marker {
     const FORMAT: u16 = 4;
 }
@@ -5111,6 +5323,12 @@ impl<'a> std::fmt::Debug for ConditionFormat4<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ConditionFormat4<'a>> for &ConditionFormat4<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for ConditionFormat5Marker {
     const FORMAT: u16 = 5;
 }
@@ -5193,6 +5411,12 @@ impl<'a> SomeTable<'a> for ConditionFormat5<'a> {
 impl<'a> std::fmt::Debug for ConditionFormat5<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ConditionFormat5<'a>> for &ConditionFormat5<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5292,6 +5516,12 @@ impl<'a> SomeTable<'a> for FeatureTableSubstitution<'a> {
 impl<'a> std::fmt::Debug for FeatureTableSubstitution<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, FeatureTableSubstitution<'a>> for &FeatureTableSubstitution<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5474,6 +5704,12 @@ impl<'a> std::fmt::Debug for SizeParams<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SizeParams<'a>> for &SizeParams<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct StylisticSetParamsMarker {}
@@ -5548,6 +5784,12 @@ impl<'a> SomeTable<'a> for StylisticSetParams<'a> {
 impl<'a> std::fmt::Debug for StylisticSetParams<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, StylisticSetParams<'a>> for &StylisticSetParams<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -5731,5 +5973,11 @@ impl<'a> SomeTable<'a> for CharacterVariantParams<'a> {
 impl<'a> std::fmt::Debug for CharacterVariantParams<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CharacterVariantParams<'a>> for &CharacterVariantParams<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -122,6 +122,12 @@ impl<'a> std::fmt::Debug for Ltag<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Ltag<'a>> for &Ltag<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Offset and length of string in `ltag` table.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -396,3 +396,9 @@ impl<'a> std::fmt::Debug for Maxp<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Maxp<'a>> for &Maxp<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -126,6 +126,12 @@ impl<'a> std::fmt::Debug for Meta<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Meta<'a>> for &Meta<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 ///  <https://learn.microsoft.com/en-us/typography/opentype/spec/meta#table-formats>
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -154,7 +160,11 @@ impl DataMapRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn data<'a>(&self, data: FontData<'a>) -> Result<Metadata<'a>, ReadError> {
+    pub fn data<'a>(
+        &self,
+        data: impl OffsetSource<'a, Meta<'a>>,
+    ) -> Result<Metadata<'a>, ReadError> {
+        let data = data.offset_source();
         let args = (self.tag(), self.data_length());
         self.data_offset().resolve_with_args(data, &args)
     }

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -154,6 +154,12 @@ impl<'a> std::fmt::Debug for Mvar<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Mvar<'a>> for &Mvar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [ValueRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/mvar#table-formats) metrics variation record
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -183,6 +183,12 @@ impl<'a> std::fmt::Debug for Name<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Name<'a>> for &Name<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Part of [Name]
 #[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -1064,3 +1064,9 @@ impl<'a> std::fmt::Debug for Os2<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Os2<'a>> for &Os2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -279,3 +279,9 @@ impl<'a> std::fmt::Debug for Post<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Post<'a>> for &Post<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -113,6 +113,12 @@ impl<'a> std::fmt::Debug for Index1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Index1<'a>> for &Index1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// An array of variable-sized objects in a `CFF2` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -218,6 +224,12 @@ impl<'a> SomeTable<'a> for Index2<'a> {
 impl<'a> std::fmt::Debug for Index2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Index2<'a>> for &Index2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -378,6 +390,12 @@ impl<'a> std::fmt::Debug for FdSelectFormat0<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, FdSelectFormat0<'a>> for &FdSelectFormat0<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for FdSelectFormat3Marker {
     const FORMAT: u8 = 3;
 }
@@ -489,6 +507,12 @@ impl<'a> SomeTable<'a> for FdSelectFormat3<'a> {
 impl<'a> std::fmt::Debug for FdSelectFormat3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, FdSelectFormat3<'a>> for &FdSelectFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -645,6 +669,12 @@ impl<'a> SomeTable<'a> for FdSelectFormat4<'a> {
 impl<'a> std::fmt::Debug for FdSelectFormat4<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, FdSelectFormat4<'a>> for &FdSelectFormat4<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -847,6 +877,12 @@ impl<'a> std::fmt::Debug for CharsetFormat0<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, CharsetFormat0<'a>> for &CharsetFormat0<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for CharsetFormat1Marker {
     const FORMAT: u8 = 1;
 }
@@ -931,6 +967,12 @@ impl<'a> SomeTable<'a> for CharsetFormat1<'a> {
 impl<'a> std::fmt::Debug for CharsetFormat1<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CharsetFormat1<'a>> for &CharsetFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -1060,6 +1102,12 @@ impl<'a> SomeTable<'a> for CharsetFormat2<'a> {
 impl<'a> std::fmt::Debug for CharsetFormat2<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CharsetFormat2<'a>> for &CharsetFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -469,6 +469,12 @@ impl<'a> std::fmt::Debug for Sbix<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Sbix<'a>> for &Sbix<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Strike](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#strikes) header table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -577,6 +583,12 @@ impl<'a> std::fmt::Debug for Strike<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Strike<'a>> for &Strike<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -675,5 +687,11 @@ impl<'a> SomeTable<'a> for GlyphData<'a> {
 impl<'a> std::fmt::Debug for GlyphData<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, GlyphData<'a>> for &GlyphData<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -201,6 +201,12 @@ impl<'a> std::fmt::Debug for Stat<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Stat<'a>> for &Stat<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [Axis Records](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -357,6 +363,12 @@ impl<'a> SomeTable<'a> for AxisValueArray<'a> {
 impl<'a> std::fmt::Debug for AxisValueArray<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AxisValueArray<'a>> for &AxisValueArray<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -583,6 +595,12 @@ impl<'a> std::fmt::Debug for AxisValueFormat1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, AxisValueFormat1<'a>> for &AxisValueFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for AxisValueFormat2Marker {
     const FORMAT: u16 = 2;
 }
@@ -729,6 +747,12 @@ impl<'a> std::fmt::Debug for AxisValueFormat2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, AxisValueFormat2<'a>> for &AxisValueFormat2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for AxisValueFormat3Marker {
     const FORMAT: u16 = 3;
 }
@@ -857,6 +881,12 @@ impl<'a> SomeTable<'a> for AxisValueFormat3<'a> {
 impl<'a> std::fmt::Debug for AxisValueFormat3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AxisValueFormat3<'a>> for &AxisValueFormat3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -989,6 +1019,12 @@ impl<'a> SomeTable<'a> for AxisValueFormat4<'a> {
 impl<'a> std::fmt::Debug for AxisValueFormat4<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, AxisValueFormat4<'a>> for &AxisValueFormat4<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -98,6 +98,12 @@ impl<'a> std::fmt::Debug for Svg<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Svg<'a>> for &Svg<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// [SVGDocumentList](https://learn.microsoft.com/en-us/typography/opentype/spec/svg)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -181,6 +187,12 @@ impl<'a> SomeTable<'a> for SVGDocumentList<'a> {
 impl<'a> std::fmt::Debug for SVGDocumentList<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SVGDocumentList<'a>> for &SVGDocumentList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -120,6 +120,12 @@ impl<'a> std::fmt::Debug for MajorMinorVersion<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MajorMinorVersion<'a>> for &MajorMinorVersion<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
@@ -558,6 +564,12 @@ impl<'a> std::fmt::Debug for FlagDay<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, FlagDay<'a>> for &FlagDay<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct FieldsAfterConditionalsMarker {
@@ -720,5 +732,11 @@ impl<'a> SomeTable<'a> for FieldsAfterConditionals<'a> {
 impl<'a> std::fmt::Debug for FieldsAfterConditionals<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, FieldsAfterConditionals<'a>> for &FieldsAfterConditionals<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -76,6 +76,12 @@ impl<'a> std::fmt::Debug for CountAll16<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, CountAll16<'a>> for &CountAll16<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct CountAll32Marker {
@@ -144,5 +150,11 @@ impl<'a> SomeTable<'a> for CountAll32<'a> {
 impl<'a> std::fmt::Debug for CountAll32<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, CountAll32<'a>> for &CountAll32<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -89,6 +89,12 @@ impl<'a> std::fmt::Debug for Table1<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Table1<'a>> for &Table1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Table2Marker {
     const FORMAT: u16 = 2;
 }
@@ -178,6 +184,12 @@ impl<'a> std::fmt::Debug for Table2<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Table2<'a>> for &Table2<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for Table3Marker {
     const FORMAT: u16 = 3;
 }
@@ -247,6 +259,12 @@ impl<'a> SomeTable<'a> for Table3<'a> {
 impl<'a> std::fmt::Debug for Table3<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Table3<'a>> for &Table3<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -278,6 +278,12 @@ impl<'a> std::fmt::Debug for KindsOfOffsets<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, KindsOfOffsets<'a>> for &KindsOfOffsets<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct KindsOfArraysOfOffsetsMarker {
@@ -523,6 +529,12 @@ impl<'a> std::fmt::Debug for KindsOfArraysOfOffsets<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, KindsOfArraysOfOffsets<'a>> for &KindsOfArraysOfOffsets<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct KindsOfArraysMarker {
@@ -704,6 +716,12 @@ impl<'a> std::fmt::Debug for KindsOfArrays<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, KindsOfArrays<'a>> for &KindsOfArrays<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct VarLenHaverMarker {
@@ -790,6 +808,12 @@ impl<'a> std::fmt::Debug for VarLenHaver<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, VarLenHaver<'a>> for &VarLenHaver<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct DummyMarker {}
@@ -849,6 +873,12 @@ impl<'a> SomeTable<'a> for Dummy<'a> {
 impl<'a> std::fmt::Debug for Dummy<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, Dummy<'a>> for &Dummy<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -142,6 +142,12 @@ impl<'a> std::fmt::Debug for BasicTable<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, BasicTable<'a>> for &BasicTable<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
@@ -288,7 +294,11 @@ impl ContainsOffsets {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn array<'a>(&self, data: FontData<'a>) -> Result<&'a [SimpleRecord], ReadError> {
+    pub fn array<'a>(
+        &self,
+        data: impl OffsetSource<'a, BasicTable<'a>>,
+    ) -> Result<&'a [SimpleRecord], ReadError> {
+        let data = data.offset_source();
         let args = self.off_array_count();
         self.array_offset().resolve_with_args(data, &args)
     }
@@ -300,7 +310,11 @@ impl ContainsOffsets {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
-    pub fn other<'a>(&self, data: FontData<'a>) -> Result<BasicTable<'a>, ReadError> {
+    pub fn other<'a>(
+        &self,
+        data: impl OffsetSource<'a, BasicTable<'a>>,
+    ) -> Result<BasicTable<'a>, ReadError> {
+        let data = data.offset_source();
         self.other_offset().resolve(data)
     }
 }

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -181,6 +181,12 @@ impl<'a> std::fmt::Debug for Varc<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Varc<'a>> for &Varc<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u16> for MultiItemVariationStoreMarker {
     const FORMAT: u16 = 1;
 }
@@ -320,6 +326,12 @@ impl<'a> std::fmt::Debug for MultiItemVariationStore<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MultiItemVariationStore<'a>> for &MultiItemVariationStore<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct SparseVariationRegionListMarker {
@@ -415,6 +427,12 @@ impl<'a> std::fmt::Debug for SparseVariationRegionList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, SparseVariationRegionList<'a>> for &SparseVariationRegionList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct SparseVariationRegionMarker {
@@ -494,6 +512,12 @@ impl<'a> SomeTable<'a> for SparseVariationRegion<'a> {
 impl<'a> std::fmt::Debug for SparseVariationRegion<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, SparseVariationRegion<'a>> for &SparseVariationRegion<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -654,6 +678,12 @@ impl<'a> std::fmt::Debug for MultiItemVariationData<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, MultiItemVariationData<'a>> for &MultiItemVariationData<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct ConditionListMarker {
@@ -746,6 +776,12 @@ impl<'a> SomeTable<'a> for ConditionList<'a> {
 impl<'a> std::fmt::Debug for ConditionList<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ConditionList<'a>> for &ConditionList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -135,6 +135,12 @@ impl<'a> std::fmt::Debug for TupleVariationHeader<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, TupleVariationHeader<'a>> for &TupleVariationHeader<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// A [Tuple Record](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuple-records)
 ///
 /// The tuple variation store formats reference regions within the font’s
@@ -317,6 +323,12 @@ impl<'a> std::fmt::Debug for DeltaSetIndexMapFormat0<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, DeltaSetIndexMapFormat0<'a>> for &DeltaSetIndexMapFormat0<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 impl Format<u8> for DeltaSetIndexMapFormat1Marker {
     const FORMAT: u8 = 1;
 }
@@ -422,6 +434,12 @@ impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat1<'a> {
 impl<'a> std::fmt::Debug for DeltaSetIndexMapFormat1<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, DeltaSetIndexMapFormat1<'a>> for &DeltaSetIndexMapFormat1<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }
 
@@ -926,6 +944,12 @@ impl<'a> std::fmt::Debug for VariationRegionList<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, VariationRegionList<'a>> for &VariationRegionList<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// The [VariationRegion](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VariationRegion<'a> {
@@ -1194,6 +1218,12 @@ impl<'a> std::fmt::Debug for ItemVariationStore<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, ItemVariationStore<'a>> for &ItemVariationStore<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1316,5 +1346,11 @@ impl<'a> SomeTable<'a> for ItemVariationData<'a> {
 impl<'a> std::fmt::Debug for ItemVariationData<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl<'a> OffsetSource<'a, ItemVariationData<'a>> for &ItemVariationData<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
     }
 }

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -262,3 +262,9 @@ impl<'a> std::fmt::Debug for Vhea<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Vhea<'a>> for &Vhea<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -122,3 +122,9 @@ impl<'a> std::fmt::Debug for Vmtx<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Vmtx<'a>> for &Vmtx<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -130,6 +130,12 @@ impl<'a> std::fmt::Debug for Vorg<'a> {
     }
 }
 
+impl<'a> OffsetSource<'a, Vorg<'a>> for &Vorg<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
 /// Vertical origin Y metrics record.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -185,3 +185,9 @@ impl<'a> std::fmt::Debug for Vvar<'a> {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
 }
+
+impl<'a> OffsetSource<'a, Vvar<'a>> for &Vvar<'a> {
+    fn offset_source(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -86,7 +86,7 @@ pub mod traversal;
 pub mod codegen_test;
 
 pub use font_data::FontData;
-pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
+pub use offset::{Offset, OffsetSource, ResolveNullableOffset, ResolveOffset};
 pub use offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
 pub use read::{ComputeSize, FontRead, FontReadWithArgs, ReadArgs, ReadError, VarSize};
 pub use table_provider::{TableProvider, TopLevelTable};
@@ -100,9 +100,8 @@ pub extern crate font_types as types;
 pub(crate) mod codegen_prelude {
     pub use crate::array::{ComputedArray, VarLenArray};
     pub use crate::font_data::{Cursor, FontData};
-    pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
+    pub use crate::offset::{Offset, OffsetSource, ResolveNullableOffset, ResolveOffset};
     pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
-    //pub(crate) use crate::read::sealed;
     pub use crate::read::{
         ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
     };

--- a/resources/codegen_inputs/base.rs
+++ b/resources/codegen_inputs/base.rs
@@ -57,6 +57,7 @@ record BaseScriptRecord {
     /// 4-byte script identification tag
     base_script_tag: Tag,
     /// Offset to BaseScript table, from beginning of BaseScriptList
+    #[offset_from(BaseScriptList)]
     base_script_offset: Offset16<BaseScript>,
 }
 
@@ -82,6 +83,7 @@ record BaseLangSysRecord {
     /// 4-byte language system identification tag
     base_lang_sys_tag: Tag,
     /// Offset to MinMax table, from beginning of BaseScript table
+    #[offset_from(BaseScript)]
     min_max_offset: Offset16<MinMax>,
 }
 
@@ -129,10 +131,12 @@ record FeatMinMaxRecord {
     /// Offset to BaseCoord table that defines the minimum extent
     /// value, from beginning of MinMax table (may be NULL)
     #[nullable]
+    #[offset_from(MinMax)]
     min_coord_offset: Offset16<MinMax>,
     /// Offset to BaseCoord table that defines the maximum extent
     /// value, from beginning of MinMax table (may be NULL)
     #[nullable]
+    #[offset_from(MinMax)]
     max_coord_offset: Offset16<MinMax>,
 }
 

--- a/resources/codegen_inputs/bitmap.rs
+++ b/resources/codegen_inputs/bitmap.rs
@@ -102,6 +102,7 @@ record IndexSubtableRecord {
     last_glyph_index: GlyphId16,
     /// Offset to an IndexSubtable from the start of the IndexSubtableList.
     #[read_offset_with($last_glyph_index, $first_glyph_index)]
+    #[offset_from(IndexSubtableList)]
     index_subtable_offset: Offset32<IndexSubtable>,
 }
 

--- a/resources/codegen_inputs/cmap.rs
+++ b/resources/codegen_inputs/cmap.rs
@@ -21,6 +21,7 @@ record EncodingRecord {
     encoding_id: u16,
     /// Byte offset from beginning of the [`Cmap`] table to the subtable for this
     /// encoding.
+    #[offset_from(Cmap)]
     subtable_offset: Offset32<CmapSubtable>,
 }
 
@@ -307,10 +308,12 @@ record VariationSelector {
     /// Offset from the start of the [`Cmap14`] subtable to Default UVS
     /// Table. May be NULL.
     #[nullable]
+    #[offset_from(Cmap14)]
     default_uvs_offset: Offset32<DefaultUvs>,
     /// Offset from the start of the [`Cmap14`] subtable to Non-Default
     /// UVS Table. May be NULL.
     #[nullable]
+    #[offset_from(Cmap14)]
     non_default_uvs_offset: Offset32<NonDefaultUvs>,
 }
 

--- a/resources/codegen_inputs/colr.rs
+++ b/resources/codegen_inputs/colr.rs
@@ -72,6 +72,7 @@ record BaseGlyphPaint {
     /// Glyph ID of the base glyph.
     glyph_id: GlyphId16,
     /// Offset to a Paint table, from the beginning of the [`BaseGlyphList`] table.
+    #[offset_from(BaseGlyphList)]
     paint_offset: Offset32<Paint>,
 }
 
@@ -101,6 +102,7 @@ record Clip {
     /// Last glyph ID in the range.
     end_glyph_id: GlyphId16,
     /// Offset to a ClipBox table, from the beginning of the [`ClipList`] table.
+    #[offset_from(ClipList)]
     clip_box_offset: Offset24<ClipBox>,
 }
 

--- a/resources/codegen_inputs/feat.rs
+++ b/resources/codegen_inputs/feat.rs
@@ -31,6 +31,7 @@ record FeatureName {
     /// setting name array. The actual type of record this offset refers 
     /// to will depend on the exclusivity value, as described below.
     #[read_offset_with($n_settings)]
+    #[offset_from(Feat)]
     setting_table_offset: Offset32<SettingNameArray>,
     /// Flags associated with the feature type.
     feature_flags: u16,

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -128,6 +128,7 @@ record MarkRecord {
     /// Class defined for the associated mark.
     mark_class: u16,
     /// Offset to Anchor table, from beginning of MarkArray table.
+    #[offset_from(MarkArray)]
     mark_anchor_offset: Offset16<AnchorTable>,
 }
 
@@ -312,10 +313,12 @@ record EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
     #[nullable]
+    #[offset_from(CursivePosFormat1)]
     entry_anchor_offset: Offset16<AnchorTable>,
     /// Offset to exitAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
     #[nullable]
+    #[offset_from(CursivePosFormat1)]
     exit_anchor_offset: Offset16<AnchorTable>,
 }
 
@@ -368,6 +371,7 @@ record BaseRecord<'a> {
     /// (offsets may be NULL).
     #[nullable]
     #[count($mark_class_count)]
+    #[offset_from(BaseArray)]
     base_anchor_offsets: [Offset16<AnchorTable>],
 }
 
@@ -428,6 +432,7 @@ record ComponentRecord<'a> {
     /// (offsets may be NULL).
     #[nullable]
     #[count($mark_class_count)]
+    #[offset_from(LigatureAttach)]
     ligature_anchor_offsets: [Offset16<AnchorTable>],
 }
 
@@ -474,6 +479,7 @@ record Mark2Record<'a> {
     /// be NULL).
     #[count($mark_class_count)]
     #[nullable]
+    #[offset_from(Mark2Array)]
     mark2_anchor_offsets: [Offset16<AnchorTable>],
 }
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -18,6 +18,7 @@ record ScriptRecord {
     /// 4-byte script tag identifier
     script_tag: Tag,
     /// Offset to Script table, from beginning of ScriptList
+    #[offset_from(ScriptList)]
     script_offset: Offset16<Script>,
 }
 
@@ -40,6 +41,7 @@ record LangSysRecord {
     /// 4-byte LangSysTag identifier
     lang_sys_tag: Tag,
     /// Offset to LangSys table, from beginning of Script table
+    #[offset_from(Script)]
     lang_sys_offset: Offset16<LangSys>,
 }
 
@@ -79,6 +81,7 @@ record FeatureRecord {
     feature_tag: Tag,
     /// Offset to Feature table, from beginning of FeatureList
     #[read_offset_with($feature_tag)]
+    #[offset_from(FeatureList)]
     feature_offset: Offset16<Feature>,
 }
 
@@ -597,10 +600,12 @@ record FeatureVariationRecord {
     /// Offset to a condition set table, from beginning of
     /// FeatureVariations table.
     #[nullable]
+    #[offset_from(FeatureVariations)]
     condition_set_offset: Offset32<ConditionSet>,
     /// Offset to a feature table substitution table, from beginning of
     /// the FeatureVariations table.
     #[nullable]
+    #[offset_from(FeatureVariations)]
     feature_table_substitution_offset: Offset32<FeatureTableSubstitution>,
 }
 

--- a/resources/codegen_inputs/meta.rs
+++ b/resources/codegen_inputs/meta.rs
@@ -30,6 +30,7 @@ record DataMapRecord {
     #[read_offset_with($tag, $data_length)]
     #[traverse_with(skip)]
     #[validate(validate_data_type)]
+    #[offset_from(Meta)]
     data_offset: Offset32<Metadata>,
     /// Length of the data, in bytes. The data is not required to be padded to any byte boundary.
     #[compile(self.compute_data_len())]

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -39,6 +39,8 @@ record ContainsOffsets {
     #[compile(array_len($array_offset))]
     off_array_count: u16,
     #[read_offset_with($off_array_count)]
+    #[offset_from(BasicTable)]
     array_offset: Offset16<[SimpleRecord]>,
+    #[offset_from(BasicTable)]
     other_offset: Offset32<BasicTable>,
 }


### PR DESCRIPTION
This is a way of encoding the source of offset data in the case where it has to be passed in, which has been a longstanding request.

With this change, the method for getting a `Script` from a `ScriptRecord` looks like,

```rust
fn script<'a>(&self, data: impl OffsetSource<'a, ScriptList<'a>>)
```

instead of,

```rust
fn script<'a>(&self, data: FontData<'a>)
```

To avoid breakage (this should break no existing code), `FontData` can still be passed directly to any method that accepts an `OffsetSource` argument. This is not publicly documented, though, and it is expected that new code would pass in the tables themselves.


- closes #681 
- closes #1123 