### PR TITLE
[IFT] Fix patch selection order for entries with child indices.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -487,7 +487,7 @@ pub fn child_indices_format2() -> BeBuffer {
 
       [1, 2, 3, 4u32],          // compat id
 
-      3u8,                      // default patch encoding = glyph keyed
+      {3u8: "encoding"},          // default patch encoding = glyph keyed
       (Uint24::new(9)),         // entry count
       {0u32: "entries_offset"}, // entries offset
       0u32,                     // entry id string data offset


### PR DESCRIPTION
Patch selection order requires us to order based on the intersection of the union of all child entries. We were only using the intersection of the root entry (ignoring children).

Context: https://w3c.github.io/IFT/Overview.html#invalidating-patch-selection