### PR TITLE
[chore] Bump read-fonts to 0.33.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.33.0", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.33.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.35.0", path = "skrifa", default-features = false, features = ["std"] }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.33.0"
+version = "0.33.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
This brings in a fix for a bug in glyph closure, needed by fontc.