### PR TITLE
Provide glyph bounds in VF and CFF cases

### DIFF
--- a/font-test-data/src/lib.rs
+++ b/font-test-data/src/lib.rs
@@ -34,6 +34,9 @@ pub static NOTO_SERIF_DISPLAY_TRIMMED: &[u8] =
 pub static NOTO_SERIF_DISPLAY_TRIMMED_GLYPHS: &str =
     include_str!("../test_data/extracted/noto_serif_display_trimmed-glyphs.txt");
 
+pub static NOTO_SANS_JP_CFF: &[u8] =
+    include_bytes!("../test_data/ttf/NotoSansJP-Regular.subset.otf");
+
 pub static CANTARELL_VF_TRIMMED: &[u8] =
     include_bytes!("../test_data/ttf/cantarell_vf_trimmed.ttf");
 

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -219,6 +219,7 @@ impl Metrics {
 #[derive(Clone)]
 pub struct GlyphMetrics<'a> {
     font: FontRef<'a>,
+    size: Size,
     glyph_count: u32,
     fixed_scale: FixedScaleFactor,
     h_metrics: &'a [LongMetric],
@@ -382,7 +383,7 @@ impl GlyphMetrics<'_> {
 
     fn bounds_from_outline(&self, glyph_id: GlyphId) -> Option<BoundingBox> {
         if let Some(outline) = self.font.outline_glyphs().get(glyph_id) {
-            let settings = DrawSettings::unhinted(Size::unscaled(), self.coords);
+            let settings = DrawSettings::unhinted(self.size, self.coords);
             let mut pen = ControlBoundsPen::default();
             outline.draw(settings, &mut pen).ok()?;
             pen.bounding_box()

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -409,7 +409,7 @@ impl FixedScaleFactor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use font_test_data::{SIMPLE_GLYF, VAZIRMATN_VAR};
+    use font_test_data::{NOTO_SANS_JP_CFF, SIMPLE_GLYF, VAZIRMATN_VAR};
     use read_fonts::FontRef;
 
     #[test]
@@ -537,6 +537,36 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(expected, &result[..]);
+
+        // Check bounds
+        let coords = &[NormalizedCoord::from_f32(-1.0)];
+        let glyph_metrics = font.glyph_metrics(Size::unscaled(), LocationRef::new(coords));
+        let bounds = glyph_metrics.bounds(GlyphId::new(1)).unwrap();
+        assert_eq!(
+            bounds,
+            BoundingBox {
+                x_min: 33.0,
+                y_min: 0.0,
+                x_max: 1189.0,
+                y_max: 1456.0
+            }
+        );
+    }
+
+    #[test]
+    fn glyph_metrics_cff() {
+        let font = FontRef::new(NOTO_SANS_JP_CFF).unwrap();
+        let glyph_metrics = font.glyph_metrics(Size::unscaled(), LocationRef::default());
+        let bounds = glyph_metrics.bounds(GlyphId::new(34)).unwrap();
+        assert_eq!(
+            bounds,
+            BoundingBox {
+                x_min: 4.0,
+                y_min: 0.0,
+                x_max: 604.0,
+                y_max: 733.0
+            }
+        );
     }
 
     #[test]

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -213,6 +213,7 @@ impl Metrics {
 /// Glyph specific metrics.
 #[derive(Clone)]
 pub struct GlyphMetrics<'a> {
+    font: FontRef<'a>,
     glyph_count: u32,
     fixed_scale: FixedScaleFactor,
     h_metrics: &'a [LongMetric],
@@ -255,6 +256,8 @@ impl<'a> GlyphMetrics<'a> {
             None
         };
         Self {
+            font: font.clone(),
+            size,
             glyph_count,
             fixed_scale,
             h_metrics,


### PR DESCRIPTION
Fixes #1528. Adds a ControlBoundsPen structure, stores the FontRef in the GlyphMetrics struct (with appropriate changes to lifetimes everywhere), and uses outlining to get the glyph bounds when the font has variations or a CFF/CFF2 table.