### PR TITLE
Improve error message for Klippa file not found

### DIFF
--- a/klippa/src/main.rs
+++ b/klippa/src/main.rs
@@ -127,8 +127,10 @@ fn main() {
         }
     };
 
-    let font_bytes = std::fs::read(&args.path).expect("Invalid input font file found");
-    let font = FontRef::new(&font_bytes).expect("Error reading font bytes");
+    let font_bytes = std::fs::read(&args.path)
+        .unwrap_or_else(|err| panic!("Failed to read file {path:?}.\n{err}", path = &args.path));
+    let font = FontRef::new(&font_bytes)
+        .unwrap_or_else(|err| panic!("Failed to read {path:?} as font.\n{err}", path = &args.path));
     let drop_tables = match &args.drop_tables {
         Some(drop_tables_input) => match parse_tag_list(drop_tables_input) {
             Ok(drop_tables) => drop_tables,
@@ -253,7 +255,12 @@ fn main() {
             }
         };
     }
-    std::fs::write(&args.output_file, output_bytes).unwrap();
+    std::fs::write(&args.output_file, output_bytes).unwrap_or_else(|err| {
+        panic!(
+            "Failed to write output to {path:?}.\n{err}",
+            path = &args.output_file
+        )
+    });
 }
 
 fn parse_subset_flags(args: &Args) -> SubsetFlags {


### PR DESCRIPTION
Made it easier to distinguish if the failure was reading or writing. Also reprinted the path to avoid having to look elsewhere for debugging.

# Examples

### Read input failure

*Before*

```
wmedrano@wmedrano:~/src$ klippa --path ~/Downloads/NotoColorEmoji-Regular.ttf --output-file resources/testdata/NotoColorEmoji.ttf --unicodes U+1F973

thread 'main' (4178927) panicked at klippa/src/main.rs:130:48:
Invalid input font file found: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

*After*

```
wmedrano@wmedrano:~/src$ klippa --path ~/Downloads/NotoColorEmoji-Regular.ttf --output-file resources/testdata/NotoColorEmoji.ttf --unicodes U+1F973

thread 'main' (4188671) panicked at klippa/src/main.rs:131:31:
Failed to read file "/usr/local/google/home/wmedrano/Downloads/NotoColorEmoji-Regular.ttf"
No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Write output failure

*Before*

```
wmedrano@wmedrano:~/src$ klippa --path ~/Downloads/Noto_Color_Emoji/NotoColorEmoji-Regular.ttf --output-file resources/testdata/NotoColorEmoji.ttf --unicodes U+1F973

thread 'main' (5408) panicked at klippa/src/main.rs:258:53:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

*After*

```
wmedrano@wmedrano:~/src$ jj
wmedrano@wmedrano:~/src$ klippa --path ~/Downloads/Noto_Color_Emoji/NotoColorEmoji-Regular.ttf --output-file resources/testdata/NotoColorEmoji.ttf --unicodes U+1F973

thread 'main' (7241) panicked at klippa/src/main.rs:259:9:
Failed to write output to "resources/testdata/NotoColorEmoji.ttf".
No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```