### PR TITLE
[chore] bump minor for read/skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.29.3", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.30.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.31.3", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.32.0", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.38.2", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.29.3"
+version = "0.30.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.31.3"
+version = "0.32.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.29.3 to 0.30.0
             02ace2e FontRef API changes (#1536)
             f37c230 inline some commonly used methods (#1535)
             920c801 Change the `is_sorted` implementation
             e606cba [cff] handle implied seac operator (#1533)
             d035a15 Update remaining IFT code for the URL template change.
             687f07a [klippa] clousre glyphs
             de9558c Don't use `is_sorted`
             03c3294 Support loading hmtx tables with missing left side bearings
             f92657a Support fonts with unsorted table directories
             f47a300 [klippa] layout closure: closure lookups
             d776fd6 Test that we select the correct shallow component to derive metrics from
             51f6ea4 Prefer the last component in the tree with USE_MY_METRICS set
     Changes for skrifa from skrifa-v0.31.3 to 0.32.0
             e606cba [cff] handle implied seac operator (#1533)
             5f3ea6c Save size and draw scaled outline
             2b73599 Tests for VF and CFF bounding boxes
             6eb3abc Use the control bounds pen in tricky cases
             f9a40dd Add a control bounds pen
             a3dfdb3 Store the fontref in the GlyphMetrics structure
             4ea99dc Update generated_autohint_styles.rs
             9eebe40 Avoid invisible chars in source code