### PR TITLE
[IntSet] speedup IntSet::contains() by caching the last page index.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,7 @@
 # Don't warn about these identifiers when using `clippy::doc_markdown`.
 doc-valid-idents = ["ClearType", "FreeType", "HarfBuzz", "OpenType", "PostScript", ".."]
+
+# U32Set uses interior mutability to cache the last page lookup, the fields value
+# does not affect external behaviour of the type, and is not referenced in hash/equality
+# implementations.
+ignore-interior-mutability = ["read_fonts::collections::int_set::bitset::U32Set"]

--- a/read-fonts/benches/bench_helper.rs
+++ b/read-fonts/benches/bench_helper.rs
@@ -1,10 +1,25 @@
-use read_fonts::collections::IntSet;
+use read_fonts::collections::{IntSet, U32Set};
 
 use rand::Rng;
 
 pub fn random_set(size: u32, max_value: u32) -> IntSet<u32> {
     let mut rng = rand::thread_rng();
     let mut set = IntSet::<u32>::empty();
+    for _ in 0..size {
+        loop {
+            let candidate: u32 = rng.gen::<u32>() % max_value;
+            if set.insert(candidate) {
+                break;
+            }
+        }
+    }
+    set
+}
+
+#[allow(dead_code)]
+pub fn random_u32_set(size: u32, max_value: u32) -> U32Set {
+    let mut rng = rand::thread_rng();
+    let mut set = U32Set::empty();
     for _ in 0..size {
         loop {
             let candidate: u32 = rng.gen::<u32>() % max_value;

--- a/read-fonts/benches/int_set_benchmark.rs
+++ b/read-fonts/benches/int_set_benchmark.rs
@@ -1,7 +1,7 @@
 mod bench_helper;
-use bench_helper::random_set;
+use bench_helper::{random_set, random_u32_set};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use read_fonts::collections::IntSet;
+use read_fonts::collections::{IntSet, U32Set};
 
 struct SetTest {
     set_size: u32,
@@ -115,6 +115,25 @@ pub fn lookup_ordered_benchmark(c: &mut Criterion) {
     }
 }
 
+pub fn lookup_ordered_u32_benchmark(c: &mut Criterion) {
+    let inputs = set_parameters();
+
+    for input in inputs {
+        let set = random_u32_set(input.set_size, input.max_value());
+        let mut needle = input.max_value() / 2;
+        c.bench_with_input(
+            BenchmarkId::new("BM_SetLookup/ordered_u32", &input),
+            &set,
+            |b, s: &U32Set| {
+                b.iter(|| {
+                    needle += 3;
+                    s.contains(needle % input.max_value())
+                })
+            },
+        );
+    }
+}
+
 pub fn iteration_benchmark(c: &mut Criterion) {
     let inputs = set_parameters();
 
@@ -140,6 +159,7 @@ criterion_group!(
     ordered_extend_benchmark,
     lookup_random_benchmark,
     lookup_ordered_benchmark,
+    lookup_ordered_u32_benchmark,
     iteration_benchmark,
 );
 criterion_main!(benches);

--- a/read-fonts/src/collections.rs
+++ b/read-fonts/src/collections.rs
@@ -2,6 +2,7 @@
 
 pub mod int_set;
 pub use int_set::IntSet;
+pub use int_set::U32Set;
 
 mod range_set;
 pub use range_set::RangeSet;

--- a/read-fonts/src/collections/int_set/bitpage.rs
+++ b/read-fonts/src/collections/int_set/bitpage.rs
@@ -803,7 +803,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn hash_and_eq() {
         let mut page1 = BitPage::new_zeroes();
         let mut page2 = BitPage::new_zeroes();

--- a/read-fonts/src/collections/int_set/mod.rs
+++ b/read-fonts/src/collections/int_set/mod.rs
@@ -1488,7 +1488,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn equal_and_hash() {
         let mut inc1 = IntSet::<u32>::empty();
         inc1.insert(14);
@@ -1518,7 +1517,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::mutable_key_type)]
     fn equal_and_hash_mixed_membership_types() {
         let mut inverted_all = IntSet::<TwoParts>::all();
         let mut all = IntSet::<TwoParts>::empty();


### PR DESCRIPTION
Copies the approach used in harfbuzz. By caching the last page index we can avoid a binary search in subsequent contains() calls when the val resides on the same page as the previous call. This is common in IntSet use cases due to lookups commonly being done in sorted order and high levels of locality typical in shaping and subsetting use cases.

This does add some additional overhead to non-local lookups, but those are small and outweighed by the significant speedups on local lookups. In the benchmarks:
- for the completely unordered (0 locality) cases there's at most a 7% regression.
- for the ordered lookups there's a 25-80% speedup.

