### PR TITLE
[chore] bump patch for types, read, skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ core_maths = "0.1"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.10.0", path = "font-types" }
-read-fonts = { version = "0.35.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.10.1", path = "font-types" }
+read-fonts = { version = "0.35.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.37.0", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.37.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.43.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.10.0"
+version = "0.10.1"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.35.0"
+version = "0.35.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.37.0"
+version = "0.37.1"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for font-types from font-types-v0.10.0 to 0.10.1
             654503c Negation overflow in Fixed::div (#1662)
     Changes for read-fonts from read-fonts-v0.35.0 to 0.35.1
             b022894 [read-fonts+skrifa] CFF: clear stem hints for seac components (#1688)
             0bd210e [read-fonts] CFF: ignore unknown operators (#1687)
             8b20dfd [read-fonts] CFF: relax stack checks (#1686)
             0a82dd4 Handle NO_VARIATION_INDEX case when computing deltas, fixes #1720
             2edf2f2 [klippa] subset GSUB/GPOS tables
             a747f45 Fix clippy::obfuscated_if_else lint
             244c4ec Fix mismatched lifetimes syntax warning
             1b5175d [read-fonts] add mapping/iter support to CmapSubtable (#1656)
             caab2c5 [read-fonts] extend support for cmap 6 and 10 (#1655)
             707ebc8 Add CPAL interface in skrifa (#1632)
     Changes for skrifa from skrifa-v0.37.0 to 0.37.1
             b022894 [read-fonts+skrifa] CFF: clear stem hints for seac components (#1688)
             8b6497d [skrifa] Make traversal feature non-default (#1666)
             237e696 Add with overflow in CFF hint scale computation (#1665)
             512ae1c Subtract overflow in autohint State::apply_to_segment (#1664)
             a6e7e45 Add with overflow in ColrInstance::var_deltas (#1663)
             707ebc8 Add CPAL interface in skrifa (#1632)