### PR TITLE
Optimize/specialize `outline::path::contour_to_path`

### DIFF
--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -204,9 +204,13 @@ impl Outline {
             let Some(points) = self.points.get(contour.range()) else {
                 continue;
             };
-            if let Some(last_point) = points.last().map(Point::as_contour_point) {
+            if let (Some(first_point), Some(last_point)) = (
+                points.first().map(Point::as_contour_point),
+                points.last().map(Point::as_contour_point),
+            ) {
                 path::contour_to_path(
                     points.iter().map(Point::as_contour_point),
+                    first_point,
                     last_point,
                     style,
                     pen,


### PR DESCRIPTION
I'm playing around with a port of ab_glyph to skrifa, and it's a bit slower than ttf_parser currently.

The biggest culprit currently, at least for TrueType outlines, is `contour_to_path`. I *think* the issue is that it creates a peekable iterator for the contour points, and that iterator seems to not be getting fully inlined or optimized.

I've specialized the function into two separate "FreeType-style" and "HarfBuzz-style" functions, and now also pass in the first point. This lets us get rid of the peekable iterator in the FreeType path, as well as removing code paths not taken for the given `PathStyle`, and improves performance by ~13% on an outlining-only benchmark.

Before:
![image](https://github.com/user-attachments/assets/563c7462-1403-4543-8530-55fc15fd1ddc)
![image](https://github.com/user-attachments/assets/0d423fca-6e53-4e74-97d3-d4be98f84766)

After:
![image](https://github.com/user-attachments/assets/ce3b66b7-eebc-4eef-8b0f-cb958d54b5ac)
![image](https://github.com/user-attachments/assets/3529d46f-0211-416f-9072-a238d081d05a)
