### PR TITLE
[chore] bump minor for write-fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ read-fonts = { version = "0.33.0", path = "read-fonts", default-features = false
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.35.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.40.0", path = "write-fonts" }
+write-fonts = { version = "0.41.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.40.0"
+version = "0.41.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
To release a version that is usable with the latest read-fonts/skrifa/harfrust.