### PR TITLE
Mark `dict::parse_int` as inlineable

### DIFF
--- a/read-fonts/src/tables/postscript/dict.rs
+++ b/read-fonts/src/tables/postscript/dict.rs
@@ -479,6 +479,7 @@ impl StemSnaps {
     }
 }
 
+#[inline]
 pub(crate) fn parse_int(cursor: &mut Cursor, b0: u8) -> Result<i32, Error> {
     // Size   b0 range     Value range              Value calculation
     //--------------------------------------------------------------------------------


### PR DESCRIPTION
This is a very simple change, but provides a ~12% performance boost on outlining CFF glyphs (using ab_glyph's benchmarks; see #1550):
![image](https://github.com/user-attachments/assets/ada7217b-aa40-4a17-b47e-87f9b3cdbb42)

Not sure why this wasn't getting inlined before; it's a pretty small function.