### PR TITLE
Support preload lists on patch map entries.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -658,7 +658,7 @@ pub fn string_ids_format2_with_preloads() -> BeBuffer {
       // Entry id = {abc, "", defg}
       0b00000100u8,                           // format = ID_DELTA
       (Uint24::new(CONTINUE_MASK | 3)),       // id length 3
-      (Uint24::new(CONTINUE_MASK | 0)),       // id length 0
+      (Uint24::new(CONTINUE_MASK)),           // id length 0
       (Uint24::new(4)),                       // id length 4
 
       // Entry id = defg

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -552,18 +552,18 @@ pub fn custom_ids_format2() -> BeBuffer {
       // Entries Array
       // Entry id = 0
       {0b00010100u8: "entries[0]"},           // format = CODEPOINT_BIT_1 | ID_DELTA
-      (Int24::new(-1)),                       // id delta
+      (Int24::new(-2)),                       // id delta = -1
       [0b00001101, 0b00000011, 0b00110001u8], // codepoints = [0..17]
 
       // Entry id = 6
       {0b00100100u8: "entries[1]"},            // format = CODEPOINT_BIT_2 | ID_DELTA
-      {(Int24::new(5)): "id delta"},           // id delta
+      {(Int24::new(10)): "id delta"},           // id delta = 5
       5u16,                                   // bias
       [0b00001101, 0b00000011, 0b00110001u8], // codepoints = [5..22]
 
       // Entry id = 14
       {0b01000100u8: "entries[2]"},                  // format = ID_DELTA | IGNORED
-      {(Int24::new(7)): "id delta - ignored entry"}, // id delta
+      {(Int24::new(14)): "id delta - ignored entry"}, // id delta = 7
 
       // Entry id = 15
       {0b00101000u8: "entries[3]"},           // format = CODEPOINT_BIT_2 | PATCH_FORMAT
@@ -602,22 +602,22 @@ pub fn string_ids_format2() -> BeBuffer {
 
       // Entry id = abc
       0b00000100u8,                           // format = ID_DELTA
-      3u16,                                   // id length
+      (Uint24::new(3)),                       // id length
 
       // Entry id = defg
       0b00000100u8,                           // format = ID_DELTA
-      4u16,                                   // id length
+      (Uint24::new(4)),                       // id length
 
       // Entry id = defg
       0b00000000u8,                           // format = {}
 
       // Entry id = hij
       0b00000100u8,                           // format = ID_DELTA
-      {3u16: "entry[4] id length"},           // id length
+      {(Uint24::new(3)): "entry[4] id length"},           // id length
 
       // Entry id = ""
       0b00000100u8,                           // format = ID_DELTA
-      0u16,                                   // id length
+      (Uint24::new(0)),                                   // id length
 
       /* ### String Data ### */
       {b'a': "string_data"},

--- a/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
+++ b/fuzz/fuzz_targets/fuzz_ift_patch_group.rs
@@ -86,7 +86,9 @@ fuzz_target!(|input: FuzzInput| {
 
     let subset_definition = input.to_subset_definition();
 
-    let Ok(group) = PatchGroup::select_next_patches(font, &subset_definition) else {
+    // TODO(garretrieger): generate a random patch data map.
+    let Ok(group) = PatchGroup::select_next_patches(font, &Default::default(), &subset_definition)
+    else {
         return;
     };
 

--- a/incremental-font-transfer/src/bin/ift_extend.rs
+++ b/incremental-font-transfer/src/bin/ift_extend.rs
@@ -126,13 +126,14 @@ fn main() {
                     }
                 }
 
-                let patch_bytes = std::fs::read(uri_path.clone()).unwrap_or_else(|e| {
-                    panic!(
+                let patch_bytes = match std::fs::read(uri_path.clone()) {
+                    Result::Ok(bytes) => bytes,
+                    Result::Err(e) => panic!(
                         "Unable to read patch file ({}): {:?}",
                         uri_path.display(),
                         e
-                    )
-                });
+                    ),
+                };
 
                 UriStatus::Pending(patch_bytes)
             });

--- a/incremental-font-transfer/src/bin/ift_graph.rs
+++ b/incremental-font-transfer/src/bin/ift_graph.rs
@@ -226,13 +226,13 @@ fn to_graph(
     graph.entry(node_name.clone()).or_default();
 
     for patch in patches {
-        if !matches!(patch.encoding(), PatchFormat::TableKeyed { .. }) {
+        if !matches!(patch.uri.encoding(), PatchFormat::TableKeyed { .. }) {
             // This graph only considers invalidating (that is table keyed patches), so skip all other types.
             continue;
         }
 
-        let uri_string = patch.uri_string()?;
-        let next_font = to_next_font(base_path, &font, patch)?;
+        let uri_string = patch.uri.uri_string()?;
+        let next_font = to_next_font(base_path, &font, patch.uri)?;
         let next_font = FontRef::new(&next_font).expect("Downstream font parsing failed");
 
         {

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -221,22 +221,20 @@ impl PatchGroup<'_> {
         });
 
         // URI's which have been selected for use above should not show up in other selections.
-        if let (Some(uri), None) = (&ift_selected_uri, &iftx_selected_uri) {
-            no_invalidation_iftx.remove(uri);
-        }
-        if let (None, Some(uri)) = (&ift_selected_uri, &iftx_selected_uri) {
-            no_invalidation_ift.remove(uri);
-        }
+        match (&ift_selected_uri, &iftx_selected_uri) {
+            (Some(uri), None) => no_invalidation_iftx.remove(uri),
+            (None, Some(uri)) => no_invalidation_ift.remove(uri),
+            _ => None,
+        };
 
         let no_invalidation_ift: BTreeMap<String, NoInvalidationPatch> = match ift_selected_uri {
             None => Self::extract_preloads(no_invalidation_ift, &mut combined_preload_uris),
             _ => Default::default(),
         };
-        let mut no_invalidation_iftx: BTreeMap<String, NoInvalidationPatch> =
-            match iftx_selected_uri {
-                None => Self::extract_preloads(no_invalidation_iftx, &mut combined_preload_uris),
-                _ => Default::default(),
-            };
+        let mut no_invalidation_iftx = iftx_selected_uri
+            .is_none()
+            .then(|| Self::extract_preloads(no_invalidation_iftx, &mut combined_preload_uris))
+            .unwrap_or_default();
 
         match (ift_scope, iftx_scope) {
             (Some(scope1), Some(scope2)) => Ok((

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -58,8 +58,13 @@ impl PatchGroup<'_> {
             return Err(ReadError::ValidationError);
         }
 
-        let compat_group =
-            Self::select_next_patches_from_candidates(candidates, ift_compat_id, iftx_compat_id)?;
+        // TODO XXXX collect up preload uris
+        let uri_candidates: Vec<_> = candidates.into_iter().map(|e| e.uri).collect();
+        let compat_group = Self::select_next_patches_from_candidates(
+            uri_candidates,
+            ift_compat_id,
+            iftx_compat_id,
+        )?;
 
         Ok(PatchGroup {
             font: ift_font,

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -472,7 +472,7 @@ impl TryFrom<PatchMapEntry> for CandidatePatch {
         Ok(Self {
             intersection_info: value.uri.intersection_info(),
             patch_info: value.uri.try_into()?,
-            preload_uris: preload_uris,
+            preload_uris,
         })
     }
 }
@@ -484,7 +484,7 @@ impl TryFrom<PatchMapEntry> for CandidateNoInvalidationPatch {
         let preload_uris = value.preload_uri_strings()?;
         Ok(Self {
             patch_info: value.uri.try_into()?,
-            preload_uris: preload_uris,
+            preload_uris,
         })
     }
 }
@@ -810,10 +810,10 @@ mod tests {
     }
 
     fn preload_list(uris: &[String]) -> Vec<PatchUri> {
-        uris.into_iter()
+        uris.iter()
             .map(|uri| {
                 PatchUri::from_index(
-                    &uri,
+                    uri,
                     0,
                     IftTableTag::Ift(CompatibilityId::from_u32s([0, 0, 0, 0])),
                     0,

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -868,7 +868,7 @@ impl IftTableTag {
 /// Each entry has a primary URI which is what is loaded and applied when the entry is selected.
 /// Additionally each entry has an optional set of preload URI's which should be preloaded if the
 /// entry is selected
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PatchMapEntry {
     pub uri: PatchUri,
     pub preload_uris: Vec<PatchUri>,
@@ -880,6 +880,15 @@ impl PatchMapEntry {
             uri,
             preload_uris: vec![],
         }
+    }
+
+    pub fn preload_uri_strings(&self) -> Result<Vec<String>, UriTemplateError> {
+        let mut result: Vec<String> = Default::default();
+        for uri in self.preload_uris.iter() {
+            let uri_string = uri.uri_string()?;
+            result.push(uri_string);
+        }
+        Ok(result)
     }
 }
 

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -465,7 +465,7 @@ fn add_intersecting_format2_patches(
                 order,
             );
         }
-        let preload_uris: Vec<PatchUri> = it.map(|uri| uri.clone()).collect();
+        let preload_uris: Vec<PatchUri> = it.cloned().collect();
         patches.push(PatchMapEntry {
             uri: first_uri,
             preload_uris,

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -685,9 +685,7 @@ fn decode_format2_patch_format(
         return Ok((None, format_data));
     }
 
-    let Some(format_byte) = format_data.first() else {
-        return Err(ReadError::OutOfBounds);
-    };
+    let format_byte = format_data.first().ok_or(ReadError::OutOfBounds)?;
 
     let patch_format = PatchFormat::from_format_number(*format_byte)?;
 

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -166,45 +166,6 @@ impl U16Or24 {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct IdDeltaOrLength(i32);
-
-impl ReadArgs for IdDeltaOrLength {
-    type Args = Offset32;
-}
-
-impl ComputeSize for IdDeltaOrLength {
-    fn compute_size(entry_id_string_data_offset: &Offset32) -> Result<usize, ReadError> {
-        // This field is either a u16 or an int24 depending on whether or not string data
-        // is present. See: <https://w3c.github.io/IFT/Overview.html#mapping-entry-entryiddelta>
-        Ok(if entry_id_string_data_offset.is_null() {
-            3
-        } else {
-            2
-        })
-    }
-}
-
-impl FontReadWithArgs<'_> for IdDeltaOrLength {
-    fn read_with_args(
-        data: FontData<'_>,
-        entry_id_string_data_offset: &Self::Args,
-    ) -> Result<Self, ReadError> {
-        if entry_id_string_data_offset.is_null() {
-            data.read_at::<Int24>(0).map(|v| Self(i32::from(v)))
-        } else {
-            data.read_at::<u16>(0).map(|v| Self(v as i32))
-        }
-    }
-}
-
-impl IdDeltaOrLength {
-    #[inline]
-    pub fn into_inner(self) -> i32 {
-        self.0
-    }
-}
-
 impl<'a> PatchMapFormat1<'a> {
     pub fn gid_to_entry_iter(&'a self) -> impl Iterator<Item = (GlyphId, u16)> + 'a {
         GidToEntryIter {

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -3,7 +3,6 @@
 extern scalar MatchModeAndCount;
 extern record U8Or16;
 extern record U16Or24;
-extern record IdDeltaOrLength;
 extern scalar CompatibilityId;
 
 format u8 Ift {
@@ -181,7 +180,6 @@ table MappingEntries {
   entry_data: [u8],
 }
 
-#[read_args(entry_id_string_data_offset: Offset32)]
 table EntryData {
   format_flags: EntryFormatFlags,
 
@@ -208,20 +206,13 @@ table EntryData {
   child_indices: [Uint24],
 
   // ENTRY_ID_DELTA
-  #[read_with($entry_id_string_data_offset)]
-  #[if_flag($format_flags, EntryFormatFlags::ENTRY_ID_DELTA)]
-  #[traverse_with(skip)]
-  #[compile(skip)]
-  entry_id_delta: IdDeltaOrLength,
-
   // PATCH_FORMAT
-  #[if_flag($format_flags, EntryFormatFlags::PATCH_FORMAT)]
-  patch_format: u8,
-
   // CODEPOINT_BIT_1 or CODEPOINT_BIT_2
-  // Non-conditional since we also use this to find the end of the entry.
+  //
+  // These remaining fields don't have well defined widths and are handling with
+  // custom parsing.
   #[count(..)]
-  codepoint_data: [u8],
+  trailing_data: [u8],
 }
 
 // See <https://w3c.github.io/IFT/Overview.html#mapping-entry-formatflags>


### PR DESCRIPTION
This updates the fontations IFT client to match spec changes made in: https://github.com/w3c/IFT/pull/262

Overview:
- Format 2 entries now have the ability to specify lists of entry id deltas (previously each entry had exactly one delta)
- These delta lists become a list of URIs where the first URI is the patch to be applied as usual and any additional URIs should be preloaded if the entry is selected.
- The format 2 parsing is updated to handle multiple deltas and all of the patch map handling has been updated to correctly handle preloads specified in this way.