### PR TITLE
Fix documentation build

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [data types]: https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(clippy::doc_markdown)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/incremental-font-transfer/src/lib.rs
+++ b/incremental-font-transfer/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! Built on top of the read-fonts crate.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 
 pub mod font_patch;

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -56,7 +56,7 @@
 //! [NameString]: tables::name::NameString
 //! [table-directory]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -11,7 +11,7 @@
 //! See the [readme](https://github.com/googlefonts/fontations/blob/main/skrifa/README.md)
 //! for additional details.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -134,7 +134,7 @@
 //! [`FromTableRef`]: from_obj::FromTableRef
 //! [`ToOwnedTable`]: from_obj::ToOwnedTable
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod collections;
 pub mod error;


### PR DESCRIPTION
Replace `doc_auto_cfg` with `doc_cfg`, see
https://github.com/rust-lang/rust/pull/138907

Fixes issues with docs.rs builds of Fontations crates.