### PR TITLE
[codegen] capture initial fixed fields in a struct

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -19,12 +19,9 @@ impl Fields {
             .flat_map(Field::input_fields)
             .collect::<ReferencedFields>();
 
-        let mut is_fixed = true;
         for field in fields.iter_mut() {
             field.read_at_parse_time =
                 field.attrs.version.is_some() || referenced_fields.needs_at_parsetime(&field.name);
-            is_fixed &= field.is_zerocopy_compatible() && !field.is_conditional();
-            field.is_fixed = is_fixed;
         }
 
         Ok(Fields {

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -175,6 +175,9 @@ pub(crate) struct Field {
     /// For instance: in a versioned table, the version must be read to determine
     /// whether to expect version-dependent fields.
     pub(crate) read_at_parse_time: bool,
+    /// `true` if this field is always present and at a fixed position relative
+    /// to its parent.
+    pub(crate) is_fixed: bool,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -770,6 +773,7 @@ impl Parse for Field {
             typ,
             // computed later
             read_at_parse_time: false,
+            is_fixed: false,
         })
     }
 }

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -1324,8 +1324,11 @@ impl Items {
                 Item::Table(item) => &mut item.fields.fields,
                 _ => continue,
             };
+            let mut is_fixed = true;
             for field in fields {
                 resolve_field(&known, field)?;
+                is_fixed &= field.is_zerocopy_compatible() && !field.is_conditional();
+                field.is_fixed = is_fixed;
             }
         }
         Ok(())

--- a/klippa/src/offset.rs
+++ b/klippa/src/offset.rs
@@ -50,8 +50,8 @@ impl<O: Scalar> SerializeSubset for O {
 
 // this is trait is used to copy simple tables only which implemented MinByteRange trait
 pub(crate) trait SerializeCopy {
-    fn serialize_copy<T: MinByteRange>(
-        t: &TableRef<T>,
+    fn serialize_copy<T: MinByteRange, F>(
+        t: &TableRef<T, F>,
         s: &mut Serializer,
         pos: usize,
     ) -> Result<(), SerializeErrorFlags>;
@@ -64,8 +64,8 @@ pub(crate) trait SerializeCopy {
 }
 
 impl<O: Scalar> SerializeCopy for O {
-    fn serialize_copy<T: MinByteRange>(
-        t: &TableRef<T>,
+    fn serialize_copy<T: MinByteRange, F>(
+        t: &TableRef<T, F>,
         s: &mut Serializer,
         pos: usize,
     ) -> Result<(), SerializeErrorFlags> {

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -39,62 +39,74 @@ pub struct BitmapSize {
 
 impl BitmapSize {
     /// Offset to IndexSubtableList, from beginning of EBLC/CBLC.
+    #[inline]
     pub fn index_subtable_list_offset(&self) -> u32 {
         self.index_subtable_list_offset.get()
     }
 
     /// Total size in bytes of the IndexSubtableList including its array of IndexSubtables.
+    #[inline]
     pub fn index_subtable_list_size(&self) -> u32 {
         self.index_subtable_list_size.get()
     }
 
     /// Number of IndexSubtables in the IndexSubtableList.
+    #[inline]
     pub fn number_of_index_subtables(&self) -> u32 {
         self.number_of_index_subtables.get()
     }
 
     /// Not used; set to 0.
+    #[inline]
     pub fn color_ref(&self) -> u32 {
         self.color_ref.get()
     }
 
     /// Line metrics for text rendered horizontally.
+    #[inline]
     pub fn hori(&self) -> &SbitLineMetrics {
         &self.hori
     }
 
     /// Line metrics for text rendered vertically.
+    #[inline]
     pub fn vert(&self) -> &SbitLineMetrics {
         &self.vert
     }
 
     /// Lowest glyph index for this size.
+    #[inline]
     pub fn start_glyph_index(&self) -> GlyphId16 {
         self.start_glyph_index.get()
     }
 
     /// Highest glyph index for this size.
+    #[inline]
     pub fn end_glyph_index(&self) -> GlyphId16 {
         self.end_glyph_index.get()
     }
 
     /// Horizontal pixels per em.
+    #[inline]
     pub fn ppem_x(&self) -> u8 {
         self.ppem_x
     }
 
     /// Vertical pixels per em.
+    #[inline]
     pub fn ppem_y(&self) -> u8 {
         self.ppem_y
     }
 
     /// The Microsoft rasterizer v.1.7 or greater supports the following
     /// bitDepth values, as described below: 1, 2, 4, and 8 (and 32 for CBLC).
+    #[inline]
     pub fn bit_depth(&self) -> u8 {
         self.bit_depth
     }
 
     /// Vertical or horizontal.
+    #[inline]
     pub fn flags(&self) -> BitmapFlags {
         self.flags.get()
     }
@@ -169,50 +181,62 @@ pub struct SbitLineMetrics {
 }
 
 impl SbitLineMetrics {
+    #[inline]
     pub fn ascender(&self) -> i8 {
         self.ascender.get()
     }
 
+    #[inline]
     pub fn descender(&self) -> i8 {
         self.descender.get()
     }
 
+    #[inline]
     pub fn width_max(&self) -> u8 {
         self.width_max
     }
 
+    #[inline]
     pub fn caret_slope_numerator(&self) -> i8 {
         self.caret_slope_numerator.get()
     }
 
+    #[inline]
     pub fn caret_slope_denominator(&self) -> u8 {
         self.caret_slope_denominator
     }
 
+    #[inline]
     pub fn caret_offset(&self) -> i8 {
         self.caret_offset.get()
     }
 
+    #[inline]
     pub fn min_origin_sb(&self) -> i8 {
         self.min_origin_sb.get()
     }
 
+    #[inline]
     pub fn min_advance_sb(&self) -> i8 {
         self.min_advance_sb.get()
     }
 
+    #[inline]
     pub fn max_before_bl(&self) -> i8 {
         self.max_before_bl.get()
     }
 
+    #[inline]
     pub fn min_after_bl(&self) -> i8 {
         self.min_after_bl.get()
     }
 
+    #[inline]
     pub fn pad1(&self) -> i8 {
         self.pad1.get()
     }
 
+    #[inline]
     pub fn pad2(&self) -> i8 {
         self.pad2.get()
     }
@@ -597,41 +621,49 @@ pub struct BigGlyphMetrics {
 
 impl BigGlyphMetrics {
     /// Number of rows of data.
+    #[inline]
     pub fn height(&self) -> u8 {
         self.height
     }
 
     /// Number of columns of data.
+    #[inline]
     pub fn width(&self) -> u8 {
         self.width
     }
 
     /// Distance in pixels from the horizontal origin to the left edge of the bitmap.
+    #[inline]
     pub fn hori_bearing_x(&self) -> i8 {
         self.hori_bearing_x.get()
     }
 
     /// Distance in pixels from the horizontal origin to the top edge of the bitmap.
+    #[inline]
     pub fn hori_bearing_y(&self) -> i8 {
         self.hori_bearing_y.get()
     }
 
     /// Horizontal advance width in pixels.
+    #[inline]
     pub fn hori_advance(&self) -> u8 {
         self.hori_advance
     }
 
     /// Distance in pixels from the vertical origin to the left edge of the bitmap.
+    #[inline]
     pub fn vert_bearing_x(&self) -> i8 {
         self.vert_bearing_x.get()
     }
 
     /// Distance in pixels from the vertical origin to the top edge of the bitmap.
+    #[inline]
     pub fn vert_bearing_y(&self) -> i8 {
         self.vert_bearing_y.get()
     }
 
     /// Vertical advance width in pixels.
+    #[inline]
     pub fn vert_advance(&self) -> u8 {
         self.vert_advance
     }
@@ -688,26 +720,31 @@ pub struct SmallGlyphMetrics {
 
 impl SmallGlyphMetrics {
     /// Number of rows of data.
+    #[inline]
     pub fn height(&self) -> u8 {
         self.height
     }
 
     /// Number of columns of data.
+    #[inline]
     pub fn width(&self) -> u8 {
         self.width
     }
 
     /// Distance in pixels from the horizontal origin to the left edge of the bitmap (for horizontal text); or distance in pixels from the vertical origin to the top edge of the bitmap (for vertical text).
+    #[inline]
     pub fn bearing_x(&self) -> i8 {
         self.bearing_x.get()
     }
 
     /// Distance in pixels from the horizontal origin to the top edge of the bitmap (for horizontal text); or distance in pixels from the vertical origin to the left edge of the bitmap (for vertical text).
+    #[inline]
     pub fn bearing_y(&self) -> i8 {
         self.bearing_y.get()
     }
 
     /// Horizontal or vertical advance width in pixels.
+    #[inline]
     pub fn advance(&self) -> u8 {
         self.advance
     }
@@ -739,6 +776,15 @@ impl<'a> SomeRecord<'a> for SmallGlyphMetrics {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct IndexSubtableListFixedFields {}
+
+impl FixedSize for IndexSubtableListFixedFields {
+    const RAW_BYTE_LEN: usize = 0;
+}
+
 /// [IndexSubtableList](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtablelist) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -764,16 +810,21 @@ impl ReadArgs for IndexSubtableList<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for IndexSubtableList<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u32) -> Result<Self, ReadError> {
         let number_of_index_subtables = *args;
         let mut cursor = data.cursor();
+        let fixed_fields: &'a IndexSubtableListFixedFields = cursor.read_ref()?;
         let index_subtable_records_byte_len = (number_of_index_subtables as usize)
             .checked_mul(IndexSubtableRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(index_subtable_records_byte_len);
-        cursor.finish(IndexSubtableListMarker {
-            index_subtable_records_byte_len,
-        })
+        cursor.finish(
+            IndexSubtableListMarker {
+                index_subtable_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -782,6 +833,7 @@ impl<'a> IndexSubtableList<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, number_of_index_subtables: u32) -> Result<Self, ReadError> {
         let args = number_of_index_subtables;
         Self::read_with_args(data, &args)
@@ -789,11 +841,13 @@ impl<'a> IndexSubtableList<'a> {
 }
 
 /// [IndexSubtableList](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtablelist) table.
-pub type IndexSubtableList<'a> = TableRef<'a, IndexSubtableListMarker>;
+pub type IndexSubtableList<'a> =
+    TableRef<'a, IndexSubtableListMarker, IndexSubtableListFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtableList<'a> {
     /// Array of IndexSubtableRecords.
+    #[inline]
     pub fn index_subtable_records(&self) -> &'a [IndexSubtableRecord] {
         let range = self.shape.index_subtable_records_byte_range();
         self.data.read_array(range).unwrap()
@@ -842,16 +896,19 @@ pub struct IndexSubtableRecord {
 
 impl IndexSubtableRecord {
     /// First glyph ID of this range.
+    #[inline]
     pub fn first_glyph_index(&self) -> GlyphId16 {
         self.first_glyph_index.get()
     }
 
     /// Last glyph ID of this range (inclusive).
+    #[inline]
     pub fn last_glyph_index(&self) -> GlyphId16 {
         self.last_glyph_index.get()
     }
 
     /// Offset to an IndexSubtable from the start of the IndexSubtableList.
+    #[inline]
     pub fn index_subtable_offset(&self) -> Offset32 {
         self.index_subtable_offset.get()
     }
@@ -860,6 +917,7 @@ impl IndexSubtableRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn index_subtable<'a>(&self, data: FontData<'a>) -> Result<IndexSubtable<'a>, ReadError> {
         let args = (self.last_glyph_index(), self.first_glyph_index());
         self.index_subtable_offset().resolve_with_args(data, &args)
@@ -892,6 +950,19 @@ impl<'a> SomeRecord<'a> for IndexSubtableRecord {
 
 impl Format<u16> for IndexSubtable1Marker {
     const FORMAT: u16 = 1;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct IndexSubtable1FixedFields {
+    pub index_format: BigEndian<u16>,
+    pub image_format: BigEndian<u16>,
+    pub image_data_offset: BigEndian<u32>,
+}
+
+impl FixedSize for IndexSubtable1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 /// [IndexSubTable1](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable1-variable-metrics-glyphs-with-4-byte-offsets): variable-metrics glyphs with 4-byte offsets.
@@ -934,23 +1005,25 @@ impl ReadArgs for IndexSubtable1<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for IndexSubtable1<'a> {
+    #[inline]
     fn read_with_args(
         data: FontData<'a>,
         args: &(GlyphId16, GlyphId16),
     ) -> Result<Self, ReadError> {
         let (last_glyph_index, first_glyph_index) = *args;
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
+        let fixed_fields: &'a IndexSubtable1FixedFields = cursor.read_ref()?;
         let sbit_offsets_byte_len =
             (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
                 .checked_mul(u32::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(sbit_offsets_byte_len);
-        cursor.finish(IndexSubtable1Marker {
-            sbit_offsets_byte_len,
-        })
+        cursor.finish(
+            IndexSubtable1Marker {
+                sbit_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -959,6 +1032,7 @@ impl<'a> IndexSubtable1<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(
         data: FontData<'a>,
         last_glyph_index: GlyphId16,
@@ -970,28 +1044,29 @@ impl<'a> IndexSubtable1<'a> {
 }
 
 /// [IndexSubTable1](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable1-variable-metrics-glyphs-with-4-byte-offsets): variable-metrics glyphs with 4-byte offsets.
-pub type IndexSubtable1<'a> = TableRef<'a, IndexSubtable1Marker>;
+pub type IndexSubtable1<'a> = TableRef<'a, IndexSubtable1Marker, IndexSubtable1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable1<'a> {
     /// Format of this IndexSubTable.
+    #[inline]
     pub fn index_format(&self) -> u16 {
-        let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().index_format.get()
     }
 
     /// Format of EBDT image data.
+    #[inline]
     pub fn image_format(&self) -> u16 {
-        let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_format.get()
     }
 
     /// Offset to image data in EBDT table.
+    #[inline]
     pub fn image_data_offset(&self) -> u32 {
-        let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_data_offset.get()
     }
 
+    #[inline]
     pub fn sbit_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.sbit_offsets_byte_range();
         self.data.read_array(range).unwrap()
@@ -1024,6 +1099,21 @@ impl<'a> std::fmt::Debug for IndexSubtable1<'a> {
 
 impl Format<u16> for IndexSubtable2Marker {
     const FORMAT: u16 = 2;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct IndexSubtable2FixedFields {
+    pub index_format: BigEndian<u16>,
+    pub image_format: BigEndian<u16>,
+    pub image_data_offset: BigEndian<u32>,
+    pub image_size: BigEndian<u32>,
+}
+
+impl FixedSize for IndexSubtable2FixedFields {
+    const RAW_BYTE_LEN: usize =
+        u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 /// [IndexSubTable2](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable2-all-glyphs-have-identical-metrics): all glyphs have identical metrics.
@@ -1067,50 +1157,52 @@ impl MinByteRange for IndexSubtable2Marker {
 }
 
 impl<'a> FontRead<'a> for IndexSubtable2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
+        let fixed_fields: &'a IndexSubtable2FixedFields = cursor.read_ref()?;
         let big_metrics_byte_len = BigGlyphMetrics::RAW_BYTE_LEN;
         cursor.advance_by(big_metrics_byte_len);
-        cursor.finish(IndexSubtable2Marker {
-            big_metrics_byte_len,
-        })
+        cursor.finish(
+            IndexSubtable2Marker {
+                big_metrics_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [IndexSubTable2](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable2-all-glyphs-have-identical-metrics): all glyphs have identical metrics.
-pub type IndexSubtable2<'a> = TableRef<'a, IndexSubtable2Marker>;
+pub type IndexSubtable2<'a> = TableRef<'a, IndexSubtable2Marker, IndexSubtable2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable2<'a> {
     /// Format of this IndexSubTable.
+    #[inline]
     pub fn index_format(&self) -> u16 {
-        let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().index_format.get()
     }
 
     /// Format of EBDT image data.
+    #[inline]
     pub fn image_format(&self) -> u16 {
-        let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_format.get()
     }
 
     /// Offset to image data in EBDT table.
+    #[inline]
     pub fn image_data_offset(&self) -> u32 {
-        let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_data_offset.get()
     }
 
     /// All the glyphs are of the same size.
+    #[inline]
     pub fn image_size(&self) -> u32 {
-        let range = self.shape.image_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_size.get()
     }
 
     /// All glyphs have the same metrics; glyph data may be compressed, byte-aligned, or bit-aligned.
+    #[inline]
     pub fn big_metrics(&self) -> &'a [BigGlyphMetrics] {
         let range = self.shape.big_metrics_byte_range();
         self.data.read_array(range).unwrap()
@@ -1153,6 +1245,19 @@ impl Format<u16> for IndexSubtable3Marker {
     const FORMAT: u16 = 3;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct IndexSubtable3FixedFields {
+    pub index_format: BigEndian<u16>,
+    pub image_format: BigEndian<u16>,
+    pub image_data_offset: BigEndian<u32>,
+}
+
+impl FixedSize for IndexSubtable3FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+}
+
 /// [IndexSubTable3](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with 2-byte offsets.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1193,23 +1298,25 @@ impl ReadArgs for IndexSubtable3<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for IndexSubtable3<'a> {
+    #[inline]
     fn read_with_args(
         data: FontData<'a>,
         args: &(GlyphId16, GlyphId16),
     ) -> Result<Self, ReadError> {
         let (last_glyph_index, first_glyph_index) = *args;
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
+        let fixed_fields: &'a IndexSubtable3FixedFields = cursor.read_ref()?;
         let sbit_offsets_byte_len =
             (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
                 .checked_mul(u16::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(sbit_offsets_byte_len);
-        cursor.finish(IndexSubtable3Marker {
-            sbit_offsets_byte_len,
-        })
+        cursor.finish(
+            IndexSubtable3Marker {
+                sbit_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -1218,6 +1325,7 @@ impl<'a> IndexSubtable3<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(
         data: FontData<'a>,
         last_glyph_index: GlyphId16,
@@ -1229,28 +1337,29 @@ impl<'a> IndexSubtable3<'a> {
 }
 
 /// [IndexSubTable3](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with 2-byte offsets.
-pub type IndexSubtable3<'a> = TableRef<'a, IndexSubtable3Marker>;
+pub type IndexSubtable3<'a> = TableRef<'a, IndexSubtable3Marker, IndexSubtable3FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable3<'a> {
     /// Format of this IndexSubTable.
+    #[inline]
     pub fn index_format(&self) -> u16 {
-        let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().index_format.get()
     }
 
     /// Format of EBDT image data.
+    #[inline]
     pub fn image_format(&self) -> u16 {
-        let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_format.get()
     }
 
     /// Offset to image data in EBDT table.
+    #[inline]
     pub fn image_data_offset(&self) -> u32 {
-        let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_data_offset.get()
     }
 
+    #[inline]
     pub fn sbit_offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.sbit_offsets_byte_range();
         self.data.read_array(range).unwrap()
@@ -1283,6 +1392,21 @@ impl<'a> std::fmt::Debug for IndexSubtable3<'a> {
 
 impl Format<u16> for IndexSubtable4Marker {
     const FORMAT: u16 = 4;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct IndexSubtable4FixedFields {
+    pub index_format: BigEndian<u16>,
+    pub image_format: BigEndian<u16>,
+    pub image_data_offset: BigEndian<u32>,
+    pub num_glyphs: BigEndian<u32>,
+}
+
+impl FixedSize for IndexSubtable4FixedFields {
+    const RAW_BYTE_LEN: usize =
+        u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 /// [IndexSubTable4](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with sparse glyph codes.
@@ -1326,52 +1450,55 @@ impl MinByteRange for IndexSubtable4Marker {
 }
 
 impl<'a> FontRead<'a> for IndexSubtable4<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let num_glyphs: u32 = cursor.read()?;
+        let fixed_fields: &'a IndexSubtable4FixedFields = cursor.read_ref()?;
+        let num_glyphs = fixed_fields.num_glyphs.get();
         let glyph_array_byte_len = (transforms::add(num_glyphs, 1_usize))
             .checked_mul(GlyphIdOffsetPair::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_array_byte_len);
-        cursor.finish(IndexSubtable4Marker {
-            glyph_array_byte_len,
-        })
+        cursor.finish(
+            IndexSubtable4Marker {
+                glyph_array_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [IndexSubTable4](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with sparse glyph codes.
-pub type IndexSubtable4<'a> = TableRef<'a, IndexSubtable4Marker>;
+pub type IndexSubtable4<'a> = TableRef<'a, IndexSubtable4Marker, IndexSubtable4FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable4<'a> {
     /// Format of this IndexSubTable.
+    #[inline]
     pub fn index_format(&self) -> u16 {
-        let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().index_format.get()
     }
 
     /// Format of EBDT image data.
+    #[inline]
     pub fn image_format(&self) -> u16 {
-        let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_format.get()
     }
 
     /// Offset to image data in EBDT table.
+    #[inline]
     pub fn image_data_offset(&self) -> u32 {
-        let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_data_offset.get()
     }
 
     /// Array length.
+    #[inline]
     pub fn num_glyphs(&self) -> u32 {
-        let range = self.shape.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().num_glyphs.get()
     }
 
     /// One per glyph.
+    #[inline]
     pub fn glyph_array(&self) -> &'a [GlyphIdOffsetPair] {
         let range = self.shape.glyph_array_byte_range();
         self.data.read_array(range).unwrap()
@@ -1423,11 +1550,13 @@ pub struct GlyphIdOffsetPair {
 
 impl GlyphIdOffsetPair {
     /// Glyph ID of glyph present.
+    #[inline]
     pub fn glyph_id(&self) -> GlyphId16 {
         self.glyph_id.get()
     }
 
     /// Location in EBDT.
+    #[inline]
     pub fn sbit_offset(&self) -> u16 {
         self.sbit_offset.get()
     }
@@ -1454,6 +1583,21 @@ impl<'a> SomeRecord<'a> for GlyphIdOffsetPair {
 
 impl Format<u16> for IndexSubtable5Marker {
     const FORMAT: u16 = 5;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct IndexSubtable5FixedFields {
+    pub index_format: BigEndian<u16>,
+    pub image_format: BigEndian<u16>,
+    pub image_data_offset: BigEndian<u32>,
+    pub image_size: BigEndian<u32>,
+}
+
+impl FixedSize for IndexSubtable5FixedFields {
+    const RAW_BYTE_LEN: usize =
+        u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 /// [IndexSubTable5](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable5-constant-metrics-glyphs-with-sparse-glyph-codes): constant-metrics glyphs with sparse glyph codes
@@ -1508,12 +1652,10 @@ impl MinByteRange for IndexSubtable5Marker {
 }
 
 impl<'a> FontRead<'a> for IndexSubtable5<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
+        let fixed_fields: &'a IndexSubtable5FixedFields = cursor.read_ref()?;
         let big_metrics_byte_len = BigGlyphMetrics::RAW_BYTE_LEN;
         cursor.advance_by(big_metrics_byte_len);
         let num_glyphs: u32 = cursor.read()?;
@@ -1521,55 +1663,61 @@ impl<'a> FontRead<'a> for IndexSubtable5<'a> {
             .checked_mul(GlyphId16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_array_byte_len);
-        cursor.finish(IndexSubtable5Marker {
-            big_metrics_byte_len,
-            glyph_array_byte_len,
-        })
+        cursor.finish(
+            IndexSubtable5Marker {
+                big_metrics_byte_len,
+                glyph_array_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [IndexSubTable5](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable5-constant-metrics-glyphs-with-sparse-glyph-codes): constant-metrics glyphs with sparse glyph codes
-pub type IndexSubtable5<'a> = TableRef<'a, IndexSubtable5Marker>;
+pub type IndexSubtable5<'a> = TableRef<'a, IndexSubtable5Marker, IndexSubtable5FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable5<'a> {
     /// Format of this IndexSubTable.
+    #[inline]
     pub fn index_format(&self) -> u16 {
-        let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().index_format.get()
     }
 
     /// Format of EBDT image data.
+    #[inline]
     pub fn image_format(&self) -> u16 {
-        let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_format.get()
     }
 
     /// Offset to image data in EBDT table.
+    #[inline]
     pub fn image_data_offset(&self) -> u32 {
-        let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_data_offset.get()
     }
 
     /// All glyphs have the same data size.
+    #[inline]
     pub fn image_size(&self) -> u32 {
-        let range = self.shape.image_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().image_size.get()
     }
 
     /// All glyphs have the same metrics.
+    #[inline]
     pub fn big_metrics(&self) -> &'a [BigGlyphMetrics] {
         let range = self.shape.big_metrics_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Array length.
+    #[inline]
     pub fn num_glyphs(&self) -> u32 {
         let range = self.shape.num_glyphs_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// One per glyph, sorted by glyhph ID.
+    #[inline]
     pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.glyph_array_byte_range();
         self.data.read_array(range).unwrap()
@@ -1625,16 +1773,19 @@ pub struct BdtComponent {
 
 impl BdtComponent {
     /// Component glyph ID.
+    #[inline]
     pub fn glyph_id(&self) -> GlyphId16 {
         self.glyph_id.get()
     }
 
     /// Position of component left.
+    #[inline]
     pub fn x_offset(&self) -> i8 {
         self.x_offset.get()
     }
 
     /// Position of component top.
+    #[inline]
     pub fn y_offset(&self) -> i8 {
         self.y_offset.get()
     }

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -5,6 +5,17 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CvarFixedFields {
+    pub version: BigEndian<MajorMinor>,
+}
+
+impl FixedSize for CvarFixedFields {
+    const RAW_BYTE_LEN: usize = MajorMinor::RAW_BYTE_LEN;
+}
+
 /// The [cvar](https://learn.microsoft.com/en-us/typography/opentype/spec/cvar) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -46,52 +57,60 @@ impl TopLevelTable for Cvar<'_> {
 }
 
 impl<'a> FontRead<'a> for Cvar<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
+        let fixed_fields: &'a CvarFixedFields = cursor.read_ref()?;
         cursor.advance::<TupleVariationCount>();
         cursor.advance::<Offset16>();
         let tuple_variation_headers_byte_len = cursor.remaining_bytes();
         cursor.advance_by(tuple_variation_headers_byte_len);
-        cursor.finish(CvarMarker {
-            tuple_variation_headers_byte_len,
-        })
+        cursor.finish(
+            CvarMarker {
+                tuple_variation_headers_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// The [cvar](https://learn.microsoft.com/en-us/typography/opentype/spec/cvar) table.
-pub type Cvar<'a> = TableRef<'a, CvarMarker>;
+pub type Cvar<'a> = TableRef<'a, CvarMarker, CvarFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cvar<'a> {
     /// Major/minor version number of the CVT variations table — set to (1,0).
+    #[inline]
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// A packed field. The high 4 bits are flags, and the low 12 bits
     /// are the number of tuple variation tables for this glyph. The
     /// number of tuple variation tables can be any number between 1
     /// and 4095.
+    #[inline]
     pub fn tuple_variation_count(&self) -> TupleVariationCount {
         let range = self.shape.tuple_variation_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset from the start of the 'cvar' table to the serialized data.
+    #[inline]
     pub fn data_offset(&self) -> Offset16 {
         let range = self.shape.data_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`data_offset`][Self::data_offset].
+    #[inline]
     pub fn data(&self) -> Result<FontData<'a>, ReadError> {
         let data = self.data;
         self.data_offset().resolve(data)
     }
 
     /// Array of tuple variation headers.
+    #[inline]
     pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader> {
         let range = self.shape.tuple_variation_headers_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -5,6 +5,19 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct EblcFixedFields {
+    pub major_version: BigEndian<u16>,
+    pub minor_version: BigEndian<u16>,
+    pub num_sizes: BigEndian<u32>,
+}
+
+impl FixedSize for EblcFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+}
+
 /// The [Embedded Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -46,45 +59,49 @@ impl TopLevelTable for Eblc<'_> {
 }
 
 impl<'a> FontRead<'a> for Eblc<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let num_sizes: u32 = cursor.read()?;
+        let fixed_fields: &'a EblcFixedFields = cursor.read_ref()?;
+        let num_sizes = fixed_fields.num_sizes.get();
         let bitmap_sizes_byte_len = (num_sizes as usize)
             .checked_mul(BitmapSize::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(bitmap_sizes_byte_len);
-        cursor.finish(EblcMarker {
-            bitmap_sizes_byte_len,
-        })
+        cursor.finish(
+            EblcMarker {
+                bitmap_sizes_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// The [Embedded Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc) table
-pub type Eblc<'a> = TableRef<'a, EblcMarker>;
+pub type Eblc<'a> = TableRef<'a, EblcMarker, EblcFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Eblc<'a> {
     /// Major version of the EBLC table, = 2.
+    #[inline]
     pub fn major_version(&self) -> u16 {
-        let range = self.shape.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().major_version.get()
     }
 
     /// Minor version of EBLC table, = 0.
+    #[inline]
     pub fn minor_version(&self) -> u16 {
-        let range = self.shape.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().minor_version.get()
     }
 
     /// Number of BitmapSize records.
+    #[inline]
     pub fn num_sizes(&self) -> u32 {
-        let range = self.shape.num_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().num_sizes.get()
     }
 
     /// BitmapSize records array.
+    #[inline]
     pub fn bitmap_sizes(&self) -> &'a [BitmapSize] {
         let range = self.shape.bitmap_sizes_byte_range();
         self.data.read_array(range).unwrap()

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -5,6 +5,23 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct GposFixedFields {
+    pub version: BigEndian<MajorMinor>,
+    pub script_list_offset: BigEndian<Offset16>,
+    pub feature_list_offset: BigEndian<Offset16>,
+    pub lookup_list_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for GposFixedFields {
+    const RAW_BYTE_LEN: usize = MajorMinor::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN;
+}
+
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
 #[derive(Debug, Clone, Copy)]
@@ -52,12 +69,11 @@ impl TopLevelTable for Gpos<'_> {
 }
 
 impl<'a> FontRead<'a> for Gpos<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let version: MajorMinor = cursor.read()?;
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
+        let fixed_fields: &'a GposFixedFields = cursor.read_ref()?;
+        let version = fixed_fields.version.get();
         let feature_variations_offset_byte_start = version
             .compatible((1u16, 1u16))
             .then(|| cursor.position())
@@ -65,66 +81,74 @@ impl<'a> FontRead<'a> for Gpos<'a> {
         version
             .compatible((1u16, 1u16))
             .then(|| cursor.advance::<Offset32>());
-        cursor.finish(GposMarker {
-            feature_variations_offset_byte_start,
-        })
+        cursor.finish(
+            GposMarker {
+                feature_variations_offset_byte_start,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
-pub type Gpos<'a> = TableRef<'a, GposMarker>;
+pub type Gpos<'a> = TableRef<'a, GposMarker, GposFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gpos<'a> {
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
+    #[inline]
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// Offset to ScriptList table, from beginning of GPOS table
+    #[inline]
     pub fn script_list_offset(&self) -> Offset16 {
-        let range = self.shape.script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().script_list_offset.get()
     }
 
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
+    #[inline]
     pub fn script_list(&self) -> Result<ScriptList<'a>, ReadError> {
         let data = self.data;
         self.script_list_offset().resolve(data)
     }
 
     /// Offset to FeatureList table, from beginning of GPOS table
+    #[inline]
     pub fn feature_list_offset(&self) -> Offset16 {
-        let range = self.shape.feature_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().feature_list_offset.get()
     }
 
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
+    #[inline]
     pub fn feature_list(&self) -> Result<FeatureList<'a>, ReadError> {
         let data = self.data;
         self.feature_list_offset().resolve(data)
     }
 
     /// Offset to LookupList table, from beginning of GPOS table
+    #[inline]
     pub fn lookup_list_offset(&self) -> Offset16 {
-        let range = self.shape.lookup_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().lookup_list_offset.get()
     }
 
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
+    #[inline]
     pub fn lookup_list(&self) -> Result<PositionLookupList<'a>, ReadError> {
         let data = self.data;
         self.lookup_list_offset().resolve(data)
     }
 
+    #[inline]
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.feature_variations_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
+    #[inline]
     pub fn feature_variations(&self) -> Option<Result<FeatureVariations<'a>, ReadError>> {
         let data = self.data;
         self.feature_variations_offset().map(|x| x.resolve(data))?
@@ -186,6 +210,7 @@ pub enum PositionLookup<'a> {
 }
 
 impl<'a> FontRead<'a> for PositionLookup<'a> {
+    #[inline]
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
         let untyped = Lookup::read(bytes)?;
         match untyped.lookup_type() {
@@ -611,6 +636,7 @@ pub enum AnchorTable<'a> {
 
 impl<'a> AnchorTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
@@ -620,6 +646,7 @@ impl<'a> AnchorTable<'a> {
     }
 
     /// Format identifier, = 1
+    #[inline]
     pub fn anchor_format(&self) -> u16 {
         match self {
             Self::Format1(item) => item.anchor_format(),
@@ -629,6 +656,7 @@ impl<'a> AnchorTable<'a> {
     }
 
     /// Horizontal value, in design units
+    #[inline]
     pub fn x_coordinate(&self) -> i16 {
         match self {
             Self::Format1(item) => item.x_coordinate(),
@@ -638,6 +666,7 @@ impl<'a> AnchorTable<'a> {
     }
 
     /// Vertical value, in design units
+    #[inline]
     pub fn y_coordinate(&self) -> i16 {
         match self {
             Self::Format1(item) => item.y_coordinate(),
@@ -701,6 +730,19 @@ impl Format<u16> for AnchorFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AnchorFormat1FixedFields {
+    pub anchor_format: BigEndian<u16>,
+    pub x_coordinate: BigEndian<i16>,
+    pub y_coordinate: BigEndian<i16>,
+}
+
+impl FixedSize for AnchorFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN;
+}
+
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -730,36 +772,35 @@ impl MinByteRange for AnchorFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for AnchorFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.finish(AnchorFormat1Marker {})
+        let fixed_fields: &'a AnchorFormat1FixedFields = cursor.read_ref()?;
+        cursor.finish(AnchorFormat1Marker {}, fixed_fields)
     }
 }
 
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
-pub type AnchorFormat1<'a> = TableRef<'a, AnchorFormat1Marker>;
+pub type AnchorFormat1<'a> = TableRef<'a, AnchorFormat1Marker, AnchorFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat1<'a> {
     /// Format identifier, = 1
+    #[inline]
     pub fn anchor_format(&self) -> u16 {
-        let range = self.shape.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().anchor_format.get()
     }
 
     /// Horizontal value, in design units
+    #[inline]
     pub fn x_coordinate(&self) -> i16 {
-        let range = self.shape.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().x_coordinate.get()
     }
 
     /// Vertical value, in design units
+    #[inline]
     pub fn y_coordinate(&self) -> i16 {
-        let range = self.shape.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().y_coordinate.get()
     }
 }
 
@@ -788,6 +829,21 @@ impl<'a> std::fmt::Debug for AnchorFormat1<'a> {
 
 impl Format<u16> for AnchorFormat2Marker {
     const FORMAT: u16 = 2;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AnchorFormat2FixedFields {
+    pub anchor_format: BigEndian<u16>,
+    pub x_coordinate: BigEndian<i16>,
+    pub y_coordinate: BigEndian<i16>,
+    pub anchor_point: BigEndian<u16>,
+}
+
+impl FixedSize for AnchorFormat2FixedFields {
+    const RAW_BYTE_LEN: usize =
+        u16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
@@ -824,43 +880,41 @@ impl MinByteRange for AnchorFormat2Marker {
 }
 
 impl<'a> FontRead<'a> for AnchorFormat2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(AnchorFormat2Marker {})
+        let fixed_fields: &'a AnchorFormat2FixedFields = cursor.read_ref()?;
+        cursor.finish(AnchorFormat2Marker {}, fixed_fields)
     }
 }
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
-pub type AnchorFormat2<'a> = TableRef<'a, AnchorFormat2Marker>;
+pub type AnchorFormat2<'a> = TableRef<'a, AnchorFormat2Marker, AnchorFormat2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat2<'a> {
     /// Format identifier, = 2
+    #[inline]
     pub fn anchor_format(&self) -> u16 {
-        let range = self.shape.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().anchor_format.get()
     }
 
     /// Horizontal value, in design units
+    #[inline]
     pub fn x_coordinate(&self) -> i16 {
-        let range = self.shape.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().x_coordinate.get()
     }
 
     /// Vertical value, in design units
+    #[inline]
     pub fn y_coordinate(&self) -> i16 {
-        let range = self.shape.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().y_coordinate.get()
     }
 
     /// Index to glyph contour point
+    #[inline]
     pub fn anchor_point(&self) -> u16 {
-        let range = self.shape.anchor_point_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().anchor_point.get()
     }
 }
 
@@ -890,6 +944,25 @@ impl<'a> std::fmt::Debug for AnchorFormat2<'a> {
 
 impl Format<u16> for AnchorFormat3Marker {
     const FORMAT: u16 = 3;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AnchorFormat3FixedFields {
+    pub anchor_format: BigEndian<u16>,
+    pub x_coordinate: BigEndian<i16>,
+    pub y_coordinate: BigEndian<i16>,
+    pub x_device_offset: BigEndian<Nullable<Offset16>>,
+    pub y_device_offset: BigEndian<Nullable<Offset16>>,
+}
+
+impl FixedSize for AnchorFormat3FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN;
 }
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
@@ -931,49 +1004,47 @@ impl MinByteRange for AnchorFormat3Marker {
 }
 
 impl<'a> FontRead<'a> for AnchorFormat3<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(AnchorFormat3Marker {})
+        let fixed_fields: &'a AnchorFormat3FixedFields = cursor.read_ref()?;
+        cursor.finish(AnchorFormat3Marker {}, fixed_fields)
     }
 }
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
-pub type AnchorFormat3<'a> = TableRef<'a, AnchorFormat3Marker>;
+pub type AnchorFormat3<'a> = TableRef<'a, AnchorFormat3Marker, AnchorFormat3FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat3<'a> {
     /// Format identifier, = 3
+    #[inline]
     pub fn anchor_format(&self) -> u16 {
-        let range = self.shape.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().anchor_format.get()
     }
 
     /// Horizontal value, in design units
+    #[inline]
     pub fn x_coordinate(&self) -> i16 {
-        let range = self.shape.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().x_coordinate.get()
     }
 
     /// Vertical value, in design units
+    #[inline]
     pub fn y_coordinate(&self) -> i16 {
-        let range = self.shape.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().y_coordinate.get()
     }
 
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for X coordinate, from beginning of
     /// Anchor table (may be NULL)
+    #[inline]
     pub fn x_device_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.x_device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().x_device_offset.get()
     }
 
     /// Attempt to resolve [`x_device_offset`][Self::x_device_offset].
+    #[inline]
     pub fn x_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
         self.x_device_offset().resolve(data)
@@ -982,12 +1053,13 @@ impl<'a> AnchorFormat3<'a> {
     /// Offset to Device table (non-variable font) / VariationIndex
     /// table (variable font) for Y coordinate, from beginning of
     /// Anchor table (may be NULL)
+    #[inline]
     pub fn y_device_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.y_device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().y_device_offset.get()
     }
 
     /// Attempt to resolve [`y_device_offset`][Self::y_device_offset].
+    #[inline]
     pub fn y_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
         self.y_device_offset().resolve(data)
@@ -1025,6 +1097,17 @@ impl<'a> std::fmt::Debug for AnchorFormat3<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct MarkArrayFixedFields {
+    pub mark_count: BigEndian<u16>,
+}
+
+impl FixedSize for MarkArrayFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1051,32 +1134,38 @@ impl MinByteRange for MarkArrayMarker {
 }
 
 impl<'a> FontRead<'a> for MarkArray<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let mark_count: u16 = cursor.read()?;
+        let fixed_fields: &'a MarkArrayFixedFields = cursor.read_ref()?;
+        let mark_count = fixed_fields.mark_count.get();
         let mark_records_byte_len = (mark_count as usize)
             .checked_mul(MarkRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(mark_records_byte_len);
-        cursor.finish(MarkArrayMarker {
-            mark_records_byte_len,
-        })
+        cursor.finish(
+            MarkArrayMarker {
+                mark_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
-pub type MarkArray<'a> = TableRef<'a, MarkArrayMarker>;
+pub type MarkArray<'a> = TableRef<'a, MarkArrayMarker, MarkArrayFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkArray<'a> {
     /// Number of MarkRecords
+    #[inline]
     pub fn mark_count(&self) -> u16 {
-        let range = self.shape.mark_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_count.get()
     }
 
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
+    #[inline]
     pub fn mark_records(&self) -> &'a [MarkRecord] {
         let range = self.shape.mark_records_byte_range();
         self.data.read_array(range).unwrap()
@@ -1125,11 +1214,13 @@ pub struct MarkRecord {
 
 impl MarkRecord {
     /// Class defined for the associated mark.
+    #[inline]
     pub fn mark_class(&self) -> u16 {
         self.mark_class.get()
     }
 
     /// Offset to Anchor table, from beginning of MarkArray table.
+    #[inline]
     pub fn mark_anchor_offset(&self) -> Offset16 {
         self.mark_anchor_offset.get()
     }
@@ -1138,6 +1229,7 @@ impl MarkRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn mark_anchor<'a>(&self, data: FontData<'a>) -> Result<AnchorTable<'a>, ReadError> {
         self.mark_anchor_offset().resolve(data)
     }
@@ -1174,6 +1266,7 @@ pub enum SinglePos<'a> {
 
 impl<'a> SinglePos<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
@@ -1182,6 +1275,7 @@ impl<'a> SinglePos<'a> {
     }
 
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
         match self {
             Self::Format1(item) => item.pos_format(),
@@ -1190,6 +1284,7 @@ impl<'a> SinglePos<'a> {
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
         match self {
             Self::Format1(item) => item.coverage_offset(),
@@ -1198,6 +1293,7 @@ impl<'a> SinglePos<'a> {
     }
 
     /// Defines the types of data in the ValueRecord.
+    #[inline]
     pub fn value_format(&self) -> ValueFormat {
         match self {
             Self::Format1(item) => item.value_format(),
@@ -1257,6 +1353,18 @@ impl Format<u16> for SinglePosFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct SinglePosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub coverage_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for SinglePosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1293,43 +1401,48 @@ impl MinByteRange for SinglePosFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
+        let fixed_fields: &'a SinglePosFormat1FixedFields = cursor.read_ref()?;
         let value_format: ValueFormat = cursor.read()?;
         let value_record_byte_len = <ValueRecord as ComputeSize>::compute_size(&value_format)?;
         cursor.advance_by(value_record_byte_len);
-        cursor.finish(SinglePosFormat1Marker {
-            value_record_byte_len,
-        })
+        cursor.finish(
+            SinglePosFormat1Marker {
+                value_record_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
-pub type SinglePosFormat1<'a> = TableRef<'a, SinglePosFormat1Marker>;
+pub type SinglePosFormat1<'a> = TableRef<'a, SinglePosFormat1Marker, SinglePosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SinglePosFormat1<'a> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().coverage_offset.get()
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
+    #[inline]
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
     /// Defines the types of data in the ValueRecord.
+    #[inline]
     pub fn value_format(&self) -> ValueFormat {
         let range = self.shape.value_format_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -1337,6 +1450,7 @@ impl<'a> SinglePosFormat1<'a> {
 
     /// Defines positioning value(s) — applied to all glyphs in the
     /// Coverage table.
+    #[inline]
     pub fn value_record(&self) -> ValueRecord {
         let range = self.shape.value_record_byte_range();
         self.data
@@ -1377,6 +1491,18 @@ impl<'a> std::fmt::Debug for SinglePosFormat1<'a> {
 
 impl Format<u16> for SinglePosFormat2Marker {
     const FORMAT: u16 = 2;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct SinglePosFormat2FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub coverage_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for SinglePosFormat2FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
 }
 
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
@@ -1420,46 +1546,51 @@ impl MinByteRange for SinglePosFormat2Marker {
 }
 
 impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
+        let fixed_fields: &'a SinglePosFormat2FixedFields = cursor.read_ref()?;
         let value_format: ValueFormat = cursor.read()?;
         let value_count: u16 = cursor.read()?;
         let value_records_byte_len = (value_count as usize)
             .checked_mul(<ValueRecord as ComputeSize>::compute_size(&value_format)?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(value_records_byte_len);
-        cursor.finish(SinglePosFormat2Marker {
-            value_records_byte_len,
-        })
+        cursor.finish(
+            SinglePosFormat2Marker {
+                value_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
-pub type SinglePosFormat2<'a> = TableRef<'a, SinglePosFormat2Marker>;
+pub type SinglePosFormat2<'a> = TableRef<'a, SinglePosFormat2Marker, SinglePosFormat2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SinglePosFormat2<'a> {
     /// Format identifier: format = 2
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().coverage_offset.get()
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
+    #[inline]
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
     /// Defines the types of data in the ValueRecords.
+    #[inline]
     pub fn value_format(&self) -> ValueFormat {
         let range = self.shape.value_format_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -1467,12 +1598,14 @@ impl<'a> SinglePosFormat2<'a> {
 
     /// Number of ValueRecords — must equal glyphCount in the
     /// Coverage table.
+    #[inline]
     pub fn value_count(&self) -> u16 {
         let range = self.shape.value_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of ValueRecords — positioning values applied to glyphs.
+    #[inline]
     pub fn value_records(&self) -> ComputedArray<'a, ValueRecord> {
         let range = self.shape.value_records_byte_range();
         self.data
@@ -1525,6 +1658,7 @@ pub enum PairPos<'a> {
 
 impl<'a> PairPos<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
@@ -1533,6 +1667,7 @@ impl<'a> PairPos<'a> {
     }
 
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
         match self {
             Self::Format1(item) => item.pos_format(),
@@ -1541,6 +1676,7 @@ impl<'a> PairPos<'a> {
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
         match self {
             Self::Format1(item) => item.coverage_offset(),
@@ -1550,6 +1686,7 @@ impl<'a> PairPos<'a> {
 
     /// Defines the types of data in valueRecord1 — for the first
     /// glyph in the pair (may be zero).
+    #[inline]
     pub fn value_format1(&self) -> ValueFormat {
         match self {
             Self::Format1(item) => item.value_format1(),
@@ -1559,6 +1696,7 @@ impl<'a> PairPos<'a> {
 
     /// Defines the types of data in valueRecord2 — for the second
     /// glyph in the pair (may be zero).
+    #[inline]
     pub fn value_format2(&self) -> ValueFormat {
         match self {
             Self::Format1(item) => item.value_format2(),
@@ -1618,6 +1756,18 @@ impl Format<u16> for PairPosFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct PairPosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub coverage_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for PairPosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1664,10 +1814,10 @@ impl MinByteRange for PairPosFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for PairPosFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
+        let fixed_fields: &'a PairPosFormat1FixedFields = cursor.read_ref()?;
         cursor.advance::<ValueFormat>();
         cursor.advance::<ValueFormat>();
         let pair_set_count: u16 = cursor.read()?;
@@ -1675,30 +1825,34 @@ impl<'a> FontRead<'a> for PairPosFormat1<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(pair_set_offsets_byte_len);
-        cursor.finish(PairPosFormat1Marker {
-            pair_set_offsets_byte_len,
-        })
+        cursor.finish(
+            PairPosFormat1Marker {
+                pair_set_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
-pub type PairPosFormat1<'a> = TableRef<'a, PairPosFormat1Marker>;
+pub type PairPosFormat1<'a> = TableRef<'a, PairPosFormat1Marker, PairPosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairPosFormat1<'a> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().coverage_offset.get()
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
+    #[inline]
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.coverage_offset().resolve(data)
@@ -1706,6 +1860,7 @@ impl<'a> PairPosFormat1<'a> {
 
     /// Defines the types of data in valueRecord1 — for the first
     /// glyph in the pair (may be zero).
+    #[inline]
     pub fn value_format1(&self) -> ValueFormat {
         let range = self.shape.value_format1_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -1713,12 +1868,14 @@ impl<'a> PairPosFormat1<'a> {
 
     /// Defines the types of data in valueRecord2 — for the second
     /// glyph in the pair (may be zero).
+    #[inline]
     pub fn value_format2(&self) -> ValueFormat {
         let range = self.shape.value_format2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of PairSet tables
+    #[inline]
     pub fn pair_set_count(&self) -> u16 {
         let range = self.shape.pair_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -1726,12 +1883,14 @@ impl<'a> PairPosFormat1<'a> {
 
     /// Array of offsets to PairSet tables. Offsets are from beginning
     /// of PairPos subtable, ordered by Coverage Index.
+    #[inline]
     pub fn pair_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.pair_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// A dynamically resolving wrapper for [`pair_set_offsets`][Self::pair_set_offsets].
+    #[inline]
     pub fn pair_sets(&self) -> ArrayOfOffsets<'a, PairSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.pair_set_offsets();
@@ -1783,6 +1942,17 @@ impl<'a> std::fmt::Debug for PairPosFormat1<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct PairSetFixedFields {
+    pub pair_value_count: BigEndian<u16>,
+}
+
+impl FixedSize for PairSetFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// Part of [PairPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1815,13 +1985,15 @@ impl ReadArgs for PairSet<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
+    #[inline]
     fn read_with_args(
         data: FontData<'a>,
         args: &(ValueFormat, ValueFormat),
     ) -> Result<Self, ReadError> {
         let (value_format1, value_format2) = *args;
         let mut cursor = data.cursor();
-        let pair_value_count: u16 = cursor.read()?;
+        let fixed_fields: &'a PairSetFixedFields = cursor.read_ref()?;
+        let pair_value_count = fixed_fields.pair_value_count.get();
         let pair_value_records_byte_len = (pair_value_count as usize)
             .checked_mul(<PairValueRecord as ComputeSize>::compute_size(&(
                 value_format1,
@@ -1829,11 +2001,14 @@ impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
             ))?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(pair_value_records_byte_len);
-        cursor.finish(PairSetMarker {
-            value_format1,
-            value_format2,
-            pair_value_records_byte_len,
-        })
+        cursor.finish(
+            PairSetMarker {
+                value_format1,
+                value_format2,
+                pair_value_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -1842,6 +2017,7 @@ impl<'a> PairSet<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(
         data: FontData<'a>,
         value_format1: ValueFormat,
@@ -1853,18 +2029,19 @@ impl<'a> PairSet<'a> {
 }
 
 /// Part of [PairPosFormat1]
-pub type PairSet<'a> = TableRef<'a, PairSetMarker>;
+pub type PairSet<'a> = TableRef<'a, PairSetMarker, PairSetFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairSet<'a> {
     /// Number of PairValueRecords
+    #[inline]
     pub fn pair_value_count(&self) -> u16 {
-        let range = self.shape.pair_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pair_value_count.get()
     }
 
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
+    #[inline]
     pub fn pair_value_records(&self) -> ComputedArray<'a, PairValueRecord> {
         let range = self.shape.pair_value_records_byte_range();
         self.data
@@ -1925,16 +2102,19 @@ pub struct PairValueRecord {
 impl PairValueRecord {
     /// Glyph ID of second glyph in the pair (first glyph is listed in
     /// the Coverage table).
+    #[inline]
     pub fn second_glyph(&self) -> GlyphId16 {
         self.second_glyph.get()
     }
 
     /// Positioning data for the first glyph in the pair.
+    #[inline]
     pub fn value_record1(&self) -> &ValueRecord {
         &self.value_record1
     }
 
     /// Positioning data for the second glyph in the pair.
+    #[inline]
     pub fn value_record2(&self) -> &ValueRecord {
         &self.value_record2
     }
@@ -2019,6 +2199,18 @@ impl Format<u16> for PairPosFormat2Marker {
     const FORMAT: u16 = 2;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct PairPosFormat2FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub coverage_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for PairPosFormat2FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2080,10 +2272,10 @@ impl MinByteRange for PairPosFormat2Marker {
 }
 
 impl<'a> FontRead<'a> for PairPosFormat2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
+        let fixed_fields: &'a PairPosFormat2FixedFields = cursor.read_ref()?;
         let value_format1: ValueFormat = cursor.read()?;
         let value_format2: ValueFormat = cursor.read()?;
         cursor.advance::<Offset16>();
@@ -2098,30 +2290,34 @@ impl<'a> FontRead<'a> for PairPosFormat2<'a> {
             ))?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class1_records_byte_len);
-        cursor.finish(PairPosFormat2Marker {
-            class1_records_byte_len,
-        })
+        cursor.finish(
+            PairPosFormat2Marker {
+                class1_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
-pub type PairPosFormat2<'a> = TableRef<'a, PairPosFormat2Marker>;
+pub type PairPosFormat2<'a> = TableRef<'a, PairPosFormat2Marker, PairPosFormat2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairPosFormat2<'a> {
     /// Format identifier: format = 2
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().coverage_offset.get()
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
+    #[inline]
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.coverage_offset().resolve(data)
@@ -2129,6 +2325,7 @@ impl<'a> PairPosFormat2<'a> {
 
     /// ValueRecord definition — for the first glyph of the pair (may
     /// be zero).
+    #[inline]
     pub fn value_format1(&self) -> ValueFormat {
         let range = self.shape.value_format1_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -2136,6 +2333,7 @@ impl<'a> PairPosFormat2<'a> {
 
     /// ValueRecord definition — for the second glyph of the pair
     /// (may be zero).
+    #[inline]
     pub fn value_format2(&self) -> ValueFormat {
         let range = self.shape.value_format2_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -2143,12 +2341,14 @@ impl<'a> PairPosFormat2<'a> {
 
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the first glyph of the pair.
+    #[inline]
     pub fn class_def1_offset(&self) -> Offset16 {
         let range = self.shape.class_def1_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`class_def1_offset`][Self::class_def1_offset].
+    #[inline]
     pub fn class_def1(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
         self.class_def1_offset().resolve(data)
@@ -2156,30 +2356,35 @@ impl<'a> PairPosFormat2<'a> {
 
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the second glyph of the pair.
+    #[inline]
     pub fn class_def2_offset(&self) -> Offset16 {
         let range = self.shape.class_def2_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Attempt to resolve [`class_def2_offset`][Self::class_def2_offset].
+    #[inline]
     pub fn class_def2(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
         self.class_def2_offset().resolve(data)
     }
 
     /// Number of classes in classDef1 table — includes Class 0.
+    #[inline]
     pub fn class1_count(&self) -> u16 {
         let range = self.shape.class1_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of classes in classDef2 table — includes Class 0.
+    #[inline]
     pub fn class2_count(&self) -> u16 {
         let range = self.shape.class2_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of Class1 records, ordered by classes in classDef1.
+    #[inline]
     pub fn class1_records(&self) -> ComputedArray<'a, Class1Record<'a>> {
         let range = self.shape.class1_records_byte_range();
         self.data
@@ -2249,6 +2454,7 @@ pub struct Class1Record<'a> {
 
 impl<'a> Class1Record<'a> {
     /// Array of Class2 records, ordered by classes in classDef2.
+    #[inline]
     pub fn class2_records(&self) -> &ComputedArray<'a, Class2Record> {
         &self.class2_records
     }
@@ -2334,11 +2540,13 @@ pub struct Class2Record {
 
 impl Class2Record {
     /// Positioning for first glyph — empty if valueFormat1 = 0.
+    #[inline]
     pub fn value_record1(&self) -> &ValueRecord {
         &self.value_record1
     }
 
     /// Positioning for second glyph — empty if valueFormat2 = 0.
+    #[inline]
     pub fn value_record2(&self) -> &ValueRecord {
         &self.value_record2
     }
@@ -2418,6 +2626,19 @@ impl Format<u16> for CursivePosFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CursivePosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub coverage_offset: BigEndian<Offset16>,
+    pub entry_exit_count: BigEndian<u16>,
+}
+
+impl FixedSize for CursivePosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2454,51 +2675,57 @@ impl MinByteRange for CursivePosFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let entry_exit_count: u16 = cursor.read()?;
+        let fixed_fields: &'a CursivePosFormat1FixedFields = cursor.read_ref()?;
+        let entry_exit_count = fixed_fields.entry_exit_count.get();
         let entry_exit_record_byte_len = (entry_exit_count as usize)
             .checked_mul(EntryExitRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(entry_exit_record_byte_len);
-        cursor.finish(CursivePosFormat1Marker {
-            entry_exit_record_byte_len,
-        })
+        cursor.finish(
+            CursivePosFormat1Marker {
+                entry_exit_record_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
-pub type CursivePosFormat1<'a> = TableRef<'a, CursivePosFormat1Marker>;
+pub type CursivePosFormat1<'a> =
+    TableRef<'a, CursivePosFormat1Marker, CursivePosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CursivePosFormat1<'a> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to Coverage table, from beginning of CursivePos subtable.
+    #[inline]
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().coverage_offset.get()
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
+    #[inline]
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.coverage_offset().resolve(data)
     }
 
     /// Number of EntryExit records
+    #[inline]
     pub fn entry_exit_count(&self) -> u16 {
-        let range = self.shape.entry_exit_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().entry_exit_count.get()
     }
 
     /// Array of EntryExit records, in Coverage index order.
+    #[inline]
     pub fn entry_exit_record(&self) -> &'a [EntryExitRecord] {
         let range = self.shape.entry_exit_record_byte_range();
         self.data.read_array(range).unwrap()
@@ -2555,6 +2782,7 @@ pub struct EntryExitRecord {
 impl EntryExitRecord {
     /// Offset to entryAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
+    #[inline]
     pub fn entry_anchor_offset(&self) -> Nullable<Offset16> {
         self.entry_anchor_offset.get()
     }
@@ -2564,6 +2792,7 @@ impl EntryExitRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn entry_anchor<'a>(
         &self,
         data: FontData<'a>,
@@ -2573,6 +2802,7 @@ impl EntryExitRecord {
 
     /// Offset to exitAnchor table, from beginning of CursivePos
     /// subtable (may be NULL).
+    #[inline]
     pub fn exit_anchor_offset(&self) -> Nullable<Offset16> {
         self.exit_anchor_offset.get()
     }
@@ -2582,6 +2812,7 @@ impl EntryExitRecord {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn exit_anchor<'a>(
         &self,
         data: FontData<'a>,
@@ -2617,6 +2848,27 @@ impl<'a> SomeRecord<'a> for EntryExitRecord {
 
 impl Format<u16> for MarkBasePosFormat1Marker {
     const FORMAT: u16 = 1;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct MarkBasePosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub mark_coverage_offset: BigEndian<Offset16>,
+    pub base_coverage_offset: BigEndian<Offset16>,
+    pub mark_class_count: BigEndian<u16>,
+    pub mark_array_offset: BigEndian<Offset16>,
+    pub base_array_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for MarkBasePosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN;
 }
 
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
@@ -2663,37 +2915,35 @@ impl MinByteRange for MarkBasePosFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkBasePosFormat1Marker {})
+        let fixed_fields: &'a MarkBasePosFormat1FixedFields = cursor.read_ref()?;
+        cursor.finish(MarkBasePosFormat1Marker {}, fixed_fields)
     }
 }
 
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
-pub type MarkBasePosFormat1<'a> = TableRef<'a, MarkBasePosFormat1Marker>;
+pub type MarkBasePosFormat1<'a> =
+    TableRef<'a, MarkBasePosFormat1Marker, MarkBasePosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkBasePosFormat1<'a> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
+    #[inline]
     pub fn mark_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_coverage_offset.get()
     }
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
+    #[inline]
     pub fn mark_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.mark_coverage_offset().resolve(data)
@@ -2701,31 +2951,33 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Offset to baseCoverage table, from beginning of MarkBasePos
     /// subtable.
+    #[inline]
     pub fn base_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.base_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().base_coverage_offset.get()
     }
 
     /// Attempt to resolve [`base_coverage_offset`][Self::base_coverage_offset].
+    #[inline]
     pub fn base_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.base_coverage_offset().resolve(data)
     }
 
     /// Number of classes defined for marks
+    #[inline]
     pub fn mark_class_count(&self) -> u16 {
-        let range = self.shape.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_class_count.get()
     }
 
     /// Offset to MarkArray table, from beginning of MarkBasePos
     /// subtable.
+    #[inline]
     pub fn mark_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_array_offset.get()
     }
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
+    #[inline]
     pub fn mark_array(&self) -> Result<MarkArray<'a>, ReadError> {
         let data = self.data;
         self.mark_array_offset().resolve(data)
@@ -2733,12 +2985,13 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Offset to BaseArray table, from beginning of MarkBasePos
     /// subtable.
+    #[inline]
     pub fn base_array_offset(&self) -> Offset16 {
-        let range = self.shape.base_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().base_array_offset.get()
     }
 
     /// Attempt to resolve [`base_array_offset`][Self::base_array_offset].
+    #[inline]
     pub fn base_array(&self) -> Result<BaseArray<'a>, ReadError> {
         let data = self.data;
         let args = self.mark_class_count();
@@ -2784,6 +3037,17 @@ impl<'a> std::fmt::Debug for MarkBasePosFormat1<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct BaseArrayFixedFields {
+    pub base_count: BigEndian<u16>,
+}
+
+impl FixedSize for BaseArrayFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// Part of [MarkBasePosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -2815,20 +3079,25 @@ impl ReadArgs for BaseArray<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
-        let base_count: u16 = cursor.read()?;
+        let fixed_fields: &'a BaseArrayFixedFields = cursor.read_ref()?;
+        let base_count = fixed_fields.base_count.get();
         let base_records_byte_len = (base_count as usize)
             .checked_mul(<BaseRecord as ComputeSize>::compute_size(
                 &mark_class_count,
             )?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_records_byte_len);
-        cursor.finish(BaseArrayMarker {
-            mark_class_count,
-            base_records_byte_len,
-        })
+        cursor.finish(
+            BaseArrayMarker {
+                mark_class_count,
+                base_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -2837,6 +3106,7 @@ impl<'a> BaseArray<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, &args)
@@ -2844,17 +3114,18 @@ impl<'a> BaseArray<'a> {
 }
 
 /// Part of [MarkBasePosFormat1]
-pub type BaseArray<'a> = TableRef<'a, BaseArrayMarker>;
+pub type BaseArray<'a> = TableRef<'a, BaseArrayMarker, BaseArrayFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseArray<'a> {
     /// Number of BaseRecords
+    #[inline]
     pub fn base_count(&self) -> u16 {
-        let range = self.shape.base_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().base_count.get()
     }
 
     /// Array of BaseRecords, in order of baseCoverage Index.
+    #[inline]
     pub fn base_records(&self) -> ComputedArray<'a, BaseRecord<'a>> {
         let range = self.shape.base_records_byte_range();
         self.data
@@ -2909,6 +3180,7 @@ impl<'a> BaseRecord<'a> {
     /// Array of offsets (one per mark class) to Anchor tables. Offsets
     /// are from beginning of BaseArray table, ordered by class
     /// (offsets may be NULL).
+    #[inline]
     pub fn base_anchor_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         self.base_anchor_offsets
     }
@@ -2919,6 +3191,7 @@ impl<'a> BaseRecord<'a> {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn base_anchors(
         &self,
         data: FontData<'a>,
@@ -2994,6 +3267,27 @@ impl Format<u16> for MarkLigPosFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct MarkLigPosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub mark_coverage_offset: BigEndian<Offset16>,
+    pub ligature_coverage_offset: BigEndian<Offset16>,
+    pub mark_class_count: BigEndian<u16>,
+    pub mark_array_offset: BigEndian<Offset16>,
+    pub ligature_array_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for MarkLigPosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN;
+}
+
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3038,37 +3332,35 @@ impl MinByteRange for MarkLigPosFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkLigPosFormat1Marker {})
+        let fixed_fields: &'a MarkLigPosFormat1FixedFields = cursor.read_ref()?;
+        cursor.finish(MarkLigPosFormat1Marker {}, fixed_fields)
     }
 }
 
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
-pub type MarkLigPosFormat1<'a> = TableRef<'a, MarkLigPosFormat1Marker>;
+pub type MarkLigPosFormat1<'a> =
+    TableRef<'a, MarkLigPosFormat1Marker, MarkLigPosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkLigPosFormat1<'a> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
+    #[inline]
     pub fn mark_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_coverage_offset.get()
     }
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
+    #[inline]
     pub fn mark_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.mark_coverage_offset().resolve(data)
@@ -3076,31 +3368,33 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Offset to ligatureCoverage table, from beginning of MarkLigPos
     /// subtable.
+    #[inline]
     pub fn ligature_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.ligature_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().ligature_coverage_offset.get()
     }
 
     /// Attempt to resolve [`ligature_coverage_offset`][Self::ligature_coverage_offset].
+    #[inline]
     pub fn ligature_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.ligature_coverage_offset().resolve(data)
     }
 
     /// Number of defined mark classes
+    #[inline]
     pub fn mark_class_count(&self) -> u16 {
-        let range = self.shape.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_class_count.get()
     }
 
     /// Offset to MarkArray table, from beginning of MarkLigPos
     /// subtable.
+    #[inline]
     pub fn mark_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_array_offset.get()
     }
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
+    #[inline]
     pub fn mark_array(&self) -> Result<MarkArray<'a>, ReadError> {
         let data = self.data;
         self.mark_array_offset().resolve(data)
@@ -3108,12 +3402,13 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Offset to LigatureArray table, from beginning of MarkLigPos
     /// subtable.
+    #[inline]
     pub fn ligature_array_offset(&self) -> Offset16 {
-        let range = self.shape.ligature_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().ligature_array_offset.get()
     }
 
     /// Attempt to resolve [`ligature_array_offset`][Self::ligature_array_offset].
+    #[inline]
     pub fn ligature_array(&self) -> Result<LigatureArray<'a>, ReadError> {
         let data = self.data;
         let args = self.mark_class_count();
@@ -3159,6 +3454,17 @@ impl<'a> std::fmt::Debug for MarkLigPosFormat1<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct LigatureArrayFixedFields {
+    pub ligature_count: BigEndian<u16>,
+}
+
+impl FixedSize for LigatureArrayFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// Part of [MarkLigPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3190,18 +3496,23 @@ impl ReadArgs for LigatureArray<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
-        let ligature_count: u16 = cursor.read()?;
+        let fixed_fields: &'a LigatureArrayFixedFields = cursor.read_ref()?;
+        let ligature_count = fixed_fields.ligature_count.get();
         let ligature_attach_offsets_byte_len = (ligature_count as usize)
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ligature_attach_offsets_byte_len);
-        cursor.finish(LigatureArrayMarker {
-            mark_class_count,
-            ligature_attach_offsets_byte_len,
-        })
+        cursor.finish(
+            LigatureArrayMarker {
+                mark_class_count,
+                ligature_attach_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -3210,6 +3521,7 @@ impl<'a> LigatureArray<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, &args)
@@ -3217,25 +3529,27 @@ impl<'a> LigatureArray<'a> {
 }
 
 /// Part of [MarkLigPosFormat1]
-pub type LigatureArray<'a> = TableRef<'a, LigatureArrayMarker>;
+pub type LigatureArray<'a> = TableRef<'a, LigatureArrayMarker, LigatureArrayFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureArray<'a> {
     /// Number of LigatureAttach table offsets
+    #[inline]
     pub fn ligature_count(&self) -> u16 {
-        let range = self.shape.ligature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().ligature_count.get()
     }
 
     /// Array of offsets to LigatureAttach tables. Offsets are from
     /// beginning of LigatureArray table, ordered by ligatureCoverage
     /// index.
+    #[inline]
     pub fn ligature_attach_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.ligature_attach_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// A dynamically resolving wrapper for [`ligature_attach_offsets`][Self::ligature_attach_offsets].
+    #[inline]
     pub fn ligature_attaches(&self) -> ArrayOfOffsets<'a, LigatureAttach<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_attach_offsets();
@@ -3284,6 +3598,17 @@ impl<'a> std::fmt::Debug for LigatureArray<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct LigatureAttachFixedFields {
+    pub component_count: BigEndian<u16>,
+}
+
+impl FixedSize for LigatureAttachFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// Part of [MarkLigPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3315,20 +3640,25 @@ impl ReadArgs for LigatureAttach<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
-        let component_count: u16 = cursor.read()?;
+        let fixed_fields: &'a LigatureAttachFixedFields = cursor.read_ref()?;
+        let component_count = fixed_fields.component_count.get();
         let component_records_byte_len = (component_count as usize)
             .checked_mul(<ComponentRecord as ComputeSize>::compute_size(
                 &mark_class_count,
             )?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(component_records_byte_len);
-        cursor.finish(LigatureAttachMarker {
-            mark_class_count,
-            component_records_byte_len,
-        })
+        cursor.finish(
+            LigatureAttachMarker {
+                mark_class_count,
+                component_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -3337,6 +3667,7 @@ impl<'a> LigatureAttach<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, &args)
@@ -3344,17 +3675,18 @@ impl<'a> LigatureAttach<'a> {
 }
 
 /// Part of [MarkLigPosFormat1]
-pub type LigatureAttach<'a> = TableRef<'a, LigatureAttachMarker>;
+pub type LigatureAttach<'a> = TableRef<'a, LigatureAttachMarker, LigatureAttachFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureAttach<'a> {
     /// Number of ComponentRecords in this ligature
+    #[inline]
     pub fn component_count(&self) -> u16 {
-        let range = self.shape.component_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().component_count.get()
     }
 
     /// Array of Component records, ordered in writing direction.
+    #[inline]
     pub fn component_records(&self) -> ComputedArray<'a, ComponentRecord<'a>> {
         let range = self.shape.component_records_byte_range();
         self.data
@@ -3409,6 +3741,7 @@ impl<'a> ComponentRecord<'a> {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of LigatureAttach table, ordered by class
     /// (offsets may be NULL).
+    #[inline]
     pub fn ligature_anchor_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         self.ligature_anchor_offsets
     }
@@ -3419,6 +3752,7 @@ impl<'a> ComponentRecord<'a> {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn ligature_anchors(
         &self,
         data: FontData<'a>,
@@ -3494,6 +3828,27 @@ impl Format<u16> for MarkMarkPosFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct MarkMarkPosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub mark1_coverage_offset: BigEndian<Offset16>,
+    pub mark2_coverage_offset: BigEndian<Offset16>,
+    pub mark_class_count: BigEndian<u16>,
+    pub mark1_array_offset: BigEndian<Offset16>,
+    pub mark2_array_offset: BigEndian<Offset16>,
+}
+
+impl FixedSize for MarkMarkPosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN
+        + Offset16::RAW_BYTE_LEN;
+}
+
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3538,37 +3893,35 @@ impl MinByteRange for MarkMarkPosFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkMarkPosFormat1Marker {})
+        let fixed_fields: &'a MarkMarkPosFormat1FixedFields = cursor.read_ref()?;
+        cursor.finish(MarkMarkPosFormat1Marker {}, fixed_fields)
     }
 }
 
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
-pub type MarkMarkPosFormat1<'a> = TableRef<'a, MarkMarkPosFormat1Marker>;
+pub type MarkMarkPosFormat1<'a> =
+    TableRef<'a, MarkMarkPosFormat1Marker, MarkMarkPosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkMarkPosFormat1<'a> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
+    #[inline]
     pub fn mark1_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark1_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark1_coverage_offset.get()
     }
 
     /// Attempt to resolve [`mark1_coverage_offset`][Self::mark1_coverage_offset].
+    #[inline]
     pub fn mark1_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.mark1_coverage_offset().resolve(data)
@@ -3576,31 +3929,33 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Offset to Base Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
+    #[inline]
     pub fn mark2_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark2_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark2_coverage_offset.get()
     }
 
     /// Attempt to resolve [`mark2_coverage_offset`][Self::mark2_coverage_offset].
+    #[inline]
     pub fn mark2_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
         self.mark2_coverage_offset().resolve(data)
     }
 
     /// Number of Combining Mark classes defined
+    #[inline]
     pub fn mark_class_count(&self) -> u16 {
-        let range = self.shape.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark_class_count.get()
     }
 
     /// Offset to MarkArray table for mark1, from beginning of
     /// MarkMarkPos subtable.
+    #[inline]
     pub fn mark1_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark1_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark1_array_offset.get()
     }
 
     /// Attempt to resolve [`mark1_array_offset`][Self::mark1_array_offset].
+    #[inline]
     pub fn mark1_array(&self) -> Result<MarkArray<'a>, ReadError> {
         let data = self.data;
         self.mark1_array_offset().resolve(data)
@@ -3608,12 +3963,13 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Offset to Mark2Array table for mark2, from beginning of
     /// MarkMarkPos subtable.
+    #[inline]
     pub fn mark2_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark2_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark2_array_offset.get()
     }
 
     /// Attempt to resolve [`mark2_array_offset`][Self::mark2_array_offset].
+    #[inline]
     pub fn mark2_array(&self) -> Result<Mark2Array<'a>, ReadError> {
         let data = self.data;
         let args = self.mark_class_count();
@@ -3659,6 +4015,17 @@ impl<'a> std::fmt::Debug for MarkMarkPosFormat1<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Mark2ArrayFixedFields {
+    pub mark2_count: BigEndian<u16>,
+}
+
+impl FixedSize for Mark2ArrayFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// Part of [MarkMarkPosFormat1]Class2Record
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -3690,20 +4057,25 @@ impl ReadArgs for Mark2Array<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let mark_class_count = *args;
         let mut cursor = data.cursor();
-        let mark2_count: u16 = cursor.read()?;
+        let fixed_fields: &'a Mark2ArrayFixedFields = cursor.read_ref()?;
+        let mark2_count = fixed_fields.mark2_count.get();
         let mark2_records_byte_len = (mark2_count as usize)
             .checked_mul(<Mark2Record as ComputeSize>::compute_size(
                 &mark_class_count,
             )?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(mark2_records_byte_len);
-        cursor.finish(Mark2ArrayMarker {
-            mark_class_count,
-            mark2_records_byte_len,
-        })
+        cursor.finish(
+            Mark2ArrayMarker {
+                mark_class_count,
+                mark2_records_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -3712,6 +4084,7 @@ impl<'a> Mark2Array<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, &args)
@@ -3719,17 +4092,18 @@ impl<'a> Mark2Array<'a> {
 }
 
 /// Part of [MarkMarkPosFormat1]Class2Record
-pub type Mark2Array<'a> = TableRef<'a, Mark2ArrayMarker>;
+pub type Mark2Array<'a> = TableRef<'a, Mark2ArrayMarker, Mark2ArrayFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Mark2Array<'a> {
     /// Number of Mark2 records
+    #[inline]
     pub fn mark2_count(&self) -> u16 {
-        let range = self.shape.mark2_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().mark2_count.get()
     }
 
     /// Array of Mark2Records, in Coverage order.
+    #[inline]
     pub fn mark2_records(&self) -> ComputedArray<'a, Mark2Record<'a>> {
         let range = self.shape.mark2_records_byte_range();
         self.data
@@ -3784,6 +4158,7 @@ impl<'a> Mark2Record<'a> {
     /// Array of offsets (one per class) to Anchor tables. Offsets are
     /// from beginning of Mark2Array table, in class order (offsets may
     /// be NULL).
+    #[inline]
     pub fn mark2_anchor_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         self.mark2_anchor_offsets
     }
@@ -3794,6 +4169,7 @@ impl<'a> Mark2Record<'a> {
     ///
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
+    #[inline]
     pub fn mark2_anchors(
         &self,
         data: FontData<'a>,
@@ -3869,6 +4245,19 @@ impl Format<u16> for ExtensionPosFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct ExtensionPosFormat1FixedFields {
+    pub pos_format: BigEndian<u16>,
+    pub extension_lookup_type: BigEndian<u16>,
+    pub extension_offset: BigEndian<Offset32>,
+}
+
+impl FixedSize for ExtensionPosFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
+}
+
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
 #[derive(Debug)]
 #[doc(hidden)]
@@ -3908,26 +4297,31 @@ impl<T> Clone for ExtensionPosFormat1Marker<T> {
 impl<T> Copy for ExtensionPosFormat1Marker<T> {}
 
 impl<'a, T> FontRead<'a> for ExtensionPosFormat1<'a, T> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        cursor.finish(ExtensionPosFormat1Marker {
-            offset_type: std::marker::PhantomData,
-        })
+        let fixed_fields: &'a ExtensionPosFormat1FixedFields = cursor.read_ref()?;
+        cursor.finish(
+            ExtensionPosFormat1Marker {
+                offset_type: std::marker::PhantomData,
+            },
+            fixed_fields,
+        )
     }
 }
 
 impl<'a> ExtensionPosFormat1<'a, ()> {
     #[allow(dead_code)]
     pub(crate) fn into_concrete<T>(self) -> ExtensionPosFormat1<'a, T> {
-        let TableRef { data, .. } = self;
+        let TableRef {
+            data, fixed_fields, ..
+        } = self;
         TableRef {
             shape: ExtensionPosFormat1Marker {
                 offset_type: std::marker::PhantomData,
             },
             data,
+            fixed_fields,
         }
     }
 }
@@ -3936,43 +4330,48 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`
     pub(crate) fn of_unit_type(&self) -> ExtensionPosFormat1<'a, ()> {
-        let TableRef { data, .. } = self;
+        let TableRef {
+            data, fixed_fields, ..
+        } = self;
         TableRef {
             shape: ExtensionPosFormat1Marker {
                 offset_type: std::marker::PhantomData,
             },
             data: *data,
+            fixed_fields: *fixed_fields,
         }
     }
 }
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
-pub type ExtensionPosFormat1<'a, T> = TableRef<'a, ExtensionPosFormat1Marker<T>>;
+pub type ExtensionPosFormat1<'a, T> =
+    TableRef<'a, ExtensionPosFormat1Marker<T>, ExtensionPosFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// Format identifier: format = 1
+    #[inline]
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().pos_format.get()
     }
 
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
+    #[inline]
     pub fn extension_lookup_type(&self) -> u16 {
-        let range = self.shape.extension_lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().extension_lookup_type.get()
     }
 
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
     /// ExtensionPosFormat1 subtable.
+    #[inline]
     pub fn extension_offset(&self) -> Offset32 {
-        let range = self.shape.extension_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().extension_offset.get()
     }
 
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].
+    #[inline]
     pub fn extension(&self) -> Result<T, ReadError>
     where
         T: FontRead<'a>,
@@ -4024,6 +4423,7 @@ pub enum ExtensionSubtable<'a> {
 }
 
 impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
+    #[inline]
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
         let untyped = ExtensionPosFormat1::read(bytes)?;
         match untyped.extension_lookup_type() {

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -692,6 +692,21 @@ impl<'a> From<Flags> for FieldType<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct HeadFixedFields {
+    pub version: BigEndian<MajorMinor>,
+    pub font_revision: BigEndian<Fixed>,
+    pub checksum_adjustment: BigEndian<u32>,
+    pub magic_number: BigEndian<u32>,
+}
+
+impl FixedSize for HeadFixedFields {
+    const RAW_BYTE_LEN: usize =
+        MajorMinor::RAW_BYTE_LEN + Fixed::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+}
+
 /// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
 /// (font header) table.
 #[derive(Debug, Clone, Copy)]
@@ -797,12 +812,10 @@ impl TopLevelTable for Head<'_> {
 }
 
 impl<'a> FontRead<'a> for Head<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
+        let fixed_fields: &'a HeadFixedFields = cursor.read_ref()?;
         cursor.advance::<Flags>();
         cursor.advance::<u16>();
         cursor.advance::<LongDateTime>();
@@ -816,26 +829,26 @@ impl<'a> FontRead<'a> for Head<'a> {
         cursor.advance::<i16>();
         cursor.advance::<i16>();
         cursor.advance::<i16>();
-        cursor.finish(HeadMarker {})
+        cursor.finish(HeadMarker {}, fixed_fields)
     }
 }
 
 /// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
 /// (font header) table.
-pub type Head<'a> = TableRef<'a, HeadMarker>;
+pub type Head<'a> = TableRef<'a, HeadMarker, HeadFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Head<'a> {
     /// Version number of the font header table, set to (1, 0)
+    #[inline]
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// Set by font manufacturer.
+    #[inline]
     pub fn font_revision(&self) -> Fixed {
-        let range = self.shape.font_revision_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().font_revision.get()
     }
 
     /// To compute: set it to 0, sum the entire font as uint32, then
@@ -843,18 +856,19 @@ impl<'a> Head<'a> {
     /// font collection file, the value of this field will be
     /// invalidated by changes to the file structure and font table
     /// directory, and must be ignored.
+    #[inline]
     pub fn checksum_adjustment(&self) -> u32 {
-        let range = self.shape.checksum_adjustment_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().checksum_adjustment.get()
     }
 
     /// Set to 0x5F0F3CF5.
+    #[inline]
     pub fn magic_number(&self) -> u32 {
-        let range = self.shape.magic_number_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().magic_number.get()
     }
 
     /// See the flags enum.
+    #[inline]
     pub fn flags(&self) -> Flags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -864,6 +878,7 @@ impl<'a> Head<'a> {
     /// valid. In fonts that have TrueType outlines, a power of 2 is
     /// recommended as this allows performance optimizations in some
     /// rasterizers.
+    #[inline]
     pub fn units_per_em(&self) -> u16 {
         let range = self.shape.units_per_em_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -871,6 +886,7 @@ impl<'a> Head<'a> {
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
+    #[inline]
     pub fn created(&self) -> LongDateTime {
         let range = self.shape.created_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -878,60 +894,70 @@ impl<'a> Head<'a> {
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
+    #[inline]
     pub fn modified(&self) -> LongDateTime {
         let range = self.shape.modified_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum x coordinate across all glyph bounding boxes.
+    #[inline]
     pub fn x_min(&self) -> i16 {
         let range = self.shape.x_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum y coordinate across all glyph bounding boxes.
+    #[inline]
     pub fn y_min(&self) -> i16 {
         let range = self.shape.y_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum x coordinate across all glyph bounding boxes.
+    #[inline]
     pub fn x_max(&self) -> i16 {
         let range = self.shape.x_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum y coordinate across all glyph bounding boxes.
+    #[inline]
     pub fn y_max(&self) -> i16 {
         let range = self.shape.y_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Bits identifying the font's style; see [MacStyle]
+    #[inline]
     pub fn mac_style(&self) -> MacStyle {
         let range = self.shape.mac_style_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Smallest readable size in pixels.
+    #[inline]
     pub fn lowest_rec_ppem(&self) -> u16 {
         let range = self.shape.lowest_rec_ppem_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Deprecated (Set to 2).
+    #[inline]
     pub fn font_direction_hint(&self) -> i16 {
         let range = self.shape.font_direction_hint_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for short offsets (Offset16), 1 for long (Offset32).
+    #[inline]
     pub fn index_to_loc_format(&self) -> i16 {
         let range = self.shape.index_to_loc_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for current format.
+    #[inline]
     pub fn glyph_data_format(&self) -> i16 {
         let range = self.shape.glyph_data_format_byte_range();
         self.data.read_at(range.start).unwrap()

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -444,11 +444,27 @@ pub struct PatchMapFormat1FixedFields {
     pub _reserved_0: u8,
     pub _reserved_1: u8,
     pub _reserved_2: u8,
+    pub field_flags: BigEndian<PatchMapFieldPresenceFlags>,
+    pub compatibility_id: BigEndian<CompatibilityId>,
+    pub max_entry_index: BigEndian<u16>,
+    pub max_glyph_map_entry_index: BigEndian<u16>,
+    pub glyph_count: BigEndian<Uint24>,
+    pub glyph_map_offset: BigEndian<Offset32>,
+    pub feature_map_offset: BigEndian<Nullable<Offset32>>,
 }
 
 impl FixedSize for PatchMapFormat1FixedFields {
-    const RAW_BYTE_LEN: usize =
-        u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + PatchMapFieldPresenceFlags::RAW_BYTE_LEN
+        + CompatibilityId::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + Uint24::RAW_BYTE_LEN
+        + Offset32::RAW_BYTE_LEN
+        + Offset32::RAW_BYTE_LEN;
 }
 
 /// [Patch Map Format Format 1](https://w3c.github.io/IFT/Overview.html#patch-map-format-1)
@@ -559,13 +575,8 @@ impl<'a> FontRead<'a> for PatchMapFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a PatchMapFormat1FixedFields = cursor.read_ref()?;
-        let field_flags: PatchMapFieldPresenceFlags = cursor.read()?;
-        cursor.advance::<CompatibilityId>();
-        let max_entry_index: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<Uint24>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
+        let field_flags = fixed_fields.field_flags.get();
+        let max_entry_index = fixed_fields.max_entry_index.get();
         let applied_entries_bitmap_byte_len = (transforms::max_value_bitmap_len(max_entry_index))
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
@@ -615,42 +626,36 @@ impl<'a> PatchMapFormat1<'a> {
 
     #[inline]
     pub fn field_flags(&self) -> PatchMapFieldPresenceFlags {
-        let range = self.shape.field_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().field_flags.get()
     }
 
     /// Unique ID that identifies compatible patches.
     #[inline]
     pub fn compatibility_id(&self) -> CompatibilityId {
-        let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().compatibility_id.get()
     }
 
     /// Largest entry index which appears in either the glyph map or feature map.
     #[inline]
     pub fn max_entry_index(&self) -> u16 {
-        let range = self.shape.max_entry_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().max_entry_index.get()
     }
 
     /// Largest entry index which appears in the glyph map.
     #[inline]
     pub fn max_glyph_map_entry_index(&self) -> u16 {
-        let range = self.shape.max_glyph_map_entry_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().max_glyph_map_entry_index.get()
     }
 
     #[inline]
     pub fn glyph_count(&self) -> Uint24 {
-        let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().glyph_count.get()
     }
 
     /// Sub table that maps glyph ids to entry indices.
     #[inline]
     pub fn glyph_map_offset(&self) -> Offset32 {
-        let range = self.shape.glyph_map_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().glyph_map_offset.get()
     }
 
     /// Attempt to resolve [`glyph_map_offset`][Self::glyph_map_offset].
@@ -664,8 +669,7 @@ impl<'a> PatchMapFormat1<'a> {
     /// Sub table that maps feature and glyph ids to entry indices.
     #[inline]
     pub fn feature_map_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.feature_map_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().feature_map_offset.get()
     }
 
     /// Attempt to resolve [`feature_map_offset`][Self::feature_map_offset].
@@ -1218,11 +1222,27 @@ pub struct PatchMapFormat2FixedFields {
     pub _reserved_0: u8,
     pub _reserved_1: u8,
     pub _reserved_2: u8,
+    pub field_flags: BigEndian<PatchMapFieldPresenceFlags>,
+    pub compatibility_id: BigEndian<CompatibilityId>,
+    pub default_patch_format: u8,
+    pub entry_count: BigEndian<Uint24>,
+    pub entries_offset: BigEndian<Offset32>,
+    pub entry_id_string_data_offset: BigEndian<Nullable<Offset32>>,
+    pub url_template_length: BigEndian<u16>,
 }
 
 impl FixedSize for PatchMapFormat2FixedFields {
-    const RAW_BYTE_LEN: usize =
-        u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + PatchMapFieldPresenceFlags::RAW_BYTE_LEN
+        + CompatibilityId::RAW_BYTE_LEN
+        + u8::RAW_BYTE_LEN
+        + Uint24::RAW_BYTE_LEN
+        + Offset32::RAW_BYTE_LEN
+        + Offset32::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN;
 }
 
 /// [Patch Map Format Format 2](https://w3c.github.io/IFT/Overview.html#patch-map-format-2)
@@ -1317,13 +1337,8 @@ impl<'a> FontRead<'a> for PatchMapFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a PatchMapFormat2FixedFields = cursor.read_ref()?;
-        let field_flags: PatchMapFieldPresenceFlags = cursor.read()?;
-        cursor.advance::<CompatibilityId>();
-        cursor.advance::<u8>();
-        cursor.advance::<Uint24>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        let url_template_length: u16 = cursor.read()?;
+        let field_flags = fixed_fields.field_flags.get();
+        let url_template_length = fixed_fields.url_template_length.get();
         let url_template_byte_len = (url_template_length as usize)
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
@@ -1366,34 +1381,29 @@ impl<'a> PatchMapFormat2<'a> {
 
     #[inline]
     pub fn field_flags(&self) -> PatchMapFieldPresenceFlags {
-        let range = self.shape.field_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().field_flags.get()
     }
 
     /// Unique ID that identifies compatible patches.
     #[inline]
     pub fn compatibility_id(&self) -> CompatibilityId {
-        let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().compatibility_id.get()
     }
 
     /// Patch format number for patches referenced by this mapping.
     #[inline]
     pub fn default_patch_format(&self) -> u8 {
-        let range = self.shape.default_patch_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().default_patch_format
     }
 
     #[inline]
     pub fn entry_count(&self) -> Uint24 {
-        let range = self.shape.entry_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().entry_count.get()
     }
 
     #[inline]
     pub fn entries_offset(&self) -> Offset32 {
-        let range = self.shape.entries_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().entries_offset.get()
     }
 
     /// Attempt to resolve [`entries_offset`][Self::entries_offset].
@@ -1405,8 +1415,7 @@ impl<'a> PatchMapFormat2<'a> {
 
     #[inline]
     pub fn entry_id_string_data_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.entry_id_string_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().entry_id_string_data_offset.get()
     }
 
     /// Attempt to resolve [`entry_id_string_data_offset`][Self::entry_id_string_data_offset].
@@ -1418,8 +1427,7 @@ impl<'a> PatchMapFormat2<'a> {
 
     #[inline]
     pub fn url_template_length(&self) -> u16 {
-        let range = self.shape.url_template_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().url_template_length.get()
     }
 
     #[inline]
@@ -1582,10 +1590,12 @@ impl<'a> std::fmt::Debug for MappingEntries<'a> {
 #[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
-pub struct EntryDataFixedFields {}
+pub struct EntryDataFixedFields {
+    pub format_flags: BigEndian<EntryFormatFlags>,
+}
 
 impl FixedSize for EntryDataFixedFields {
-    const RAW_BYTE_LEN: usize = 0;
+    const RAW_BYTE_LEN: usize = EntryFormatFlags::RAW_BYTE_LEN;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1681,7 +1691,7 @@ impl<'a> FontRead<'a> for EntryData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a EntryDataFixedFields = cursor.read_ref()?;
-        let format_flags: EntryFormatFlags = cursor.read()?;
+        let format_flags = fixed_fields.format_flags.get();
         let feature_count_byte_start = format_flags
             .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
             .then(|| cursor.position())
@@ -1777,8 +1787,7 @@ pub type EntryData<'a> = TableRef<'a, EntryDataMarker, EntryDataFixedFields>;
 impl<'a> EntryData<'a> {
     #[inline]
     pub fn format_flags(&self) -> EntryFormatFlags {
-        let range = self.shape.format_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format_flags.get()
     }
 
     #[inline]
@@ -2326,10 +2335,13 @@ impl<'a> std::fmt::Debug for IdStringData<'a> {
 pub struct TableKeyedPatchFixedFields {
     pub format: BigEndian<Tag>,
     pub _reserved: BigEndian<u32>,
+    pub compatibility_id: BigEndian<CompatibilityId>,
+    pub patches_count: BigEndian<u16>,
 }
 
 impl FixedSize for TableKeyedPatchFixedFields {
-    const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize =
+        Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + CompatibilityId::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// [Table Keyed Patch](https://w3c.github.io/IFT/Overview.html#table-keyed)
@@ -2377,8 +2389,7 @@ impl<'a> FontRead<'a> for TableKeyedPatch<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a TableKeyedPatchFixedFields = cursor.read_ref()?;
-        cursor.advance::<CompatibilityId>();
-        let patches_count: u16 = cursor.read()?;
+        let patches_count = fixed_fields.patches_count.get();
         let patch_offsets_byte_len = (transforms::add(patches_count, 1_usize))
             .checked_mul(Offset32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
@@ -2405,14 +2416,12 @@ impl<'a> TableKeyedPatch<'a> {
     /// Unique ID that identifies compatible patches.
     #[inline]
     pub fn compatibility_id(&self) -> CompatibilityId {
-        let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().compatibility_id.get()
     }
 
     #[inline]
     pub fn patches_count(&self) -> u16 {
-        let range = self.shape.patches_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().patches_count.get()
     }
 
     #[inline]
@@ -2475,10 +2484,13 @@ impl<'a> std::fmt::Debug for TableKeyedPatch<'a> {
 #[repr(packed)]
 pub struct TablePatchFixedFields {
     pub tag: BigEndian<Tag>,
+    pub flags: BigEndian<TablePatchFlags>,
+    pub max_uncompressed_length: BigEndian<u32>,
 }
 
 impl FixedSize for TablePatchFixedFields {
-    const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize =
+        Tag::RAW_BYTE_LEN + TablePatchFlags::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 /// [TablePatch](https://w3c.github.io/IFT/Overview.html#tablepatch)
@@ -2521,8 +2533,6 @@ impl<'a> FontRead<'a> for TablePatch<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a TablePatchFixedFields = cursor.read_ref()?;
-        cursor.advance::<TablePatchFlags>();
-        cursor.advance::<u32>();
         let brotli_stream_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(brotli_stream_byte_len);
         cursor.finish(
@@ -2546,14 +2556,12 @@ impl<'a> TablePatch<'a> {
 
     #[inline]
     pub fn flags(&self) -> TablePatchFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     #[inline]
     pub fn max_uncompressed_length(&self) -> u32 {
-        let range = self.shape.max_uncompressed_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().max_uncompressed_length.get()
     }
 
     #[inline]
@@ -2901,10 +2909,17 @@ impl<'a> From<TablePatchFlags> for FieldType<'a> {
 pub struct GlyphKeyedPatchFixedFields {
     pub format: BigEndian<Tag>,
     pub _reserved: BigEndian<u32>,
+    pub flags: BigEndian<GlyphKeyedFlags>,
+    pub compatibility_id: BigEndian<CompatibilityId>,
+    pub max_uncompressed_length: BigEndian<u32>,
 }
 
 impl FixedSize for GlyphKeyedPatchFixedFields {
-    const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN
+        + GlyphKeyedFlags::RAW_BYTE_LEN
+        + CompatibilityId::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN;
 }
 
 /// [Glyph Keyed Patch](https://w3c.github.io/IFT/Overview.html#glyph-keyed)
@@ -2957,9 +2972,6 @@ impl<'a> FontRead<'a> for GlyphKeyedPatch<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a GlyphKeyedPatchFixedFields = cursor.read_ref()?;
-        cursor.advance::<GlyphKeyedFlags>();
-        cursor.advance::<CompatibilityId>();
-        cursor.advance::<u32>();
         let brotli_stream_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(brotli_stream_byte_len);
         cursor.finish(
@@ -2983,20 +2995,17 @@ impl<'a> GlyphKeyedPatch<'a> {
 
     #[inline]
     pub fn flags(&self) -> GlyphKeyedFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     #[inline]
     pub fn compatibility_id(&self) -> CompatibilityId {
-        let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().compatibility_id.get()
     }
 
     #[inline]
     pub fn max_uncompressed_length(&self) -> u32 {
-        let range = self.shape.max_uncompressed_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().max_uncompressed_length.get()
     }
 
     #[inline]

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -5,6 +5,33 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct PostFixedFields {
+    pub version: BigEndian<Version16Dot16>,
+    pub italic_angle: BigEndian<Fixed>,
+    pub underline_position: BigEndian<FWord>,
+    pub underline_thickness: BigEndian<FWord>,
+    pub is_fixed_pitch: BigEndian<u32>,
+    pub min_mem_type42: BigEndian<u32>,
+    pub max_mem_type42: BigEndian<u32>,
+    pub min_mem_type1: BigEndian<u32>,
+    pub max_mem_type1: BigEndian<u32>,
+}
+
+impl FixedSize for PostFixedFields {
+    const RAW_BYTE_LEN: usize = Version16Dot16::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN
+        + u32::RAW_BYTE_LEN;
+}
+
 /// [post (PostScript)](https://docs.microsoft.com/en-us/typography/opentype/spec/post#header) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -90,17 +117,11 @@ impl TopLevelTable for Post<'_> {
 }
 
 impl<'a> FontRead<'a> for Post<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let version: Version16Dot16 = cursor.read()?;
-        cursor.advance::<Fixed>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
+        let fixed_fields: &'a PostFixedFields = cursor.read_ref()?;
+        let version = fixed_fields.version.get();
         let num_glyphs_byte_start = version
             .compatible((2u16, 0u16))
             .then(|| cursor.position())
@@ -132,35 +153,38 @@ impl<'a> FontRead<'a> for Post<'a> {
         if let Some(value) = string_data_byte_len {
             cursor.advance_by(value);
         }
-        cursor.finish(PostMarker {
-            num_glyphs_byte_start,
-            glyph_name_index_byte_start,
-            glyph_name_index_byte_len,
-            string_data_byte_start,
-            string_data_byte_len,
-        })
+        cursor.finish(
+            PostMarker {
+                num_glyphs_byte_start,
+                glyph_name_index_byte_start,
+                glyph_name_index_byte_len,
+                string_data_byte_start,
+                string_data_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [post (PostScript)](https://docs.microsoft.com/en-us/typography/opentype/spec/post#header) table
-pub type Post<'a> = TableRef<'a, PostMarker>;
+pub type Post<'a> = TableRef<'a, PostMarker, PostFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Post<'a> {
     /// 0x00010000 for version 1.0 0x00020000 for version 2.0
     /// 0x00025000 for version 2.5 (deprecated) 0x00030000 for version
     /// 3.0
+    #[inline]
     pub fn version(&self) -> Version16Dot16 {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// Italic angle in counter-clockwise degrees from the vertical.
     /// Zero for upright text, negative for text that leans to the
     /// right (forward).
+    #[inline]
     pub fn italic_angle(&self) -> Fixed {
-        let range = self.shape.italic_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().italic_angle.get()
     }
 
     /// This is the suggested distance of the top of the underline from
@@ -170,67 +194,70 @@ impl<'a> Post<'a> {
     /// historical reasons. The value of the PostScript key may be
     /// calculated by subtracting half the underlineThickness from the
     /// value of this field.
+    #[inline]
     pub fn underline_position(&self) -> FWord {
-        let range = self.shape.underline_position_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().underline_position.get()
     }
 
     /// Suggested values for the underline thickness. In general, the
     /// underline thickness should match the thickness of the
     /// underscore character (U+005F LOW LINE), and should also match
     /// the strikeout thickness, which is specified in the OS/2 table.
+    #[inline]
     pub fn underline_thickness(&self) -> FWord {
-        let range = self.shape.underline_thickness_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().underline_thickness.get()
     }
 
     /// Set to 0 if the font is proportionally spaced, non-zero if the
     /// font is not proportionally spaced (i.e. monospaced).
+    #[inline]
     pub fn is_fixed_pitch(&self) -> u32 {
-        let range = self.shape.is_fixed_pitch_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().is_fixed_pitch.get()
     }
 
     /// Minimum memory usage when an OpenType font is downloaded.
+    #[inline]
     pub fn min_mem_type42(&self) -> u32 {
-        let range = self.shape.min_mem_type42_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().min_mem_type42.get()
     }
 
     /// Maximum memory usage when an OpenType font is downloaded.
+    #[inline]
     pub fn max_mem_type42(&self) -> u32 {
-        let range = self.shape.max_mem_type42_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().max_mem_type42.get()
     }
 
     /// Minimum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
+    #[inline]
     pub fn min_mem_type1(&self) -> u32 {
-        let range = self.shape.min_mem_type1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().min_mem_type1.get()
     }
 
     /// Maximum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
+    #[inline]
     pub fn max_mem_type1(&self) -> u32 {
-        let range = self.shape.max_mem_type1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().max_mem_type1.get()
     }
 
     /// Number of glyphs (this should be the same as numGlyphs in
     /// 'maxp' table).
+    #[inline]
     pub fn num_glyphs(&self) -> Option<u16> {
         let range = self.shape.num_glyphs_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Array of indices into the string data. See below for details.
+    #[inline]
     pub fn glyph_name_index(&self) -> Option<&'a [BigEndian<u16>]> {
         let range = self.shape.glyph_name_index_byte_range()?;
         Some(self.data.read_array(range).unwrap())
     }
 
     /// Storage for the string data.
+    #[inline]
     pub fn string_data(&self) -> Option<VarLenArray<'a, PString<'a>>> {
         let range = self.shape.string_data_byte_range()?;
         Some(VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap())

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -5,6 +5,18 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Index1FixedFields {
+    pub count: BigEndian<u16>,
+    pub off_size: u8,
+}
+
+impl FixedSize for Index1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
+}
+
 /// An array of variable-sized objects in a `CFF` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -42,47 +54,54 @@ impl MinByteRange for Index1Marker {
 }
 
 impl<'a> FontRead<'a> for Index1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let count: u16 = cursor.read()?;
-        let off_size: u8 = cursor.read()?;
+        let fixed_fields: &'a Index1FixedFields = cursor.read_ref()?;
+        let count = fixed_fields.count.get();
+        let off_size = fixed_fields.off_size;
         let offsets_byte_len = (transforms::add_multiply(count, 1_usize, off_size))
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(offsets_byte_len);
         let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
-        cursor.finish(Index1Marker {
-            offsets_byte_len,
-            data_byte_len,
-        })
+        cursor.finish(
+            Index1Marker {
+                offsets_byte_len,
+                data_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// An array of variable-sized objects in a `CFF` table.
-pub type Index1<'a> = TableRef<'a, Index1Marker>;
+pub type Index1<'a> = TableRef<'a, Index1Marker, Index1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Index1<'a> {
     /// Number of objects stored in INDEX.
+    #[inline]
     pub fn count(&self) -> u16 {
-        let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().count.get()
     }
 
     /// Object array element size.
+    #[inline]
     pub fn off_size(&self) -> u8 {
-        let range = self.shape.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().off_size
     }
 
     /// Bytes containing `count + 1` offsets each of `off_size`.
+    #[inline]
     pub fn offsets(&self) -> &'a [u8] {
         let range = self.shape.offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Array containing the object data.
+    #[inline]
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
         self.data.read_array(range).unwrap()
@@ -111,6 +130,18 @@ impl<'a> std::fmt::Debug for Index1<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Index2FixedFields {
+    pub count: BigEndian<u32>,
+    pub off_size: u8,
+}
+
+impl FixedSize for Index2FixedFields {
+    const RAW_BYTE_LEN: usize = u32::RAW_BYTE_LEN + u8::RAW_BYTE_LEN;
 }
 
 /// An array of variable-sized objects in a `CFF2` table.
@@ -150,47 +181,54 @@ impl MinByteRange for Index2Marker {
 }
 
 impl<'a> FontRead<'a> for Index2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let count: u32 = cursor.read()?;
-        let off_size: u8 = cursor.read()?;
+        let fixed_fields: &'a Index2FixedFields = cursor.read_ref()?;
+        let count = fixed_fields.count.get();
+        let off_size = fixed_fields.off_size;
         let offsets_byte_len = (transforms::add_multiply(count, 1_usize, off_size))
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(offsets_byte_len);
         let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
-        cursor.finish(Index2Marker {
-            offsets_byte_len,
-            data_byte_len,
-        })
+        cursor.finish(
+            Index2Marker {
+                offsets_byte_len,
+                data_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// An array of variable-sized objects in a `CFF2` table.
-pub type Index2<'a> = TableRef<'a, Index2Marker>;
+pub type Index2<'a> = TableRef<'a, Index2Marker, Index2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Index2<'a> {
     /// Number of objects stored in INDEX.
+    #[inline]
     pub fn count(&self) -> u32 {
-        let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().count.get()
     }
 
     /// Object array element size.
+    #[inline]
     pub fn off_size(&self) -> u8 {
-        let range = self.shape.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().off_size
     }
 
     /// Bytes containing `count + 1` offsets each of `off_size`.
+    #[inline]
     pub fn offsets(&self) -> &'a [u8] {
         let range = self.shape.offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Array containing the object data.
+    #[inline]
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
         self.data.read_array(range).unwrap()
@@ -231,6 +269,7 @@ pub enum FdSelect<'a> {
 
 impl<'a> FdSelect<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format0(item) => item.offset_data(),
@@ -240,6 +279,7 @@ impl<'a> FdSelect<'a> {
     }
 
     /// Format = 0.
+    #[inline]
     pub fn format(&self) -> u8 {
         match self {
             Self::Format0(item) => item.format(),
@@ -303,6 +343,17 @@ impl Format<u8> for FdSelectFormat0Marker {
     const FORMAT: u8 = 0;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct FdSelectFormat0FixedFields {
+    pub format: u8,
+}
+
+impl FixedSize for FdSelectFormat0FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN;
+}
+
 /// FdSelect format 0.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -329,27 +380,29 @@ impl MinByteRange for FdSelectFormat0Marker {
 }
 
 impl<'a> FontRead<'a> for FdSelectFormat0<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
+        let fixed_fields: &'a FdSelectFormat0FixedFields = cursor.read_ref()?;
         let fds_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(fds_byte_len);
-        cursor.finish(FdSelectFormat0Marker { fds_byte_len })
+        cursor.finish(FdSelectFormat0Marker { fds_byte_len }, fixed_fields)
     }
 }
 
 /// FdSelect format 0.
-pub type FdSelectFormat0<'a> = TableRef<'a, FdSelectFormat0Marker>;
+pub type FdSelectFormat0<'a> = TableRef<'a, FdSelectFormat0Marker, FdSelectFormat0FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FdSelectFormat0<'a> {
     /// Format = 0.
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// FD selector array (one entry for each glyph).
+    #[inline]
     pub fn fds(&self) -> &'a [u8] {
         let range = self.shape.fds_byte_range();
         self.data.read_array(range).unwrap()
@@ -380,6 +433,18 @@ impl<'a> std::fmt::Debug for FdSelectFormat0<'a> {
 
 impl Format<u8> for FdSelectFormat3Marker {
     const FORMAT: u8 = 3;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct FdSelectFormat3FixedFields {
+    pub format: u8,
+    pub n_ranges: BigEndian<u16>,
+}
+
+impl FixedSize for FdSelectFormat3FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// FdSelect format 3.
@@ -418,43 +483,46 @@ impl MinByteRange for FdSelectFormat3Marker {
 }
 
 impl<'a> FontRead<'a> for FdSelectFormat3<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let n_ranges: u16 = cursor.read()?;
+        let fixed_fields: &'a FdSelectFormat3FixedFields = cursor.read_ref()?;
+        let n_ranges = fixed_fields.n_ranges.get();
         let ranges_byte_len = (n_ranges as usize)
             .checked_mul(FdSelectRange3::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ranges_byte_len);
         cursor.advance::<u16>();
-        cursor.finish(FdSelectFormat3Marker { ranges_byte_len })
+        cursor.finish(FdSelectFormat3Marker { ranges_byte_len }, fixed_fields)
     }
 }
 
 /// FdSelect format 3.
-pub type FdSelectFormat3<'a> = TableRef<'a, FdSelectFormat3Marker>;
+pub type FdSelectFormat3<'a> = TableRef<'a, FdSelectFormat3Marker, FdSelectFormat3FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FdSelectFormat3<'a> {
     /// Format = 3.
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// Number of ranges.
+    #[inline]
     pub fn n_ranges(&self) -> u16 {
-        let range = self.shape.n_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().n_ranges.get()
     }
 
     /// Range3 array.
+    #[inline]
     pub fn ranges(&self) -> &'a [FdSelectRange3] {
         let range = self.shape.ranges_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Sentinel GID. Set equal to the number of glyphs in the font.
+    #[inline]
     pub fn sentinel(&self) -> u16 {
         let range = self.shape.sentinel_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -505,11 +573,13 @@ pub struct FdSelectRange3 {
 
 impl FdSelectRange3 {
     /// First glyph index in range.
+    #[inline]
     pub fn first(&self) -> u16 {
         self.first.get()
     }
 
     /// FD index for all glyphs in range.
+    #[inline]
     pub fn fd(&self) -> u8 {
         self.fd
     }
@@ -536,6 +606,18 @@ impl<'a> SomeRecord<'a> for FdSelectRange3 {
 
 impl Format<u8> for FdSelectFormat4Marker {
     const FORMAT: u8 = 4;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct FdSelectFormat4FixedFields {
+    pub format: u8,
+    pub n_ranges: BigEndian<u32>,
+}
+
+impl FixedSize for FdSelectFormat4FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN + u32::RAW_BYTE_LEN;
 }
 
 /// FdSelect format 4.
@@ -574,43 +656,46 @@ impl MinByteRange for FdSelectFormat4Marker {
 }
 
 impl<'a> FontRead<'a> for FdSelectFormat4<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let n_ranges: u32 = cursor.read()?;
+        let fixed_fields: &'a FdSelectFormat4FixedFields = cursor.read_ref()?;
+        let n_ranges = fixed_fields.n_ranges.get();
         let ranges_byte_len = (n_ranges as usize)
             .checked_mul(FdSelectRange4::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ranges_byte_len);
         cursor.advance::<u32>();
-        cursor.finish(FdSelectFormat4Marker { ranges_byte_len })
+        cursor.finish(FdSelectFormat4Marker { ranges_byte_len }, fixed_fields)
     }
 }
 
 /// FdSelect format 4.
-pub type FdSelectFormat4<'a> = TableRef<'a, FdSelectFormat4Marker>;
+pub type FdSelectFormat4<'a> = TableRef<'a, FdSelectFormat4Marker, FdSelectFormat4FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FdSelectFormat4<'a> {
     /// Format = 4.
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// Number of ranges.
+    #[inline]
     pub fn n_ranges(&self) -> u32 {
-        let range = self.shape.n_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().n_ranges.get()
     }
 
     /// Range4 array.
+    #[inline]
     pub fn ranges(&self) -> &'a [FdSelectRange4] {
         let range = self.shape.ranges_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Sentinel GID. Set equal to the number of glyphs in the font.
+    #[inline]
     pub fn sentinel(&self) -> u32 {
         let range = self.shape.sentinel_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -661,11 +746,13 @@ pub struct FdSelectRange4 {
 
 impl FdSelectRange4 {
     /// First glyph index in range.
+    #[inline]
     pub fn first(&self) -> u32 {
         self.first.get()
     }
 
     /// FD index for all glyphs in range.
+    #[inline]
     pub fn fd(&self) -> u16 {
         self.fd.get()
     }
@@ -700,6 +787,7 @@ pub enum CustomCharset<'a> {
 
 impl<'a> CustomCharset<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format0(item) => item.offset_data(),
@@ -709,6 +797,7 @@ impl<'a> CustomCharset<'a> {
     }
 
     /// Format; =0
+    #[inline]
     pub fn format(&self) -> u8 {
         match self {
             Self::Format0(item) => item.format(),
@@ -772,6 +861,17 @@ impl Format<u8> for CharsetFormat0Marker {
     const FORMAT: u8 = 0;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CharsetFormat0FixedFields {
+    pub format: u8,
+}
+
+impl FixedSize for CharsetFormat0FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN;
+}
+
 /// Charset format 0.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -798,27 +898,29 @@ impl MinByteRange for CharsetFormat0Marker {
 }
 
 impl<'a> FontRead<'a> for CharsetFormat0<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
+        let fixed_fields: &'a CharsetFormat0FixedFields = cursor.read_ref()?;
         let glyph_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
         cursor.advance_by(glyph_byte_len);
-        cursor.finish(CharsetFormat0Marker { glyph_byte_len })
+        cursor.finish(CharsetFormat0Marker { glyph_byte_len }, fixed_fields)
     }
 }
 
 /// Charset format 0.
-pub type CharsetFormat0<'a> = TableRef<'a, CharsetFormat0Marker>;
+pub type CharsetFormat0<'a> = TableRef<'a, CharsetFormat0Marker, CharsetFormat0FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharsetFormat0<'a> {
     /// Format; =0
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// Glyph name array.
+    #[inline]
     pub fn glyph(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.glyph_byte_range();
         self.data.read_array(range).unwrap()
@@ -851,6 +953,17 @@ impl Format<u8> for CharsetFormat1Marker {
     const FORMAT: u8 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CharsetFormat1FixedFields {
+    pub format: u8,
+}
+
+impl FixedSize for CharsetFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN;
+}
+
 /// Charset format 1.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -877,28 +990,30 @@ impl MinByteRange for CharsetFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for CharsetFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
+        let fixed_fields: &'a CharsetFormat1FixedFields = cursor.read_ref()?;
         let ranges_byte_len =
             cursor.remaining_bytes() / CharsetRange1::RAW_BYTE_LEN * CharsetRange1::RAW_BYTE_LEN;
         cursor.advance_by(ranges_byte_len);
-        cursor.finish(CharsetFormat1Marker { ranges_byte_len })
+        cursor.finish(CharsetFormat1Marker { ranges_byte_len }, fixed_fields)
     }
 }
 
 /// Charset format 1.
-pub type CharsetFormat1<'a> = TableRef<'a, CharsetFormat1Marker>;
+pub type CharsetFormat1<'a> = TableRef<'a, CharsetFormat1Marker, CharsetFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharsetFormat1<'a> {
     /// Format; =1
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// Range1 array.
+    #[inline]
     pub fn ranges(&self) -> &'a [CharsetRange1] {
         let range = self.shape.ranges_byte_range();
         self.data.read_array(range).unwrap()
@@ -947,11 +1062,13 @@ pub struct CharsetRange1 {
 
 impl CharsetRange1 {
     /// First glyph in range.
+    #[inline]
     pub fn first(&self) -> u16 {
         self.first.get()
     }
 
     /// Glyphs left in range (excluding first).
+    #[inline]
     pub fn n_left(&self) -> u8 {
         self.n_left
     }
@@ -980,6 +1097,17 @@ impl Format<u8> for CharsetFormat2Marker {
     const FORMAT: u8 = 2;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CharsetFormat2FixedFields {
+    pub format: u8,
+}
+
+impl FixedSize for CharsetFormat2FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN;
+}
+
 /// Charset format 2.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1006,28 +1134,30 @@ impl MinByteRange for CharsetFormat2Marker {
 }
 
 impl<'a> FontRead<'a> for CharsetFormat2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
+        let fixed_fields: &'a CharsetFormat2FixedFields = cursor.read_ref()?;
         let ranges_byte_len =
             cursor.remaining_bytes() / CharsetRange2::RAW_BYTE_LEN * CharsetRange2::RAW_BYTE_LEN;
         cursor.advance_by(ranges_byte_len);
-        cursor.finish(CharsetFormat2Marker { ranges_byte_len })
+        cursor.finish(CharsetFormat2Marker { ranges_byte_len }, fixed_fields)
     }
 }
 
 /// Charset format 2.
-pub type CharsetFormat2<'a> = TableRef<'a, CharsetFormat2Marker>;
+pub type CharsetFormat2<'a> = TableRef<'a, CharsetFormat2Marker, CharsetFormat2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharsetFormat2<'a> {
     /// Format; =2
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// Range2 array.
+    #[inline]
     pub fn ranges(&self) -> &'a [CharsetRange2] {
         let range = self.shape.ranges_byte_range();
         self.data.read_array(range).unwrap()
@@ -1076,11 +1206,13 @@ pub struct CharsetRange2 {
 
 impl CharsetRange2 {
     /// First glyph in range.
+    #[inline]
     pub fn first(&self) -> u16 {
         self.first.get()
     }
 
     /// Glyphs left in range (excluding first).
+    #[inline]
     pub fn n_left(&self) -> u16 {
         self.n_left.get()
     }

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -313,6 +313,17 @@ impl<'a> From<HeaderFlags> for FieldType<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct SbixFixedFields {
+    pub version: BigEndian<u16>,
+}
+
+impl FixedSize for SbixFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// The [sbix (Standard Bitmap Graphics)](https://docs.microsoft.com/en-us/typography/opentype/spec/sbix) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -359,20 +370,24 @@ impl ReadArgs for Sbix<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Sbix<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let num_glyphs = *args;
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a SbixFixedFields = cursor.read_ref()?;
         cursor.advance::<HeaderFlags>();
         let num_strikes: u32 = cursor.read()?;
         let strike_offsets_byte_len = (num_strikes as usize)
             .checked_mul(Offset32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(strike_offsets_byte_len);
-        cursor.finish(SbixMarker {
-            num_glyphs,
-            strike_offsets_byte_len,
-        })
+        cursor.finish(
+            SbixMarker {
+                num_glyphs,
+                strike_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -381,6 +396,7 @@ impl<'a> Sbix<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, num_glyphs: u16) -> Result<Self, ReadError> {
         let args = num_glyphs;
         Self::read_with_args(data, &args)
@@ -388,37 +404,41 @@ impl<'a> Sbix<'a> {
 }
 
 /// The [sbix (Standard Bitmap Graphics)](https://docs.microsoft.com/en-us/typography/opentype/spec/sbix) table
-pub type Sbix<'a> = TableRef<'a, SbixMarker>;
+pub type Sbix<'a> = TableRef<'a, SbixMarker, SbixFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Sbix<'a> {
     /// Table version number — set to 1.
+    #[inline]
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// Bit 0: Set to 1.
     /// Bit 1: Draw outlines.
     /// Bits 2 to 15: reserved (set to 0).
+    #[inline]
     pub fn flags(&self) -> HeaderFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of bitmap strikes.
+    #[inline]
     pub fn num_strikes(&self) -> u32 {
         let range = self.shape.num_strikes_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offsets from the beginning of the 'sbix' table to data for each individual bitmap strike.
+    #[inline]
     pub fn strike_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.strike_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// A dynamically resolving wrapper for [`strike_offsets`][Self::strike_offsets].
+    #[inline]
     pub fn strikes(&self) -> ArrayOfOffsets<'a, Strike<'a>, Offset32> {
         let data = self.data;
         let offsets = self.strike_offsets();
@@ -469,6 +489,18 @@ impl<'a> std::fmt::Debug for Sbix<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct StrikeFixedFields {
+    pub ppem: BigEndian<u16>,
+    pub ppi: BigEndian<u16>,
+}
+
+impl FixedSize for StrikeFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 /// [Strike](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#strikes) header table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -504,18 +536,21 @@ impl ReadArgs for Strike<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for Strike<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let num_glyphs = *args;
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a StrikeFixedFields = cursor.read_ref()?;
         let glyph_data_offsets_byte_len = (transforms::add(num_glyphs, 1_usize))
             .checked_mul(u32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_data_offsets_byte_len);
-        cursor.finish(StrikeMarker {
-            glyph_data_offsets_byte_len,
-        })
+        cursor.finish(
+            StrikeMarker {
+                glyph_data_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -524,6 +559,7 @@ impl<'a> Strike<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, num_glyphs: u16) -> Result<Self, ReadError> {
         let args = num_glyphs;
         Self::read_with_args(data, &args)
@@ -531,23 +567,24 @@ impl<'a> Strike<'a> {
 }
 
 /// [Strike](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#strikes) header table
-pub type Strike<'a> = TableRef<'a, StrikeMarker>;
+pub type Strike<'a> = TableRef<'a, StrikeMarker, StrikeFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Strike<'a> {
     /// The PPEM size for which this strike was designed.
+    #[inline]
     pub fn ppem(&self) -> u16 {
-        let range = self.shape.ppem_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().ppem.get()
     }
 
     /// The device pixel density (in PPI) for which this strike was designed. (E.g., 96 PPI, 192 PPI.)
+    #[inline]
     pub fn ppi(&self) -> u16 {
-        let range = self.shape.ppi_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().ppi.get()
     }
 
     /// Offset from the beginning of the strike data header to bitmap data for an individual glyph ID.
+    #[inline]
     pub fn glyph_data_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.glyph_data_offsets_byte_range();
         self.data.read_array(range).unwrap()
@@ -575,6 +612,19 @@ impl<'a> std::fmt::Debug for Strike<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct GlyphDataFixedFields {
+    pub origin_offset_x: BigEndian<i16>,
+    pub origin_offset_y: BigEndian<i16>,
+    pub graphic_type: BigEndian<Tag>,
+}
+
+impl FixedSize for GlyphDataFixedFields {
+    const RAW_BYTE_LEN: usize = i16::RAW_BYTE_LEN + i16::RAW_BYTE_LEN + Tag::RAW_BYTE_LEN;
 }
 
 /// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
@@ -613,41 +663,41 @@ impl MinByteRange for GlyphDataMarker {
 }
 
 impl<'a> FontRead<'a> for GlyphData<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<Tag>();
+        let fixed_fields: &'a GlyphDataFixedFields = cursor.read_ref()?;
         let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
-        cursor.finish(GlyphDataMarker { data_byte_len })
+        cursor.finish(GlyphDataMarker { data_byte_len }, fixed_fields)
     }
 }
 
 /// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
-pub type GlyphData<'a> = TableRef<'a, GlyphDataMarker>;
+pub type GlyphData<'a> = TableRef<'a, GlyphDataMarker, GlyphDataFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> GlyphData<'a> {
     /// The horizontal (x-axis) position of the left edge of the bitmap graphic in relation to the glyph design space origin.
+    #[inline]
     pub fn origin_offset_x(&self) -> i16 {
-        let range = self.shape.origin_offset_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().origin_offset_x.get()
     }
 
     /// The vertical (y-axis) position of the bottom edge of the bitmap graphic in relation to the glyph design space origin.
+    #[inline]
     pub fn origin_offset_y(&self) -> i16 {
-        let range = self.shape.origin_offset_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().origin_offset_y.get()
     }
 
     /// Indicates the format of the embedded graphic data: one of 'jpg ', 'png ' or 'tiff', or the special format 'dupe'.
+    #[inline]
     pub fn graphic_type(&self) -> Tag {
-        let range = self.shape.graphic_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().graphic_type.get()
     }
 
     /// The actual embedded graphic data. The total length is inferred from sequential entries in the glyphDataOffsets array and the fixed size (8 bytes) of the preceding fields.
+    #[inline]
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
         self.data.read_array(range).unwrap()

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -523,10 +523,17 @@ impl Format<u16> for AxisValueFormat1Marker {
 pub struct AxisValueFormat1FixedFields {
     pub format: BigEndian<u16>,
     pub axis_index: BigEndian<u16>,
+    pub flags: BigEndian<AxisValueTableFlags>,
+    pub value_name_id: BigEndian<NameId>,
+    pub value: BigEndian<Fixed>,
 }
 
 impl FixedSize for AxisValueFormat1FixedFields {
-    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + AxisValueTableFlags::RAW_BYTE_LEN
+        + NameId::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
@@ -572,9 +579,6 @@ impl<'a> FontRead<'a> for AxisValueFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a AxisValueFormat1FixedFields = cursor.read_ref()?;
-        cursor.advance::<AxisValueTableFlags>();
-        cursor.advance::<NameId>();
-        cursor.advance::<Fixed>();
         cursor.finish(AxisValueFormat1Marker {}, fixed_fields)
     }
 }
@@ -601,23 +605,20 @@ impl<'a> AxisValueFormat1<'a> {
     /// Flags — see below for details.
     #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     #[inline]
     pub fn value_name_id(&self) -> NameId {
-        let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value_name_id.get()
     }
 
     /// A numeric value for this attribute value.
     #[inline]
     pub fn value(&self) -> Fixed {
-        let range = self.shape.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value.get()
     }
 }
 
@@ -656,10 +657,21 @@ impl Format<u16> for AxisValueFormat2Marker {
 pub struct AxisValueFormat2FixedFields {
     pub format: BigEndian<u16>,
     pub axis_index: BigEndian<u16>,
+    pub flags: BigEndian<AxisValueTableFlags>,
+    pub value_name_id: BigEndian<NameId>,
+    pub nominal_value: BigEndian<Fixed>,
+    pub range_min_value: BigEndian<Fixed>,
+    pub range_max_value: BigEndian<Fixed>,
 }
 
 impl FixedSize for AxisValueFormat2FixedFields {
-    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + AxisValueTableFlags::RAW_BYTE_LEN
+        + NameId::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2)
@@ -715,11 +727,6 @@ impl<'a> FontRead<'a> for AxisValueFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a AxisValueFormat2FixedFields = cursor.read_ref()?;
-        cursor.advance::<AxisValueTableFlags>();
-        cursor.advance::<NameId>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
         cursor.finish(AxisValueFormat2Marker {}, fixed_fields)
     }
 }
@@ -746,39 +753,34 @@ impl<'a> AxisValueFormat2<'a> {
     /// Flags — see below for details.
     #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     #[inline]
     pub fn value_name_id(&self) -> NameId {
-        let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value_name_id.get()
     }
 
     /// A nominal numeric value for this attribute value.
     #[inline]
     pub fn nominal_value(&self) -> Fixed {
-        let range = self.shape.nominal_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().nominal_value.get()
     }
 
     /// The minimum value for a range associated with the specified
     /// name ID.
     #[inline]
     pub fn range_min_value(&self) -> Fixed {
-        let range = self.shape.range_min_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().range_min_value.get()
     }
 
     /// The maximum value for a range associated with the specified
     /// name ID.
     #[inline]
     pub fn range_max_value(&self) -> Fixed {
-        let range = self.shape.range_max_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().range_max_value.get()
     }
 }
 
@@ -819,10 +821,19 @@ impl Format<u16> for AxisValueFormat3Marker {
 pub struct AxisValueFormat3FixedFields {
     pub format: BigEndian<u16>,
     pub axis_index: BigEndian<u16>,
+    pub flags: BigEndian<AxisValueTableFlags>,
+    pub value_name_id: BigEndian<NameId>,
+    pub value: BigEndian<Fixed>,
+    pub linked_value: BigEndian<Fixed>,
 }
 
 impl FixedSize for AxisValueFormat3FixedFields {
-    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + AxisValueTableFlags::RAW_BYTE_LEN
+        + NameId::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN
+        + Fixed::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3)
@@ -873,10 +884,6 @@ impl<'a> FontRead<'a> for AxisValueFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a AxisValueFormat3FixedFields = cursor.read_ref()?;
-        cursor.advance::<AxisValueTableFlags>();
-        cursor.advance::<NameId>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
         cursor.finish(AxisValueFormat3Marker {}, fixed_fields)
     }
 }
@@ -903,30 +910,26 @@ impl<'a> AxisValueFormat3<'a> {
     /// Flags — see below for details.
     #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     #[inline]
     pub fn value_name_id(&self) -> NameId {
-        let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value_name_id.get()
     }
 
     /// A numeric value for this attribute value.
     #[inline]
     pub fn value(&self) -> Fixed {
-        let range = self.shape.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value.get()
     }
 
     /// The numeric value for a style-linked mapping from this value.
     #[inline]
     pub fn linked_value(&self) -> Fixed {
-        let range = self.shape.linked_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().linked_value.get()
     }
 }
 
@@ -966,10 +969,15 @@ impl Format<u16> for AxisValueFormat4Marker {
 pub struct AxisValueFormat4FixedFields {
     pub format: BigEndian<u16>,
     pub axis_count: BigEndian<u16>,
+    pub flags: BigEndian<AxisValueTableFlags>,
+    pub value_name_id: BigEndian<NameId>,
 }
 
 impl FixedSize for AxisValueFormat4FixedFields {
-    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + AxisValueTableFlags::RAW_BYTE_LEN
+        + NameId::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4)
@@ -1018,8 +1026,6 @@ impl<'a> FontRead<'a> for AxisValueFormat4<'a> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a AxisValueFormat4FixedFields = cursor.read_ref()?;
         let axis_count = fixed_fields.axis_count.get();
-        cursor.advance::<AxisValueTableFlags>();
-        cursor.advance::<NameId>();
         let axis_values_byte_len = (axis_count as usize)
             .checked_mul(AxisValueRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
@@ -1054,16 +1060,14 @@ impl<'a> AxisValueFormat4<'a> {
     /// Flags — see below for details.
     #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this combination of axis values.
     #[inline]
     pub fn value_name_id(&self) -> NameId {
-        let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value_name_id.get()
     }
 
     /// Array of AxisValue records that provide the combination of axis

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -5,6 +5,27 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct StatFixedFields {
+    pub version: BigEndian<MajorMinor>,
+    pub design_axis_size: BigEndian<u16>,
+    pub design_axis_count: BigEndian<u16>,
+    pub design_axes_offset: BigEndian<Offset32>,
+    pub axis_value_count: BigEndian<u16>,
+    pub offset_to_axis_value_offsets: BigEndian<Nullable<Offset32>>,
+}
+
+impl FixedSize for StatFixedFields {
+    const RAW_BYTE_LEN: usize = MajorMinor::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + Offset32::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN
+        + Offset32::RAW_BYTE_LEN;
+}
+
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -61,14 +82,11 @@ impl TopLevelTable for Stat<'_> {
 }
 
 impl<'a> FontRead<'a> for Stat<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let version: MajorMinor = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
+        let fixed_fields: &'a StatFixedFields = cursor.read_ref()?;
+        let version = fixed_fields.version.get();
         let elided_fallback_name_id_byte_start = version
             .compatible((1u16, 1u16))
             .then(|| cursor.position())
@@ -76,48 +94,52 @@ impl<'a> FontRead<'a> for Stat<'a> {
         version
             .compatible((1u16, 1u16))
             .then(|| cursor.advance::<NameId>());
-        cursor.finish(StatMarker {
-            elided_fallback_name_id_byte_start,
-        })
+        cursor.finish(
+            StatMarker {
+                elided_fallback_name_id_byte_start,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [STAT](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) (Style Attributes Table)
-pub type Stat<'a> = TableRef<'a, StatMarker>;
+pub type Stat<'a> = TableRef<'a, StatMarker, StatFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Stat<'a> {
     /// Major/minor version number. Set to 1.2 for new fonts.
+    #[inline]
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// The size in bytes of each axis record.
+    #[inline]
     pub fn design_axis_size(&self) -> u16 {
-        let range = self.shape.design_axis_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().design_axis_size.get()
     }
 
     /// The number of axis records. In a font with an 'fvar' table,
     /// this value must be greater than or equal to the axisCount value
     /// in the 'fvar' table. In all fonts, must be greater than zero if
     /// axisValueCount is greater than zero.
+    #[inline]
     pub fn design_axis_count(&self) -> u16 {
-        let range = self.shape.design_axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().design_axis_count.get()
     }
 
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes array. If designAxisCount is zero, set
     /// to zero; if designAxisCount is greater than zero, must be
     /// greater than zero.
+    #[inline]
     pub fn design_axes_offset(&self) -> Offset32 {
-        let range = self.shape.design_axes_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().design_axes_offset.get()
     }
 
     /// Attempt to resolve [`design_axes_offset`][Self::design_axes_offset].
+    #[inline]
     pub fn design_axes(&self) -> Result<&'a [AxisRecord], ReadError> {
         let data = self.data;
         let args = self.design_axis_count();
@@ -125,21 +147,22 @@ impl<'a> Stat<'a> {
     }
 
     /// The number of axis value tables.
+    #[inline]
     pub fn axis_value_count(&self) -> u16 {
-        let range = self.shape.axis_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().axis_value_count.get()
     }
 
     /// Offset in bytes from the beginning of the STAT table to the
     /// start of the design axes value offsets array. If axisValueCount
     /// is zero, set to zero; if axisValueCount is greater than zero,
     /// must be greater than zero.
+    #[inline]
     pub fn offset_to_axis_value_offsets(&self) -> Nullable<Offset32> {
-        let range = self.shape.offset_to_axis_value_offsets_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().offset_to_axis_value_offsets.get()
     }
 
     /// Attempt to resolve [`offset_to_axis_value_offsets`][Self::offset_to_axis_value_offsets].
+    #[inline]
     pub fn offset_to_axis_values(&self) -> Option<Result<AxisValueArray<'a>, ReadError>> {
         let data = self.data;
         let args = self.axis_value_count();
@@ -150,6 +173,7 @@ impl<'a> Stat<'a> {
     /// Name ID used as fallback when projection of names into a
     /// particular font model produces a subfamily name containing only
     /// elidable elements.
+    #[inline]
     pub fn elided_fallback_name_id(&self) -> Option<NameId> {
         let range = self.shape.elided_fallback_name_id_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
@@ -219,12 +243,14 @@ pub struct AxisRecord {
 
 impl AxisRecord {
     /// A tag identifying the axis of design variation.
+    #[inline]
     pub fn axis_tag(&self) -> Tag {
         self.axis_tag.get()
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this axis.
+    #[inline]
     pub fn axis_name_id(&self) -> NameId {
         self.axis_name_id.get()
     }
@@ -232,6 +258,7 @@ impl AxisRecord {
     /// A value that applications can use to determine primary sorting
     /// of face names, or for ordering of labels when composing family
     /// or face names.
+    #[inline]
     pub fn axis_ordering(&self) -> u16 {
         self.axis_ordering.get()
     }
@@ -255,6 +282,15 @@ impl<'a> SomeRecord<'a> for AxisRecord {
             data,
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AxisValueArrayFixedFields {}
+
+impl FixedSize for AxisValueArrayFixedFields {
+    const RAW_BYTE_LEN: usize = 0;
 }
 
 /// An array of [AxisValue] tables.
@@ -282,16 +318,21 @@ impl ReadArgs for AxisValueArray<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for AxisValueArray<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let axis_value_count = *args;
         let mut cursor = data.cursor();
+        let fixed_fields: &'a AxisValueArrayFixedFields = cursor.read_ref()?;
         let axis_value_offsets_byte_len = (axis_value_count as usize)
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(axis_value_offsets_byte_len);
-        cursor.finish(AxisValueArrayMarker {
-            axis_value_offsets_byte_len,
-        })
+        cursor.finish(
+            AxisValueArrayMarker {
+                axis_value_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -300,6 +341,7 @@ impl<'a> AxisValueArray<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, axis_value_count: u16) -> Result<Self, ReadError> {
         let args = axis_value_count;
         Self::read_with_args(data, &args)
@@ -307,18 +349,20 @@ impl<'a> AxisValueArray<'a> {
 }
 
 /// An array of [AxisValue] tables.
-pub type AxisValueArray<'a> = TableRef<'a, AxisValueArrayMarker>;
+pub type AxisValueArray<'a> = TableRef<'a, AxisValueArrayMarker, AxisValueArrayFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AxisValueArray<'a> {
     /// Array of offsets to axis value tables, in bytes from the start
     /// of the axis value offsets array.
+    #[inline]
     pub fn axis_value_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.axis_value_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// A dynamically resolving wrapper for [`axis_value_offsets`][Self::axis_value_offsets].
+    #[inline]
     pub fn axis_values(&self) -> ArrayOfOffsets<'a, AxisValue<'a>, Offset16> {
         let data = self.data;
         let offsets = self.axis_value_offsets();
@@ -371,6 +415,7 @@ pub enum AxisValue<'a> {
 
 impl<'a> AxisValue<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
@@ -381,6 +426,7 @@ impl<'a> AxisValue<'a> {
     }
 
     /// Format identifier — set to 1.
+    #[inline]
     pub fn format(&self) -> u16 {
         match self {
             Self::Format1(item) => item.format(),
@@ -391,6 +437,7 @@ impl<'a> AxisValue<'a> {
     }
 
     /// Flags — see below for details.
+    #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
         match self {
             Self::Format1(item) => item.flags(),
@@ -402,6 +449,7 @@ impl<'a> AxisValue<'a> {
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
+    #[inline]
     pub fn value_name_id(&self) -> NameId {
         match self {
             Self::Format1(item) => item.value_name_id(),
@@ -469,6 +517,18 @@ impl Format<u16> for AxisValueFormat1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AxisValueFormat1FixedFields {
+    pub format: BigEndian<u16>,
+    pub axis_index: BigEndian<u16>,
+}
+
+impl FixedSize for AxisValueFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -508,37 +568,38 @@ impl MinByteRange for AxisValueFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for AxisValueFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a AxisValueFormat1FixedFields = cursor.read_ref()?;
         cursor.advance::<AxisValueTableFlags>();
         cursor.advance::<NameId>();
         cursor.advance::<Fixed>();
-        cursor.finish(AxisValueFormat1Marker {})
+        cursor.finish(AxisValueFormat1Marker {}, fixed_fields)
     }
 }
 
 /// [Axis value table format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1)
-pub type AxisValueFormat1<'a> = TableRef<'a, AxisValueFormat1Marker>;
+pub type AxisValueFormat1<'a> = TableRef<'a, AxisValueFormat1Marker, AxisValueFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AxisValueFormat1<'a> {
     /// Format identifier — set to 1.
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
     /// be less than designAxisCount.
+    #[inline]
     pub fn axis_index(&self) -> u16 {
-        let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().axis_index.get()
     }
 
     /// Flags — see below for details.
+    #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -546,12 +607,14 @@ impl<'a> AxisValueFormat1<'a> {
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
+    #[inline]
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A numeric value for this attribute value.
+    #[inline]
     pub fn value(&self) -> Fixed {
         let range = self.shape.value_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -585,6 +648,18 @@ impl<'a> std::fmt::Debug for AxisValueFormat1<'a> {
 
 impl Format<u16> for AxisValueFormat2Marker {
     const FORMAT: u16 = 2;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AxisValueFormat2FixedFields {
+    pub format: BigEndian<u16>,
+    pub axis_index: BigEndian<u16>,
+}
+
+impl FixedSize for AxisValueFormat2FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2)
@@ -636,39 +711,40 @@ impl MinByteRange for AxisValueFormat2Marker {
 }
 
 impl<'a> FontRead<'a> for AxisValueFormat2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a AxisValueFormat2FixedFields = cursor.read_ref()?;
         cursor.advance::<AxisValueTableFlags>();
         cursor.advance::<NameId>();
         cursor.advance::<Fixed>();
         cursor.advance::<Fixed>();
         cursor.advance::<Fixed>();
-        cursor.finish(AxisValueFormat2Marker {})
+        cursor.finish(AxisValueFormat2Marker {}, fixed_fields)
     }
 }
 
 /// [Axis value table format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2)
-pub type AxisValueFormat2<'a> = TableRef<'a, AxisValueFormat2Marker>;
+pub type AxisValueFormat2<'a> = TableRef<'a, AxisValueFormat2Marker, AxisValueFormat2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AxisValueFormat2<'a> {
     /// Format identifier — set to 2.
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
     /// be less than designAxisCount.
+    #[inline]
     pub fn axis_index(&self) -> u16 {
-        let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().axis_index.get()
     }
 
     /// Flags — see below for details.
+    #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -676,12 +752,14 @@ impl<'a> AxisValueFormat2<'a> {
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
+    #[inline]
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A nominal numeric value for this attribute value.
+    #[inline]
     pub fn nominal_value(&self) -> Fixed {
         let range = self.shape.nominal_value_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -689,6 +767,7 @@ impl<'a> AxisValueFormat2<'a> {
 
     /// The minimum value for a range associated with the specified
     /// name ID.
+    #[inline]
     pub fn range_min_value(&self) -> Fixed {
         let range = self.shape.range_min_value_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -696,6 +775,7 @@ impl<'a> AxisValueFormat2<'a> {
 
     /// The maximum value for a range associated with the specified
     /// name ID.
+    #[inline]
     pub fn range_max_value(&self) -> Fixed {
         let range = self.shape.range_max_value_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -731,6 +811,18 @@ impl<'a> std::fmt::Debug for AxisValueFormat2<'a> {
 
 impl Format<u16> for AxisValueFormat3Marker {
     const FORMAT: u16 = 3;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AxisValueFormat3FixedFields {
+    pub format: BigEndian<u16>,
+    pub axis_index: BigEndian<u16>,
+}
+
+impl FixedSize for AxisValueFormat3FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3)
@@ -777,38 +869,39 @@ impl MinByteRange for AxisValueFormat3Marker {
 }
 
 impl<'a> FontRead<'a> for AxisValueFormat3<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a AxisValueFormat3FixedFields = cursor.read_ref()?;
         cursor.advance::<AxisValueTableFlags>();
         cursor.advance::<NameId>();
         cursor.advance::<Fixed>();
         cursor.advance::<Fixed>();
-        cursor.finish(AxisValueFormat3Marker {})
+        cursor.finish(AxisValueFormat3Marker {}, fixed_fields)
     }
 }
 
 /// [Axis value table format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3)
-pub type AxisValueFormat3<'a> = TableRef<'a, AxisValueFormat3Marker>;
+pub type AxisValueFormat3<'a> = TableRef<'a, AxisValueFormat3Marker, AxisValueFormat3FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AxisValueFormat3<'a> {
     /// Format identifier — set to 3.
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
     /// Zero-base index into the axis record array identifying the axis
     /// of design variation to which the axis value table applies. Must
     /// be less than designAxisCount.
+    #[inline]
     pub fn axis_index(&self) -> u16 {
-        let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().axis_index.get()
     }
 
     /// Flags — see below for details.
+    #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -816,18 +909,21 @@ impl<'a> AxisValueFormat3<'a> {
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
+    #[inline]
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A numeric value for this attribute value.
+    #[inline]
     pub fn value(&self) -> Fixed {
         let range = self.shape.value_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The numeric value for a style-linked mapping from this value.
+    #[inline]
     pub fn linked_value(&self) -> Fixed {
         let range = self.shape.linked_value_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -862,6 +958,18 @@ impl<'a> std::fmt::Debug for AxisValueFormat3<'a> {
 
 impl Format<u16> for AxisValueFormat4Marker {
     const FORMAT: u16 = 4;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct AxisValueFormat4FixedFields {
+    pub format: BigEndian<u16>,
+    pub axis_count: BigEndian<u16>,
+}
+
+impl FixedSize for AxisValueFormat4FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// [Axis value table format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4)
@@ -905,41 +1013,46 @@ impl MinByteRange for AxisValueFormat4Marker {
 }
 
 impl<'a> FontRead<'a> for AxisValueFormat4<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let axis_count: u16 = cursor.read()?;
+        let fixed_fields: &'a AxisValueFormat4FixedFields = cursor.read_ref()?;
+        let axis_count = fixed_fields.axis_count.get();
         cursor.advance::<AxisValueTableFlags>();
         cursor.advance::<NameId>();
         let axis_values_byte_len = (axis_count as usize)
             .checked_mul(AxisValueRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(axis_values_byte_len);
-        cursor.finish(AxisValueFormat4Marker {
-            axis_values_byte_len,
-        })
+        cursor.finish(
+            AxisValueFormat4Marker {
+                axis_values_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// [Axis value table format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4)
-pub type AxisValueFormat4<'a> = TableRef<'a, AxisValueFormat4Marker>;
+pub type AxisValueFormat4<'a> = TableRef<'a, AxisValueFormat4Marker, AxisValueFormat4FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AxisValueFormat4<'a> {
     /// Format identifier — set to 4.
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
     /// The total number of axes contributing to this axis-values
     /// combination.
+    #[inline]
     pub fn axis_count(&self) -> u16 {
-        let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().axis_count.get()
     }
 
     /// Flags — see below for details.
+    #[inline]
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -947,6 +1060,7 @@ impl<'a> AxisValueFormat4<'a> {
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this combination of axis values.
+    #[inline]
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -954,6 +1068,7 @@ impl<'a> AxisValueFormat4<'a> {
 
     /// Array of AxisValue records that provide the combination of axis
     /// values, one for each contributing axis.
+    #[inline]
     pub fn axis_values(&self) -> &'a [AxisValueRecord] {
         let range = self.shape.axis_values_byte_range();
         self.data.read_array(range).unwrap()
@@ -1007,11 +1122,13 @@ pub struct AxisValueRecord {
 impl AxisValueRecord {
     /// Zero-base index into the axis record array identifying the axis
     /// to which this value applies. Must be less than designAxisCount.
+    #[inline]
     pub fn axis_index(&self) -> u16 {
         self.axis_index.get()
     }
 
     /// A numeric value for this attribute value.
+    #[inline]
     pub fn value(&self) -> Fixed {
         self.value.get()
     }

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -5,6 +5,18 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct MajorMinorVersionFixedFields {
+    pub version: BigEndian<MajorMinor>,
+    pub always_present: BigEndian<u16>,
+}
+
+impl FixedSize for MajorMinorVersionFixedFields {
+    const RAW_BYTE_LEN: usize = MajorMinor::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct MajorMinorVersionMarker {
@@ -41,10 +53,11 @@ impl MinByteRange for MajorMinorVersionMarker {
 }
 
 impl<'a> FontRead<'a> for MajorMinorVersion<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let version: MajorMinor = cursor.read()?;
-        cursor.advance::<u16>();
+        let fixed_fields: &'a MajorMinorVersionFixedFields = cursor.read_ref()?;
+        let version = fixed_fields.version.get();
         let if_11_byte_start = version
             .compatible((1u16, 1u16))
             .then(|| cursor.position())
@@ -59,32 +72,38 @@ impl<'a> FontRead<'a> for MajorMinorVersion<'a> {
         version
             .compatible((2u16, 0u16))
             .then(|| cursor.advance::<u32>());
-        cursor.finish(MajorMinorVersionMarker {
-            if_11_byte_start,
-            if_20_byte_start,
-        })
+        cursor.finish(
+            MajorMinorVersionMarker {
+                if_11_byte_start,
+                if_20_byte_start,
+            },
+            fixed_fields,
+        )
     }
 }
 
-pub type MajorMinorVersion<'a> = TableRef<'a, MajorMinorVersionMarker>;
+pub type MajorMinorVersion<'a> =
+    TableRef<'a, MajorMinorVersionMarker, MajorMinorVersionFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MajorMinorVersion<'a> {
+    #[inline]
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
+    #[inline]
     pub fn always_present(&self) -> u16 {
-        let range = self.shape.always_present_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().always_present.get()
     }
 
+    #[inline]
     pub fn if_11(&self) -> Option<u16> {
         let range = self.shape.if_11_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    #[inline]
     pub fn if_20(&self) -> Option<u32> {
         let range = self.shape.if_20_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
@@ -425,6 +444,17 @@ impl<'a> From<GotFlags> for FieldType<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct FlagDayFixedFields {
+    pub volume: BigEndian<u16>,
+}
+
+impl FixedSize for FlagDayFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct FlagDayMarker {
@@ -467,9 +497,10 @@ impl MinByteRange for FlagDayMarker {
 }
 
 impl<'a> FontRead<'a> for FlagDay<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a FlagDayFixedFields = cursor.read_ref()?;
         let flags: GotFlags = cursor.read()?;
         let foo_byte_start = flags
             .contains(GotFlags::FOO)
@@ -492,38 +523,45 @@ impl<'a> FontRead<'a> for FlagDay<'a> {
         flags
             .intersects(GotFlags::BAZ | GotFlags::FOO)
             .then(|| cursor.advance::<u16>());
-        cursor.finish(FlagDayMarker {
-            foo_byte_start,
-            bar_byte_start,
-            baz_byte_start,
-        })
+        cursor.finish(
+            FlagDayMarker {
+                foo_byte_start,
+                bar_byte_start,
+                baz_byte_start,
+            },
+            fixed_fields,
+        )
     }
 }
 
-pub type FlagDay<'a> = TableRef<'a, FlagDayMarker>;
+pub type FlagDay<'a> = TableRef<'a, FlagDayMarker, FlagDayFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FlagDay<'a> {
+    #[inline]
     pub fn volume(&self) -> u16 {
-        let range = self.shape.volume_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().volume.get()
     }
 
+    #[inline]
     pub fn flags(&self) -> GotFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
+    #[inline]
     pub fn foo(&self) -> Option<u16> {
         let range = self.shape.foo_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    #[inline]
     pub fn bar(&self) -> Option<u16> {
         let range = self.shape.bar_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    #[inline]
     pub fn baz(&self) -> Option<u16> {
         let range = self.shape.baz_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
@@ -556,6 +594,15 @@ impl<'a> std::fmt::Debug for FlagDay<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct FieldsAfterConditionalsFixedFields {}
+
+impl FixedSize for FieldsAfterConditionalsFixedFields {
+    const RAW_BYTE_LEN: usize = 0;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -620,8 +667,10 @@ impl MinByteRange for FieldsAfterConditionalsMarker {
 }
 
 impl<'a> FontRead<'a> for FieldsAfterConditionals<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
+        let fixed_fields: &'a FieldsAfterConditionalsFixedFields = cursor.read_ref()?;
         let flags: GotFlags = cursor.read()?;
         let foo_byte_start = flags
             .contains(GotFlags::FOO)
@@ -647,48 +696,59 @@ impl<'a> FontRead<'a> for FieldsAfterConditionals<'a> {
             .then(|| cursor.advance::<u16>());
         cursor.advance::<u16>();
         cursor.advance::<u16>();
-        cursor.finish(FieldsAfterConditionalsMarker {
-            foo_byte_start,
-            bar_byte_start,
-            baz_byte_start,
-        })
+        cursor.finish(
+            FieldsAfterConditionalsMarker {
+                foo_byte_start,
+                bar_byte_start,
+                baz_byte_start,
+            },
+            fixed_fields,
+        )
     }
 }
 
-pub type FieldsAfterConditionals<'a> = TableRef<'a, FieldsAfterConditionalsMarker>;
+pub type FieldsAfterConditionals<'a> =
+    TableRef<'a, FieldsAfterConditionalsMarker, FieldsAfterConditionalsFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FieldsAfterConditionals<'a> {
+    #[inline]
     pub fn flags(&self) -> GotFlags {
         let range = self.shape.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
+    #[inline]
     pub fn foo(&self) -> Option<u16> {
         let range = self.shape.foo_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    #[inline]
     pub fn always_here(&self) -> u16 {
         let range = self.shape.always_here_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
+    #[inline]
     pub fn bar(&self) -> Option<u16> {
         let range = self.shape.bar_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    #[inline]
     pub fn baz(&self) -> Option<u16> {
         let range = self.shape.baz_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
+    #[inline]
     pub fn also_always_here(&self) -> u16 {
         let range = self.shape.also_always_here_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
+    #[inline]
     pub fn and_me_too(&self) -> u16 {
         let range = self.shape.and_me_too_byte_range();
         self.data.read_at(range.start).unwrap()

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -449,10 +449,11 @@ impl<'a> From<GotFlags> for FieldType<'a> {
 #[repr(packed)]
 pub struct FlagDayFixedFields {
     pub volume: BigEndian<u16>,
+    pub flags: BigEndian<GotFlags>,
 }
 
 impl FixedSize for FlagDayFixedFields {
-    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + GotFlags::RAW_BYTE_LEN;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -501,7 +502,7 @@ impl<'a> FontRead<'a> for FlagDay<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a FlagDayFixedFields = cursor.read_ref()?;
-        let flags: GotFlags = cursor.read()?;
+        let flags = fixed_fields.flags.get();
         let foo_byte_start = flags
             .contains(GotFlags::FOO)
             .then(|| cursor.position())
@@ -545,8 +546,7 @@ impl<'a> FlagDay<'a> {
 
     #[inline]
     pub fn flags(&self) -> GotFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     #[inline]
@@ -599,10 +599,12 @@ impl<'a> std::fmt::Debug for FlagDay<'a> {
 #[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
-pub struct FieldsAfterConditionalsFixedFields {}
+pub struct FieldsAfterConditionalsFixedFields {
+    pub flags: BigEndian<GotFlags>,
+}
 
 impl FixedSize for FieldsAfterConditionalsFixedFields {
-    const RAW_BYTE_LEN: usize = 0;
+    const RAW_BYTE_LEN: usize = GotFlags::RAW_BYTE_LEN;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -671,7 +673,7 @@ impl<'a> FontRead<'a> for FieldsAfterConditionals<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
         let fixed_fields: &'a FieldsAfterConditionalsFixedFields = cursor.read_ref()?;
-        let flags: GotFlags = cursor.read()?;
+        let flags = fixed_fields.flags.get();
         let foo_byte_start = flags
             .contains(GotFlags::FOO)
             .then(|| cursor.position())
@@ -714,8 +716,7 @@ pub type FieldsAfterConditionals<'a> =
 impl<'a> FieldsAfterConditionals<'a> {
     #[inline]
     pub fn flags(&self) -> GotFlags {
-        let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flags.get()
     }
 
     #[inline]

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -5,6 +5,17 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CountAll16FixedFields {
+    pub some_field: BigEndian<u16>,
+}
+
+impl FixedSize for CountAll16FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct CountAll16Marker {
@@ -30,24 +41,26 @@ impl MinByteRange for CountAll16Marker {
 }
 
 impl<'a> FontRead<'a> for CountAll16<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a CountAll16FixedFields = cursor.read_ref()?;
         let remainder_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
         cursor.advance_by(remainder_byte_len);
-        cursor.finish(CountAll16Marker { remainder_byte_len })
+        cursor.finish(CountAll16Marker { remainder_byte_len }, fixed_fields)
     }
 }
 
-pub type CountAll16<'a> = TableRef<'a, CountAll16Marker>;
+pub type CountAll16<'a> = TableRef<'a, CountAll16Marker, CountAll16FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CountAll16<'a> {
+    #[inline]
     pub fn some_field(&self) -> u16 {
-        let range = self.shape.some_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().some_field.get()
     }
 
+    #[inline]
     pub fn remainder(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.remainder_byte_range();
         self.data.read_array(range).unwrap()
@@ -76,6 +89,17 @@ impl<'a> std::fmt::Debug for CountAll16<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct CountAll32FixedFields {
+    pub some_field: BigEndian<u16>,
+}
+
+impl FixedSize for CountAll32FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct CountAll32Marker {
@@ -101,24 +125,26 @@ impl MinByteRange for CountAll32Marker {
 }
 
 impl<'a> FontRead<'a> for CountAll32<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a CountAll32FixedFields = cursor.read_ref()?;
         let remainder_byte_len = cursor.remaining_bytes() / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN;
         cursor.advance_by(remainder_byte_len);
-        cursor.finish(CountAll32Marker { remainder_byte_len })
+        cursor.finish(CountAll32Marker { remainder_byte_len }, fixed_fields)
     }
 }
 
-pub type CountAll32<'a> = TableRef<'a, CountAll32Marker>;
+pub type CountAll32<'a> = TableRef<'a, CountAll32Marker, CountAll32FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CountAll32<'a> {
+    #[inline]
     pub fn some_field(&self) -> u16 {
-        let range = self.shape.some_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().some_field.get()
     }
 
+    #[inline]
     pub fn remainder(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.remainder_byte_range();
         self.data.read_array(range).unwrap()

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -105,10 +105,12 @@ pub struct MyRecord {
 }
 
 impl MyRecord {
+    #[inline]
     pub fn my_enum1(&self) -> MyEnum1 {
         self.my_enum1.get()
     }
 
+    #[inline]
     pub fn my_enum2(&self) -> MyEnum2 {
         self.my_enum2.get()
     }

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -9,6 +9,19 @@ impl Format<u16> for Table1Marker {
     const FORMAT: u16 = 1;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Table1FixedFields {
+    pub format: BigEndian<u16>,
+    pub heft: BigEndian<u32>,
+    pub flex: BigEndian<u16>,
+}
+
+impl FixedSize for Table1FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u32::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct Table1Marker {}
@@ -37,32 +50,31 @@ impl MinByteRange for Table1Marker {
 }
 
 impl<'a> FontRead<'a> for Table1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u16>();
-        cursor.finish(Table1Marker {})
+        let fixed_fields: &'a Table1FixedFields = cursor.read_ref()?;
+        cursor.finish(Table1Marker {}, fixed_fields)
     }
 }
 
-pub type Table1<'a> = TableRef<'a, Table1Marker>;
+pub type Table1<'a> = TableRef<'a, Table1Marker, Table1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table1<'a> {
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
+    #[inline]
     pub fn heft(&self) -> u32 {
-        let range = self.shape.heft_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().heft.get()
     }
 
+    #[inline]
     pub fn flex(&self) -> u16 {
-        let range = self.shape.flex_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().flex.get()
     }
 }
 
@@ -91,6 +103,18 @@ impl<'a> std::fmt::Debug for Table1<'a> {
 
 impl Format<u16> for Table2Marker {
     const FORMAT: u16 = 2;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Table2FixedFields {
+    pub format: BigEndian<u16>,
+    pub value_count: BigEndian<u16>,
+}
+
+impl FixedSize for Table2FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -123,32 +147,34 @@ impl MinByteRange for Table2Marker {
 }
 
 impl<'a> FontRead<'a> for Table2<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let value_count: u16 = cursor.read()?;
+        let fixed_fields: &'a Table2FixedFields = cursor.read_ref()?;
+        let value_count = fixed_fields.value_count.get();
         let values_byte_len = (value_count as usize)
             .checked_mul(u16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(values_byte_len);
-        cursor.finish(Table2Marker { values_byte_len })
+        cursor.finish(Table2Marker { values_byte_len }, fixed_fields)
     }
 }
 
-pub type Table2<'a> = TableRef<'a, Table2Marker>;
+pub type Table2<'a> = TableRef<'a, Table2Marker, Table2FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table2<'a> {
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
+    #[inline]
     pub fn value_count(&self) -> u16 {
-        let range = self.shape.value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().value_count.get()
     }
 
+    #[inline]
     pub fn values(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.values_byte_range();
         self.data.read_array(range).unwrap()
@@ -182,6 +208,18 @@ impl Format<u16> for Table3Marker {
     const FORMAT: u16 = 3;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct Table3FixedFields {
+    pub format: BigEndian<u16>,
+    pub something: BigEndian<u16>,
+}
+
+impl FixedSize for Table3FixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct Table3Marker {}
@@ -205,26 +243,26 @@ impl MinByteRange for Table3Marker {
 }
 
 impl<'a> FontRead<'a> for Table3<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.finish(Table3Marker {})
+        let fixed_fields: &'a Table3FixedFields = cursor.read_ref()?;
+        cursor.finish(Table3Marker {}, fixed_fields)
     }
 }
 
-pub type Table3<'a> = TableRef<'a, Table3Marker>;
+pub type Table3<'a> = TableRef<'a, Table3Marker, Table3FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table3<'a> {
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
+    #[inline]
     pub fn something(&self) -> u16 {
-        let range = self.shape.something_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().something.get()
     }
 }
 
@@ -259,6 +297,7 @@ pub enum MyTable<'a> {
 
 impl<'a> MyTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
@@ -267,6 +306,7 @@ impl<'a> MyTable<'a> {
         }
     }
 
+    #[inline]
     pub fn format(&self) -> u16 {
         match self {
             Self::Format1(item) => item.format(),

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -5,6 +5,17 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct TupleVariationHeaderFixedFields {
+    pub variation_data_size: BigEndian<u16>,
+}
+
+impl FixedSize for TupleVariationHeaderFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN;
+}
+
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -52,10 +63,11 @@ impl ReadArgs for TupleVariationHeader<'_> {
 }
 
 impl<'a> FontReadWithArgs<'a> for TupleVariationHeader<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let axis_count = *args;
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
+        let fixed_fields: &'a TupleVariationHeaderFixedFields = cursor.read_ref()?;
         let tuple_index: TupleIndex = cursor.read()?;
         let peak_tuple_byte_len = (TupleIndex::tuple_len(tuple_index, axis_count, 0_usize))
             .checked_mul(F2Dot14::RAW_BYTE_LEN)
@@ -71,11 +83,14 @@ impl<'a> FontReadWithArgs<'a> for TupleVariationHeader<'a> {
                 .checked_mul(F2Dot14::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(intermediate_end_tuple_byte_len);
-        cursor.finish(TupleVariationHeaderMarker {
-            peak_tuple_byte_len,
-            intermediate_start_tuple_byte_len,
-            intermediate_end_tuple_byte_len,
-        })
+        cursor.finish(
+            TupleVariationHeaderMarker {
+                peak_tuple_byte_len,
+                intermediate_start_tuple_byte_len,
+                intermediate_end_tuple_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
@@ -84,6 +99,7 @@ impl<'a> TupleVariationHeader<'a> {
     ///
     /// This type requires some external state in order to be
     /// parsed.
+    #[inline]
     pub fn read(data: FontData<'a>, axis_count: u16) -> Result<Self, ReadError> {
         let args = axis_count;
         Self::read_with_args(data, &args)
@@ -91,19 +107,21 @@ impl<'a> TupleVariationHeader<'a> {
 }
 
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
-pub type TupleVariationHeader<'a> = TableRef<'a, TupleVariationHeaderMarker>;
+pub type TupleVariationHeader<'a> =
+    TableRef<'a, TupleVariationHeaderMarker, TupleVariationHeaderFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> TupleVariationHeader<'a> {
     /// The size in bytes of the serialized data for this tuple
     /// variation table.
+    #[inline]
     pub fn variation_data_size(&self) -> u16 {
-        let range = self.shape.variation_data_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().variation_data_size.get()
     }
 
     /// A packed field. The high 4 bits are flags (see below). The low
     /// 12 bits are an index into a shared tuple records array.
+    #[inline]
     pub fn tuple_index(&self) -> TupleIndex {
         let range = self.shape.tuple_index_byte_range();
         self.data.read_at(range.start).unwrap()
@@ -154,6 +172,7 @@ impl<'a> Tuple<'a> {
     ///
     /// The number of elements must match the axisCount specified in the
     /// 'fvar' table.
+    #[inline]
     pub fn values(&self) -> &'a [BigEndian<F2Dot14>] {
         self.values
     }
@@ -213,6 +232,17 @@ impl Format<u8> for DeltaSetIndexMapFormat0Marker {
     const FORMAT: u8 = 0;
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct DeltaSetIndexMapFormat0FixedFields {
+    pub format: u8,
+}
+
+impl FixedSize for DeltaSetIndexMapFormat0FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN;
+}
+
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -249,44 +279,52 @@ impl MinByteRange for DeltaSetIndexMapFormat0Marker {
 }
 
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
+        let fixed_fields: &'a DeltaSetIndexMapFormat0FixedFields = cursor.read_ref()?;
         let entry_format: EntryFormat = cursor.read()?;
         let map_count: u16 = cursor.read()?;
         let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(map_data_byte_len);
-        cursor.finish(DeltaSetIndexMapFormat0Marker { map_data_byte_len })
+        cursor.finish(
+            DeltaSetIndexMapFormat0Marker { map_data_byte_len },
+            fixed_fields,
+        )
     }
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
-pub type DeltaSetIndexMapFormat0<'a> = TableRef<'a, DeltaSetIndexMapFormat0Marker>;
+pub type DeltaSetIndexMapFormat0<'a> =
+    TableRef<'a, DeltaSetIndexMapFormat0Marker, DeltaSetIndexMapFormat0FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> DeltaSetIndexMapFormat0<'a> {
     /// DeltaSetIndexMap format: set to 0.
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
+    #[inline]
     pub fn entry_format(&self) -> EntryFormat {
         let range = self.shape.entry_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of mapping entries.
+    #[inline]
     pub fn map_count(&self) -> u16 {
         let range = self.shape.map_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The delta-set index mapping data. See details below.
+    #[inline]
     pub fn map_data(&self) -> &'a [u8] {
         let range = self.shape.map_data_byte_range();
         self.data.read_array(range).unwrap()
@@ -319,6 +357,17 @@ impl<'a> std::fmt::Debug for DeltaSetIndexMapFormat0<'a> {
 
 impl Format<u8> for DeltaSetIndexMapFormat1Marker {
     const FORMAT: u8 = 1;
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct DeltaSetIndexMapFormat1FixedFields {
+    pub format: u8,
+}
+
+impl FixedSize for DeltaSetIndexMapFormat1FixedFields {
+    const RAW_BYTE_LEN: usize = u8::RAW_BYTE_LEN;
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
@@ -357,44 +406,52 @@ impl MinByteRange for DeltaSetIndexMapFormat1Marker {
 }
 
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u8>();
+        let fixed_fields: &'a DeltaSetIndexMapFormat1FixedFields = cursor.read_ref()?;
         let entry_format: EntryFormat = cursor.read()?;
         let map_count: u32 = cursor.read()?;
         let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(map_data_byte_len);
-        cursor.finish(DeltaSetIndexMapFormat1Marker { map_data_byte_len })
+        cursor.finish(
+            DeltaSetIndexMapFormat1Marker { map_data_byte_len },
+            fixed_fields,
+        )
     }
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
-pub type DeltaSetIndexMapFormat1<'a> = TableRef<'a, DeltaSetIndexMapFormat1Marker>;
+pub type DeltaSetIndexMapFormat1<'a> =
+    TableRef<'a, DeltaSetIndexMapFormat1Marker, DeltaSetIndexMapFormat1FixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> DeltaSetIndexMapFormat1<'a> {
     /// DeltaSetIndexMap format: set to 1.
+    #[inline]
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
+    #[inline]
     pub fn entry_format(&self) -> EntryFormat {
         let range = self.shape.entry_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of mapping entries.
+    #[inline]
     pub fn map_count(&self) -> u32 {
         let range = self.shape.map_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The delta-set index mapping data. See details below.
+    #[inline]
     pub fn map_data(&self) -> &'a [u8] {
         let range = self.shape.map_data_byte_range();
         self.data.read_array(range).unwrap()
@@ -434,6 +491,7 @@ pub enum DeltaSetIndexMap<'a> {
 
 impl<'a> DeltaSetIndexMap<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
+    #[inline]
     pub fn offset_data(&self) -> FontData<'a> {
         match self {
             Self::Format0(item) => item.offset_data(),
@@ -442,6 +500,7 @@ impl<'a> DeltaSetIndexMap<'a> {
     }
 
     /// DeltaSetIndexMap format: set to 0.
+    #[inline]
     pub fn format(&self) -> u8 {
         match self {
             Self::Format0(item) => item.format(),
@@ -451,6 +510,7 @@ impl<'a> DeltaSetIndexMap<'a> {
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
+    #[inline]
     pub fn entry_format(&self) -> EntryFormat {
         match self {
             Self::Format0(item) => item.entry_format(),
@@ -459,6 +519,7 @@ impl<'a> DeltaSetIndexMap<'a> {
     }
 
     /// The delta-set index mapping data. See details below.
+    #[inline]
     pub fn map_data(&self) -> &'a [u8] {
         match self {
             Self::Format0(item) => item.map_data(),
@@ -825,6 +886,18 @@ impl<'a> From<EntryFormat> for FieldType<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct VariationRegionListFixedFields {
+    pub axis_count: BigEndian<u16>,
+    pub region_count: BigEndian<u16>,
+}
+
+impl FixedSize for VariationRegionListFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -856,40 +929,47 @@ impl MinByteRange for VariationRegionListMarker {
 }
 
 impl<'a> FontRead<'a> for VariationRegionList<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let axis_count: u16 = cursor.read()?;
-        let region_count: u16 = cursor.read()?;
+        let fixed_fields: &'a VariationRegionListFixedFields = cursor.read_ref()?;
+        let axis_count = fixed_fields.axis_count.get();
+        let region_count = fixed_fields.region_count.get();
         let variation_regions_byte_len = (region_count as usize)
             .checked_mul(<VariationRegion as ComputeSize>::compute_size(&axis_count)?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(variation_regions_byte_len);
-        cursor.finish(VariationRegionListMarker {
-            variation_regions_byte_len,
-        })
+        cursor.finish(
+            VariationRegionListMarker {
+                variation_regions_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
-pub type VariationRegionList<'a> = TableRef<'a, VariationRegionListMarker>;
+pub type VariationRegionList<'a> =
+    TableRef<'a, VariationRegionListMarker, VariationRegionListFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VariationRegionList<'a> {
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
+    #[inline]
     pub fn axis_count(&self) -> u16 {
-        let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().axis_count.get()
     }
 
     /// The number of variation region tables in the variation region
     /// list. Must be less than 32,768.
+    #[inline]
     pub fn region_count(&self) -> u16 {
-        let range = self.shape.region_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().region_count.get()
     }
 
     /// Array of variation regions.
+    #[inline]
     pub fn variation_regions(&self) -> ComputedArray<'a, VariationRegion<'a>> {
         let range = self.shape.variation_regions_byte_range();
         self.data.read_with_args(range, &self.axis_count()).unwrap()
@@ -937,6 +1017,7 @@ pub struct VariationRegion<'a> {
 impl<'a> VariationRegion<'a> {
     /// Array of region axis coordinates records, in the order of axes
     /// given in the 'fvar' table.
+    #[inline]
     pub fn region_axes(&self) -> &'a [RegionAxisCoordinates] {
         self.region_axes
     }
@@ -1014,16 +1095,19 @@ pub struct RegionAxisCoordinates {
 
 impl RegionAxisCoordinates {
     /// The region start coordinate value for the current axis.
+    #[inline]
     pub fn start_coord(&self) -> F2Dot14 {
         self.start_coord.get()
     }
 
     /// The region peak coordinate value for the current axis.
+    #[inline]
     pub fn peak_coord(&self) -> F2Dot14 {
         self.peak_coord.get()
     }
 
     /// The region end coordinate value for the current axis.
+    #[inline]
     pub fn end_coord(&self) -> F2Dot14 {
         self.end_coord.get()
     }
@@ -1048,6 +1132,19 @@ impl<'a> SomeRecord<'a> for RegionAxisCoordinates {
             data,
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct ItemVariationStoreFixedFields {
+    pub format: BigEndian<u16>,
+    pub variation_region_list_offset: BigEndian<Offset32>,
+    pub item_variation_data_count: BigEndian<u16>,
+}
+
+impl FixedSize for ItemVariationStoreFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
@@ -1086,59 +1183,66 @@ impl MinByteRange for ItemVariationStoreMarker {
 }
 
 impl<'a> FontRead<'a> for ItemVariationStore<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        let item_variation_data_count: u16 = cursor.read()?;
+        let fixed_fields: &'a ItemVariationStoreFixedFields = cursor.read_ref()?;
+        let item_variation_data_count = fixed_fields.item_variation_data_count.get();
         let item_variation_data_offsets_byte_len = (item_variation_data_count as usize)
             .checked_mul(Offset32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(item_variation_data_offsets_byte_len);
-        cursor.finish(ItemVariationStoreMarker {
-            item_variation_data_offsets_byte_len,
-        })
+        cursor.finish(
+            ItemVariationStoreMarker {
+                item_variation_data_offsets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
-pub type ItemVariationStore<'a> = TableRef<'a, ItemVariationStoreMarker>;
+pub type ItemVariationStore<'a> =
+    TableRef<'a, ItemVariationStoreMarker, ItemVariationStoreFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ItemVariationStore<'a> {
     /// Format— set to 1
+    #[inline]
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().format.get()
     }
 
     /// Offset in bytes from the start of the item variation store to
     /// the variation region list.
+    #[inline]
     pub fn variation_region_list_offset(&self) -> Offset32 {
-        let range = self.shape.variation_region_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().variation_region_list_offset.get()
     }
 
     /// Attempt to resolve [`variation_region_list_offset`][Self::variation_region_list_offset].
+    #[inline]
     pub fn variation_region_list(&self) -> Result<VariationRegionList<'a>, ReadError> {
         let data = self.data;
         self.variation_region_list_offset().resolve(data)
     }
 
     /// The number of item variation data subtables.
+    #[inline]
     pub fn item_variation_data_count(&self) -> u16 {
-        let range = self.shape.item_variation_data_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().item_variation_data_count.get()
     }
 
     /// Offsets in bytes from the start of the item variation store to
     /// each item variation data subtable.
+    #[inline]
     pub fn item_variation_data_offsets(&self) -> &'a [BigEndian<Nullable<Offset32>>] {
         let range = self.shape.item_variation_data_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
+    #[inline]
     pub fn item_variation_data(
         &self,
     ) -> ArrayOfNullableOffsets<'a, ItemVariationData<'a>, Offset32> {
@@ -1194,6 +1298,19 @@ impl<'a> std::fmt::Debug for ItemVariationStore<'a> {
     }
 }
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct ItemVariationDataFixedFields {
+    pub item_count: BigEndian<u16>,
+    pub word_delta_count: BigEndian<u16>,
+    pub region_index_count: BigEndian<u16>,
+}
+
+impl FixedSize for ItemVariationDataFixedFields {
+    const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -1236,11 +1353,13 @@ impl MinByteRange for ItemVariationDataMarker {
 }
 
 impl<'a> FontRead<'a> for ItemVariationData<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        let item_count: u16 = cursor.read()?;
-        let word_delta_count: u16 = cursor.read()?;
-        let region_index_count: u16 = cursor.read()?;
+        let fixed_fields: &'a ItemVariationDataFixedFields = cursor.read_ref()?;
+        let item_count = fixed_fields.item_count.get();
+        let word_delta_count = fixed_fields.word_delta_count.get();
+        let region_index_count = fixed_fields.region_index_count.get();
         let region_indexes_byte_len = (region_index_count as usize)
             .checked_mul(u16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
@@ -1250,44 +1369,50 @@ impl<'a> FontRead<'a> for ItemVariationData<'a> {
                 .checked_mul(u8::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(delta_sets_byte_len);
-        cursor.finish(ItemVariationDataMarker {
-            region_indexes_byte_len,
-            delta_sets_byte_len,
-        })
+        cursor.finish(
+            ItemVariationDataMarker {
+                region_indexes_byte_len,
+                delta_sets_byte_len,
+            },
+            fixed_fields,
+        )
     }
 }
 
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
-pub type ItemVariationData<'a> = TableRef<'a, ItemVariationDataMarker>;
+pub type ItemVariationData<'a> =
+    TableRef<'a, ItemVariationDataMarker, ItemVariationDataFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ItemVariationData<'a> {
     /// The number of delta sets for distinct items.
+    #[inline]
     pub fn item_count(&self) -> u16 {
-        let range = self.shape.item_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().item_count.get()
     }
 
     /// A packed field: the high bit is a flag—see details below.
+    #[inline]
     pub fn word_delta_count(&self) -> u16 {
-        let range = self.shape.word_delta_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().word_delta_count.get()
     }
 
     /// The number of variation regions referenced.
+    #[inline]
     pub fn region_index_count(&self) -> u16 {
-        let range = self.shape.region_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().region_index_count.get()
     }
 
     /// Array of indices into the variation region list for the regions
     /// referenced by this item variation data table.
+    #[inline]
     pub fn region_indexes(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.region_indexes_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Delta-set rows.
+    #[inline]
     pub fn delta_sets(&self) -> &'a [u8] {
         let range = self.shape.delta_sets_byte_range();
         self.data.read_array(range).unwrap()

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -5,6 +5,49 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+#[derive(Copy, Clone, Debug, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct VheaFixedFields {
+    pub version: BigEndian<Version16Dot16>,
+    pub ascender: BigEndian<FWord>,
+    pub descender: BigEndian<FWord>,
+    pub line_gap: BigEndian<FWord>,
+    pub advance_height_max: BigEndian<UfWord>,
+    pub min_top_side_bearing: BigEndian<FWord>,
+    pub min_bottom_side_bearing: BigEndian<FWord>,
+    pub y_max_extent: BigEndian<FWord>,
+    pub caret_slope_rise: BigEndian<i16>,
+    pub caret_slope_run: BigEndian<i16>,
+    pub caret_offset: BigEndian<i16>,
+    pub reserved1: BigEndian<i16>,
+    pub reserved2: BigEndian<i16>,
+    pub reserved3: BigEndian<i16>,
+    pub reserved4: BigEndian<i16>,
+    pub metric_data_format: BigEndian<i16>,
+    pub number_of_long_ver_metrics: BigEndian<u16>,
+}
+
+impl FixedSize for VheaFixedFields {
+    const RAW_BYTE_LEN: usize = Version16Dot16::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + UfWord::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + FWord::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + i16::RAW_BYTE_LEN
+        + u16::RAW_BYTE_LEN;
+}
+
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -109,115 +152,100 @@ impl TopLevelTable for Vhea<'_> {
 }
 
 impl<'a> FontRead<'a> for Vhea<'a> {
+    #[inline]
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         let mut cursor = data.cursor();
-        cursor.advance::<Version16Dot16>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(VheaMarker {})
+        let fixed_fields: &'a VheaFixedFields = cursor.read_ref()?;
+        cursor.finish(VheaMarker {}, fixed_fields)
     }
 }
 
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
-pub type Vhea<'a> = TableRef<'a, VheaMarker>;
+pub type Vhea<'a> = TableRef<'a, VheaMarker, VheaFixedFields>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Vhea<'a> {
     /// The major/minor version (1, 1)
+    #[inline]
     pub fn version(&self) -> Version16Dot16 {
-        let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().version.get()
     }
 
     /// Typographic ascent.
+    #[inline]
     pub fn ascender(&self) -> FWord {
-        let range = self.shape.ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().ascender.get()
     }
 
     /// Typographic descent.
+    #[inline]
     pub fn descender(&self) -> FWord {
-        let range = self.shape.descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().descender.get()
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
+    #[inline]
     pub fn line_gap(&self) -> FWord {
-        let range = self.shape.line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().line_gap.get()
     }
 
     /// Maximum advance height value in 'vmtx' table.
+    #[inline]
     pub fn advance_height_max(&self) -> UfWord {
-        let range = self.shape.advance_height_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().advance_height_max.get()
     }
 
     /// Minimum top sidebearing value in 'vmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
+    #[inline]
     pub fn min_top_side_bearing(&self) -> FWord {
-        let range = self.shape.min_top_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().min_top_side_bearing.get()
     }
 
     /// Minimum bottom sidebearing value
+    #[inline]
     pub fn min_bottom_side_bearing(&self) -> FWord {
-        let range = self.shape.min_bottom_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().min_bottom_side_bearing.get()
     }
 
     /// Defined as max( tsb + (yMax-yMin)).
+    #[inline]
     pub fn y_max_extent(&self) -> FWord {
-        let range = self.shape.y_max_extent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().y_max_extent.get()
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
+    #[inline]
     pub fn caret_slope_rise(&self) -> i16 {
-        let range = self.shape.caret_slope_rise_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().caret_slope_rise.get()
     }
 
     /// 0 for vertical caret, 1 for horizontal.
+    #[inline]
     pub fn caret_slope_run(&self) -> i16 {
-        let range = self.shape.caret_slope_run_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().caret_slope_run.get()
     }
 
     /// The amount by which a slanted highlight on a glyph needs to be
     /// shifted to produce the best appearance. Set to 0 for
     /// non-slanted fonts
+    #[inline]
     pub fn caret_offset(&self) -> i16 {
-        let range = self.shape.caret_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().caret_offset.get()
     }
 
     /// 0 for current format.
+    #[inline]
     pub fn metric_data_format(&self) -> i16 {
-        let range = self.shape.metric_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().metric_data_format.get()
     }
 
     /// Number of advance heights in the vertical metrics (`vmtx`) table.
+    #[inline]
     pub fn number_of_long_ver_metrics(&self) -> u16 {
-        let range = self.shape.number_of_long_ver_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        self.fixed_fields().number_of_long_ver_metrics.get()
     }
 }
 

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -15,12 +15,13 @@ pub trait MinByteRange {
 
 #[derive(Clone)]
 /// Typed access to raw table data.
-pub struct TableRef<'a, T> {
+pub struct TableRef<'a, T, F> {
     pub(crate) shape: T,
+    pub(crate) fixed_fields: &'a F,
     pub(crate) data: FontData<'a>,
 }
 
-impl<'a, T> TableRef<'a, T> {
+impl<'a, T, F> TableRef<'a, T, F> {
     /// Resolve the provided offset from the start of this table.
     pub fn resolve_offset<O: Offset, R: FontRead<'a>>(&self, offset: O) -> Result<R, ReadError> {
         offset.resolve(self.data)
@@ -41,14 +42,20 @@ impl<'a, T> TableRef<'a, T> {
     pub fn shape(&self) -> &T {
         &self.shape
     }
+
+    /// Returns a reference to a structure containing all of the fixed size
+    /// fields at the start of the table.
+    pub fn fixed_fields(&self) -> &'a F {
+        self.fixed_fields
+    }
 }
 
 // a blanket impl so that the format is available through a TableRef
-impl<U, T: Format<U>> Format<U> for TableRef<'_, T> {
+impl<U, T: Format<U>, F> Format<U> for TableRef<'_, T, F> {
     const FORMAT: U = T::FORMAT;
 }
 
-impl<'a, T: MinByteRange> TableRef<'a, T> {
+impl<'a, T: MinByteRange, F> TableRef<'a, T, F> {
     /// Return the minimum byte range of this table
     pub fn min_byte_range(&self) -> Range<usize> {
         self.shape.min_byte_range()

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -63,7 +63,7 @@ impl types::Scalar for MatchModeAndCount {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Default, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Ord, PartialOrd, Hash)]
 pub struct CompatibilityId([u8; 16]);
 
 impl CompatibilityId {


### PR DESCRIPTION
This is a fairly large update to codegen. It is technically breaking but will only affect users that reference the `TableRef` type explicitly.

The change basically captures the sequence of "fixed" fields for each table into a separate zerocopy struct (fixed is defined as always present and existing at a constant offset). At read time, we parse a reference to this struct and store it as a new field on `TableRef`. Any subsequent access to the fields from the fixed set simply reads from that reference. 

Note that we still continue to validate the trailing conditional/variable size fields at this point. We may want to reconsider that as a next step.