### PR TITLE
Don't recompute cmap12 limits

### DIFF
--- a/skrifa/src/charmap.rs
+++ b/skrifa/src/charmap.rs
@@ -188,7 +188,7 @@ impl MappingIndex {
                     CmapSubtable::Format14(cmap14) => Some(cmap14),
                     _ => None,
                 }),
-            cmap12_limits: CmapIterLimits::default_for_font(font),
+            cmap12_limits: self.cmap12_limits,
         }
     }
 }


### PR DESCRIPTION
It looks like we're recomputing the `cmap12_limits` when building a charmap from a `MappingIndex` despite it already being calculated within `MappingSelection`:

https://github.com/taj-p/fontations/blob/07df8391a0b33f2402cf8ab78f5bf01c90c3a647/skrifa/src/charmap.rs#L398

This PR uses the precomputed `cmap12_limits` instead of recomputing its value.