### PR TITLE
Subtract overflow in autohint State::apply_to_segment

### DIFF
--- a/skrifa/src/outline/autohint/topo/segments.rs
+++ b/skrifa/src/outline/autohint/topo/segments.rs
@@ -579,7 +579,7 @@ impl State {
         }
         segment.min_coord = self.min_coord as i16;
         segment.max_coord = self.max_coord as i16;
-        segment.height = segment.max_coord - segment.min_coord;
+        segment.height = (self.max_coord - self.min_coord) as i16;
     }
 }
 

--- a/skrifa/src/outline/autohint/topo/segments.rs
+++ b/skrifa/src/outline/autohint/topo/segments.rs
@@ -1068,4 +1068,19 @@ mod tests {
             })
             .collect()
     }
+
+    /// OSS Fuzz caught subtract with overflow in State::apply_to_segment.
+    /// See <https://oss-fuzz.com/testcase-detail/5446493076258816>
+    /// and <https://issues.oss-fuzz.com/issues/438909305>
+    #[test]
+    fn state_apply_overflow() {
+        let mut segment = Segment::default();
+        let state = State {
+            min_coord: MAX_SCORE,
+            max_coord: MIN_SCORE,
+            ..Default::default()
+        };
+        // Just don't panic with overflow
+        state.apply_to_segment(&mut segment, 0);
+    }
 }


### PR DESCRIPTION
OSS fuzz ref: https://oss-fuzz.com/testcase-detail/5446493076258816 and https://oss-fuzz.com/testcase-detail/5446493076258816

First commit contains failing test.