### PR TITLE
[write] Cv FeatureParam name IDs are 'nullable'

### DIFF
--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -767,19 +767,23 @@ table CharacterVariantParams {
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) for a user-interface label for this
     /// feature. (May be NULL.)
+    #[default(NameId::COPYRIGHT_NOTICE)] // aka 'NULL'
     feat_ui_label_name_id: NameId,
     /// The 'name' table name ID that specifies a string (or strings,
     /// for multiple languages) that an application can use for tooltip
     /// text for this feature. (May be NULL.)
+    #[default(NameId::COPYRIGHT_NOTICE)]
     feat_ui_tooltip_text_name_id: NameId,
     /// The 'name' table name ID that specifies sample text that
     /// illustrates the effect of this feature. (May be NULL.)
+    #[default(NameId::COPYRIGHT_NOTICE)]
     sample_text_name_id: NameId,
     /// Number of named parameters. (May be zero.)
     num_named_parameters: u16,
     /// The first 'name' table name ID used to specify strings for
     /// user-interface labels for the feature parameters. (Must be zero
     /// if numParameters is zero.)
+    #[default(NameId::COPYRIGHT_NOTICE)]
     first_param_ui_label_name_id: NameId,
     /// The count of characters for which this feature provides glyph
     /// variants. (May be zero.)

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -3703,7 +3703,7 @@ impl<'a> FontRead<'a> for StylisticSetParams {
 }
 
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CharacterVariantParams {
     /// The 'name' table name ID that specifies a string (or strings,
@@ -3728,23 +3728,26 @@ pub struct CharacterVariantParams {
     pub character: Vec<Uint24>,
 }
 
+impl Default for CharacterVariantParams {
+    fn default() -> Self {
+        Self {
+            feat_ui_label_name_id: NameId::COPYRIGHT_NOTICE,
+            feat_ui_tooltip_text_name_id: NameId::COPYRIGHT_NOTICE,
+            sample_text_name_id: NameId::COPYRIGHT_NOTICE,
+            num_named_parameters: Default::default(),
+            first_param_ui_label_name_id: NameId::COPYRIGHT_NOTICE,
+            character: Default::default(),
+        }
+    }
+}
+
 impl CharacterVariantParams {
     /// Construct a new `CharacterVariantParams`
-    pub fn new(
-        feat_ui_label_name_id: NameId,
-        feat_ui_tooltip_text_name_id: NameId,
-        sample_text_name_id: NameId,
-        num_named_parameters: u16,
-        first_param_ui_label_name_id: NameId,
-        character: Vec<Uint24>,
-    ) -> Self {
+    pub fn new(num_named_parameters: u16, character: Vec<Uint24>) -> Self {
         Self {
-            feat_ui_label_name_id,
-            feat_ui_tooltip_text_name_id,
-            sample_text_name_id,
             num_named_parameters,
-            first_param_ui_label_name_id,
             character,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
[Kind of a funny little corner of the spec](https://learn.microsoft.com/en-us/typography/opentype/spec/features_ae#:~:text=The%20name%20ID%20provided%20by%20featUiLabelNameId%20is%20intended%20to%20provide%20a%20user%2Dinterface%20string%20for%20the%20feature;%20for%20example%2C%20“Capital%2Deng%20variants”.%20If%20set%20to%20NULL%2C%20no%20'name'%20table%20string%20is%20used%20for%20the%20feature%20name.), but this seems right.

JMM