### PR TITLE
Ability to create a `PString` programmatically

### DIFF
--- a/write-fonts/src/tables/post.rs
+++ b/write-fonts/src/tables/post.rs
@@ -11,6 +11,12 @@ include!("../../generated/generated_post.rs");
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PString(String);
 
+impl<I : Into<String>> From<I> for PString {
+    fn from(value: I) -> Self {
+        Self(value.into())
+    }
+}
+
 impl Post {
     /// Construct a new version 2.0 table from a glyph order.
     pub fn new_v2<'a>(order: impl IntoIterator<Item = &'a str>) -> Self {
@@ -132,5 +138,11 @@ mod tests {
         assert_eq!(loaded.glyph_name(GlyphId16::new(3)), Some("C"));
         assert_eq!(loaded.glyph_name(GlyphId16::new(4)), Some("A"));
         assert_eq!(loaded.glyph_name(GlyphId16::new(5)), Some("flarb"));
+    }
+    
+    #[test]
+    fn test_pstring_dref() {
+        let string = PString::from("Hello");
+        assert_eq!("Hello", std::ops::Deref::deref(&string));
     }
 }


### PR DESCRIPTION
This library seems oriented toward *modifying* font files, but some of us are insane enough to want to create one programmatically from scratch.  That requires being able to populate strings programmatically from scratch, but there is no clean way to construct a `PString`.

There is no obvious way to construct a `PString` from a `str` or `String`.  While it is possible to hack around that by putting the desired string in quotes and then using `serde_json` to deserialize it, that is a pretty ugly solution.

This patch simply adds a `From<I : Into<String>>` implementation for it.