### PR TITLE
[skrifa] support interpreter-version 35

### DIFF
--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -5,7 +5,7 @@ use ::skrifa::{
     raw::{FontRef, TableProvider},
     GlyphId, MetadataProvider, OutlineGlyphCollection,
 };
-use skrifa::outline::HintingOptions;
+use skrifa::outline::{HintingOptions, InterpreterVersion};
 
 use super::{InstanceOptions, SharedFontData};
 
@@ -38,11 +38,21 @@ impl<'a> SkrifaInstance<'a> {
                             engine: skrifa::outline::Engine::Interpreter,
                             target: skrifa::outline::Target::Mono,
                         },
+                        InterpreterVersion::_40,
                     )
                     .ok()?,
                 )
             } else if let Some(hinting_options) = options.hinting.skrifa_options() {
-                Some(HintingInstance::new(&outlines, size, options.coords, hinting_options).ok()?)
+                Some(
+                    HintingInstance::new(
+                        &outlines,
+                        size,
+                        options.coords,
+                        hinting_options,
+                        InterpreterVersion::_40,
+                    )
+                    .ok()?,
+                )
             } else {
                 None
             }

--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -966,6 +966,7 @@ fn matrix_mul_scaled(a: &[Fixed; 6], b: &[Fixed; 6], scaling: i32) -> [Fixed; 6]
 #[cfg(test)]
 mod tests {
     use super::{super::pen::SvgPen, *};
+    use crate::outline::InterpreterVersion;
     use crate::{
         outline::{HintingInstance, HintingOptions},
         prelude::{LocationRef, Size},
@@ -1085,6 +1086,7 @@ mod tests {
             Size::unscaled(),
             LocationRef::default(),
             HintingOptions::default(),
+            InterpreterVersion::default(),
         )
         .unwrap();
         let glyph = glyphs.get(GlyphId::new(1)).unwrap();

--- a/skrifa/src/outline/glyf/hint/engine/data.rs
+++ b/skrifa/src/outline/glyf/hint/engine/data.rs
@@ -8,6 +8,7 @@ use super::{
     super::{math, zone::ZonePointer},
     Engine, OpResult,
 };
+use crate::outline::InterpreterVersion;
 
 impl Engine<'_> {
     /// Get coordinate project in to the projection vector.
@@ -142,11 +143,15 @@ impl Engine<'_> {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#measure-point-size>
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2623>
     pub(super) fn op_mps(&mut self) -> OpResult {
-        // Note: FreeType computes this at
-        // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttdriver.c#L392>
-        // which is mul_div(ppem, 64 * 72, resolution) where resolution
-        // is always 72 for our purposes (Skia), resulting in ppem * 64.
-        self.value_stack.push(self.graphics.ppem * 64)
+        if self.graphics.interpreter_version == InterpreterVersion::_35 {
+            self.value_stack.push(self.graphics.ppem)
+        } else {
+            // Note: FreeType computes this at
+            // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttdriver.c#L392>
+            // which is mul_div(ppem, 64 * 72, resolution) where resolution
+            // is always 72 for our purposes (Skia), resulting in ppem * 64.
+            self.value_stack.push(self.graphics.ppem * 64)
+        }
     }
 }
 

--- a/skrifa/src/outline/glyf/hint/engine/delta.rs
+++ b/skrifa/src/outline/glyf/hint/engine/delta.rs
@@ -5,6 +5,7 @@
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#managing-exceptions>
 
 use super::{super::graphics::CoordAxis, Engine, F26Dot6, OpResult};
+use crate::outline::InterpreterVersion;
 use read_fonts::tables::glyf::bytecode::Opcode;
 
 impl Engine<'_> {
@@ -41,6 +42,7 @@ impl Engine<'_> {
             Opcode::DELTAP3 => 32,
             _ => 0,
         } + gs.delta_base as u32;
+        let iv = gs.interpreter_version;
         let back_compat = gs.backward_compatibility;
         let did_iup = gs.did_iup_x && gs.did_iup_y;
         for _ in 0..n {
@@ -63,7 +65,7 @@ impl Engine<'_> {
                 }
                 b *= 1 << (6 - gs.delta_shift as i32);
                 let distance = F26Dot6::from_bits(b);
-                if back_compat {
+                if iv == InterpreterVersion::_40 && back_compat {
                     if !did_iup
                         && ((gs.is_composite && gs.freedom_vector.y != 0)
                             || gs.zp0().is_touched(point_ix, CoordAxis::Y)?)

--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -3,6 +3,7 @@
 use read_fonts::tables::glyf::bytecode::Opcode;
 
 use super::{super::program::Program, Engine, HintError, HintErrorKind, Instruction};
+use crate::outline::InterpreterVersion;
 
 /// Maximum number of instructions we will execute in `Engine::run()`. This
 /// is used to ensure termination of a hinting program.
@@ -39,11 +40,15 @@ impl<'a> Engine<'a> {
                     self.graphics.reset_retained();
                 }
                 // Set backward compatibility mode
-                if self.graphics.target.preserve_linear_metrics() {
-                    self.graphics.backward_compatibility = true;
-                } else if self.graphics.target.is_smooth() {
-                    self.graphics.backward_compatibility =
-                        (self.graphics.instruct_control & 0x4) == 0;
+                if self.graphics.interpreter_version == InterpreterVersion::_40 {
+                    if self.graphics.target.preserve_linear_metrics() {
+                        self.graphics.backward_compatibility = true;
+                    } else if self.graphics.target.is_smooth() {
+                        self.graphics.backward_compatibility =
+                            (self.graphics.instruct_control & 0x4) == 0;
+                    } else {
+                        self.graphics.backward_compatibility = false;
+                    }
                 } else {
                     self.graphics.backward_compatibility = false;
                 }

--- a/skrifa/src/outline/glyf/hint/engine/graphics.rs
+++ b/skrifa/src/outline/glyf/hint/engine/graphics.rs
@@ -8,6 +8,7 @@ use super::{
     super::{math, program::Program, round::RoundMode},
     Engine, F26Dot6, HintErrorKind, OpResult, Point,
 };
+use crate::outline::InterpreterVersion;
 
 impl Engine<'_> {
     /// Set vectors to coordinate axis.
@@ -586,7 +587,9 @@ impl Engine<'_> {
             // Allow an exception in the glyph program for selector 3 which can
             // temporarily disable backward compatibility mode.
             (Program::Glyph, 3) => {
-                self.graphics.backward_compatibility = value != 4;
+                if self.graphics.interpreter_version == InterpreterVersion::_40 {
+                    self.graphics.backward_compatibility = value != 4;
+                }
             }
             _ => {}
         }

--- a/skrifa/src/outline/glyf/hint/engine/misc.rs
+++ b/skrifa/src/outline/glyf/hint/engine/misc.rs
@@ -5,6 +5,7 @@
 //! See <https://learn.microsoft.com/en-us/typography/opentype/spec/tt_instructions#miscellaneous-instructions>
 
 use super::{Engine, OpResult};
+use crate::outline::InterpreterVersion;
 
 impl Engine<'_> {
     /// Get information.
@@ -27,7 +28,7 @@ impl Engine<'_> {
         let mut result = 0;
         // Interpreter version (selector bit: 0, result bits: 0-7)
         if (selector & VERSION_SELECTOR_BIT) != 0 {
-            result = 40;
+            result = self.graphics.interpreter_version as i32;
         }
         // Glyph rotated (selector bit: 1, result bit: 8)
         if (selector & GLYPH_ROTATED_SELECTOR_BIT) != 0 && self.graphics.is_rotated {
@@ -42,7 +43,9 @@ impl Engine<'_> {
             result |= FONT_VARIATIONS_RESULT_BIT;
         }
         // The following only apply for smooth hinting.
-        if self.graphics.target.is_smooth() {
+        if self.graphics.interpreter_version == InterpreterVersion::_40
+            && self.graphics.target.is_smooth()
+        {
             // Subpixel hinting [cleartype enabled] (selector bit: 6, result bit: 13)
             // (always enabled)
             if (selector & SUBPIXEL_HINTING_SELECTOR_BIT) != 0 {

--- a/skrifa/src/outline/glyf/hint/engine/outline.rs
+++ b/skrifa/src/outline/glyf/hint/engine/outline.rs
@@ -11,6 +11,7 @@ use super::{
     },
     math, Engine, F26Dot6, HintErrorKind, OpResult,
 };
+use crate::outline::InterpreterVersion;
 
 impl Engine<'_> {
     /// Flip point.
@@ -33,7 +34,8 @@ impl Engine<'_> {
         self.graphics.loop_counter = 1;
         // In backward compatibility mode, don't flip points after IUP has
         // been done.
-        if self.graphics.backward_compatibility
+        if self.graphics.interpreter_version == InterpreterVersion::_40
+            && self.graphics.backward_compatibility
             && self.graphics.did_iup_x
             && self.graphics.did_iup_y
         {
@@ -229,7 +231,7 @@ impl Engine<'_> {
         let did_iup = gs.did_iup_x && gs.did_iup_y;
         for _ in 0..count {
             let p = self.value_stack.pop_usize()?;
-            if gs.backward_compatibility {
+            if gs.interpreter_version == InterpreterVersion::_40 && gs.backward_compatibility {
                 if in_twilight
                     || (!did_iup
                         && ((gs.is_composite && gs.freedom_vector.y != 0)
@@ -782,7 +784,7 @@ impl Engine<'_> {
         let mut run = true;
         // In backward compatibility mode, allow IUP until it has been done on
         // both axes.
-        if gs.backward_compatibility {
+        if gs.interpreter_version == InterpreterVersion::_40 && gs.backward_compatibility {
             if gs.did_iup_x && gs.did_iup_y {
                 run = false;
             }
@@ -842,7 +844,8 @@ impl Engine<'_> {
             .ok_or(HintErrorKind::InvalidPointIndex(high_point))?;
         // In backward compatibility mode, don't flip points after IUP has
         // been done.
-        if self.graphics.backward_compatibility
+        if self.graphics.interpreter_version == InterpreterVersion::_40
+            && self.graphics.backward_compatibility
             && self.graphics.did_iup_x
             && self.graphics.did_iup_y
         {

--- a/skrifa/src/outline/glyf/hint/graphics.rs
+++ b/skrifa/src/outline/glyf/hint/graphics.rs
@@ -5,6 +5,7 @@ use super::{
     zone::{Zone, ZonePointer},
     F26Dot6, Point, Target,
 };
+use crate::outline::InterpreterVersion;
 use core::ops::{Deref, DerefMut};
 
 /// Describes the axis to which a measurement or point movement operation
@@ -262,14 +263,22 @@ pub struct RetainedGraphicsState {
     pub is_rotated: bool,
     /// True if a non-uniform scale is being applied.
     pub is_stretched: bool,
+    /// The interpreter version.
+    pub interpreter_version: InterpreterVersion,
 }
 
 impl RetainedGraphicsState {
-    pub fn new(scale: i32, ppem: i32, target: Target) -> Self {
+    pub fn new(
+        scale: i32,
+        ppem: i32,
+        target: Target,
+        interpreter_version: InterpreterVersion,
+    ) -> Self {
         Self {
             scale,
             ppem,
             target,
+            interpreter_version,
             ..Default::default()
         }
     }
@@ -297,6 +306,7 @@ impl Default for RetainedGraphicsState {
             ppem: 0,
             is_rotated: false,
             is_stretched: false,
+            interpreter_version: InterpreterVersion::default(),
         }
     }
 }

--- a/skrifa/src/outline/hint.rs
+++ b/skrifa/src/outline/hint.rs
@@ -10,6 +10,10 @@ use super::{
 use crate::alloc::{boxed::Box, vec::Vec};
 use raw::types::Fixed;
 
+#[cfg(feature = "libm")]
+#[allow(unused_imports)]
+use core_maths::CoreFloat;
+
 /// Configuration settings for a hinting instance.
 #[derive(Clone, Default, Debug)]
 pub struct HintingOptions {
@@ -386,10 +390,15 @@ impl HintingInstance {
     pub fn reconfigure<'a>(
         &mut self,
         outlines: &OutlineGlyphCollection,
-        size: Size,
+        mut size: Size,
         location: impl Into<LocationRef<'a>>,
         options: impl Into<HintingOptions>,
     ) -> Result<(), DrawError> {
+        if self.interpreter_version == InterpreterVersion::_35 {
+            if let Some(ppem) = size.ppem() {
+                size = Size::new(ppem.round());
+            }
+        }
         self.size = size;
         self.coords.clear();
         self.coords

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -96,7 +96,8 @@ pub mod pen;
 
 pub use autohint::GlyphStyles;
 pub use hint::{
-    Engine, HintingInstance, HintingMode, HintingOptions, LcdLayout, SmoothMode, Target,
+    Engine, HintingInstance, HintingMode, HintingOptions, InterpreterVersion, LcdLayout,
+    SmoothMode, Target,
 };
 use metrics::GlyphHMetrics;
 use raw::FontRef;
@@ -1405,6 +1406,7 @@ mod tests {
             Size::new(16.0),
             LocationRef::default(),
             HintingOptions::default(),
+            InterpreterVersion::default(),
         )
         .unwrap();
         let glyph = glyphs.get(GlyphId::new(1)).unwrap();
@@ -1442,6 +1444,7 @@ mod tests {
             Size::new(24.0),
             LocationRef::new(&coords),
             HintingOptions::default(),
+            InterpreterVersion::default(),
         )
         .unwrap();
         let gid = font.charmap().map(' ').unwrap();
@@ -1465,6 +1468,7 @@ mod tests {
             Size::new(24.8),
             LocationRef::default(),
             HintingOptions::default(),
+            InterpreterVersion::_40,
         )
         .unwrap();
         let gid = GlyphId::new(2);


### PR DESCRIPTION
With this change, font rendering appears to be essentially identical to freetype.

Chromium compiled with this patch (and a small skia patch to use `InterpreterVersion::from_environment`):

![image](https://github.com/user-attachments/assets/4be3a5bb-3f9c-4973-957d-b78cdf80ea2b)

Firefox:

![image](https://github.com/user-attachments/assets/d357eff5-cddd-4475-b5b7-e86c4ca4211d)

There are some small differences but they might be caused by a different component.

I've not added any tests. Let me know if/how this should be tested.

Closes #1215 