### PR TITLE
[skrifa] tthint: round value for MPPEM instruction

### DIFF
--- a/fauntlet/src/compare_glyphs.rs
+++ b/fauntlet/src/compare_glyphs.rs
@@ -31,7 +31,7 @@ pub fn compare_glyphs(
         }
     }
     let glyph_count = skrifa_instance.glyph_count();
-    let is_scaled = options.ppem != 0;
+    let is_scaled = options.ppem != 0.0;
 
     let mut ft_outline = vec![];
     let mut skrifa_outline = vec![];

--- a/fauntlet/src/font/freetype.rs
+++ b/fauntlet/src/font/freetype.rs
@@ -32,8 +32,11 @@ impl FreeTypeInstance {
                 Some(hinting) => load_flags |= hinting.freetype_load_flags(),
             };
         }
-        if options.ppem != 0 {
-            face.set_pixel_sizes(options.ppem, options.ppem).ok()?;
+        if options.ppem != 0.0 {
+            // Set a fractional size using the same code as Skia:
+            // <https://github.com/google/skia/blob/a462e701b493d8f30b3130af3bbd4440c7946ccd/src/ports/SkFontHost_FreeType.cpp#L1034>
+            let size = (options.ppem * 64.0) as isize;
+            face.set_char_size(size, size, 72, 72).ok()?;
         } else {
             load_flags |= LoadFlag::NO_SCALE | LoadFlag::NO_HINTING | LoadFlag::NO_AUTOHINT;
         }

--- a/fauntlet/src/font/mod.rs
+++ b/fauntlet/src/font/mod.rs
@@ -79,13 +79,13 @@ impl Hinting {
 #[derive(Copy, Clone, Debug)]
 pub struct InstanceOptions<'a> {
     pub index: usize,
-    pub ppem: u32,
+    pub ppem: f32,
     pub coords: &'a [F2Dot14],
     pub hinting: Option<Hinting>,
 }
 
 impl<'a> InstanceOptions<'a> {
-    pub fn new(index: usize, ppem: u32, coords: &'a [F2Dot14], hinting: Option<Hinting>) -> Self {
+    pub fn new(index: usize, ppem: f32, coords: &'a [F2Dot14], hinting: Option<Hinting>) -> Self {
         Self {
             index,
             ppem,

--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -20,13 +20,13 @@ pub struct SkrifaInstance<'a> {
 impl<'a> SkrifaInstance<'a> {
     pub fn new(data: &'a SharedFontData, options: &InstanceOptions) -> Option<Self> {
         let font = FontRef::from_index(data.0.as_ref(), options.index as u32).ok()?;
-        let size = if options.ppem != 0 {
-            Size::new(options.ppem as f32)
+        let size = if options.ppem != 0.0 {
+            Size::new(options.ppem)
         } else {
             Size::unscaled()
         };
         let outlines = font.outline_glyphs();
-        let hinter = if options.ppem != 0 {
+        let hinter = if options.ppem != 0.0 {
             if options.hinting.is_some() {
                 Some(
                     HintingInstance::new(

--- a/fauntlet/src/main.rs
+++ b/fauntlet/src/main.rs
@@ -29,7 +29,7 @@ enum Command {
 #[allow(clippy::explicit_write)]
 fn main() {
     // Pixels per em sizes. A size of 0 means an explicit unscaled comparison
-    let ppem_sizes = [0, 8, 16, 50, 72, 113, 144];
+    let ppem_sizes = [0.0, 8.0, 24.8, 16.0, 50.0, 72.0, 113.0, 144.0];
 
     // Locations in normalized variation space
     let var_locations = [-1.0, -0.32, 0.0, 0.42, 1.0].map(F2Dot14::from_f32);


### PR DESCRIPTION
The MPPEM instruction is expected to produce an integral value and when hinting at fractional sizes we were truncating rather than rounding. This changes our computation to use a fixed point round that matches FreeType.

Also updates fauntlet to support testing at fractional sizes.

Fixes #1544