### PR TITLE
[Skrifa] Expose LocalizedString::new() constructor as public

### DIFF
--- a/skrifa/src/string.rs
+++ b/skrifa/src/string.rs
@@ -131,7 +131,7 @@ pub struct LocalizedString<'a> {
 }
 
 impl<'a> LocalizedString<'a> {
-    fn new(name: &Name<'a>, record: &NameRecord) -> Self {
+    pub fn new(name: &Name<'a>, record: &NameRecord) -> Self {
         let language = Language::new(name, record);
         let value = record.string(name.string_data()).ok();
         Self { language, value }


### PR DESCRIPTION
Useful for combining name string decoding/reading and language id to string mapping when reading a single NameRecord.

Needed in FontConfig indexing where a specific custom NameRecord traversal order is needed, different from the convenience of LocalizedStrings.

Fixes #1505.