### PR TITLE
[fauntlet] add CLI options for hinting modes

### DIFF
--- a/fauntlet/src/compare_glyphs.rs
+++ b/fauntlet/src/compare_glyphs.rs
@@ -15,7 +15,7 @@ pub fn compare_glyphs(
         // Don't run on bitmap fonts (yet)
         return true;
     }
-    if let Some(Hinting::Auto(_)) = options.hinting {
+    if let Hinting::Auto(_) = options.hinting {
         // This font is a pathological case for autohinting due to the
         // extreme number of generated segments and edges. To be
         // precise, it takes longer to test this single font than the
@@ -67,10 +67,11 @@ pub fn compare_glyphs(
                     if hvar_adv == gvar_adv || (ft_advance - skrifa_advance).abs() > 1.0 {
                         writeln!(
                             std::io::stderr(),
-                            "[{path:?}#{} ppem: {} coords: {:?}] glyph id {} advance doesn't match:\nFreeType: {ft_advance:?}\nSkrifa:   {skrifa_advance:?}",
+                            "[{path:?}#{} ppem: {} coords: {:?} hinting: {:?}] glyph id {} advance doesn't match:\nFreeType: {ft_advance:?}\nSkrifa:   {skrifa_advance:?}",
                             options.index,
                             options.ppem,
                             options.coords,
+                            options.hinting,
                             gid.to_u32(),
                         )
                         .unwrap();

--- a/fauntlet/src/font/freetype.rs
+++ b/fauntlet/src/font/freetype.rs
@@ -27,10 +27,7 @@ impl FreeTypeInstance {
         // Ignore hinting settings for tricky fonts. Let FreeType do its own
         // thing
         if !face.is_tricky() {
-            match options.hinting {
-                None => load_flags |= LoadFlag::NO_HINTING,
-                Some(hinting) => load_flags |= hinting.freetype_load_flags(),
-            };
+            load_flags |= options.hinting.freetype_load_flags();
         }
         if options.ppem != 0.0 {
             // Set a fractional size using the same code as Skia:

--- a/fauntlet/src/font/mod.rs
+++ b/fauntlet/src/font/mod.rs
@@ -50,26 +50,29 @@ impl HintingTarget {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Hinting {
+    None,
     Interpreter(HintingTarget),
     Auto(HintingTarget),
 }
 
 impl Hinting {
-    pub fn skrifa_options(self) -> HintingOptions {
+    pub fn skrifa_options(self) -> Option<HintingOptions> {
         match self {
-            Self::Interpreter(target) => HintingOptions {
+            Self::None => None,
+            Self::Interpreter(target) => Some(HintingOptions {
                 engine: ::skrifa::outline::Engine::Interpreter,
                 target: target.to_skrifa_target(),
-            },
-            Self::Auto(target) => HintingOptions {
+            }),
+            Self::Auto(target) => Some(HintingOptions {
                 engine: ::skrifa::outline::Engine::Auto(None),
                 target: target.to_skrifa_target(),
-            },
+            }),
         }
     }
 
     pub fn freetype_load_flags(self) -> LoadFlag {
         match self {
+            Self::None => LoadFlag::NO_HINTING,
             Self::Interpreter(target) => LoadFlag::NO_AUTOHINT | target.to_freetype_load_flags(),
             Self::Auto(target) => LoadFlag::FORCE_AUTOHINT | target.to_freetype_load_flags(),
         }
@@ -81,11 +84,11 @@ pub struct InstanceOptions<'a> {
     pub index: usize,
     pub ppem: f32,
     pub coords: &'a [F2Dot14],
-    pub hinting: Option<Hinting>,
+    pub hinting: Hinting,
 }
 
 impl<'a> InstanceOptions<'a> {
-    pub fn new(index: usize, ppem: f32, coords: &'a [F2Dot14], hinting: Option<Hinting>) -> Self {
+    pub fn new(index: usize, ppem: f32, coords: &'a [F2Dot14], hinting: Hinting) -> Self {
         Self {
             index,
             ppem,

--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -27,17 +27,7 @@ impl<'a> SkrifaInstance<'a> {
         };
         let outlines = font.outline_glyphs();
         let hinter = if options.ppem != 0.0 {
-            if options.hinting.is_some() {
-                Some(
-                    HintingInstance::new(
-                        &outlines,
-                        size,
-                        options.coords,
-                        options.hinting.unwrap().skrifa_options(),
-                    )
-                    .ok()?,
-                )
-            } else if outlines.require_interpreter() {
+            if outlines.require_interpreter() {
                 // In this case, we must use the interpreter to match FreeType
                 Some(
                     HintingInstance::new(
@@ -51,6 +41,8 @@ impl<'a> SkrifaInstance<'a> {
                     )
                     .ok()?,
                 )
+            } else if let Some(hinting_options) = options.hinting.skrifa_options() {
+                Some(HintingInstance::new(&outlines, size, options.coords, hinting_options).ok()?)
             } else {
                 None
             }

--- a/fauntlet/src/main.rs
+++ b/fauntlet/src/main.rs
@@ -178,6 +178,7 @@ fn hinting_modes(engine: Option<HintingEngine>, target: Option<HintingTarget>) -
         Some(HintingEngine::Interpreter) => collect_hinting_modes(false, target, &mut modes),
         Some(HintingEngine::Auto) => collect_hinting_modes(true, target, &mut modes),
         Some(HintingEngine::All) => {
+            modes.push(Hinting::None);
             collect_hinting_modes(false, target, &mut modes);
             collect_hinting_modes(true, target, &mut modes);
         }

--- a/fauntlet/src/main.rs
+++ b/fauntlet/src/main.rs
@@ -2,13 +2,45 @@ use std::io::Write;
 
 use rayon::prelude::*;
 
-use fauntlet::{compare_glyphs, InstanceOptions};
+use fauntlet::{compare_glyphs, Hinting, InstanceOptions};
 use skrifa::raw::types::F2Dot14;
 
 #[derive(clap::Parser, Debug)]
 struct Args {
     #[command(subcommand)]
     command: Command,
+}
+
+/// Specifies which hinting engine(s) to test.
+#[derive(clap::ValueEnum, Copy, Clone, Default, Debug)]
+enum HintingEngine {
+    /// Disable hinting.
+    #[default]
+    None,
+    /// The TrueType or CFF interpreter.
+    Interpreter,
+    /// The autohinter.
+    Auto,
+    /// Test with all hinting engines.
+    All,
+}
+
+/// Specifies which hinting engine(s) to test.
+#[derive(clap::ValueEnum, Copy, Clone, Default, Debug)]
+enum HintingTarget {
+    /// The standard hinting mode.
+    #[default]
+    Normal,
+    /// The light hinting mode.
+    Light,
+    /// The horizontal LCD hinting mode.
+    Lcd,
+    /// The vertical LCD hinting mode.
+    VerticalLcd,
+    /// The monochrome hinting mode.
+    Mono,
+    /// Test with all hinting modes.
+    All,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -18,6 +50,15 @@ enum Command {
         /// Print the path for each font file as it is processed
         #[arg(long)]
         print_paths: bool,
+        /// Print the settings for each instance as it is processed
+        #[arg(long)]
+        print_instances: bool,
+        /// The hinting engine to test
+        #[arg(long)]
+        hinting_engine: Option<HintingEngine>,
+        /// The hinting target to test
+        #[arg(long)]
+        hinting_target: Option<HintingTarget>,
         #[arg(long)]
         /// End the process immediately if a comparison fails
         exit_on_fail: bool,
@@ -39,19 +80,19 @@ fn main() {
     // Locations in normalized variation space
     let var_locations = [-1.0, -0.32, 0.0, 0.42, 1.0].map(F2Dot14::from_f32);
 
-    // We don't currently test hinting.
-    // Waiting on <https://github.com/googlefonts/fontations/issues/620>
-    let hinting = None;
-
     use clap::Parser as _;
     let args = Args::parse_from(wild::args());
 
     match args.command {
         Command::CompareGlyphs {
             print_paths,
+            print_instances,
+            hinting_engine,
+            hinting_target,
             exit_on_fail,
             files,
         } => {
+            let hinting_matrix = hinting_modes(hinting_engine, hinting_target);
             use std::sync::atomic::{AtomicBool, Ordering};
             let ok = AtomicBool::new(true);
             files.par_iter().for_each(|font_path| {
@@ -67,9 +108,45 @@ fn main() {
                                 for coord in &var_locations {
                                     coords.clear();
                                     coords.extend(std::iter::repeat_n(*coord, axis_count));
-                                    let options = fauntlet::InstanceOptions::new(
-                                        font_ix, *ppem, &coords, hinting,
-                                    );
+                                    for hinting in &hinting_matrix {
+                                        let options = fauntlet::InstanceOptions::new(
+                                            font_ix, *ppem, &coords, *hinting,
+                                        );
+                                        if print_instances {
+                                            writeln!(
+                                                std::io::stdout(),
+                                                "<size: {}, coords: {:?}, hinting: {:?}>",
+                                                *ppem,
+                                                &coords,
+                                                *hinting
+                                            )
+                                            .unwrap();
+                                        }
+                                        if let Some(instances) = font_data.instantiate(&options) {
+                                            if !compare_glyphs(
+                                                font_path,
+                                                &options,
+                                                instances,
+                                                exit_on_fail,
+                                            ) {
+                                                ok.store(false, Ordering::Release);
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                for hinting in &hinting_matrix {
+                                    let options =
+                                        InstanceOptions::new(font_ix, *ppem, &[], *hinting);
+                                    if print_instances {
+                                        writeln!(
+                                            std::io::stdout(),
+                                            "<size: {}, hinting: {:?}>",
+                                            *ppem,
+                                            *hinting
+                                        )
+                                        .unwrap();
+                                    }
                                     if let Some(instances) = font_data.instantiate(&options) {
                                         if !compare_glyphs(
                                             font_path,
@@ -81,14 +158,6 @@ fn main() {
                                         }
                                     }
                                 }
-                            } else {
-                                let options = InstanceOptions::new(font_ix, *ppem, &[], hinting);
-                                if let Some(instances) = font_data.instantiate(&options) {
-                                    if !compare_glyphs(font_path, &options, instances, exit_on_fail)
-                                    {
-                                        ok.store(false, Ordering::Release);
-                                    }
-                                }
                             }
                         }
                     }
@@ -98,5 +167,46 @@ fn main() {
                 std::process::exit(1);
             }
         }
+    }
+}
+
+fn hinting_modes(engine: Option<HintingEngine>, target: Option<HintingTarget>) -> Vec<Hinting> {
+    let target = target.unwrap_or_default();
+    let mut modes = vec![];
+    match engine {
+        None | Some(HintingEngine::None) => return vec![Hinting::None],
+        Some(HintingEngine::Interpreter) => collect_hinting_modes(false, target, &mut modes),
+        Some(HintingEngine::Auto) => collect_hinting_modes(true, target, &mut modes),
+        Some(HintingEngine::All) => {
+            collect_hinting_modes(false, target, &mut modes);
+            collect_hinting_modes(true, target, &mut modes);
+        }
+    }
+    modes
+}
+
+fn collect_hinting_modes(is_auto: bool, target: HintingTarget, modes: &mut Vec<Hinting>) {
+    use fauntlet::HintingTarget::*;
+    let actual_target = match target {
+        HintingTarget::Normal => Normal,
+        HintingTarget::Light => Light,
+        HintingTarget::Lcd => Lcd,
+        HintingTarget::VerticalLcd => VerticalLcd,
+        HintingTarget::Mono => Mono,
+        HintingTarget::All => {
+            for target in [Normal, Light, Lcd, VerticalLcd, Mono] {
+                if is_auto {
+                    modes.push(Hinting::Auto(target))
+                } else {
+                    modes.push(Hinting::Interpreter(target))
+                }
+            }
+            return;
+        }
+    };
+    if is_auto {
+        modes.push(Hinting::Auto(actual_target))
+    } else {
+        modes.push(Hinting::Interpreter(actual_target))
     }
 }


### PR DESCRIPTION
Adds new `--hinting-engine` and `--hinting-target` CLI options to select the hinting mode. Allows specifying `all` for each to run the full matrix of modes.