### PR TITLE
[read-fonts] kerx: handle tuple count for format 6

### DIFF
--- a/read-fonts/src/tables/kerx.rs
+++ b/read-fonts/src/tables/kerx.rs
@@ -696,7 +696,7 @@ mod tests {
             let kerning_array = [0i32, 10, 20, 30, -10, -20, 8, 4, -2];
             let mut offset =
                 Subtable::HEADER_LEN + u32::RAW_BYTE_LEN * if self.is_six() { 5 } else { 4 };
-            if is_long {
+            if has_kerning_vector {
                 // optional offset for kerning vector
                 offset += 4;
             }


### PR DESCRIPTION
This handles a completely non-sensical case where the kerx format 6 subtable has a tuple count even though it's not marked as variable which happens to occur in SFNSDisplay.

@behdad with this fix, we match HB kerning for the above font

(unfortunately, this is yet another breaking change)