### PR TITLE
Support vertical metrics in `Metrics`

### DIFF
--- a/read-fonts/src/tables/hvar.rs
+++ b/read-fonts/src/tables/hvar.rs
@@ -31,7 +31,7 @@ impl Hvar<'_> {
         )
     }
 
-    /// Returns the left side bearing delta for the specified glyph identifier and
+    /// Returns the right side bearing delta for the specified glyph identifier and
     /// normalized variation coordinates.
     pub fn rsb_delta(&self, glyph_id: GlyphId, coords: &[F2Dot14]) -> Result<Fixed, ReadError> {
         variations::item_delta(

--- a/skrifa/src/bitmap.rs
+++ b/skrifa/src/bitmap.rs
@@ -127,6 +127,7 @@ impl<'a> BitmapStrikes<'a> {
 }
 
 #[derive(Clone)]
+#[expect(clippy::large_enum_variant)]
 enum StrikesKind<'a> {
     None,
     Sbix(sbix::Sbix<'a>, GlyphMetrics<'a>),


### PR DESCRIPTION
I mainly implemented this because ttf-parser and swash support this, and its API consumers often expose that functionality. Superseding those packages will require implementing it here.

The `AdjustedMetrics` returned when outlining a glyph does not yet include vertical metrics--the `Metrics` metadata provider is already large and has some very involved preparsing code, so I don't feel bad about adding more to it. On the other hand, `AdjustedMetrics` is a lot smaller and is likely to be present in the hot path of laying out multiple glyphs, and we want to avoid computing metrics that may never be used and will likely be 0 for most non-CJK fonts. I'm not yet sure of the best way to expose that functionality. FreeType lets you specify whether you want the horizontal or vertical metrics using the `FT_LOAD_VERTICAL_LAYOUT` flag--would something similar here work well?

Some of the doc comments for the new metrics properties were swiped from Swash; the existing comments seem to be as well so that shouldn't be a big problem. I've put the vertical metrics in their own struct which may not be present; they are present/absent as a group, so I think that makes sense semantically.

For `GlyphMetrics`, I've added an `HVMetrics` helper struct for storing one "set" of metrics tables and metadata for each dimension (horizontal and vertical). I'm not sure if it's worth it to reduce boilerplate, but the code felt kinda ugly without it. I'm very open to removing it and just duplicating the parsing/conversion code.

I'm not parsing the `VORG` table for now; if I understand correctly, a glyph's vertical origin is the sort of thing you'd return when outlining a glyph, which I'm punting on for now.