### PR TITLE
FontRef API changes

### DIFF
--- a/fauntlet/src/font/mod.rs
+++ b/fauntlet/src/font/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use ::freetype::{face::LoadFlag, Library};
 use ::skrifa::{
     outline::{HintingOptions, SmoothMode, Target},
-    raw::{types::F2Dot14, FileRef, FontRef, TableProvider},
+    raw::{types::F2Dot14, FontRef, TableProvider},
 };
 
 mod freetype;
@@ -107,10 +107,7 @@ impl Font {
         let path = path.as_ref().to_owned();
         let file = std::fs::File::open(&path).ok()?;
         let data = SharedFontData(unsafe { Arc::new(memmap2::Mmap::map(&file).ok()?) });
-        let count = match FileRef::new(data.0.as_ref()).ok()? {
-            FileRef::Font(_) => 1,
-            FileRef::Collection(collection) => collection.len() as usize,
-        };
+        let count = FontRef::all_in(data.0.as_ref()).count();
         let _ft_library = ::freetype::Library::init().ok()?;
         Some(Self {
             path,

--- a/fauntlet/src/font/mod.rs
+++ b/fauntlet/src/font/mod.rs
@@ -107,7 +107,7 @@ impl Font {
         let path = path.as_ref().to_owned();
         let file = std::fs::File::open(&path).ok()?;
         let data = SharedFontData(unsafe { Arc::new(memmap2::Mmap::map(&file).ok()?) });
-        let count = FontRef::all_in(data.0.as_ref()).count();
+        let count = FontRef::fonts(data.0.as_ref()).count();
         let _ft_library = ::freetype::Library::init().ok()?;
         Some(Self {
             path,

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -1146,13 +1146,13 @@ pub(crate) mod tests {
 
     fn check_tables_equal(a: &FontRef, b: &FontRef, excluding: BTreeSet<Tag>) {
         let it_a = a
-            .table_directory
+            .table_directory()
             .table_records()
             .iter()
             .map(|r| r.tag())
             .filter(|tag| !excluding.contains(tag));
         let it_b = b
-            .table_directory
+            .table_directory()
             .table_records()
             .iter()
             .map(|r| r.tag())

--- a/incremental-font-transfer/src/table_keyed.rs
+++ b/incremental-font-transfer/src/table_keyed.rs
@@ -127,7 +127,7 @@ pub(crate) fn copy_unprocessed_tables<'a>(
     processed_tables: BTreeSet<Tag>,
     font_builder: &mut FontBuilder<'a>,
 ) {
-    font.table_directory
+    font.table_directory()
         .table_records()
         .iter()
         .map(|r| r.tag())

--- a/incremental-font-transfer/src/table_keyed.rs
+++ b/incremental-font-transfer/src/table_keyed.rs
@@ -177,7 +177,7 @@ mod tests {
         let font = r.unwrap();
         let font = FontRef::new(&font).unwrap();
 
-        assert_eq!(font.table_directory.num_tables(), 4);
+        assert_eq!(font.table_directory().num_tables(), 4);
 
         assert_eq!(font.table_data(IFT_TAG).unwrap().as_bytes(), IFT_TABLE);
         assert_eq!(
@@ -208,11 +208,11 @@ mod tests {
         let expected_font = FontRef::new(&expected_font).unwrap();
 
         assert_eq!(
-            font.table_directory.num_tables(),
-            expected_font.table_directory.num_tables()
+            font.table_directory().num_tables(),
+            expected_font.table_directory().num_tables()
         );
 
-        for t in expected_font.table_directory.table_records() {
+        for t in expected_font.table_directory().table_records() {
             let data = font.table_data(t.tag()).unwrap();
             let expected_data = expected_font.table_data(t.tag()).unwrap();
             assert_eq!(data.as_bytes(), expected_data.as_bytes());
@@ -247,7 +247,7 @@ mod tests {
         let font = r.unwrap();
         let font = FontRef::new(&font).unwrap();
 
-        assert_eq!(font.table_directory.num_tables(), 5);
+        assert_eq!(font.table_directory().num_tables(), 5);
 
         assert_eq!(font.table_data(IFT_TAG).unwrap().as_bytes(), IFT_TABLE);
         assert_eq!(
@@ -323,7 +323,7 @@ mod tests {
         let font = r.unwrap();
         let font = FontRef::new(&font).unwrap();
 
-        assert_eq!(font.table_directory.num_tables(), 4);
+        assert_eq!(font.table_directory().num_tables(), 4);
 
         assert_eq!(font.table_data(IFT_TAG).unwrap().as_bytes(), IFT_TABLE);
         assert_eq!(
@@ -372,7 +372,7 @@ mod tests {
         let font = r.unwrap();
         let font = FontRef::new(&font).unwrap();
 
-        assert_eq!(font.table_directory.num_tables(), 5);
+        assert_eq!(font.table_directory().num_tables(), 5);
 
         assert_eq!(font.table_data(IFT_TAG).unwrap().as_bytes(), IFT_TABLE);
         assert_eq!(
@@ -407,7 +407,7 @@ mod tests {
         let font = r.unwrap();
         let font = FontRef::new(&font).unwrap();
 
-        assert_eq!(font.table_directory.num_tables(), 5);
+        assert_eq!(font.table_directory().num_tables(), 5);
 
         assert_eq!(font.table_data(IFT_TAG).unwrap().as_bytes(), IFT_TABLE);
         assert_eq!(

--- a/klippa/src/lib.rs
+++ b/klippa/src/lib.rs
@@ -999,7 +999,7 @@ trait Serialize<'a> {
 pub fn subset_font(font: &FontRef, plan: &Plan) -> Result<Vec<u8>, SubsetError> {
     let mut builder = FontBuilder::default();
 
-    for record in font.table_directory.table_records() {
+    for record in font.table_directory().table_records() {
         let tag = record.tag();
         if should_drop_table(tag, plan) {
             continue;

--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -43,7 +43,7 @@ fn list_tables(font: &FontRef) {
 
     let offset_pad = get_offset_width(font);
 
-    for record in font.table_directory.table_records() {
+    for record in font.table_directory().table_records() {
         println!(
             "{0} 0x{1:02$X} {3:8} 0x{4:08X} ",
             record.tag(),
@@ -58,7 +58,7 @@ fn list_tables(font: &FontRef) {
 fn print_tables(font: &FontRef, filter: &TableFilter) {
     let mut printed = HashSet::new();
     for tag in font
-        .table_directory
+        .table_directory()
         .table_records()
         .iter()
         .map(|rec| rec.tag())
@@ -78,7 +78,7 @@ fn print_tables(font: &FontRef, filter: &TableFilter) {
 fn get_offset_width(font: &FontRef) -> usize {
     // pick how much padding we use for offsets based on the max offset in directory
     let max_off = font
-        .table_directory
+        .table_directory()
         .table_records()
         .iter()
         .map(|rec| rec.offset())

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -389,7 +389,7 @@ impl<'a> FontRef<'a> {
 
     /// Returns an iterator over all of the available fonts in
     /// the given font data.
-    pub fn all_in(
+    pub fn fonts(
         data: &'a [u8],
     ) -> impl Iterator<Item = Result<FontRef<'a>, ReadError>> + 'a + Clone {
         let count = match FileRef::new(data) {
@@ -452,14 +452,14 @@ mod tests {
 
     #[test]
     fn font_ref_all_in() {
-        assert_eq!(FontRef::all_in(AHEM).count(), 1);
-        assert_eq!(FontRef::all_in(TTC).count(), 2);
-        assert_eq!(FontRef::all_in(b"NOT_A_FONT").count(), 0);
+        assert_eq!(FontRef::fonts(AHEM).count(), 1);
+        assert_eq!(FontRef::fonts(TTC).count(), 2);
+        assert_eq!(FontRef::fonts(b"NOT_A_FONT").count(), 0);
     }
 
     #[test]
     fn ttc_index() {
-        for (idx, font) in FontRef::all_in(TTC).map(|font| font.unwrap()).enumerate() {
+        for (idx, font) in FontRef::fonts(TTC).map(|font| font.unwrap()).enumerate() {
             assert_eq!(font.ttc_index(), Some(idx as u32));
         }
         assert!(FontRef::new(AHEM).unwrap().ttc_index().is_none());

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn font_ref_all_in() {
+    fn font_ref_fonts_iter() {
         assert_eq!(FontRef::fonts(AHEM).count(), 1);
         assert_eq!(FontRef::fonts(TTC).count(), 2);
         assert_eq!(FontRef::fonts(b"NOT_A_FONT").count(), 0);

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -109,7 +109,7 @@ impl<'a> FontBuilder<'a> {
 
     /// Copy each table from the source font if it does not already exist
     pub fn copy_missing_tables(&mut self, font: FontRef<'a>) -> &mut Self {
-        for record in font.table_directory.table_records() {
+        for record in font.table_directory().table_records() {
             let tag = record.tag();
             if !self.tables.contains_key(&tag) {
                 if let Some(data) = font.data_for_tag(tag) {
@@ -288,7 +288,7 @@ mod tests {
         });
         let bytes = builder.build();
         let font = FontRef::new(&bytes).unwrap();
-        let td = font.table_directory;
+        let td = font.table_directory();
         assert_eq!(
             (256, 4, 96),
             (td.search_range(), td.entry_selector(), td.range_shift())


### PR DESCRIPTION
This does a few things:
* Makes all `FontRef` fields private and adds accessor methods. Hopefully will avoid breaking changes on this type in the future.
* Adds a new field/accessor for the ttc index of the font.
* Adds a new `FontRef::all_in(&[u8])` method that returns an iterator over all fonts in the given data (as `Result<FontRef, _>`).

There were some uses of the `FontRef::table_directory` field in other crates. Updates those to use the new method.