### PR TITLE
Avoid invisible Unicode chars in source code

### DIFF
--- a/skrifa/generated/generated_autohint_styles.rs
+++ b/skrifa/generated/generated_autohint_styles.rs
@@ -486,7 +486,7 @@ pub(super) const SCRIPT_CLASSES: &[ScriptClass] = &[
         hint_top_to_bottom: true,
         std_chars: "ᡂ ᠪ",
         blues: &[
-            ("ᠳ ᠴ ᠶ ᠽ ᡂ ᡊ ‍ᡡ‍ ‍ᡳ‍", BlueZones::TOP),
+            ("ᠳ ᠴ ᠶ ᠽ ᡂ ᡊ \u{200d}ᡡ\u{200d} \u{200d}ᡳ\u{200d}", BlueZones::TOP),
             ("ᡃ", BlueZones::NONE),
         ],
     },

--- a/skrifa/scripts/gen_autohint_styles.py
+++ b/skrifa/scripts/gen_autohint_styles.py
@@ -873,7 +873,9 @@ SCRIPT_CLASSES = [
             (0x18A9, 0x18A9),
         ],
         "blues": [
-            ("ᠳ ᠴ ᠶ ᠽ ᡂ ᡊ ‍ᡡ‍ ‍ᡳ‍", "TOP"),
+            # U+200D is escaped to avoid the presence of suspicious-looking
+            # invisible chars in the generated Rust source.
+            ("ᠳ ᠴ ᠶ ᠽ ᡂ ᡊ \\u{200d}ᡡ\\u{200d} \\u{200d}ᡳ\\u{200d}", "TOP"),
             ("ᡃ", "0"),
         ],
     },


### PR DESCRIPTION
Invisible Unicodes such as U+200D in source code can get flagged as "suspicious". Using visible escape sequences makes it clearer exactly what's present.