### PR TITLE
[chore] bump patch for read/skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.31.1", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.31.2", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.33.1", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.33.2", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.39.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.31.1"
+version = "0.31.2"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.33.1"
+version = "0.33.2"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
    Changes for read-fonts from read-fonts-v0.31.1 to 0.31.2
             9b17cdc [read/skrifa] CFF: parse and apply font matrix (#1590)
             856e877 Minor improvement to docs in gsub closure
     Changes for skrifa from skrifa-v0.33.1 to 0.33.2
             9b17cdc [read/skrifa] CFF: parse and apply font matrix (#1590)