### PR TITLE
[chore] Bump for skrifa, font-test-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ font-types = { version = "0.9.0", path = "font-types" }
 read-fonts = { version = "0.29.2", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.31.2", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.31.3", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.38.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.4.0"
+version = "0.4.1"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.31.2"
+version = "0.31.3"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
Changes for skrifa from skrifa-v0.31.2 to 0.31.2
        1df721b [Skrifa] Expose LocalizedString::new() constructor as public (#1509)
Changes for font-test-data from font-test-data-v0.4.0 to 0.4.0
        44758ed Fix clippy.
        e38e601 Add tests for format2 patch maps with preload urls.
        fa3ad59 Update format 2 parsing to support multiple lengths/deltas per entry.