### PR TITLE
[chore] bump patch for read-fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.31.2", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.31.3", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.33.2", path = "skrifa", default-features = false, features = ["std"] }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.31.2"
+version = "0.31.3"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.31.2 to 0.31.3
             436bf9e [read-fonts] Avoid overflow in matrix degeneracy check (#1596)
             641471f [Coverage/ClassDef] Add a cost() method (#1591)