### PR TITLE
Add `SomeTableProvider` trait for traversal and use it in otexplorer

### DIFF
--- a/otexplorer/src/main.rs
+++ b/otexplorer/src/main.rs
@@ -6,7 +6,10 @@
 use std::{collections::HashSet, str::FromStr};
 
 use font_types::Tag;
-use read_fonts::{traversal::SomeTable, FileRef, FontRef, ReadError, TableProvider, TopLevelTable};
+use read_fonts::{
+    traversal::{SomeTable, SomeTableProvider},
+    FileRef, FontRef,
+};
 
 mod print;
 mod query;
@@ -96,38 +99,8 @@ fn hex_width(val: u32) -> usize {
     }
 }
 
-/// Given a font and a tag, return the appropriate table as a [`dyn SomeTable`][SomeTable].
-fn get_some_table<'a>(
-    font: &FontRef<'a>,
-    tag: Tag,
-) -> Result<Box<dyn SomeTable<'a> + 'a>, ReadError> {
-    use read_fonts::tables;
-    match tag {
-        tables::gpos::Gpos::TAG => font.gpos().map(|x| Box::new(x) as _),
-        tables::gsub::Gsub::TAG => font.gsub().map(|x| Box::new(x) as _),
-        tables::cmap::Cmap::TAG => font.cmap().map(|x| Box::new(x) as _),
-        tables::fvar::Fvar::TAG => font.fvar().map(|x| Box::new(x) as _),
-        tables::avar::Avar::TAG => font.avar().map(|x| Box::new(x) as _),
-        tables::gdef::Gdef::TAG => font.gdef().map(|x| Box::new(x) as _),
-        tables::glyf::Glyf::TAG => font.glyf().map(|x| Box::new(x) as _),
-        tables::head::Head::TAG => font.head().map(|x| Box::new(x) as _),
-        tables::hhea::Hhea::TAG => font.hhea().map(|x| Box::new(x) as _),
-        tables::hmtx::Hmtx::TAG => font.hmtx().map(|x| Box::new(x) as _),
-        tables::loca::Loca::TAG => font.loca(None).map(|x| Box::new(x) as _),
-        tables::maxp::Maxp::TAG => font.maxp().map(|x| Box::new(x) as _),
-        tables::name::Name::TAG => font.name().map(|x| Box::new(x) as _),
-        tables::post::Post::TAG => font.post().map(|x| Box::new(x) as _),
-        tables::colr::Colr::TAG => font.colr().map(|x| Box::new(x) as _),
-        tables::stat::Stat::TAG => font.stat().map(|x| Box::new(x) as _),
-        tables::vhea::Vhea::TAG => font.vhea().map(|x| Box::new(x) as _),
-        tables::vmtx::Vmtx::TAG => font.vmtx().map(|x| Box::new(x) as _),
-        tables::svg::Svg::TAG => font.svg().map(|x| Box::new(x) as _),
-        _ => Err(ReadError::TableIsMissing(tag)),
-    }
-}
-
 fn print_table(font: &FontRef, tag: Tag) {
-    match get_some_table(font, tag) {
+    match font.expect_some_table(tag) {
         Ok(table) => fancy_print_table(&table).unwrap(),
         Err(err) => println!("{tag}: Error '{err}'"),
     }

--- a/otexplorer/src/query.rs
+++ b/otexplorer/src/query.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, fmt::Write, str::FromStr};
 
 use font_types::Tag;
 use read_fonts::{
-    traversal::{Field, FieldType, ResolvedOffset, SomeTable},
+    traversal::{Field, FieldType, ResolvedOffset, SomeTable, SomeTableProvider},
     FontRef,
 };
 
@@ -21,7 +21,7 @@ pub enum QueryElement {
 }
 
 pub fn print_query(font: &FontRef, query: &Query) -> Result<(), String> {
-    let table = match super::get_some_table(font, query.tag) {
+    let table = match font.expect_some_table(query.tag) {
         Ok(table) => table,
         Err(err) => return Err(err.to_string()),
     };


### PR DESCRIPTION
The `get_some_table` function was getting a bit out-of-date (it was last updated 3 years ago). I feel like it's tied more to `read-fonts` than `otexplorer`, since it needs to know all of the tables that the `TableProvider` trait is capable of returning. As such, I've created a `SomeTableProvider` trait in `read-fonts`, which has one method that does what `get_some_table` used to do.

I read through the issues a bit and it seems like the traversal API might get removed at some point, but some people find `otexplorer` very useful for debugging. I concur; I've found myself using it a lot to look inside fonts.