### PR TITLE
[release.sh] Allow CTRL-C during publish without breaking release flow

### DIFF
--- a/resources/scripts/release.sh
+++ b/resources/scripts/release.sh
@@ -26,7 +26,7 @@ if [ $# -eq 1 ]; then
   crate_specifier="-p ${crates[0]}"
 fi
 
-# Do the thing. We set errexit so step failure should break us out.
+# Do the thing. We set errexit (in rel-common.sh) so step failure should break us out.
 
 echo "Dry run..."
 cargo release publish ${crate_specifier}
@@ -34,7 +34,28 @@ cargo release publish ${crate_specifier}
 echo "Doing the thing; ${COLOR_RED}PRESS CTRL+C if anything looks suspicious${TEXT_RESET}"
 
 echo "Publish to crates.io"
-cargo release publish -x ${crate_specifier}  # this prompts y/N
+# Temporarily disable errexit so we can catch a CTRL-C at the end of `publish`
+# from the impatient who doesn't want to wait for index changes to propagate
+set +e
+cargo release publish -x ${crate_specifier}
+publish_result=$?
+set -e  # Re-enable errexit
+
+if [ $publish_result -eq 130 ]; then  # exit code for SIGINT (CTRL-C)
+    echo "Publish interrupted by CTRL-C."
+    echo -n "Do you want to continue with tagging? [auto-continue in 5 seconds] (Y/n): "
+    if read -t 5 -r response; then
+        if [[ "$response" =~ ^[Nn]$ ]]; then
+            echo "Stopping release process"
+            exit $publish_result
+        fi
+    else
+        echo  # newline after timeout
+    fi
+elif [ $publish_result -ne 0 ]; then
+    exit $publish_result
+fi
+
 echo "Generate tags"
 cargo release tag -x ${crate_specifier}  # this prompts y/N
 echo "Pushing tag to github"


### PR DESCRIPTION
When users press CTRL-C during cargo release publish (often to skip waiting for crates.io index propagation), the script would exit entirely because we globally set errexit, thus skipping the following commands (cargo release tag and git push --tags).

The script now intercepts CTRL-C and gives a confirmation prompt with 5-second timeout that defaults to continuing.

Hopefully this will prevent people (myself included) from forgetting to tag the release.