### PR TITLE
[chore] bump patch for read/skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.29.0", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.29.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.31.0", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.31.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.38.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.29.0"
+version = "0.29.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.31.0"
+version = "0.31.1"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.29.0 to 0.29.1
             02eef9f [gvar] Inline a couple of methods
             fa3ad59 Update format 2 parsing to support multiple lengths/deltas per entry.
             6449c34 [read-fonts] parse the `kerx` table (#1494)
     Changes for skrifa from skrifa-v0.31.0 to 0.31.1
             83287c7 Partial revert of "bypass variation processing for default location" (#1501)