### PR TITLE
Add CPAL interface in skrifa

### DIFF
--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -197,7 +197,7 @@ impl<'a> Cpal<'a> {
     }
 
     /// Attempt to resolve [`palette_labels_array_offset`][Self::palette_labels_array_offset].
-    pub fn palette_labels_array(&self) -> Option<Result<&'a [BigEndian<u16>], ReadError>> {
+    pub fn palette_labels_array(&self) -> Option<Result<&'a [BigEndian<NameId>], ReadError>> {
         let data = self.data;
         let args = self.num_palettes();
         self.palette_labels_array_offset()
@@ -604,6 +604,8 @@ impl<'a> From<PaletteType> for FieldType<'a> {
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
+///
+/// Contains a color in non-premultiplied BGRA form, in the sRGB color space.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
@@ -612,7 +614,7 @@ pub struct ColorRecord {
     pub blue: u8,
     /// Green value (B1).
     pub green: u8,
-    ///     Red value (B2).
+    /// Red value (B2).
     pub red: u8,
     /// Alpha value (B3).
     pub alpha: u8,
@@ -629,7 +631,7 @@ impl ColorRecord {
         self.green
     }
 
-    ///     Red value (B2).
+    /// Red value (B2).
     pub fn red(&self) -> u8 {
         self.red
     }

--- a/resources/codegen_inputs/cpal.rs
+++ b/resources/codegen_inputs/cpal.rs
@@ -42,7 +42,7 @@ table Cpal {
     #[since_version(1)]
     #[nullable]
     #[read_offset_with($num_palettes)]
-    palette_labels_array_offset: Offset32<[u16]>,
+    palette_labels_array_offset: Offset32<[NameId]>,
     /// Offset from the beginning of CPAL table to the [Palette Entry Labels Array][].
     ///
     /// This is an array of 'name' table IDs (typically in the font-specific name
@@ -67,12 +67,14 @@ flags u32 PaletteType {
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
+///
+/// Contains a color in non-premultiplied BGRA form, in the sRGB color space.
 record ColorRecord {
     /// Blue value (B0).
     blue: u8,
     /// Green value (B1).
     green: u8,
-    ///     Red value (B2).
+    /// Red value (B2).
     red: u8,
     /// Alpha value (B3).
     alpha: u8,

--- a/skrifa/src/provider.rs
+++ b/skrifa/src/provider.rs
@@ -1,4 +1,4 @@
-use crate::GlyphNames;
+use crate::{color::ColorPaletteCollection, GlyphNames};
 
 use super::{
     attribute::Attributes,
@@ -50,8 +50,11 @@ pub trait MetadataProvider<'a>: Sized {
     /// source, use the [`OutlineGlyphCollection::with_format`] method.
     fn outline_glyphs(&self) -> OutlineGlyphCollection<'a>;
 
-    // Returns a collection of paintable color glyphs.
+    /// Returns a collection of paintable color glyphs.
     fn color_glyphs(&self) -> ColorGlyphCollection<'a>;
+
+    /// Returns a collection of color palettes for color glyphs.
+    fn color_palettes(&self) -> ColorPaletteCollection<'a>;
 
     /// Returns a collection of bitmap strikes.
     fn bitmap_strikes(&self) -> BitmapStrikes<'a>;
@@ -114,6 +117,11 @@ impl<'a> MetadataProvider<'a> for FontRef<'a> {
     // Returns a collection of paintable color glyphs.
     fn color_glyphs(&self) -> ColorGlyphCollection<'a> {
         ColorGlyphCollection::new(self)
+    }
+
+    /// Returns a collection of color palettes for color glyphs.
+    fn color_palettes(&self) -> ColorPaletteCollection<'a> {
+        ColorPaletteCollection::new(self)
     }
 
     /// Returns a collection of bitmap strikes.

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -36,7 +36,7 @@ pub struct Cpal {
     /// Use 0xFFFF if no name ID is provided for a palette.
     ///
     /// [Palette Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-labels-array
-    pub palette_labels_array: NullableOffsetMarker<Vec<u16>, WIDTH_32>,
+    pub palette_labels_array: NullableOffsetMarker<Vec<NameId>, WIDTH_32>,
     /// Offset from the beginning of CPAL table to the [Palette Entry Labels Array][].
     ///
     /// This is an array of 'name' table IDs (typically in the font-specific name
@@ -145,6 +145,8 @@ impl FontWrite for PaletteType {
 }
 
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
+///
+/// Contains a color in non-premultiplied BGRA form, in the sRGB color space.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColorRecord {
@@ -152,7 +154,7 @@ pub struct ColorRecord {
     pub blue: u8,
     /// Green value (B1).
     pub green: u8,
-    ///     Red value (B2).
+    /// Red value (B2).
     pub red: u8,
     /// Alpha value (B3).
     pub alpha: u8,


### PR DESCRIPTION
Involves some read-fonts changes too: when the `NameId` type was added, `palette_entry_labels_array` was updated to use it but `palette_labels_array` was not. I've changed the latter to use `NameId` as well. I've also adjusted some doc comments.

Resolves #1382. This should be a lot nicer than roughing it with read-fonts.

This adds a `color_palettes` method to `MetadataProvider` which returns the new high-level `ColorPaletteCollection`. Each palette can then be individually fetched from it, wrapped in the `ColorPalette` type.

I'm assuming a usage pattern where the API consumer fetches one palette and then fetches a bunch of colors from it (probably via painter callbacks), and I've optimized accordingly for that use case.

Some questions I have about the API design:
- Should `ColorPalette::palette_type` return `cpal::PaletteType::empty()` if the palette type array is missing entirely? Currently it returns an `Option<PaletteType>`, and returns `None` in that case.
- Should `ColorPalette::label` and `ColorPaletteCollection::color_label` return `NameId(0xFFFF)` or `None` if the name ID is `0xFFFF`? I think the latter makes more sense so that's what I went with.
- Should Skrifa define its own color type or just use `ColorRecord`? I can't think of any fancy methods to add to such a type.
- Should `ColorPaletteCollection` have a method for returning a color directly based on a palette index *and* color index? I prefer the approach of "get palette, then get color" to avoid redundant bounds checks and ensure the indices don't get mixed up, but it might be nice to provide a convenience method.