### PR TITLE
[read-fonts] VarLenArray: stop iteration at zero length item

### DIFF
--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -42,3 +42,9 @@ record ContainsOffsets {
     array_offset: Offset16<[SimpleRecord]>,
     other_offset: Offset32<BasicTable>,
 }
+
+table VarLenItem {
+    length: u32,
+    #[count(..)]
+    data: [u8],
+}

--- a/resources/codegen_inputs/test_records.rs
+++ b/resources/codegen_inputs/test_records.rs
@@ -43,6 +43,7 @@ record ContainsOffsets {
     other_offset: Offset32<BasicTable>,
 }
 
+#[skip_constructor]
 table VarLenItem {
     length: u32,
     #[count(..)]

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -232,13 +232,6 @@ pub struct VarLenItem {
     pub data: Vec<u8>,
 }
 
-impl VarLenItem {
-    /// Construct a new `VarLenItem`
-    pub fn new(length: u32, data: Vec<u8>) -> Self {
-        Self { length, data }
-    }
-}
-
 impl FontWrite for VarLenItem {
     fn write_into(&self, writer: &mut TableWriter) {
         self.length.write_into(writer);

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -224,3 +224,51 @@ impl FromObjRef<read_fonts::codegen_test::records::ContainsOffsets> for Contains
         }
     }
 }
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VarLenItem {
+    pub length: u32,
+    pub data: Vec<u8>,
+}
+
+impl VarLenItem {
+    /// Construct a new `VarLenItem`
+    pub fn new(length: u32, data: Vec<u8>) -> Self {
+        Self { length, data }
+    }
+}
+
+impl FontWrite for VarLenItem {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.length.write_into(writer);
+        self.data.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("VarLenItem")
+    }
+}
+
+impl Validate for VarLenItem {
+    fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
+}
+
+impl<'a> FromObjRef<read_fonts::codegen_test::records::VarLenItem<'a>> for VarLenItem {
+    fn from_obj_ref(obj: &read_fonts::codegen_test::records::VarLenItem<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        VarLenItem {
+            length: obj.length(),
+            data: obj.data().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::codegen_test::records::VarLenItem<'a>> for VarLenItem {}
+
+impl<'a> FontRead<'a> for VarLenItem {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::codegen_test::records::VarLenItem as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}


### PR DESCRIPTION
Since we use the item length to track the iterator state, zero length items will cause the iterator to loop forever.

JMM if happy