### PR TITLE
Implement Clone for Brush

### DIFF
--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -140,7 +140,7 @@ pub struct ColorStop {
 ///
 /// The client receives the information about the fill type in the
 /// [`fill`](ColorPainter::fill) callback of the [`ColorPainter`] trait.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Brush<'a> {
     /// A solid fill with the color specified by `palette_index`. The respective
     /// color from the CPAL table then needs to be multiplied with `alpha`.


### PR DESCRIPTION
- Technically, we can also derive Copy, but this would make it harder to add non-copy variants