### PR TITLE
[chore] bump minor for everything

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,12 @@ core_maths = "0.1"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.8.4", path = "font-types" }
-read-fonts = { version = "0.28.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.9.0", path = "font-types" }
+read-fonts = { version = "0.29.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.30.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.37.0", path = "write-fonts" }
+skrifa = { version = "0.31.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.38.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.3.2"
+version = "0.4.0"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.8.4"
+version = "0.9.0"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.28.0"
+version = "0.29.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.30.0"
+version = "0.31.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.37.0"
+version = "0.38.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for font-types from font-types-v0.8.4 to 0.9.0
             4f802e9 [chore] bump minor for everything
             7d6b8d5 [chore] Set MSRV to 1.75
             126d981 Set MSRV for font-types, read-fonts, write-fonts and skrifa to 1.71
             d418836 Reformat
             b42f5b2 Fix wrong message
     Changes for read-fonts from read-fonts-v0.28.0 to 0.29.0
             4f802e9 [chore] bump minor for everything
             c181a5a [read-fonts] small perf improvement in IVS (#1461)
             4ba610c unify code for cmap 12/13, add cmap13 tests
             b413669 [chore] Get cargo test working on 1.75
             7d6b8d5 [chore] Set MSRV to 1.75
             3d3bd85 Replace get_or_insert_default with get_or_insert_with(Default::default)
             126d981 Set MSRV for font-types, read-fonts, write-fonts and skrifa to 1.71
             3ebd31c Use predicate matcher instead of array matches
             bee845d Remove eprintln
             ce09c6f Fix clippy
             f00e3b4 Support the format 6 subtable
             3d45d1a Add support for mapping codepoints via cmap0 subtable
             d706c80 [read-fonts] VarLenArray: stop iteration at zero length item (#1484)
             0af3a0c Update CFF hinting to match FreeType (#1458)
             2fe8e5d [read-fonts] parse the morx table  (#1478)
             db32bdd [IntSet] use RangeBound for range() to give maximum flexibility.
             2a20fae Add public IntSet methods iter_from() and range(). iter_from() iterates over set members >= to the given value. range() iterates over set members in the given range (inclusive).
             0588f56 [klippa] implement intersects() for (Chain)Context lookups
             30c5377 [klippa] closure lookups step 1: implement intersects()
             8292a1e [read/write] Fix offset type in FeatMinMaxRecord
             f522158 [read-fonts] parse trak table (#1469)
             b69dacf [klippa] move code that will be used by both gsub and gpos
             d139c08 [klippa] layout closure: collect features
             90fe244 Rework cff charstring offset fields to use a presence bit flag.
             1179b69 Add charstrings offset loading to patch map format 1.
             5888997 [IFT] Use stored charstring offsets during glyph keyed patching.
             fde9566 Update IFT table to support optional charstring offsets.
             8a9369c [closure] Fixup the memoization logic
             ed09b1a [read] Add a context type for glyph closure
             5754098 [clippy] Roll the rock back up the hill
             ae80c78 Add accessors to common axis values
             6234985 [read-fonts/cmap] Towards supporting format13 subtables
     Changes for font-test-data from font-test-data-v0.3.2 to 0.4.0
             4f802e9 [chore] bump minor for everything
             7d6b8d5 [chore] Set MSRV to 1.75
             2fe8e5d [read-fonts] parse the morx table  (#1478)
             49618d7 Implement
             90fe244 Rework cff charstring offset fields to use a presence bit flag.
             1179b69 Add charstrings offset loading to patch map format 1.
             5888997 [IFT] Use stored charstring offsets during glyph keyed patching.
             fde9566 Update IFT table to support optional charstring offsets.
             ed09b1a [read] Add a context type for glyph closure
             5754098 [clippy] Roll the rock back up the hill
     Changes for write-fonts from write-fonts-v0.37.0 to 0.38.0
             4f802e9 [chore] bump minor for everything
             b413669 [chore] Get cargo test working on 1.75
             7d6b8d5 [chore] Set MSRV to 1.75
             d706c80 [read-fonts] VarLenArray: stop iteration at zero length item (#1484)
             8292a1e [read/write] Fix offset type in FeatMinMaxRecord
             b10eda3 Compile `HVAR` version number as constant (1, 0)
             fa01940 Compile `VVAR` version number as constant (1, 0)
             64d7c5b Generate and expose VVAR in write-fonts
             90fe244 Rework cff charstring offset fields to use a presence bit flag.
             1179b69 Add charstrings offset loading to patch map format 1.
             fde9566 Update IFT table to support optional charstring offsets.
             5754098 [clippy] Roll the rock back up the hill
     Changes for skrifa from skrifa-v0.30.0 to 0.31.0
             4f802e9 [chore] bump minor for everything
             4ba610c unify code for cmap 12/13, add cmap13 tests
             7d6b8d5 [chore] Set MSRV to 1.75
             126d981 Set MSRV for font-types, read-fonts, write-fonts and skrifa to 1.71
             e5bd800 Fix item visibility errors with older rustc
             9361298 Use is_some_and instead of is_none_or
             0af3a0c Update CFF hinting to match FreeType (#1458)
             4c70c6e Change constructor signatures
             4b60ddb Fix comment
             49618d7 Implement
             5754098 [clippy] Roll the rock back up the hill