### PR TITLE
[IFT] reject invalid IFT table format numbers instead of ignoring the table.

### DIFF
--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -25,7 +25,7 @@ pub const ABSOLUTE_URL_TEMPLATE: &[u8] = b"\x0a//foo.bar/\x80";
 pub fn simple_format1() -> BeBuffer {
     let mut buffer = be_buffer! {
         /* ### Header ### */
-        1u8,                    // format
+        {1u8: "format"},        // format
         0u32,                   // reserved
         [1u32, 2, 3, 4],        // compat id
         2u16,                   // max entry id
@@ -296,7 +296,7 @@ pub fn feature_map_format1() -> BeBuffer {
 // Format specification: https://w3c.github.io/IFT/Overview.html#patch-map-format-2
 pub fn codepoints_only_format2() -> BeBuffer {
     let mut buffer = be_buffer! {
-      2u8,                // format
+      {2u8: "format"},    // format
 
       0u32,               // reserved
 

--- a/read-fonts/src/tables/ift.rs
+++ b/read-fonts/src/tables/ift.rs
@@ -478,6 +478,19 @@ mod tests {
     }
 
     #[test]
+    fn invalid_format_number() {
+        // No offsets
+        let mut data = test_data::codepoints_only_format2();
+        data.write_at("format", 3u8);
+
+        let Err(err) = Ift::read(FontData::new(&data)) else {
+            panic!("Read should have failed due to invalid format number.");
+        };
+
+        assert_eq!(ReadError::InvalidFormat(3), err);
+    }
+
+    #[test]
     fn compatibility_id() {
         let data = test_data::simple_format1();
         let table = Ift::read(FontData::new(&data)).unwrap();


### PR DESCRIPTION
This updates behaviour to match specification expectations (see: https://w3c.github.io/IFT/Overview.html#interpreting-patch-map-format-1 and https://w3c.github.io/IFT/Overview.html#interpreting-patch-map-format-2)