### PR TITLE
Depend on `bytemuck_derive` rather than `bytemuck` with the `derive` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rust-version = "1.82"
 # note: bytemuck version must be available in all deployment environments, 
 # specifically the floor of the versions supported by google3 and Chrome
 bytemuck = "1.13.1"
+bytemuck_derive = "1"
 # dev dependencies
 env_logger = "0.11"
 pretty_assertions = "1.3.0"

--- a/font-codegen/src/flags_enums.rs
+++ b/font-codegen/src/flags_enums.rs
@@ -24,7 +24,7 @@ pub(crate) fn generate_flags(raw: &BitFlags) -> proc_macro2::TokenStream {
 
     quote! {
         #( #docs )*
-        #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck::AnyBitPattern)]
+        #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive::AnyBitPattern)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[repr(transparent)]
         pub struct #name { bits: #typ }

--- a/font-codegen/src/record.rs
+++ b/font-codegen/src/record.rs
@@ -36,7 +36,7 @@ pub(crate) fn generate(item: &Record, all_items: &Items) -> syn::Result<TokenStr
             #[repr(packed)]
         }
     });
-    let simple_record_traits = is_zerocopy.then(|| quote!(Copy, bytemuck::AnyBitPattern,));
+    let simple_record_traits = is_zerocopy.then(|| quote!(Copy, bytemuck_derive::AnyBitPattern,));
 
     let maybe_impl_fixed_size = is_zerocopy.then(|| {
         let inner_types = item.fields.iter().map(|fld| fld.typ.cooked_type_tokens());

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -17,12 +17,13 @@ all-features = true
 
 [features]
 std = []
-bytemuck = ["dep:bytemuck"]
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
 serde = ["dep:serde"]
 
 [dependencies]
 # note: bytemuck version must be available in all deployment environments
-bytemuck = { workspace = true,  features = ["derive", "min_const_generics"], optional = true }
+bytemuck = { workspace = true,  features = ["min_const_generics"], optional = true }
+bytemuck_derive = { workspace = true, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/font-types/src/fixed.rs
+++ b/font-types/src/fixed.rs
@@ -7,7 +7,7 @@ macro_rules! fixed_impl {
     ($name:ident, $bits:literal, $fract_bits:literal, $ty:ty) => {
         #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern, bytemuck::NoUninit))]
+        #[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern, bytemuck_derive::NoUninit))]
         #[repr(transparent)]
         #[doc = concat!(stringify!($bits), "-bit signed fixed point number with ", stringify!($fract_bits), " bits of fraction." )]
         pub struct $name($ty);

--- a/font-types/src/fword.rs
+++ b/font-types/src/fword.rs
@@ -5,14 +5,14 @@ use super::Fixed;
 /// 16-bit signed quantity in font design units.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct FWord(i16);
 
 /// 16-bit unsigned quantity in font design units.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct UfWord(u16);
 

--- a/font-types/src/glyph_id.rs
+++ b/font-types/src/glyph_id.rs
@@ -6,7 +6,7 @@
 /// A 16-bit glyph identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct GlyphId16(u16);
 
@@ -69,7 +69,7 @@ crate::newtype_scalar!(GlyphId16, [u8; 2]);
 /// A 32-bit glyph identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct GlyphId(u32);
 

--- a/font-types/src/int24.rs
+++ b/font-types/src/int24.rs
@@ -1,7 +1,7 @@
 /// 24-bit unsigned integer.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct Int24(i32);
 

--- a/font-types/src/longdatetime.rs
+++ b/font-types/src/longdatetime.rs
@@ -5,7 +5,7 @@
 /// This represented as a number of seconds since 12:00 midnight, January 1, 1904, UTC.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct LongDateTime(i64);
 

--- a/font-types/src/name_id.rs
+++ b/font-types/src/name_id.rs
@@ -17,7 +17,7 @@ use core::fmt;
 /// For more detail, see <https://learn.microsoft.com/en-us/typography/opentype/spec/name#name-ids>
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct NameId(u16);
 

--- a/font-types/src/offset.rs
+++ b/font-types/src/offset.rs
@@ -5,7 +5,7 @@ use crate::{Scalar, Uint24};
 /// An offset of a given width for which NULL (zero) is a valid value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct Nullable<T>(T);
 
@@ -65,7 +65,7 @@ macro_rules! impl_offset {
         /// the `None` case.
         #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+        #[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
         #[repr(transparent)]
         pub struct $name($rawty);
 

--- a/font-types/src/point.rs
+++ b/font-types/src/point.rs
@@ -3,7 +3,7 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// Two dimensional point with a generic coordinate type.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(C)]
 pub struct Point<T> {
     /// X coordinate.

--- a/font-types/src/tag.rs
+++ b/font-types/src/tag.rs
@@ -18,7 +18,7 @@ use std::{
 ///
 /// [spec]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#data-types
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct Tag([u8; 4]);
 

--- a/font-types/src/uint24.rs
+++ b/font-types/src/uint24.rs
@@ -1,7 +1,7 @@
 /// 24-bit unsigned integer.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct Uint24(u32);
 

--- a/font-types/src/version.rs
+++ b/font-types/src/version.rs
@@ -7,7 +7,7 @@
 /// [spec]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-version-numbers
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(transparent)]
 pub struct Version16Dot16(u32);
 
@@ -21,7 +21,7 @@ pub struct Version16Dot16(u32);
 /// [spec]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-version-numbers
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::AnyBitPattern))]
 #[repr(C)]
 pub struct MajorMinor {
     /// The major version number

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -37,6 +37,7 @@ font-types = { workspace = true, features = ["bytemuck"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 core_maths = { workspace = true, optional = true }
 bytemuck = { workspace = true }
+bytemuck_derive = { workspace = true }
 
 [dev-dependencies]
 font-test-data = { workspace = true }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -141,7 +141,9 @@ impl<'a> std::fmt::Debug for TableDirectory<'a> {
 }
 
 /// Record for a table in a font.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct TableRecord {

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -495,7 +495,9 @@ impl<'a> std::fmt::Debug for Lookup4<'a> {
 }
 
 /// Lookup segment for format 4.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct LookupSegment4 {

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -207,7 +207,9 @@ impl<'a> std::fmt::Debug for GlyphDataEntry<'a> {
 }
 
 /// Individual anchor point.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AnchorPoint {

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -222,7 +222,9 @@ impl<'a> SomeRecord<'a> for SegmentMaps<'a> {
 }
 
 /// [AxisValueMap](https://learn.microsoft.com/en-us/typography/opentype/spec/avar#table-formats) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AxisValueMap {

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -406,7 +406,7 @@ impl<'a> std::fmt::Debug for BaseScriptList<'a> {
 }
 
 /// [BaseScriptRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptrecord)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BaseScriptRecord {
@@ -593,7 +593,7 @@ impl<'a> std::fmt::Debug for BaseScript<'a> {
 }
 
 /// [BaseLangSysRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BaseLangSysRecord {
@@ -899,7 +899,7 @@ impl<'a> std::fmt::Debug for MinMax<'a> {
 }
 
 /// [FeatMinMaxRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/base#baselangsysrecord)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FeatMinMaxRecord {

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -6,7 +6,9 @@
 use crate::codegen_prelude::*;
 
 /// [BitmapSize](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#bitmapsize-record) record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BitmapSize {
@@ -150,7 +152,9 @@ impl<'a> SomeRecord<'a> for BitmapSize {
 }
 
 /// [SbitLineMetrics](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#sbitlinemetrics-record) record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SbitLineMetrics {
@@ -265,7 +269,9 @@ impl<'a> SomeRecord<'a> for SbitLineMetrics {
 }
 
 /// [Bitmap flags](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#bitmap-flags).
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct BitmapFlags {
@@ -573,7 +579,9 @@ impl<'a> From<BitmapFlags> for FieldType<'a> {
 }
 
 /// [BigGlyphMetrics](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#bigglyphmetrics) record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BigGlyphMetrics {
@@ -670,7 +678,9 @@ impl<'a> SomeRecord<'a> for BigGlyphMetrics {
 }
 
 /// [SmallGlyphMetrics](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#smallglyphmetrics) record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SmallGlyphMetrics {
@@ -828,7 +838,7 @@ impl<'a> std::fmt::Debug for IndexSubtableList<'a> {
     }
 }
 
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct IndexSubtableRecord {
@@ -1411,7 +1421,9 @@ impl<'a> std::fmt::Debug for IndexSubtable4<'a> {
 }
 
 /// [GlyphIdOffsetPair](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#glyphidoffsetpair-record) record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct GlyphIdOffsetPair {
@@ -1611,7 +1623,9 @@ impl<'a> std::fmt::Debug for IndexSubtable5<'a> {
 }
 
 /// [EbdtComponent](https://learn.microsoft.com/en-us/typography/opentype/spec/ebdt#ebdtcomponent-record) record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BdtComponent {

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -109,7 +109,7 @@ impl<'a> std::fmt::Debug for Cmap<'a> {
 }
 
 /// [Encoding Record](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct EncodingRecord {
@@ -560,7 +560,9 @@ impl<'a> std::fmt::Debug for Cmap2<'a> {
 }
 
 /// Part of [Cmap2]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SubHeader {
@@ -1154,7 +1156,9 @@ impl<'a> std::fmt::Debug for Cmap8<'a> {
 }
 
 /// Used in [Cmap8] and [Cmap12]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SequentialMapGroup {
@@ -1622,7 +1626,9 @@ impl<'a> std::fmt::Debug for Cmap13<'a> {
 }
 
 /// Part of [Cmap13]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ConstantMapGroup {
@@ -1793,7 +1799,7 @@ impl<'a> std::fmt::Debug for Cmap14<'a> {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VariationSelector {
@@ -2046,7 +2052,9 @@ impl<'a> std::fmt::Debug for NonDefaultUvs<'a> {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct UvsMapping {
@@ -2088,7 +2096,9 @@ impl<'a> SomeRecord<'a> for UvsMapping {
 }
 
 /// Part of [Cmap14]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct UnicodeRange {

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -316,7 +316,9 @@ impl<'a> std::fmt::Debug for Colr<'a> {
 }
 
 /// [BaseGlyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BaseGlyph {
@@ -366,7 +368,9 @@ impl<'a> SomeRecord<'a> for BaseGlyph {
 }
 
 /// [Layer](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Layer {
@@ -495,7 +499,7 @@ impl<'a> std::fmt::Debug for BaseGlyphList<'a> {
 }
 
 /// [BaseGlyphPaint](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct BaseGlyphPaint {
@@ -743,7 +747,7 @@ impl<'a> std::fmt::Debug for ClipList<'a> {
 }
 
 /// [Clip](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Clip {
@@ -1152,7 +1156,9 @@ impl<'a> std::fmt::Debug for ClipBoxFormat2<'a> {
 }
 
 /// [ColorIndex](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ColorIndex {
@@ -1194,7 +1200,9 @@ impl<'a> SomeRecord<'a> for ColorIndex {
 }
 
 /// [VarColorIndex](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VarColorIndex {
@@ -1244,7 +1252,9 @@ impl<'a> SomeRecord<'a> for VarColorIndex {
 }
 
 /// [ColorStop](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ColorStop {
@@ -1294,7 +1304,9 @@ impl<'a> SomeRecord<'a> for ColorStop {
 }
 
 /// [VarColorStop](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VarColorStop {

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -290,7 +290,9 @@ impl<'a> std::fmt::Debug for Cpal<'a> {
 }
 
 /// The [PaletteType](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-type-array) flags.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct PaletteType {
@@ -606,7 +608,9 @@ impl<'a> From<PaletteType> for FieldType<'a> {
 /// [CPAL (Color Record)](https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entries-and-color-records) record
 ///
 /// Contains a color in non-premultiplied BGRA form, in the sRGB color space.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ColorRecord {

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -123,7 +123,9 @@ impl<'a> std::fmt::Debug for Dsig<'a> {
 }
 
 /// [Permission flags](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct PermissionFlags {
@@ -427,7 +429,7 @@ impl<'a> From<PermissionFlags> for FieldType<'a> {
 }
 
 /// [Signature Record](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SignatureRecord {

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -121,7 +121,7 @@ impl<'a> std::fmt::Debug for Feat<'a> {
 }
 
 /// Type, flags and names for a feature.
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FeatureName {
@@ -294,7 +294,9 @@ impl<'a> std::fmt::Debug for SettingNameArray<'a> {
 }
 
 /// Associates a setting with a name identifier.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SettingName {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -297,7 +297,9 @@ impl<'a> std::fmt::Debug for AxisInstanceArrays<'a> {
 }
 
 /// The [VariationAxisRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord)
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VariationAxisRecord {

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -109,7 +109,9 @@ impl<'a> std::fmt::Debug for Gasp<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct GaspRange {
@@ -153,7 +155,9 @@ impl<'a> SomeRecord<'a> for GaspRange {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct GaspRangeBehavior {

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -240,7 +240,9 @@ impl<'a> std::fmt::Debug for SimpleGlyph<'a> {
 }
 
 /// Flags used in [SimpleGlyph]
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct SimpleGlyphFlags {
@@ -771,7 +773,9 @@ impl<'a> std::fmt::Debug for CompositeGlyph<'a> {
 }
 
 /// Flags used in [CompositeGlyph]
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct CompositeGlyphFlags {

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -258,7 +258,9 @@ impl std::fmt::Debug for PositionLookup<'_> {
 }
 
 /// See [ValueRecord]
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct ValueFormat {
@@ -1113,7 +1115,7 @@ impl<'a> std::fmt::Debug for MarkArray<'a> {
 }
 
 /// Part of [MarkArray]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct MarkRecord {
@@ -2540,7 +2542,7 @@ impl<'a> std::fmt::Debug for CursivePosFormat1<'a> {
 }
 
 /// Part of [CursivePosFormat1]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct EntryExitRecord {

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -192,7 +192,9 @@ impl<'a> std::fmt::Debug for Gvar<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct GvarFlags {

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -6,7 +6,9 @@
 use crate::codegen_prelude::*;
 
 /// The `macStyle` field for the head table.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct MacStyle {
@@ -340,7 +342,9 @@ impl<'a> From<MacStyle> for FieldType<'a> {
 }
 
 /// The `flags` field for the head table.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct Flags {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -118,7 +118,9 @@ impl<'a> std::fmt::Debug for Hmtx<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct LongMetric {

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -119,7 +119,9 @@ impl<'a> SomeTable<'a> for Ift<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct PatchMapFieldPresenceFlags {
@@ -1727,7 +1729,9 @@ impl<'a> std::fmt::Debug for EntryData<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct EntryFormatFlags {
@@ -2057,7 +2061,9 @@ impl<'a> From<EntryFormatFlags> for FieldType<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct DesignSpaceSegment {
@@ -2392,7 +2398,9 @@ impl<'a> std::fmt::Debug for TablePatch<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct TablePatchFlags {
@@ -2820,7 +2828,9 @@ impl<'a> std::fmt::Debug for GlyphKeyedPatch<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct GlyphKeyedFlags {

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -334,7 +334,9 @@ impl<'a> std::fmt::Debug for Subtable0<'a> {
 }
 
 /// The type 0 `kerx` subtable kerning record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Subtable0Pair {

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -92,7 +92,7 @@ impl<'a> std::fmt::Debug for ScriptList<'a> {
 }
 
 /// [Script Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ScriptRecord {
@@ -254,7 +254,7 @@ impl<'a> std::fmt::Debug for Script<'a> {
     }
 }
 
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct LangSysRecord {
@@ -500,7 +500,7 @@ impl<'a> std::fmt::Debug for FeatureList<'a> {
 }
 
 /// Part of [FeatureList]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FeatureRecord {
@@ -1220,7 +1220,9 @@ impl<'a> std::fmt::Debug for CoverageFormat2<'a> {
 }
 
 /// Used in [CoverageFormat2]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct RangeRecord {
@@ -1558,7 +1560,9 @@ impl<'a> std::fmt::Debug for ClassDefFormat2<'a> {
 }
 
 /// Used in [ClassDefFormat2]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ClassRangeRecord {
@@ -1681,7 +1685,9 @@ impl<'a> SomeTable<'a> for ClassDef<'a> {
 }
 
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SequenceLookupRecord {
@@ -4408,7 +4414,7 @@ impl<'a> std::fmt::Debug for FeatureVariations<'a> {
 }
 
 /// Part of [FeatureVariations]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FeatureVariationRecord {
@@ -5296,7 +5302,7 @@ impl<'a> std::fmt::Debug for FeatureTableSubstitution<'a> {
 }
 
 /// Used in [FeatureTableSubstitution]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FeatureTableSubstitutionRecord {

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -123,7 +123,9 @@ impl<'a> std::fmt::Debug for Ltag<'a> {
 }
 
 /// Offset and length of string in `ltag` table.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FTStringRange {

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -127,7 +127,7 @@ impl<'a> std::fmt::Debug for Meta<'a> {
 }
 
 ///  <https://learn.microsoft.com/en-us/typography/opentype/spec/meta#table-formats>
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct DataMapRecord {

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -257,7 +257,9 @@ impl<'a> std::fmt::Debug for Chain<'a> {
 }
 
 /// Used to compute the sub-feature flags for a list of requested features and settings.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Feature {
@@ -417,7 +419,9 @@ impl<'a> std::fmt::Debug for Subtable<'a> {
 }
 
 /// Entry payload in a contextual subtable state machine.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ContextualEntryData {
@@ -463,7 +467,9 @@ impl<'a> SomeRecord<'a> for ContextualEntryData {
 }
 
 /// Entry payload in an insertion subtable state machine.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct InsertionEntryData {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -155,7 +155,9 @@ impl<'a> std::fmt::Debug for Mvar<'a> {
 }
 
 /// [ValueRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/mvar#table-formats) metrics variation record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ValueRecord {

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -184,7 +184,7 @@ impl<'a> std::fmt::Debug for Name<'a> {
 }
 
 /// Part of [Name]
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct LangTagRecord {
@@ -228,7 +228,7 @@ impl<'a> SomeRecord<'a> for LangTagRecord {
 }
 
 ///[Name Records](https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-records)
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct NameRecord {

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -6,7 +6,9 @@
 use crate::codegen_prelude::*;
 
 /// OS/2 [selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection)
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct SelectionFlags {

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -493,7 +493,9 @@ impl<'a> std::fmt::Debug for FdSelectFormat3<'a> {
 }
 
 /// Range struct for FdSelect format 3.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FdSelectRange3 {
@@ -649,7 +651,9 @@ impl<'a> std::fmt::Debug for FdSelectFormat4<'a> {
 }
 
 /// Range struct for FdSelect format 4.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct FdSelectRange4 {
@@ -935,7 +939,9 @@ impl<'a> std::fmt::Debug for CharsetFormat1<'a> {
 }
 
 /// Range struct for Charset format 1.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct CharsetRange1 {
@@ -1064,7 +1070,9 @@ impl<'a> std::fmt::Debug for CharsetFormat2<'a> {
 }
 
 /// Range struct for Charset format 2.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct CharsetRange2 {

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -6,7 +6,9 @@
 use crate::codegen_prelude::*;
 
 /// Sbix header flags.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct HeaderFlags {

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -202,7 +202,9 @@ impl<'a> std::fmt::Debug for Stat<'a> {
 }
 
 /// [Axis Records](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#axis-records)
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AxisRecord {
@@ -993,7 +995,9 @@ impl<'a> std::fmt::Debug for AxisValueFormat4<'a> {
 }
 
 /// Part of [AxisValueFormat4]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct AxisValueRecord {
@@ -1037,7 +1041,9 @@ impl<'a> SomeRecord<'a> for AxisValueRecord {
 }
 
 /// [Axis value table flags](https://docs.microsoft.com/en-us/typography/opentype/spec/stat#flags).
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct AxisValueTableFlags {

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -185,7 +185,9 @@ impl<'a> std::fmt::Debug for SVGDocumentList<'a> {
 }
 
 /// [SVGDocumentRecord](https://learn.microsoft.com/en-us/typography/opentype/spec/svg)
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SVGDocumentRecord {

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -120,7 +120,9 @@ impl<'a> std::fmt::Debug for MajorMinorVersion<'a> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct GotFlags {

--- a/read-fonts/generated/generated_test_enum.rs
+++ b/read-fonts/generated/generated_test_enum.rs
@@ -96,7 +96,9 @@ impl<'a> From<MyEnum2> for FieldType<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct MyRecord {

--- a/read-fonts/generated/generated_test_flags.rs
+++ b/read-fonts/generated/generated_test_flags.rs
@@ -6,7 +6,9 @@
 use crate::codegen_prelude::*;
 
 /// Some flags!
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct ValueFormat {

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -852,7 +852,9 @@ impl<'a> std::fmt::Debug for Dummy<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct Shmecord {

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -142,7 +142,9 @@ impl<'a> std::fmt::Debug for BasicTable<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SimpleRecord {
@@ -267,7 +269,7 @@ impl<'a> SomeRecord<'a> for ContainsArrays<'a> {
     }
 }
 
-#[derive(Clone, Debug, Copy, bytemuck :: AnyBitPattern)]
+#[derive(Clone, Debug, Copy, bytemuck_derive :: AnyBitPattern)]
 #[repr(C)]
 #[repr(packed)]
 pub struct ContainsOffsets {

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -245,7 +245,9 @@ impl<'a> std::fmt::Debug for TrackData<'a> {
 }
 
 /// Single entry in a tracking table.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct TrackTableEntry {

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -497,7 +497,9 @@ impl<'a> std::fmt::Debug for SparseVariationRegion<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct SparseRegionAxisCoordinates {
@@ -752,7 +754,9 @@ impl<'a> std::fmt::Debug for ConditionList<'a> {
 /// Flags used in the [VarcComponent] byte stream
 ///
 /// <https://github.com/harfbuzz/boring-expansion-spec/blob/main/VARC.md#variable-component-flags>
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct VarcFlags {

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -515,7 +515,9 @@ impl<'a> SomeTable<'a> for DeltaSetIndexMap<'a> {
 }
 
 /// Entry format for a [DeltaSetIndexMap].
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, bytemuck_derive :: AnyBitPattern,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(transparent)]
 pub struct EntryFormat {
@@ -1000,7 +1002,9 @@ impl<'a> SomeRecord<'a> for VariationRegion<'a> {
 }
 
 /// The [RegionAxisCoordinates](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) record
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct RegionAxisCoordinates {

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -131,7 +131,9 @@ impl<'a> std::fmt::Debug for Vorg<'a> {
 }
 
 /// Vertical origin Y metrics record.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck_derive :: AnyBitPattern,
+)]
 #[repr(C)]
 #[repr(packed)]
 pub struct VertOriginYMetrics {

--- a/read-fonts/src/tables/aat.rs
+++ b/read-fonts/src/tables/aat.rs
@@ -32,7 +32,7 @@ impl Lookup0<'_> {
 }
 
 /// Lookup segment for format 2.
-#[derive(Copy, Clone, bytemuck::AnyBitPattern)]
+#[derive(Copy, Clone, bytemuck_derive::AnyBitPattern)]
 #[repr(C, packed)]
 pub struct LookupSegment2<T>
 where
@@ -112,7 +112,7 @@ impl Lookup4<'_> {
 }
 
 /// Lookup single record for format 6.
-#[derive(Copy, Clone, bytemuck::AnyBitPattern)]
+#[derive(Copy, Clone, bytemuck_derive::AnyBitPattern)]
 #[repr(C, packed)]
 pub struct LookupSingle<T>
 where
@@ -276,7 +276,7 @@ pub type LookupGlyphId<'a> = TypedLookup<'a, GlyphId16>;
 /// Note: this type is only intended for use as the type parameter for
 /// `StateEntry`. The inner field is private and this type cannot be
 /// constructed outside of this module.
-#[derive(Copy, Clone, bytemuck::AnyBitPattern, Debug)]
+#[derive(Copy, Clone, bytemuck_derive::AnyBitPattern, Debug)]
 pub struct NoPayload(());
 
 impl FixedSize for NoPayload {
@@ -753,7 +753,7 @@ mod tests {
         assert_eq!(entry.payload.current_index, 0);
     }
 
-    #[derive(Copy, Clone, Debug, bytemuck::AnyBitPattern)]
+    #[derive(Copy, Clone, Debug, bytemuck_derive::AnyBitPattern)]
     #[repr(C, packed)]
     struct ContextualData {
         _mark_index: BigEndian<u16>,

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -55,7 +55,14 @@ impl core::ops::BitOr for PointMarker {
 /// itself. Others, designated as markers are set and cleared while an outline
 /// is being transformed during variation application and hinting.
 #[derive(
-    Copy, Clone, PartialEq, Eq, Default, Debug, bytemuck::AnyBitPattern, bytemuck::NoUninit,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Debug,
+    bytemuck_derive::AnyBitPattern,
+    bytemuck_derive::NoUninit,
 )]
 #[repr(transparent)]
 pub struct PointFlags(u8);


### PR DESCRIPTION
This is a small win for build paralellisation (meaning that the `bytemuck` crate doesn't need to wait for `bytemuck_derive` to be compiled).