### PR TITLE
[read-fonts] Fix some warnings and lints

### DIFF
--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -92,7 +92,7 @@ impl<'a> Cvar<'a> {
     }
 
     /// Array of tuple variation headers.
-    pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader> {
+    pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader<'a>> {
         let range = self.shape.tuple_variation_headers_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
     }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -658,7 +658,7 @@ impl<'a> GlyphVariationDataHeader<'a> {
     }
 
     /// Array of tuple variation headers.
-    pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader> {
+    pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader<'a>> {
         let range = self.shape.tuple_variation_headers_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
     }

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -226,10 +226,11 @@ impl<'a> TupleVariationHeader<'a> {
             } else {
                 Default::default()
             }
-            + index
-                .intermediate_region()
-                .then_some(tuple_byte_len * 2)
-                .unwrap_or_default()
+            + if index.intermediate_region() {
+                tuple_byte_len * 2
+            } else {
+                Default::default()
+            }
     }
 }
 

--- a/resources/codegen_inputs/cvar.rs
+++ b/resources/codegen_inputs/cvar.rs
@@ -24,5 +24,5 @@ table Cvar {
     /// Array of tuple variation headers.
     #[count(..)]
     #[traverse_with(skip)]
-    tuple_variation_headers: VarLenArray<TupleVariationHeader>,
+    tuple_variation_headers: VarLenArray<TupleVariationHeader<'_>>,
 }

--- a/resources/codegen_inputs/gvar.rs
+++ b/resources/codegen_inputs/gvar.rs
@@ -79,6 +79,6 @@ table GlyphVariationDataHeader {
     /// Array of tuple variation headers.
     #[count(..)]
     #[traverse_with(skip)]
-    tuple_variation_headers: VarLenArray<TupleVariationHeader>,
+    tuple_variation_headers: VarLenArray<TupleVariationHeader<'_>>,
 }
 


### PR DESCRIPTION
- Fixes the "mismatches lifetimes syntax" warning
- Fixes the obfuscated_if_else clippy lint