### PR TITLE
[chore] bump skrifa to 0.38.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ font-types = { version = "0.10.1", path = "font-types" }
 read-fonts = { version = "0.35.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.37.1", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.38.0", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.43.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.37.1"
+version = "0.38.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
We removed a default feature which was a breaking change.