### PR TITLE
[chore] bump minor for read/writes/skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.9.0", path = "font-types" }
-read-fonts = { version = "0.33.1", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.34.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.35.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.41.0", path = "write-fonts" }
+skrifa = { version = "0.36.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.42.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.33.1"
+version = "0.34.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.35.0"
+version = "0.36.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.41.0"
+version = "0.42.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.33.1 to 0.34.0
             3f3793c Fix CFF scaling with a nested font matrix (#1644)
             88494f0 [read-fonts] aat: preparse some state table fields (#1645)
             b57298c [aat/state-machine] Drop a check, since can't overflow (#1642)
             7f47a32 [aat] Inline a hot method (#1641)
             2daecae [read-fonts/bitset] Inline a hot function
             15c3543 [read-fonts/aat] Make StateMachine header public (#1637)
             c1c519d [IntSet] Correct U32Set::intersects() implementation.
             7818a9c [U32Set] Implement intersects()
             29bbde0 [read-fonts] Avoid timeout when computing array len (#1634)
             5efa529 [read_fonts/aat] Expose more of the lookup internals (#1633)
     Changes for skrifa from skrifa-v0.35.0 to 0.36.0
             3f3793c Fix CFF scaling with a nested font matrix (#1644)