### PR TITLE
Bump versions to fix broken releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ core_maths = "0.1"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.10.1", path = "font-types" }
-read-fonts = { version = "0.35.1", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.36.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.38.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.43.0", path = "write-fonts" }
+skrifa = { version = "0.39.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.44.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.6.0"
+version = "0.6.1"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.35.1"
+version = "0.36.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.38.0"
+version = "0.39.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.43.0"
+version = "0.44.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
Bumps minor for read-fonts, write-fonts and skrifa. Patch for font-test-data.

Recent releases didn't take into account a removed default feature in skrifa and a breaking change to a field type for cpal in read-fonts.