### PR TITLE
[skrifa] Don't enable `traversal` feature by default

### DIFF
--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 all-features = true
 
 [features]
-default = ["autohint_shaping", "traversal"]
+default = ["std", "autohint_shaping"]
 std = ["read-fonts/std"]
 traversal = ["std", "read-fonts/experimental_traverse"]
 # Enables extended shaping support for the autohinter. Enabled by default.


### PR DESCRIPTION
Improves compile times of `read-fonts` by around 25% (8s -> 6s on my machine) for cases where the `traversal` feature is not required.