### PR TITLE
bump read-fonts minor version and all the others that reexport it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.31.3", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.32.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.33.2", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.39.1", path = "write-fonts" }
+skrifa = { version = "0.34.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.40.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.4.1"
+version = "0.5.0"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.31.3"
+version = "0.32.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.33.2"
+version = "0.34.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.39.1"
+version = "0.40.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
```
     Changes for read-fonts from read-fonts-v0.31.3 to 0.32.0
             a68280b [read-fonts] Fix BCD parsing when fraction len <= 0 (#1618)
             5f5c6b3 [U32Set] internally cache the last page index used.
             f2b2a2a [avar] Port updated interpolation algorithm from HarfBuzz (#1616)
             4fa0288 Clippy (#1613)
             9fb668d [read-fonts] small update to use newly added APIs
             1d460a4 Fix IntSet refs in U32Set docs.
             b485e0e Rename BitSet -> U32Set and make it public.
             79a14dc Add read and write for `DSIG` table (#1589)
             a48e954 [read-fonts] take Into<GlyphId> for ClassDef types (#1605)
             f44f407 [read-fonts] small fix for cmap10  (#1604)
             7feff0f [read-fonts] new Value type and PairPos2 fast path (#1602)
     Changes for font-test-data from font-test-data-v0.4.1 to 0.5.0
             e3ef9fa [skrifa] tthint: round value for MPPEM instruction (#1545)
             96c609a [IFT] Fix patch selection order for entries with child indices.
             e606cba [cff] handle implied seac operator (#1533)
             44c299c For url template constants use literal byte strings instead of arrays.
             d035a15 Update remaining IFT code for the URL template change.
             687f07a [klippa] clousre glyphs
             2b73599 Tests for VF and CFF bounding boxes
             d776fd6 Test that we select the correct shallow component to derive metrics from
             ff0502e [IFT] use entry order to sort grouped non invalidating patch uris.
             a7b0e6e [IFT] Add tests for duplicate uri handling in patchmap.
             f0794ab [IFT] update remainder of incremental-font-transfer for the PatchUri refactor.
             3677a16 [IFT] Add tests for correct handling of duplicate uris.
     Changes for write-fonts from write-fonts-v0.39.1 to 0.40.0
             4fa0288 Clippy (#1613)
             7656554 Write gvar table shared tuples in the expected place
             79a14dc Add read and write for `DSIG` table (#1589)
             f44f407 [read-fonts] small fix for cmap10  (#1604)
     Changes for skrifa from skrifa-v0.33.2 to 0.34.0
             4fa0288 Clippy (#1613)
             f654b04 Bump MSRV to 1.80 (#1607)
```

JMM