### PR TITLE
Write gvar table shared tuples in the expected place

### DIFF
--- a/resources/codegen_inputs/gvar.rs
+++ b/resources/codegen_inputs/gvar.rs
@@ -22,6 +22,7 @@ table Gvar {
     shared_tuple_count: u16,
     /// Offset from the start of this table to the shared tuple records.
     #[read_offset_with($shared_tuple_count, $axis_count)]
+    #[compile_with(compute_shared_tuples_offset)]
     shared_tuples_offset: Offset32<SharedTuples>,
     /// The number of glyphs in this font. This must match the number
     /// of glyphs stored elsewhere in the font.

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -27,7 +27,7 @@ impl FontWrite for Gvar {
         (MajorMinor::VERSION_1_0 as MajorMinor).write_into(writer);
         self.axis_count.write_into(writer);
         (u16::try_from(array_len(&self.shared_tuples)).unwrap()).write_into(writer);
-        self.shared_tuples.write_into(writer);
+        (self.compute_shared_tuples_offset()).write_into(writer);
         (self.compute_glyph_count() as u16).write_into(writer);
         (self.compute_flags() as GvarFlags).write_into(writer);
         (self.compute_data_array_offset() as u32).write_into(writer);


### PR DESCRIPTION
fontc/fontations was writing the gvar components in a wrong order, it was pushing the Shared Tuples to the end of the table, while the spec mandates that they are between the table header and the Glyph Variation Data.

<img width="999" height="861" alt="image" src="https://github.com/user-attachments/assets/024cda62-a9b6-4676-94d8-2fb8146ac18d" />

https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#shared-tuples-array
> The shared tuples array follows the GlyphVariationData offsets array at the end of the 'gvar' header.

We believe this fixes the Windows 10 crashes of the Google Sans Code release: https://github.com/googlefonts/googlesans-code/issues/22

This also fixes unpacking the gvar table in OT Master.

We tested the previous release versus a TTF built with fontc using this fontations branch, and the new version didn't crash or mess up the system as the official release did.