### PR TITLE
[PoC] Speed up reading

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -315,11 +315,23 @@ fn if_expression(xform: &IfTransform, add_self: bool) -> TokenStream {
 }
 
 impl Condition {
-    fn condition_tokens_for_read(&self) -> TokenStream {
+    pub(crate) fn condition_tokens_for_read(&self) -> TokenStream {
         match self {
             Condition::SinceVersion(version) => quote!(version.compatible(#version)),
             Condition::IfFlag { field, flag } => quote!(#field.contains(#flag)),
             Condition::IfCond { xform } => if_expression(xform, false),
+        }
+    }
+
+    pub(crate) fn condition_tokens_for_access(&self) -> TokenStream {
+        match self {
+            Condition::SinceVersion(version) => quote!(self.version().compatible(#version)),
+            Condition::IfFlag { field, flag } => quote!(self.#field().contains(#flag)),
+            Condition::IfCond { xform } => match xform {
+                IfTransform::AnyFlag(field, flags) => {
+                    quote!(self.#field().intersects(#(#flags)|*))
+                }
+            },
         }
     }
 

--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -825,13 +825,13 @@ impl Field {
         let range_stmt = self.getter_range_stmt();
         let mut read_stmt = if let Some(args) = &self.attrs.read_with_args {
             let get_args = args.to_tokens_for_table_getter();
-            quote!( self.data.read_with_args(range, &#get_args).unwrap() )
+            quote!(unchecked::read_with_args(self.data, range, &#get_args))
         } else if is_var_array {
-            quote!(VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap())
+            quote!(VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap())
         } else if is_array {
-            quote!(self.data.read_array(range).unwrap())
+            quote!(unchecked::read_array(self.data, range))
         } else {
-            quote!(self.data.read_at(range.start).unwrap())
+            quote!(unchecked::read_at(self.data, range.start))
         };
         if is_versioned {
             read_stmt = quote!(Some(#read_stmt));

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -51,9 +51,9 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
                    pub(crate) fn into_concrete<T>(self) -> #raw_name<'a, #t> {
                        let TableRef { data, #shape_name} = self;
                        TableRef {
-                           shape: #marker_name,
                            args: std::marker::PhantomData,
                            data,
+                           _marker: std::marker::PhantomData,
                        }
                    }
                }
@@ -66,9 +66,9 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
                    pub(crate) fn of_unit_type(&self) -> #raw_name<'a, ()> {
                        let TableRef { data, #shape_name} = self;
                        TableRef {
-                           shape: #marker_name,
                            args: std::marker::PhantomData,
                            data: *data,
+                           _marker: std::marker::PhantomData,
                        }
                    }
                }
@@ -127,7 +127,6 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
 }
 
 fn generate_font_read(item: &Table) -> syn::Result<TokenStream> {
-    let marker_name = item.marker_name();
     let name = item.raw_name();
     let generic = item.attrs.generic_offset.as_ref();
     let error_if_phantom_and_read_args = generic.map(|_| {
@@ -150,9 +149,9 @@ fn generate_font_read(item: &Table) -> syn::Result<TokenStream> {
                 fn read_with_args(data: FontData<'a>, args: &#args_type) -> Result<Self, ReadError> {
                     let args = *args;
                     Ok(TableRef {
-                        shape: #marker_name,
                         args,
                         data,
+                        _marker: std::marker::PhantomData,
                     })
                 }
             }
@@ -177,9 +176,9 @@ fn generate_font_read(item: &Table) -> syn::Result<TokenStream> {
             impl<'a, #generic> FontRead<'a> for #name<'a, #generic> {
             fn read(data: FontData<'a>) -> Result<Self, ReadError> {
                 Ok(TableRef {
-                    shape: #marker_name,
                     args: #args_value,
                     data,
+                    _marker: std::marker::PhantomData,
                 })
             }
         }

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -656,7 +656,7 @@ impl CFFAndCharStrings<'_> {
         let charstrings = Index1::read(charstrings_data)?;
         let offset_type = Self::offset_type(charstrings.off_size())?;
 
-        let offset_base = charstrings.shape().data_byte_range().start;
+        let offset_base = charstrings.data_byte_range().start;
         let charstrings_object_data = charstrings_data
             .split_off(offset_base)
             .ok_or(ReadError::OutOfBounds)?
@@ -684,7 +684,7 @@ impl CFFAndCharStrings<'_> {
         let charstrings = Index2::read(charstrings_data)?;
         let offset_type = Self::offset_type(charstrings.off_size())?;
 
-        let offset_base = charstrings.shape().data_byte_range().start;
+        let offset_base = charstrings.data_byte_range().start;
         let charstrings_object_data = charstrings_data
             .split_off(offset_base)
             .ok_or(ReadError::OutOfBounds)?
@@ -883,7 +883,7 @@ impl GlyphDataOffsetArray for Gvar<'_> {
         let orig_bytes = self.as_bytes();
         let orig_size = orig_bytes.len();
 
-        let original_offsets_range = self.shape().glyph_variation_data_offsets_byte_range();
+        let original_offsets_range = self.glyph_variation_data_offsets_byte_range();
 
         if new_offset_type == self.offset_type()
             && offsets.offset_array.len()
@@ -940,7 +940,7 @@ impl GlyphDataOffsetArray for Gvar<'_> {
         let shared_tuples_bytes = shared_tuples
             .offset_data()
             .as_bytes()
-            .get(shared_tuples.shape().tuples_byte_range())
+            .get(shared_tuples.tuples_byte_range())
             .ok_or_else(|| PatchingError::SerializationError(serializer.error()))?;
 
         let shared_tuples_obj = if !shared_tuples_bytes.is_empty() {
@@ -965,14 +965,14 @@ impl GlyphDataOffsetArray for Gvar<'_> {
         // Set up offsets to shared tuples and glyph data.
         serializer
             .add_link(
-                self.shape().shared_tuples_offset_byte_range(),
+                self.shared_tuples_offset_byte_range(),
                 shared_tuples_obj,
                 OffsetWhence::Head,
                 0,
                 false,
             )
             .and(serializer.add_link(
-                self.shape().glyph_variation_data_array_offset_byte_range(),
+                self.glyph_variation_data_array_offset_byte_range(),
                 glyph_data_obj,
                 OffsetWhence::Head,
                 0,

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -109,7 +109,7 @@ fn add_intersecting_format1_patches(
 
     // Step 2: produce final output.
     let mut applied_entries_indices: HashMap<PatchUrl, IntSet<u32>> = Default::default();
-    let applied_entries_start_bit_index = map.shape().applied_entries_bitmap_byte_range().start * 8;
+    let applied_entries_start_bit_index = map.applied_entries_bitmap_byte_range().start * 8;
 
     for (index, subset_def) in entries
         .into_iter()
@@ -674,7 +674,7 @@ fn decode_format2_entry<'a>(
 
     entries.push(entry);
 
-    let consumed_bytes = entry_data.shape().trailing_data_byte_range().end - trailing_data.len();
+    let consumed_bytes = entry_data.trailing_data_byte_range().end - trailing_data.len();
     Ok((FontData::new(trailing_data), consumed_bytes))
 }
 

--- a/klippa/src/cblc.rs
+++ b/klippa/src/cblc.rs
@@ -48,7 +48,7 @@ impl Subset for Cblc<'_> {
         let bitmapsize_bytes = self
             .offset_data()
             .as_bytes()
-            .get(self.shape().bitmap_sizes_byte_range())
+            .get(self.bitmap_sizes_byte_range())
             .unwrap();
 
         // cbdt out

--- a/klippa/src/colr.rs
+++ b/klippa/src/colr.rs
@@ -534,7 +534,7 @@ impl SubsetTable<'_> for ClipBoxFormat2<'_> {
             };
             // update VarIdxBase
             s.copy_assign(
-                start_pos + self.shape().var_index_base_byte_range().start,
+                start_pos + self.var_index_base_byte_range().start,
                 *new_varidx,
             );
         }
@@ -833,7 +833,7 @@ impl SubsetTable<'_> for PaintVarLinearGradient<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -884,7 +884,7 @@ impl SubsetTable<'_> for PaintVarRadialGradient<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -935,7 +935,7 @@ impl SubsetTable<'_> for PaintVarSweepGradient<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1019,7 +1019,7 @@ impl SubsetTable<'_> for VarAffine2x3<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1120,7 +1120,7 @@ impl SubsetTable<'_> for PaintVarTranslate<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1167,7 +1167,7 @@ impl SubsetTable<'_> for PaintVarScale<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1214,7 +1214,7 @@ impl SubsetTable<'_> for PaintVarScaleAroundCenter<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1261,7 +1261,7 @@ impl SubsetTable<'_> for PaintVarScaleUniform<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1308,7 +1308,7 @@ impl SubsetTable<'_> for PaintVarScaleUniformAroundCenter<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1355,7 +1355,7 @@ impl SubsetTable<'_> for PaintVarRotate<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1402,7 +1402,7 @@ impl SubsetTable<'_> for PaintVarRotateAroundCenter<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1449,7 +1449,7 @@ impl SubsetTable<'_> for PaintVarSkew<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())
@@ -1496,7 +1496,7 @@ impl SubsetTable<'_> for PaintVarSkewAroundCenter<'_> {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER));
             };
             // update VarIdxBase
-            let pos = start_pos + self.shape().var_index_base_byte_range().start;
+            let pos = start_pos + self.var_index_base_byte_range().start;
             s.copy_assign(pos, *new_varidx);
         }
         Ok(())

--- a/klippa/src/gvar.rs
+++ b/klippa/src/gvar.rs
@@ -88,7 +88,7 @@ fn subset_with_offset_type<OffsetType: GvarOffset>(
 
     //update sharedTuplesOffset, which is of Offset32 type and byte position in gvar is 8..12
     s.copy_assign(
-        gvar.shape().shared_tuples_offset_byte_range().start,
+        gvar.shared_tuples_offset_byte_range().start,
         shared_tuples_offset,
     );
 

--- a/klippa/src/maxp.rs
+++ b/klippa/src/maxp.rs
@@ -19,7 +19,7 @@ impl Subset for Maxp<'_> {
         let num_glyphs = plan.num_output_glyphs.min(0xFFFF) as u16;
         s.embed_bytes(self.offset_data().as_bytes())
             .map_err(|_| SubsetError::SubsetTableError(Maxp::TAG))?;
-        s.copy_assign(self.shape().num_glyphs_byte_range().start, num_glyphs);
+        s.copy_assign(self.num_glyphs_byte_range().start, num_glyphs);
 
         //drop hints
         if self.version() == Version16Dot16::VERSION_1_0
@@ -28,33 +28,15 @@ impl Subset for Maxp<'_> {
                 .contains(SubsetFlags::SUBSET_FLAGS_NO_HINTING)
         {
             //maxZones
-            s.copy_assign_from_bytes(self.shape().max_zones_byte_range().unwrap().start, &[0, 1]);
+            s.copy_assign_from_bytes(self.max_zones_byte_range().unwrap().start, &[0, 1]);
             //maxTwilightPoints..maxSizeOfInstructions
+            s.copy_assign(self.max_twilight_points_byte_range().unwrap().start, 0_u16);
+            s.copy_assign(self.max_storage_byte_range().unwrap().start, 0_u16);
+            s.copy_assign(self.max_function_defs_byte_range().unwrap().start, 0_u16);
+            s.copy_assign(self.max_instruction_defs_byte_range().unwrap().start, 0_u16);
+            s.copy_assign(self.max_stack_elements_byte_range().unwrap().start, 0_u16);
             s.copy_assign(
-                self.shape().max_twilight_points_byte_range().unwrap().start,
-                0_u16,
-            );
-            s.copy_assign(self.shape().max_storage_byte_range().unwrap().start, 0_u16);
-            s.copy_assign(
-                self.shape().max_function_defs_byte_range().unwrap().start,
-                0_u16,
-            );
-            s.copy_assign(
-                self.shape()
-                    .max_instruction_defs_byte_range()
-                    .unwrap()
-                    .start,
-                0_u16,
-            );
-            s.copy_assign(
-                self.shape().max_stack_elements_byte_range().unwrap().start,
-                0_u16,
-            );
-            s.copy_assign(
-                self.shape()
-                    .max_size_of_instructions_byte_range()
-                    .unwrap()
-                    .start,
+                self.max_size_of_instructions_byte_range().unwrap().start,
                 0_u16,
             );
         }

--- a/klippa/src/name.rs
+++ b/klippa/src/name.rs
@@ -80,7 +80,7 @@ fn serialize_name_records(
 ) -> Result<(), SubsetError> {
     let data = name.offset_data().as_bytes();
     let name_records = name.name_record();
-    let name_records_bytes = data.get(name.shape().name_record_byte_range()).unwrap();
+    let name_records_bytes = data.get(name.name_record_byte_range()).unwrap();
     let storage_start = name.storage_offset() as usize;
     for idx in retained_name_record_idxes.iter() {
         let len = s.length();

--- a/klippa/src/offset.rs
+++ b/klippa/src/offset.rs
@@ -50,11 +50,13 @@ impl<O: Scalar> SerializeSubset for O {
 
 // this is trait is used to copy simple tables only which implemented MinByteRange trait
 pub(crate) trait SerializeCopy {
-    fn serialize_copy<T: MinByteRange>(
+    fn serialize_copy<T>(
         t: &TableRef<T>,
         s: &mut Serializer,
         pos: usize,
-    ) -> Result<(), SerializeErrorFlags>;
+    ) -> Result<(), SerializeErrorFlags>
+    where
+        for<'a> TableRef<'a, T>: MinByteRange;
 
     fn serialize_copy_from_bytes(
         src_bytes: &[u8],
@@ -64,11 +66,14 @@ pub(crate) trait SerializeCopy {
 }
 
 impl<O: Scalar> SerializeCopy for O {
-    fn serialize_copy<T: MinByteRange>(
+    fn serialize_copy<T>(
         t: &TableRef<T>,
         s: &mut Serializer,
         pos: usize,
-    ) -> Result<(), SerializeErrorFlags> {
+    ) -> Result<(), SerializeErrorFlags>
+    where
+        for<'a> TableRef<'a, T>: MinByteRange,
+    {
         s.push()?;
         s.embed_bytes(t.min_table_bytes())?;
 

--- a/klippa/src/os2.rs
+++ b/klippa/src/os2.rs
@@ -27,13 +27,13 @@ impl Subset for Os2<'_> {
 
         let us_first_char_index: u16 = plan.os2_info.min_cmap_codepoint.min(0xFFFF) as u16;
         s.copy_assign(
-            self.shape().us_first_char_index_byte_range().start,
+            self.us_first_char_index_byte_range().start,
             us_first_char_index,
         );
 
         let us_last_char_index: u16 = plan.os2_info.max_cmap_codepoint.min(0xFFFF) as u16;
         s.copy_assign(
-            self.shape().us_last_char_index_byte_range().start,
+            self.us_last_char_index_byte_range().start,
             us_last_char_index,
         );
 

--- a/klippa/src/post.rs
+++ b/klippa/src/post.rs
@@ -31,10 +31,7 @@ impl Subset for Post<'_> {
             .contains(SubsetFlags::SUBSET_FLAGS_GLYPH_NAMES);
         //version 3 does not have any glyph names
         if !glyph_names {
-            s.copy_assign(
-                self.shape().version_byte_range().start,
-                Version16Dot16::VERSION_3_0,
-            );
+            s.copy_assign(self.version_byte_range().start, Version16Dot16::VERSION_3_0);
         }
 
         if glyph_names && self.version() == Version16Dot16::VERSION_2_0 {

--- a/klippa/src/variations.rs
+++ b/klippa/src/variations.rs
@@ -102,7 +102,7 @@ impl<'a> SubsetTable<'a> for VariationRegionList<'a> {
         let Some(src_var_regions_bytes) = self
             .offset_data()
             .as_bytes()
-            .get(self.shape().variation_regions_byte_range())
+            .get(self.variation_regions_byte_range())
         else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -19,9 +19,9 @@ impl<'a> MinByteRange for TableDirectory<'a> {
 impl<'a> FontRead<'a> for TableDirectory<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: TableDirectoryMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -208,9 +208,9 @@ impl<'a> MinByteRange for TTCHeader<'a> {
 impl<'a> FontRead<'a> for TTCHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: TTCHeaderMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -71,34 +71,34 @@ impl<'a> TableDirectory<'a> {
     /// 0x00010000 or 0x4F54544F
     pub fn sfnt_version(&self) -> u32 {
         let range = self.sfnt_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of tables.
     pub fn num_tables(&self) -> u16 {
         let range = self.num_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn search_range(&self) -> u16 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn entry_selector(&self) -> u16 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn range_shift(&self) -> u16 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Table records array—one for each top-level table in the font
     pub fn table_records(&self) -> &'a [TableRecord] {
         let range = self.table_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -287,43 +287,43 @@ impl<'a> TTCHeader<'a> {
     /// Font Collection ID string: \"ttcf\"
     pub fn ttc_tag(&self) -> Tag {
         let range = self.ttc_tag_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Major/minor version of the TTC Header
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of fonts in TTC
     pub fn num_fonts(&self) -> u32 {
         let range = self.num_fonts_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to the TableDirectory for each font from the beginning of the file
     pub fn table_directory_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.table_directory_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
     pub fn dsig_tag(&self) -> Option<u32> {
         let range = self.dsig_tag_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// The length (in bytes) of the DSIG table (null if no signature)
     pub fn dsig_length(&self) -> Option<u32> {
         let range = self.dsig_length_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
     pub fn dsig_offset(&self) -> Option<u32> {
         let range = self.dsig_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -110,23 +110,9 @@ impl Format<u16> for Lookup0Marker {
 /// by glyph index.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup0Marker {
-    values_data_byte_len: usize,
-}
+pub struct Lookup0Marker {}
 
-impl Lookup0Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn values_data_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + self.values_data_byte_len
-    }
-}
-
-impl MinByteRange for Lookup0Marker {
+impl<'a> MinByteRange for Lookup0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.values_data_byte_range().end
     }
@@ -138,9 +124,7 @@ impl<'a> FontRead<'a> for Lookup0<'a> {
         cursor.advance::<u16>();
         let values_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(values_data_byte_len);
-        cursor.finish(Lookup0Marker {
-            values_data_byte_len,
-        })
+        cursor.finish(Lookup0Marker {})
     }
 }
 
@@ -150,15 +134,33 @@ pub type Lookup0<'a> = TableRef<'a, Lookup0Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup0<'a> {
+    fn values_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn values_data_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + self.values_data_byte_len(start)
+    }
+
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Values, indexed by glyph index.
     pub fn values_data(&self) -> &'a [u8] {
-        let range = self.shape.values_data_byte_range();
+        let range = self.values_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -194,11 +196,45 @@ impl Format<u16> for Lookup2Marker {
 /// a contiguous range of glyph indexes.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup2Marker {
-    segments_data_byte_len: usize,
+pub struct Lookup2Marker {}
+
+impl<'a> MinByteRange for Lookup2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.segments_data_byte_range().end
+    }
 }
 
-impl Lookup2Marker {
+impl<'a> FontRead<'a> for Lookup2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        let unit_size: u16 = cursor.read()?;
+        let n_units: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let segments_data_byte_len = (transforms::add_multiply(unit_size, 0_usize, n_units))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(segments_data_byte_len);
+        cursor.finish(Lookup2Marker {})
+    }
+}
+
+/// Segment single format. Each non-overlapping segment has a single lookup
+/// value that applies to all glyphs in the segment. A segment is defined as
+/// a contiguous range of glyph indexes.
+pub type Lookup2<'a> = TableRef<'a, Lookup2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Lookup2<'a> {
+    fn segments_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::add_multiply(self.unit_size(), 0_usize, self.n_units()))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -231,81 +267,48 @@ impl Lookup2Marker {
 
     pub fn segments_data_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
-        start..start + self.segments_data_byte_len
+        start..start + self.segments_data_byte_len(start)
     }
-}
 
-impl MinByteRange for Lookup2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.segments_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Lookup2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let unit_size: u16 = cursor.read()?;
-        let n_units: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let segments_data_byte_len = (transforms::add_multiply(unit_size, 0_usize, n_units))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(segments_data_byte_len);
-        cursor.finish(Lookup2Marker {
-            segments_data_byte_len,
-        })
-    }
-}
-
-/// Segment single format. Each non-overlapping segment has a single lookup
-/// value that applies to all glyphs in the segment. A segment is defined as
-/// a contiguous range of glyph indexes.
-pub type Lookup2<'a> = TableRef<'a, Lookup2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Lookup2<'a> {
     /// Format number is set to 2.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
-        let range = self.shape.unit_size_byte_range();
+        let range = self.unit_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
-        let range = self.shape.n_units_byte_range();
+        let range = self.n_units_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
-        let range = self.shape.search_range_byte_range();
+        let range = self.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
-        let range = self.shape.entry_selector_byte_range();
+        let range = self.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
-        let range = self.shape.range_shift_byte_range();
+        let range = self.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Segments.
     pub fn segments_data(&self) -> &'a [u8] {
-        let range = self.shape.segments_data_byte_range();
+        let range = self.segments_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -346,11 +349,45 @@ impl Format<u16> for Lookup4Marker {
 /// each glyph in the segment gets its own separate lookup value.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup4Marker {
-    segments_byte_len: usize,
+pub struct Lookup4Marker {}
+
+impl<'a> MinByteRange for Lookup4<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.segments_byte_range().end
+    }
 }
 
-impl Lookup4Marker {
+impl<'a> FontRead<'a> for Lookup4<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let n_units: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let segments_byte_len = (n_units as usize)
+            .checked_mul(LookupSegment4::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(segments_byte_len);
+        cursor.finish(Lookup4Marker {})
+    }
+}
+
+/// Segment array format. A segment mapping is performed (as with Format 2),
+/// but instead of a single lookup value for all the glyphs in the segment,
+/// each glyph in the segment gets its own separate lookup value.
+pub type Lookup4<'a> = TableRef<'a, Lookup4Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Lookup4<'a> {
+    fn segments_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_units()) as usize)
+            .checked_mul(LookupSegment4::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -383,79 +420,48 @@ impl Lookup4Marker {
 
     pub fn segments_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
-        start..start + self.segments_byte_len
+        start..start + self.segments_byte_len(start)
     }
-}
 
-impl MinByteRange for Lookup4Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.segments_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Lookup4<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let n_units: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let segments_byte_len = (n_units as usize)
-            .checked_mul(LookupSegment4::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(segments_byte_len);
-        cursor.finish(Lookup4Marker { segments_byte_len })
-    }
-}
-
-/// Segment array format. A segment mapping is performed (as with Format 2),
-/// but instead of a single lookup value for all the glyphs in the segment,
-/// each glyph in the segment gets its own separate lookup value.
-pub type Lookup4<'a> = TableRef<'a, Lookup4Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Lookup4<'a> {
     /// Format number is set to 4.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
-        let range = self.shape.unit_size_byte_range();
+        let range = self.unit_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
-        let range = self.shape.n_units_byte_range();
+        let range = self.n_units_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
-        let range = self.shape.search_range_byte_range();
+        let range = self.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
-        let range = self.shape.entry_selector_byte_range();
+        let range = self.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
-        let range = self.shape.range_shift_byte_range();
+        let range = self.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Segments.
     pub fn segments(&self) -> &'a [LookupSegment4] {
-        let range = self.shape.segments_byte_range();
+        let range = self.segments_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -552,11 +558,44 @@ impl Format<u16> for Lookup6Marker {
 /// <glyph index,lookup value> pairs.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup6Marker {
-    entries_data_byte_len: usize,
+pub struct Lookup6Marker {}
+
+impl<'a> MinByteRange for Lookup6<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.entries_data_byte_range().end
+    }
 }
 
-impl Lookup6Marker {
+impl<'a> FontRead<'a> for Lookup6<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        let unit_size: u16 = cursor.read()?;
+        let n_units: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let entries_data_byte_len = (transforms::add_multiply(unit_size, 0_usize, n_units))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(entries_data_byte_len);
+        cursor.finish(Lookup6Marker {})
+    }
+}
+
+/// Single table format. The lookup data is a sorted list of
+/// <glyph index,lookup value> pairs.
+pub type Lookup6<'a> = TableRef<'a, Lookup6Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Lookup6<'a> {
+    fn entries_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::add_multiply(self.unit_size(), 0_usize, self.n_units()))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -589,80 +628,48 @@ impl Lookup6Marker {
 
     pub fn entries_data_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
-        start..start + self.entries_data_byte_len
+        start..start + self.entries_data_byte_len(start)
     }
-}
 
-impl MinByteRange for Lookup6Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.entries_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Lookup6<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let unit_size: u16 = cursor.read()?;
-        let n_units: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let entries_data_byte_len = (transforms::add_multiply(unit_size, 0_usize, n_units))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(entries_data_byte_len);
-        cursor.finish(Lookup6Marker {
-            entries_data_byte_len,
-        })
-    }
-}
-
-/// Single table format. The lookup data is a sorted list of
-/// <glyph index,lookup value> pairs.
-pub type Lookup6<'a> = TableRef<'a, Lookup6Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Lookup6<'a> {
     /// Format number is set to 6.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
-        let range = self.shape.unit_size_byte_range();
+        let range = self.unit_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
-        let range = self.shape.n_units_byte_range();
+        let range = self.n_units_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
-        let range = self.shape.search_range_byte_range();
+        let range = self.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
-        let range = self.shape.entry_selector_byte_range();
+        let range = self.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
-        let range = self.shape.range_shift_byte_range();
+        let range = self.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Values, indexed by glyph index.
     pub fn entries_data(&self) -> &'a [u8] {
-        let range = self.shape.entries_data_byte_range();
+        let range = self.entries_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -702,11 +709,41 @@ impl Format<u16> for Lookup8Marker {
 /// indexed by glyph index.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup8Marker {
-    value_array_byte_len: usize,
+pub struct Lookup8Marker {}
+
+impl<'a> MinByteRange for Lookup8<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.value_array_byte_range().end
+    }
 }
 
-impl Lookup8Marker {
+impl<'a> FontRead<'a> for Lookup8<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let glyph_count: u16 = cursor.read()?;
+        let value_array_byte_len = (glyph_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(value_array_byte_len);
+        cursor.finish(Lookup8Marker {})
+    }
+}
+
+/// Trimmed array format. The lookup data is a simple trimmed array
+/// indexed by glyph index.
+pub type Lookup8<'a> = TableRef<'a, Lookup8Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Lookup8<'a> {
+    fn value_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -724,61 +761,32 @@ impl Lookup8Marker {
 
     pub fn value_array_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + self.value_array_byte_len
+        start..start + self.value_array_byte_len(start)
     }
-}
 
-impl MinByteRange for Lookup8Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.value_array_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Lookup8<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let glyph_count: u16 = cursor.read()?;
-        let value_array_byte_len = (glyph_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(value_array_byte_len);
-        cursor.finish(Lookup8Marker {
-            value_array_byte_len,
-        })
-    }
-}
-
-/// Trimmed array format. The lookup data is a simple trimmed array
-/// indexed by glyph index.
-pub type Lookup8<'a> = TableRef<'a, Lookup8Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Lookup8<'a> {
     /// Format number is set to 8.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// First glyph index included in the trimmed array.
     pub fn first_glyph(&self) -> u16 {
-        let range = self.shape.first_glyph_byte_range();
+        let range = self.first_glyph_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Total number of glyphs (equivalent to the last glyph minus the value
     /// of firstGlyph plus 1).
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The lookup values (indexed by the glyph index minus the value of
     /// firstGlyph). Entries in the value array must be two bytes.
     pub fn value_array(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.value_array_byte_range();
+        let range = self.value_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -815,11 +823,42 @@ impl Format<u16> for Lookup10Marker {
 /// indexed by glyph index.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup10Marker {
-    values_data_byte_len: usize,
+pub struct Lookup10Marker {}
+
+impl<'a> MinByteRange for Lookup10<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.values_data_byte_range().end
+    }
 }
 
-impl Lookup10Marker {
+impl<'a> FontRead<'a> for Lookup10<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        let unit_size: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        let glyph_count: u16 = cursor.read()?;
+        let values_data_byte_len = (transforms::add_multiply(glyph_count, 0_usize, unit_size))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(values_data_byte_len);
+        cursor.finish(Lookup10Marker {})
+    }
+}
+
+/// Trimmed array format. The lookup data is a simple trimmed array
+/// indexed by glyph index.
+pub type Lookup10<'a> = TableRef<'a, Lookup10Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Lookup10<'a> {
+    fn values_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::add_multiply(self.glyph_count(), 0_usize, self.unit_size()))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -842,69 +881,39 @@ impl Lookup10Marker {
 
     pub fn values_data_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + self.values_data_byte_len
+        start..start + self.values_data_byte_len(start)
     }
-}
 
-impl MinByteRange for Lookup10Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.values_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Lookup10<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let unit_size: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        let glyph_count: u16 = cursor.read()?;
-        let values_data_byte_len = (transforms::add_multiply(glyph_count, 0_usize, unit_size))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(values_data_byte_len);
-        cursor.finish(Lookup10Marker {
-            values_data_byte_len,
-        })
-    }
-}
-
-/// Trimmed array format. The lookup data is a simple trimmed array
-/// indexed by glyph index.
-pub type Lookup10<'a> = TableRef<'a, Lookup10Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Lookup10<'a> {
     /// Format number is set to 10.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Size of a lookup unit for this lookup table in bytes. Allowed values
     /// are 1, 2, 4, and 8.
     pub fn unit_size(&self) -> u16 {
-        let range = self.shape.unit_size_byte_range();
+        let range = self.unit_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// First glyph index included in the trimmed array.
     pub fn first_glyph(&self) -> u16 {
-        let range = self.shape.first_glyph_byte_range();
+        let range = self.first_glyph_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Total number of glyphs (equivalent to the last glyph minus the value
     /// of firstGlyph plus 1).
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The lookup values (indexed by the glyph index minus the value of
     /// firstGlyph).
     pub fn values_data(&self) -> &'a [u8] {
-        let range = self.shape.values_data_byte_range();
+        let range = self.values_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -939,29 +948,7 @@ impl<'a> std::fmt::Debug for Lookup10<'a> {
 #[doc(hidden)]
 pub struct StateHeaderMarker {}
 
-impl StateHeaderMarker {
-    pub fn state_size_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn class_table_offset_byte_range(&self) -> Range<usize> {
-        let start = self.state_size_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn state_array_offset_byte_range(&self) -> Range<usize> {
-        let start = self.class_table_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
-        let start = self.state_array_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for StateHeaderMarker {
+impl<'a> MinByteRange for StateHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.entry_table_offset_byte_range().end
     }
@@ -983,16 +970,36 @@ pub type StateHeader<'a> = TableRef<'a, StateHeaderMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> StateHeader<'a> {
+    pub fn state_size_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn class_table_offset_byte_range(&self) -> Range<usize> {
+        let start = self.state_size_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn state_array_offset_byte_range(&self) -> Range<usize> {
+        let start = self.class_table_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
+        let start = self.state_array_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
     /// Size of a state, in bytes. The size is limited to 8 bits, although the
     /// field is 16 bits for alignment.
     pub fn state_size(&self) -> u16 {
-        let range = self.shape.state_size_byte_range();
+        let range = self.state_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte offset from the beginning of the state table to the class subtable.
     pub fn class_table_offset(&self) -> Offset16 {
-        let range = self.shape.class_table_offset_byte_range();
+        let range = self.class_table_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1004,7 +1011,7 @@ impl<'a> StateHeader<'a> {
 
     /// Byte offset from the beginning of the state table to the state array.
     pub fn state_array_offset(&self) -> Offset16 {
-        let range = self.shape.state_array_offset_byte_range();
+        let range = self.state_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1016,7 +1023,7 @@ impl<'a> StateHeader<'a> {
 
     /// Byte offset from the beginning of the state table to the entry subtable.
     pub fn entry_table_offset(&self) -> Offset16 {
-        let range = self.shape.entry_table_offset_byte_range();
+        let range = self.entry_table_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1063,28 +1070,9 @@ impl<'a> std::fmt::Debug for StateHeader<'a> {
 /// Maps the glyph indexes of your font into classes.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassSubtableMarker {
-    class_array_byte_len: usize,
-}
+pub struct ClassSubtableMarker {}
 
-impl ClassSubtableMarker {
-    pub fn first_glyph_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn n_glyphs_byte_range(&self) -> Range<usize> {
-        let start = self.first_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn class_array_byte_range(&self) -> Range<usize> {
-        let start = self.n_glyphs_byte_range().end;
-        start..start + self.class_array_byte_len
-    }
-}
-
-impl MinByteRange for ClassSubtableMarker {
+impl<'a> MinByteRange for ClassSubtable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.class_array_byte_range().end
     }
@@ -1099,9 +1087,7 @@ impl<'a> FontRead<'a> for ClassSubtable<'a> {
             .checked_mul(u8::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_array_byte_len);
-        cursor.finish(ClassSubtableMarker {
-            class_array_byte_len,
-        })
+        cursor.finish(ClassSubtableMarker {})
     }
 }
 
@@ -1110,22 +1096,44 @@ pub type ClassSubtable<'a> = TableRef<'a, ClassSubtableMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassSubtable<'a> {
+    fn class_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_glyphs()) as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn first_glyph_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn n_glyphs_byte_range(&self) -> Range<usize> {
+        let start = self.first_glyph_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn class_array_byte_range(&self) -> Range<usize> {
+        let start = self.n_glyphs_byte_range().end;
+        start..start + self.class_array_byte_len(start)
+    }
+
     /// Glyph index of the first glyph in the class table.
     pub fn first_glyph(&self) -> u16 {
-        let range = self.shape.first_glyph_byte_range();
+        let range = self.first_glyph_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of glyphs in class table.
     pub fn n_glyphs(&self) -> u16 {
-        let range = self.shape.n_glyphs_byte_range();
+        let range = self.n_glyphs_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The class codes (indexed by glyph index minus firstGlyph). Class codes
     /// range from 0 to the value of stateSize minus 1.
     pub fn class_array(&self) -> &'a [u8] {
-        let range = self.shape.class_array_byte_range();
+        let range = self.class_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1156,18 +1164,9 @@ impl<'a> std::fmt::Debug for ClassSubtable<'a> {
 /// Used for the `state_array` and `entry_table` fields in [`StateHeader`].
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct RawBytesMarker {
-    data_byte_len: usize,
-}
+pub struct RawBytesMarker {}
 
-impl RawBytesMarker {
-    pub fn data_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + self.data_byte_len
-    }
-}
-
-impl MinByteRange for RawBytesMarker {
+impl<'a> MinByteRange for RawBytes<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.data_byte_range().end
     }
@@ -1178,7 +1177,7 @@ impl<'a> FontRead<'a> for RawBytes<'a> {
         let mut cursor = data.cursor();
         let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
-        cursor.finish(RawBytesMarker { data_byte_len })
+        cursor.finish(RawBytesMarker {})
     }
 }
 
@@ -1187,8 +1186,21 @@ pub type RawBytes<'a> = TableRef<'a, RawBytesMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> RawBytes<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn data_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + self.data_byte_len(start)
+    }
+
     pub fn data(&self) -> &'a [u8] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1219,29 +1231,7 @@ impl<'a> std::fmt::Debug for RawBytes<'a> {
 #[doc(hidden)]
 pub struct StxHeaderMarker {}
 
-impl StxHeaderMarker {
-    pub fn n_classes_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn class_table_offset_byte_range(&self) -> Range<usize> {
-        let start = self.n_classes_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn state_array_offset_byte_range(&self) -> Range<usize> {
-        let start = self.class_table_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
-        let start = self.state_array_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for StxHeaderMarker {
+impl<'a> MinByteRange for StxHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.entry_table_offset_byte_range().end
     }
@@ -1263,15 +1253,35 @@ pub type StxHeader<'a> = TableRef<'a, StxHeaderMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> StxHeader<'a> {
+    pub fn n_classes_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn class_table_offset_byte_range(&self) -> Range<usize> {
+        let start = self.n_classes_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn state_array_offset_byte_range(&self) -> Range<usize> {
+        let start = self.class_table_offset_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
+        let start = self.state_array_offset_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
     /// Number of classes, which is the number of 16-bit entry indices in a single line in the state array.
     pub fn n_classes(&self) -> u32 {
-        let range = self.shape.n_classes_byte_range();
+        let range = self.n_classes_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte offset from the beginning of the state table to the class subtable.
     pub fn class_table_offset(&self) -> Offset32 {
-        let range = self.shape.class_table_offset_byte_range();
+        let range = self.class_table_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1283,7 +1293,7 @@ impl<'a> StxHeader<'a> {
 
     /// Byte offset from the beginning of the state table to the state array.
     pub fn state_array_offset(&self) -> Offset32 {
-        let range = self.shape.state_array_offset_byte_range();
+        let range = self.state_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1295,7 +1305,7 @@ impl<'a> StxHeader<'a> {
 
     /// Byte offset from the beginning of the state table to the entry subtable.
     pub fn entry_table_offset(&self) -> Offset32 {
-        let range = self.shape.entry_table_offset_byte_range();
+        let range = self.entry_table_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1342,18 +1352,9 @@ impl<'a> std::fmt::Debug for StxHeader<'a> {
 /// Used for the `state_array` in [`StxHeader`].
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct RawWordsMarker {
-    data_byte_len: usize,
-}
+pub struct RawWordsMarker {}
 
-impl RawWordsMarker {
-    pub fn data_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + self.data_byte_len
-    }
-}
-
-impl MinByteRange for RawWordsMarker {
+impl<'a> MinByteRange for RawWords<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.data_byte_range().end
     }
@@ -1364,7 +1365,7 @@ impl<'a> FontRead<'a> for RawWords<'a> {
         let mut cursor = data.cursor();
         let data_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
         cursor.advance_by(data_byte_len);
-        cursor.finish(RawWordsMarker { data_byte_len })
+        cursor.finish(RawWordsMarker {})
     }
 }
 
@@ -1373,8 +1374,21 @@ pub type RawWords<'a> = TableRef<'a, RawWordsMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> RawWords<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn data_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + self.data_byte_len(start)
+    }
+
     pub fn data(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -110,7 +110,7 @@ impl Format<u16> for Lookup0Marker {
 /// by glyph index.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup0Marker {}
+pub struct Lookup0Marker;
 
 impl<'a> MinByteRange for Lookup0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -120,17 +120,17 @@ impl<'a> MinByteRange for Lookup0<'a> {
 
 impl<'a> FontRead<'a> for Lookup0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let values_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(values_data_byte_len);
-        cursor.finish(Lookup0Marker {})
+        Ok(TableRef {
+            shape: Lookup0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Simple array format. The lookup data is an array of lookup values, indexed
 /// by glyph index.
-pub type Lookup0<'a> = TableRef<'a, Lookup0Marker>;
+pub type Lookup0<'a> = TableRef<'a, Lookup0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup0<'a> {
@@ -196,7 +196,7 @@ impl Format<u16> for Lookup2Marker {
 /// a contiguous range of glyph indexes.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup2Marker {}
+pub struct Lookup2Marker;
 
 impl<'a> MinByteRange for Lookup2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -206,25 +206,18 @@ impl<'a> MinByteRange for Lookup2<'a> {
 
 impl<'a> FontRead<'a> for Lookup2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let unit_size: u16 = cursor.read()?;
-        let n_units: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let segments_data_byte_len = (transforms::add_multiply(unit_size, 0_usize, n_units))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(segments_data_byte_len);
-        cursor.finish(Lookup2Marker {})
+        Ok(TableRef {
+            shape: Lookup2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Segment single format. Each non-overlapping segment has a single lookup
 /// value that applies to all glyphs in the segment. A segment is defined as
 /// a contiguous range of glyph indexes.
-pub type Lookup2<'a> = TableRef<'a, Lookup2Marker>;
+pub type Lookup2<'a> = TableRef<'a, Lookup2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup2<'a> {
@@ -349,7 +342,7 @@ impl Format<u16> for Lookup4Marker {
 /// each glyph in the segment gets its own separate lookup value.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup4Marker {}
+pub struct Lookup4Marker;
 
 impl<'a> MinByteRange for Lookup4<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -359,25 +352,18 @@ impl<'a> MinByteRange for Lookup4<'a> {
 
 impl<'a> FontRead<'a> for Lookup4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let n_units: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let segments_byte_len = (n_units as usize)
-            .checked_mul(LookupSegment4::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(segments_byte_len);
-        cursor.finish(Lookup4Marker {})
+        Ok(TableRef {
+            shape: Lookup4Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Segment array format. A segment mapping is performed (as with Format 2),
 /// but instead of a single lookup value for all the glyphs in the segment,
 /// each glyph in the segment gets its own separate lookup value.
-pub type Lookup4<'a> = TableRef<'a, Lookup4Marker>;
+pub type Lookup4<'a> = TableRef<'a, Lookup4Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup4<'a> {
@@ -558,7 +544,7 @@ impl Format<u16> for Lookup6Marker {
 /// <glyph index,lookup value> pairs.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup6Marker {}
+pub struct Lookup6Marker;
 
 impl<'a> MinByteRange for Lookup6<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -568,24 +554,17 @@ impl<'a> MinByteRange for Lookup6<'a> {
 
 impl<'a> FontRead<'a> for Lookup6<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let unit_size: u16 = cursor.read()?;
-        let n_units: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let entries_data_byte_len = (transforms::add_multiply(unit_size, 0_usize, n_units))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(entries_data_byte_len);
-        cursor.finish(Lookup6Marker {})
+        Ok(TableRef {
+            shape: Lookup6Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Single table format. The lookup data is a sorted list of
 /// <glyph index,lookup value> pairs.
-pub type Lookup6<'a> = TableRef<'a, Lookup6Marker>;
+pub type Lookup6<'a> = TableRef<'a, Lookup6Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup6<'a> {
@@ -709,7 +688,7 @@ impl Format<u16> for Lookup8Marker {
 /// indexed by glyph index.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup8Marker {}
+pub struct Lookup8Marker;
 
 impl<'a> MinByteRange for Lookup8<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -719,21 +698,17 @@ impl<'a> MinByteRange for Lookup8<'a> {
 
 impl<'a> FontRead<'a> for Lookup8<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let glyph_count: u16 = cursor.read()?;
-        let value_array_byte_len = (glyph_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(value_array_byte_len);
-        cursor.finish(Lookup8Marker {})
+        Ok(TableRef {
+            shape: Lookup8Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Trimmed array format. The lookup data is a simple trimmed array
 /// indexed by glyph index.
-pub type Lookup8<'a> = TableRef<'a, Lookup8Marker>;
+pub type Lookup8<'a> = TableRef<'a, Lookup8Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup8<'a> {
@@ -823,7 +798,7 @@ impl Format<u16> for Lookup10Marker {
 /// indexed by glyph index.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Lookup10Marker {}
+pub struct Lookup10Marker;
 
 impl<'a> MinByteRange for Lookup10<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -833,22 +808,17 @@ impl<'a> MinByteRange for Lookup10<'a> {
 
 impl<'a> FontRead<'a> for Lookup10<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let unit_size: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        let glyph_count: u16 = cursor.read()?;
-        let values_data_byte_len = (transforms::add_multiply(glyph_count, 0_usize, unit_size))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(values_data_byte_len);
-        cursor.finish(Lookup10Marker {})
+        Ok(TableRef {
+            shape: Lookup10Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Trimmed array format. The lookup data is a simple trimmed array
 /// indexed by glyph index.
-pub type Lookup10<'a> = TableRef<'a, Lookup10Marker>;
+pub type Lookup10<'a> = TableRef<'a, Lookup10Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Lookup10<'a> {
@@ -946,7 +916,7 @@ impl<'a> std::fmt::Debug for Lookup10<'a> {
 /// Header for a state table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct StateHeaderMarker {}
+pub struct StateHeaderMarker;
 
 impl<'a> MinByteRange for StateHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -956,17 +926,16 @@ impl<'a> MinByteRange for StateHeader<'a> {
 
 impl<'a> FontRead<'a> for StateHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(StateHeaderMarker {})
+        Ok(TableRef {
+            shape: StateHeaderMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Header for a state table.
-pub type StateHeader<'a> = TableRef<'a, StateHeaderMarker>;
+pub type StateHeader<'a> = TableRef<'a, StateHeaderMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> StateHeader<'a> {
@@ -1070,7 +1039,7 @@ impl<'a> std::fmt::Debug for StateHeader<'a> {
 /// Maps the glyph indexes of your font into classes.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassSubtableMarker {}
+pub struct ClassSubtableMarker;
 
 impl<'a> MinByteRange for ClassSubtable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1080,19 +1049,16 @@ impl<'a> MinByteRange for ClassSubtable<'a> {
 
 impl<'a> FontRead<'a> for ClassSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let n_glyphs: u16 = cursor.read()?;
-        let class_array_byte_len = (n_glyphs as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_array_byte_len);
-        cursor.finish(ClassSubtableMarker {})
+        Ok(TableRef {
+            shape: ClassSubtableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Maps the glyph indexes of your font into classes.
-pub type ClassSubtable<'a> = TableRef<'a, ClassSubtableMarker>;
+pub type ClassSubtable<'a> = TableRef<'a, ClassSubtableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassSubtable<'a> {
@@ -1164,7 +1130,7 @@ impl<'a> std::fmt::Debug for ClassSubtable<'a> {
 /// Used for the `state_array` and `entry_table` fields in [`StateHeader`].
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct RawBytesMarker {}
+pub struct RawBytesMarker;
 
 impl<'a> MinByteRange for RawBytes<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1174,15 +1140,16 @@ impl<'a> MinByteRange for RawBytes<'a> {
 
 impl<'a> FontRead<'a> for RawBytes<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(RawBytesMarker {})
+        Ok(TableRef {
+            shape: RawBytesMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Used for the `state_array` and `entry_table` fields in [`StateHeader`].
-pub type RawBytes<'a> = TableRef<'a, RawBytesMarker>;
+pub type RawBytes<'a> = TableRef<'a, RawBytesMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> RawBytes<'a> {
@@ -1229,7 +1196,7 @@ impl<'a> std::fmt::Debug for RawBytes<'a> {
 /// Header for an extended state table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct StxHeaderMarker {}
+pub struct StxHeaderMarker;
 
 impl<'a> MinByteRange for StxHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1239,17 +1206,16 @@ impl<'a> MinByteRange for StxHeader<'a> {
 
 impl<'a> FontRead<'a> for StxHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.finish(StxHeaderMarker {})
+        Ok(TableRef {
+            shape: StxHeaderMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Header for an extended state table.
-pub type StxHeader<'a> = TableRef<'a, StxHeaderMarker>;
+pub type StxHeader<'a> = TableRef<'a, StxHeaderMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> StxHeader<'a> {
@@ -1352,7 +1318,7 @@ impl<'a> std::fmt::Debug for StxHeader<'a> {
 /// Used for the `state_array` in [`StxHeader`].
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct RawWordsMarker {}
+pub struct RawWordsMarker;
 
 impl<'a> MinByteRange for RawWords<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1362,15 +1328,16 @@ impl<'a> MinByteRange for RawWords<'a> {
 
 impl<'a> FontRead<'a> for RawWords<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let data_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(RawWordsMarker {})
+        Ok(TableRef {
+            shape: RawWordsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Used for the `state_array` in [`StxHeader`].
-pub type RawWords<'a> = TableRef<'a, RawWordsMarker>;
+pub type RawWords<'a> = TableRef<'a, RawWordsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> RawWords<'a> {

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -155,13 +155,13 @@ impl<'a> Lookup0<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Values, indexed by glyph index.
     pub fn values_data(&self) -> &'a [u8] {
         let range = self.values_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -266,43 +266,43 @@ impl<'a> Lookup2<'a> {
     /// Format number is set to 2.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
         let range = self.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
         let range = self.n_units_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Segments.
     pub fn segments_data(&self) -> &'a [u8] {
         let range = self.segments_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -412,43 +412,43 @@ impl<'a> Lookup4<'a> {
     /// Format number is set to 4.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
         let range = self.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
         let range = self.n_units_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Segments.
     pub fn segments(&self) -> &'a [LookupSegment4] {
         let range = self.segments_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -613,43 +613,43 @@ impl<'a> Lookup6<'a> {
     /// Format number is set to 6.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
         let range = self.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
         let range = self.n_units_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Values, indexed by glyph index.
     pub fn entries_data(&self) -> &'a [u8] {
         let range = self.entries_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -742,27 +742,27 @@ impl<'a> Lookup8<'a> {
     /// Format number is set to 8.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// First glyph index included in the trimmed array.
     pub fn first_glyph(&self) -> u16 {
         let range = self.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Total number of glyphs (equivalent to the last glyph minus the value
     /// of firstGlyph plus 1).
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The lookup values (indexed by the glyph index minus the value of
     /// firstGlyph). Entries in the value array must be two bytes.
     pub fn value_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.value_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -857,34 +857,34 @@ impl<'a> Lookup10<'a> {
     /// Format number is set to 10.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Size of a lookup unit for this lookup table in bytes. Allowed values
     /// are 1, 2, 4, and 8.
     pub fn unit_size(&self) -> u16 {
         let range = self.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// First glyph index included in the trimmed array.
     pub fn first_glyph(&self) -> u16 {
         let range = self.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Total number of glyphs (equivalent to the last glyph minus the value
     /// of firstGlyph plus 1).
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The lookup values (indexed by the glyph index minus the value of
     /// firstGlyph).
     pub fn values_data(&self) -> &'a [u8] {
         let range = self.values_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -963,13 +963,13 @@ impl<'a> StateHeader<'a> {
     /// field is 16 bits for alignment.
     pub fn state_size(&self) -> u16 {
         let range = self.state_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte offset from the beginning of the state table to the class subtable.
     pub fn class_table_offset(&self) -> Offset16 {
         let range = self.class_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`class_table_offset`][Self::class_table_offset].
@@ -981,7 +981,7 @@ impl<'a> StateHeader<'a> {
     /// Byte offset from the beginning of the state table to the state array.
     pub fn state_array_offset(&self) -> Offset16 {
         let range = self.state_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`state_array_offset`][Self::state_array_offset].
@@ -993,7 +993,7 @@ impl<'a> StateHeader<'a> {
     /// Byte offset from the beginning of the state table to the entry subtable.
     pub fn entry_table_offset(&self) -> Offset16 {
         let range = self.entry_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`entry_table_offset`][Self::entry_table_offset].
@@ -1087,20 +1087,20 @@ impl<'a> ClassSubtable<'a> {
     /// Glyph index of the first glyph in the class table.
     pub fn first_glyph(&self) -> u16 {
         let range = self.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of glyphs in class table.
     pub fn n_glyphs(&self) -> u16 {
         let range = self.n_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The class codes (indexed by glyph index minus firstGlyph). Class codes
     /// range from 0 to the value of stateSize minus 1.
     pub fn class_array(&self) -> &'a [u8] {
         let range = self.class_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1168,7 +1168,7 @@ impl<'a> RawBytes<'a> {
 
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1242,13 +1242,13 @@ impl<'a> StxHeader<'a> {
     /// Number of classes, which is the number of 16-bit entry indices in a single line in the state array.
     pub fn n_classes(&self) -> u32 {
         let range = self.n_classes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte offset from the beginning of the state table to the class subtable.
     pub fn class_table_offset(&self) -> Offset32 {
         let range = self.class_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`class_table_offset`][Self::class_table_offset].
@@ -1260,7 +1260,7 @@ impl<'a> StxHeader<'a> {
     /// Byte offset from the beginning of the state table to the state array.
     pub fn state_array_offset(&self) -> Offset32 {
         let range = self.state_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`state_array_offset`][Self::state_array_offset].
@@ -1272,7 +1272,7 @@ impl<'a> StxHeader<'a> {
     /// Byte offset from the beginning of the state table to the entry subtable.
     pub fn entry_table_offset(&self) -> Offset32 {
         let range = self.entry_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`entry_table_offset`][Self::entry_table_offset].
@@ -1356,7 +1356,7 @@ impl<'a> RawWords<'a> {
 
     pub fn data(&self) -> &'a [BigEndian<u16>] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -121,9 +121,9 @@ impl<'a> MinByteRange for Lookup0<'a> {
 impl<'a> FontRead<'a> for Lookup0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Lookup0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -207,9 +207,9 @@ impl<'a> MinByteRange for Lookup2<'a> {
 impl<'a> FontRead<'a> for Lookup2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Lookup2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -353,9 +353,9 @@ impl<'a> MinByteRange for Lookup4<'a> {
 impl<'a> FontRead<'a> for Lookup4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Lookup4Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -555,9 +555,9 @@ impl<'a> MinByteRange for Lookup6<'a> {
 impl<'a> FontRead<'a> for Lookup6<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Lookup6Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -699,9 +699,9 @@ impl<'a> MinByteRange for Lookup8<'a> {
 impl<'a> FontRead<'a> for Lookup8<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Lookup8Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -809,9 +809,9 @@ impl<'a> MinByteRange for Lookup10<'a> {
 impl<'a> FontRead<'a> for Lookup10<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Lookup10Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -927,9 +927,9 @@ impl<'a> MinByteRange for StateHeader<'a> {
 impl<'a> FontRead<'a> for StateHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: StateHeaderMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1050,9 +1050,9 @@ impl<'a> MinByteRange for ClassSubtable<'a> {
 impl<'a> FontRead<'a> for ClassSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClassSubtableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1141,9 +1141,9 @@ impl<'a> MinByteRange for RawBytes<'a> {
 impl<'a> FontRead<'a> for RawBytes<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: RawBytesMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1207,9 +1207,9 @@ impl<'a> MinByteRange for StxHeader<'a> {
 impl<'a> FontRead<'a> for StxHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: StxHeaderMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1329,9 +1329,9 @@ impl<'a> MinByteRange for RawWords<'a> {
 impl<'a> FontRead<'a> for RawWords<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: RawWordsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [anchor point](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ankr.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AnkrMarker {}
+pub struct AnkrMarker;
 
 impl<'a> MinByteRange for Ankr<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,17 +23,16 @@ impl TopLevelTable for Ankr<'_> {
 
 impl<'a> FontRead<'a> for Ankr<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<u32>();
-        cursor.finish(AnkrMarker {})
+        Ok(TableRef {
+            shape: AnkrMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [anchor point](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ankr.html) table.
-pub type Ankr<'a> = TableRef<'a, AnkrMarker>;
+pub type Ankr<'a> = TableRef<'a, AnkrMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Ankr<'a> {
@@ -122,7 +121,7 @@ impl<'a> std::fmt::Debug for Ankr<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GlyphDataEntryMarker {}
+pub struct GlyphDataEntryMarker;
 
 impl<'a> MinByteRange for GlyphDataEntry<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -132,17 +131,15 @@ impl<'a> MinByteRange for GlyphDataEntry<'a> {
 
 impl<'a> FontRead<'a> for GlyphDataEntry<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let num_points: u32 = cursor.read()?;
-        let anchor_points_byte_len = (num_points as usize)
-            .checked_mul(AnchorPoint::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(anchor_points_byte_len);
-        cursor.finish(GlyphDataEntryMarker {})
+        Ok(TableRef {
+            shape: GlyphDataEntryMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type GlyphDataEntry<'a> = TableRef<'a, GlyphDataEntryMarker>;
+pub type GlyphDataEntry<'a> = TableRef<'a, GlyphDataEntryMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> GlyphDataEntry<'a> {

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -59,13 +59,13 @@ impl<'a> Ankr<'a> {
     /// Version number (set to zero).
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Flags (currently unused; set to zero).
     pub fn flags(&self) -> u16 {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to the table's lookup table; currently this is always `0x0000000C`.
@@ -73,7 +73,7 @@ impl<'a> Ankr<'a> {
     /// Lookup values are two byte offsets into the glyph data table.
     pub fn lookup_table_offset(&self) -> Offset32 {
         let range = self.lookup_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`lookup_table_offset`][Self::lookup_table_offset].
@@ -85,7 +85,7 @@ impl<'a> Ankr<'a> {
     /// Offset to the glyph data table.
     pub fn glyph_data_table_offset(&self) -> u32 {
         let range = self.glyph_data_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -163,13 +163,13 @@ impl<'a> GlyphDataEntry<'a> {
     /// Number of anchor points for this glyph.
     pub fn num_points(&self) -> u32 {
         let range = self.num_points_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Individual anchor points.
     pub fn anchor_points(&self) -> &'a [AnchorPoint] {
         let range = self.anchor_points_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Ankr<'_> {
 impl<'a> FontRead<'a> for Ankr<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AnkrMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -132,9 +132,9 @@ impl<'a> MinByteRange for GlyphDataEntry<'a> {
 impl<'a> FontRead<'a> for GlyphDataEntry<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GlyphDataEntryMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Avar<'_> {
 impl<'a> FontRead<'a> for Avar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -90,25 +90,25 @@ impl<'a> Avar<'a> {
     /// Minor version number of the axis variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of variation axes for this font. This must be the same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
         let range = self.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The segment maps array — one segment map for each axis, in the order of axes specified in the 'fvar' table.
     pub fn axis_segment_maps(&self) -> VarLenArray<'a, SegmentMaps<'a>> {
         let range = self.axis_segment_maps_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 
     /// Offset to DeltaSetIndexMap table (may be NULL).
     pub fn axis_index_map_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.axis_index_map_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`axis_index_map_offset`][Self::axis_index_map_offset].
@@ -120,7 +120,7 @@ impl<'a> Avar<'a> {
     /// Offset to ItemVariationStore (may be NULL).
     pub fn var_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.var_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`var_store_offset`][Self::var_store_offset].

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Base<'_> {
 impl<'a> FontRead<'a> for Base<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -151,9 +151,9 @@ impl<'a> MinByteRange for Axis<'a> {
 impl<'a> FontRead<'a> for Axis<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AxisMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -241,9 +241,9 @@ impl<'a> MinByteRange for BaseTagList<'a> {
 impl<'a> FontRead<'a> for BaseTagList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseTagListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -321,9 +321,9 @@ impl<'a> MinByteRange for BaseScriptList<'a> {
 impl<'a> FontRead<'a> for BaseScriptList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseScriptListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -460,9 +460,9 @@ impl<'a> MinByteRange for BaseScript<'a> {
 impl<'a> FontRead<'a> for BaseScript<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseScriptMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -644,9 +644,9 @@ impl<'a> MinByteRange for BaseValues<'a> {
 impl<'a> FontRead<'a> for BaseValues<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseValuesMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -762,9 +762,9 @@ impl<'a> MinByteRange for MinMax<'a> {
 impl<'a> FontRead<'a> for MinMax<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MinMaxMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1062,9 +1062,9 @@ impl<'a> MinByteRange for BaseCoordFormat1<'a> {
 impl<'a> FontRead<'a> for BaseCoordFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseCoordFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1137,9 +1137,9 @@ impl<'a> MinByteRange for BaseCoordFormat2<'a> {
 impl<'a> FontRead<'a> for BaseCoordFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseCoordFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1236,9 +1236,9 @@ impl<'a> MinByteRange for BaseCoordFormat3<'a> {
 impl<'a> FontRead<'a> for BaseCoordFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseCoordFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -63,13 +63,13 @@ impl<'a> Base<'a> {
     /// (major, minor) Version for the BASE table (1,0) or (1,1)
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to horizontal Axis table, from beginning of BASE table (may be NULL)
     pub fn horiz_axis_offset(&self) -> Nullable<Offset16> {
         let range = self.horiz_axis_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`horiz_axis_offset`][Self::horiz_axis_offset].
@@ -81,7 +81,7 @@ impl<'a> Base<'a> {
     /// Offset to vertical Axis table, from beginning of BASE table (may be NULL)
     pub fn vert_axis_offset(&self) -> Nullable<Offset16> {
         let range = self.vert_axis_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`vert_axis_offset`][Self::vert_axis_offset].
@@ -93,7 +93,7 @@ impl<'a> Base<'a> {
     /// Offset to Item Variation Store table, from beginning of BASE table (may be null)
     pub fn item_var_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.item_var_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`item_var_store_offset`][Self::item_var_store_offset].
@@ -177,7 +177,7 @@ impl<'a> Axis<'a> {
     /// be NULL)
     pub fn base_tag_list_offset(&self) -> Nullable<Offset16> {
         let range = self.base_tag_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`base_tag_list_offset`][Self::base_tag_list_offset].
@@ -189,7 +189,7 @@ impl<'a> Axis<'a> {
     /// Offset to BaseScriptList table, from beginning of Axis table
     pub fn base_script_list_offset(&self) -> Offset16 {
         let range = self.base_script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`base_script_list_offset`][Self::base_script_list_offset].
@@ -274,14 +274,14 @@ impl<'a> BaseTagList<'a> {
     /// — may be zero (0)
     pub fn base_tag_count(&self) -> u16 {
         let range = self.base_tag_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of 4-byte baseline identification tags — must be in
     /// alphabetical order
     pub fn baseline_tags(&self) -> &'a [BigEndian<Tag>] {
         let range = self.baseline_tags_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -353,14 +353,14 @@ impl<'a> BaseScriptList<'a> {
     /// Number of BaseScriptRecords defined
     pub fn base_script_count(&self) -> u16 {
         let range = self.base_script_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of BaseScriptRecords, in alphabetical order by
     /// baseScriptTag
     pub fn base_script_records(&self) -> &'a [BaseScriptRecord] {
         let range = self.base_script_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -502,7 +502,7 @@ impl<'a> BaseScript<'a> {
     /// Offset to BaseValues table, from beginning of BaseScript table (may be NULL)
     pub fn base_values_offset(&self) -> Nullable<Offset16> {
         let range = self.base_values_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`base_values_offset`][Self::base_values_offset].
@@ -514,7 +514,7 @@ impl<'a> BaseScript<'a> {
     /// Offset to MinMax table, from beginning of BaseScript table (may be NULL)
     pub fn default_min_max_offset(&self) -> Nullable<Offset16> {
         let range = self.default_min_max_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`default_min_max_offset`][Self::default_min_max_offset].
@@ -526,14 +526,14 @@ impl<'a> BaseScript<'a> {
     /// Number of BaseLangSysRecords defined — may be zero (0)
     pub fn base_lang_sys_count(&self) -> u16 {
         let range = self.base_lang_sys_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of BaseLangSysRecords, in alphabetical order by
     /// BaseLangSysTag
     pub fn base_lang_sys_records(&self) -> &'a [BaseLangSysRecord] {
         let range = self.base_lang_sys_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -683,14 +683,14 @@ impl<'a> BaseValues<'a> {
     /// BaseTagList
     pub fn default_baseline_index(&self) -> u16 {
         let range = self.default_baseline_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of BaseCoord tables defined — should equal
     /// baseTagCount in the BaseTagList
     pub fn base_coord_count(&self) -> u16 {
         let range = self.base_coord_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to BaseCoord tables, from beginning of
@@ -698,7 +698,7 @@ impl<'a> BaseValues<'a> {
     /// BaseTagList
     pub fn base_coord_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.base_coord_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`base_coord_offsets`][Self::base_coord_offsets].
@@ -805,7 +805,7 @@ impl<'a> MinMax<'a> {
     /// value, from the beginning of MinMax table (may be NULL)
     pub fn min_coord_offset(&self) -> Nullable<Offset16> {
         let range = self.min_coord_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`min_coord_offset`][Self::min_coord_offset].
@@ -818,7 +818,7 @@ impl<'a> MinMax<'a> {
     /// from the beginning of MinMax table (may be NULL)
     pub fn max_coord_offset(&self) -> Nullable<Offset16> {
         let range = self.max_coord_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`max_coord_offset`][Self::max_coord_offset].
@@ -830,14 +830,14 @@ impl<'a> MinMax<'a> {
     /// Number of FeatMinMaxRecords — may be zero (0)
     pub fn feat_min_max_count(&self) -> u16 {
         let range = self.feat_min_max_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of FeatMinMaxRecords, in alphabetical order by
     /// featureTableTag
     pub fn feat_min_max_records(&self) -> &'a [FeatMinMaxRecord] {
         let range = self.feat_min_max_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1087,13 +1087,13 @@ impl<'a> BaseCoordFormat1<'a> {
     /// Format identifier — format = 1
     pub fn base_coord_format(&self) -> u16 {
         let range = self.base_coord_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -1172,25 +1172,25 @@ impl<'a> BaseCoordFormat2<'a> {
     /// Format identifier — format = 2
     pub fn base_coord_format(&self) -> u16 {
         let range = self.base_coord_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Glyph ID of control glyph
     pub fn reference_glyph(&self) -> u16 {
         let range = self.reference_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Index of contour point on the reference glyph
     pub fn base_coord_point(&self) -> u16 {
         let range = self.base_coord_point_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -1266,13 +1266,13 @@ impl<'a> BaseCoordFormat3<'a> {
     /// Format identifier — format = 3
     pub fn base_coord_format(&self) -> u16 {
         let range = self.base_coord_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Device table (non-variable font) / Variation Index
@@ -1280,7 +1280,7 @@ impl<'a> BaseCoordFormat3<'a> {
     /// BaseCoord table (may be NULL).
     pub fn device_offset(&self) -> Nullable<Offset16> {
         let range = self.device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -12,29 +12,7 @@ pub struct BaseMarker {
     item_var_store_offset_byte_start: Option<usize>,
 }
 
-impl BaseMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn horiz_axis_offset_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn vert_axis_offset_byte_range(&self) -> Range<usize> {
-        let start = self.horiz_axis_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn item_var_store_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.item_var_store_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for BaseMarker {
+impl<'a> MinByteRange for Base<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.vert_axis_offset_byte_range().end
     }
@@ -69,15 +47,35 @@ pub type Base<'a> = TableRef<'a, BaseMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Base<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn horiz_axis_offset_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn vert_axis_offset_byte_range(&self) -> Range<usize> {
+        let start = self.horiz_axis_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn item_var_store_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.item_var_store_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
     /// (major, minor) Version for the BASE table (1,0) or (1,1)
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to horizontal Axis table, from beginning of BASE table (may be NULL)
     pub fn horiz_axis_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.horiz_axis_offset_byte_range();
+        let range = self.horiz_axis_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -89,7 +87,7 @@ impl<'a> Base<'a> {
 
     /// Offset to vertical Axis table, from beginning of BASE table (may be NULL)
     pub fn vert_axis_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.vert_axis_offset_byte_range();
+        let range = self.vert_axis_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -101,7 +99,7 @@ impl<'a> Base<'a> {
 
     /// Offset to Item Variation Store table, from beginning of BASE table (may be null)
     pub fn item_var_store_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.item_var_store_offset_byte_range()?;
+        let range = self.item_var_store_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -151,19 +149,7 @@ impl<'a> std::fmt::Debug for Base<'a> {
 #[doc(hidden)]
 pub struct AxisMarker {}
 
-impl AxisMarker {
-    pub fn base_tag_list_offset_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn base_script_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.base_tag_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for AxisMarker {
+impl<'a> MinByteRange for Axis<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.base_script_list_offset_byte_range().end
     }
@@ -183,10 +169,20 @@ pub type Axis<'a> = TableRef<'a, AxisMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Axis<'a> {
+    pub fn base_tag_list_offset_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn base_script_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.base_tag_list_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
     /// Offset to BaseTagList table, from beginning of Axis table (may
     /// be NULL)
     pub fn base_tag_list_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.base_tag_list_offset_byte_range();
+        let range = self.base_tag_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -198,7 +194,7 @@ impl<'a> Axis<'a> {
 
     /// Offset to BaseScriptList table, from beginning of Axis table
     pub fn base_script_list_offset(&self) -> Offset16 {
-        let range = self.shape.base_script_list_offset_byte_range();
+        let range = self.base_script_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -240,23 +236,9 @@ impl<'a> std::fmt::Debug for Axis<'a> {
 /// [BaseTagList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basetaglist-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BaseTagListMarker {
-    baseline_tags_byte_len: usize,
-}
+pub struct BaseTagListMarker {}
 
-impl BaseTagListMarker {
-    pub fn base_tag_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn baseline_tags_byte_range(&self) -> Range<usize> {
-        let start = self.base_tag_count_byte_range().end;
-        start..start + self.baseline_tags_byte_len
-    }
-}
-
-impl MinByteRange for BaseTagListMarker {
+impl<'a> MinByteRange for BaseTagList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.baseline_tags_byte_range().end
     }
@@ -270,9 +252,7 @@ impl<'a> FontRead<'a> for BaseTagList<'a> {
             .checked_mul(Tag::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(baseline_tags_byte_len);
-        cursor.finish(BaseTagListMarker {
-            baseline_tags_byte_len,
-        })
+        cursor.finish(BaseTagListMarker {})
     }
 }
 
@@ -281,17 +261,34 @@ pub type BaseTagList<'a> = TableRef<'a, BaseTagListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseTagList<'a> {
+    fn baseline_tags_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.base_tag_count()) as usize)
+            .checked_mul(Tag::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn base_tag_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn baseline_tags_byte_range(&self) -> Range<usize> {
+        let start = self.base_tag_count_byte_range().end;
+        start..start + self.baseline_tags_byte_len(start)
+    }
+
     /// Number of baseline identification tags in this text direction
     /// — may be zero (0)
     pub fn base_tag_count(&self) -> u16 {
-        let range = self.shape.base_tag_count_byte_range();
+        let range = self.base_tag_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of 4-byte baseline identification tags — must be in
     /// alphabetical order
     pub fn baseline_tags(&self) -> &'a [BigEndian<Tag>] {
-        let range = self.shape.baseline_tags_byte_range();
+        let range = self.baseline_tags_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -321,23 +318,9 @@ impl<'a> std::fmt::Debug for BaseTagList<'a> {
 /// [BaseScriptList Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescriptlist-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BaseScriptListMarker {
-    base_script_records_byte_len: usize,
-}
+pub struct BaseScriptListMarker {}
 
-impl BaseScriptListMarker {
-    pub fn base_script_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_script_records_byte_range(&self) -> Range<usize> {
-        let start = self.base_script_count_byte_range().end;
-        start..start + self.base_script_records_byte_len
-    }
-}
-
-impl MinByteRange for BaseScriptListMarker {
+impl<'a> MinByteRange for BaseScriptList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.base_script_records_byte_range().end
     }
@@ -351,9 +334,7 @@ impl<'a> FontRead<'a> for BaseScriptList<'a> {
             .checked_mul(BaseScriptRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_script_records_byte_len);
-        cursor.finish(BaseScriptListMarker {
-            base_script_records_byte_len,
-        })
+        cursor.finish(BaseScriptListMarker {})
     }
 }
 
@@ -362,16 +343,33 @@ pub type BaseScriptList<'a> = TableRef<'a, BaseScriptListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseScriptList<'a> {
+    fn base_script_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.base_script_count()) as usize)
+            .checked_mul(BaseScriptRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn base_script_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_script_records_byte_range(&self) -> Range<usize> {
+        let start = self.base_script_count_byte_range().end;
+        start..start + self.base_script_records_byte_len(start)
+    }
+
     /// Number of BaseScriptRecords defined
     pub fn base_script_count(&self) -> u16 {
-        let range = self.shape.base_script_count_byte_range();
+        let range = self.base_script_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of BaseScriptRecords, in alphabetical order by
     /// baseScriptTag
     pub fn base_script_records(&self) -> &'a [BaseScriptRecord] {
-        let range = self.shape.base_script_records_byte_range();
+        let range = self.base_script_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -461,11 +459,40 @@ impl<'a> SomeRecord<'a> for BaseScriptRecord {
 /// [BaseScript Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescript-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BaseScriptMarker {
-    base_lang_sys_records_byte_len: usize,
+pub struct BaseScriptMarker {}
+
+impl<'a> MinByteRange for BaseScript<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.base_lang_sys_records_byte_range().end
+    }
 }
 
-impl BaseScriptMarker {
+impl<'a> FontRead<'a> for BaseScript<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        let base_lang_sys_count: u16 = cursor.read()?;
+        let base_lang_sys_records_byte_len = (base_lang_sys_count as usize)
+            .checked_mul(BaseLangSysRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(base_lang_sys_records_byte_len);
+        cursor.finish(BaseScriptMarker {})
+    }
+}
+
+/// [BaseScript Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescript-table)
+pub type BaseScript<'a> = TableRef<'a, BaseScriptMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> BaseScript<'a> {
+    fn base_lang_sys_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.base_lang_sys_count()) as usize)
+            .checked_mul(BaseLangSysRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn base_values_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
@@ -483,40 +510,12 @@ impl BaseScriptMarker {
 
     pub fn base_lang_sys_records_byte_range(&self) -> Range<usize> {
         let start = self.base_lang_sys_count_byte_range().end;
-        start..start + self.base_lang_sys_records_byte_len
+        start..start + self.base_lang_sys_records_byte_len(start)
     }
-}
 
-impl MinByteRange for BaseScriptMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.base_lang_sys_records_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for BaseScript<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let base_lang_sys_count: u16 = cursor.read()?;
-        let base_lang_sys_records_byte_len = (base_lang_sys_count as usize)
-            .checked_mul(BaseLangSysRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(base_lang_sys_records_byte_len);
-        cursor.finish(BaseScriptMarker {
-            base_lang_sys_records_byte_len,
-        })
-    }
-}
-
-/// [BaseScript Table](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basescript-table)
-pub type BaseScript<'a> = TableRef<'a, BaseScriptMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> BaseScript<'a> {
     /// Offset to BaseValues table, from beginning of BaseScript table (may be NULL)
     pub fn base_values_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.base_values_offset_byte_range();
+        let range = self.base_values_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -528,7 +527,7 @@ impl<'a> BaseScript<'a> {
 
     /// Offset to MinMax table, from beginning of BaseScript table (may be NULL)
     pub fn default_min_max_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.default_min_max_offset_byte_range();
+        let range = self.default_min_max_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -540,14 +539,14 @@ impl<'a> BaseScript<'a> {
 
     /// Number of BaseLangSysRecords defined — may be zero (0)
     pub fn base_lang_sys_count(&self) -> u16 {
-        let range = self.shape.base_lang_sys_count_byte_range();
+        let range = self.base_lang_sys_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of BaseLangSysRecords, in alphabetical order by
     /// BaseLangSysTag
     pub fn base_lang_sys_records(&self) -> &'a [BaseLangSysRecord] {
-        let range = self.shape.base_lang_sys_records_byte_range();
+        let range = self.base_lang_sys_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -648,28 +647,9 @@ impl<'a> SomeRecord<'a> for BaseLangSysRecord {
 /// [BaseValues](https://learn.microsoft.com/en-us/typography/opentype/spec/base#basevalues-table) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BaseValuesMarker {
-    base_coord_offsets_byte_len: usize,
-}
+pub struct BaseValuesMarker {}
 
-impl BaseValuesMarker {
-    pub fn default_baseline_index_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_coord_count_byte_range(&self) -> Range<usize> {
-        let start = self.default_baseline_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_coord_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.base_coord_count_byte_range().end;
-        start..start + self.base_coord_offsets_byte_len
-    }
-}
-
-impl MinByteRange for BaseValuesMarker {
+impl<'a> MinByteRange for BaseValues<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.base_coord_offsets_byte_range().end
     }
@@ -684,9 +664,7 @@ impl<'a> FontRead<'a> for BaseValues<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_coord_offsets_byte_len);
-        cursor.finish(BaseValuesMarker {
-            base_coord_offsets_byte_len,
-        })
+        cursor.finish(BaseValuesMarker {})
     }
 }
 
@@ -695,18 +673,40 @@ pub type BaseValues<'a> = TableRef<'a, BaseValuesMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseValues<'a> {
+    fn base_coord_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.base_coord_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn default_baseline_index_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_coord_count_byte_range(&self) -> Range<usize> {
+        let start = self.default_baseline_index_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_coord_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.base_coord_count_byte_range().end;
+        start..start + self.base_coord_offsets_byte_len(start)
+    }
+
     /// Index number of default baseline for this script — equals
     /// index position of baseline tag in baselineTags array of the
     /// BaseTagList
     pub fn default_baseline_index(&self) -> u16 {
-        let range = self.shape.default_baseline_index_byte_range();
+        let range = self.default_baseline_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of BaseCoord tables defined — should equal
     /// baseTagCount in the BaseTagList
     pub fn base_coord_count(&self) -> u16 {
-        let range = self.shape.base_coord_count_byte_range();
+        let range = self.base_coord_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -714,7 +714,7 @@ impl<'a> BaseValues<'a> {
     /// BaseValues table — order matches baselineTags array in the
     /// BaseTagList
     pub fn base_coord_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.base_coord_offsets_byte_range();
+        let range = self.base_coord_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -768,11 +768,40 @@ impl<'a> std::fmt::Debug for BaseValues<'a> {
 /// [MinMax](https://learn.microsoft.com/en-us/typography/opentype/spec/base#minmax-table) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MinMaxMarker {
-    feat_min_max_records_byte_len: usize,
+pub struct MinMaxMarker {}
+
+impl<'a> MinByteRange for MinMax<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.feat_min_max_records_byte_range().end
+    }
 }
 
-impl MinMaxMarker {
+impl<'a> FontRead<'a> for MinMax<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        let feat_min_max_count: u16 = cursor.read()?;
+        let feat_min_max_records_byte_len = (feat_min_max_count as usize)
+            .checked_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(feat_min_max_records_byte_len);
+        cursor.finish(MinMaxMarker {})
+    }
+}
+
+/// [MinMax](https://learn.microsoft.com/en-us/typography/opentype/spec/base#minmax-table) table
+pub type MinMax<'a> = TableRef<'a, MinMaxMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> MinMax<'a> {
+    fn feat_min_max_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.feat_min_max_count()) as usize)
+            .checked_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn min_coord_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Offset16::RAW_BYTE_LEN
@@ -790,41 +819,13 @@ impl MinMaxMarker {
 
     pub fn feat_min_max_records_byte_range(&self) -> Range<usize> {
         let start = self.feat_min_max_count_byte_range().end;
-        start..start + self.feat_min_max_records_byte_len
+        start..start + self.feat_min_max_records_byte_len(start)
     }
-}
 
-impl MinByteRange for MinMaxMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.feat_min_max_records_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for MinMax<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let feat_min_max_count: u16 = cursor.read()?;
-        let feat_min_max_records_byte_len = (feat_min_max_count as usize)
-            .checked_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(feat_min_max_records_byte_len);
-        cursor.finish(MinMaxMarker {
-            feat_min_max_records_byte_len,
-        })
-    }
-}
-
-/// [MinMax](https://learn.microsoft.com/en-us/typography/opentype/spec/base#minmax-table) table
-pub type MinMax<'a> = TableRef<'a, MinMaxMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> MinMax<'a> {
     /// Offset to BaseCoord table that defines the minimum extent
     /// value, from the beginning of MinMax table (may be NULL)
     pub fn min_coord_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.min_coord_offset_byte_range();
+        let range = self.min_coord_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -837,7 +838,7 @@ impl<'a> MinMax<'a> {
     /// Offset to BaseCoord table that defines maximum extent value,
     /// from the beginning of MinMax table (may be NULL)
     pub fn max_coord_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.max_coord_offset_byte_range();
+        let range = self.max_coord_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -849,14 +850,14 @@ impl<'a> MinMax<'a> {
 
     /// Number of FeatMinMaxRecords — may be zero (0)
     pub fn feat_min_max_count(&self) -> u16 {
-        let range = self.shape.feat_min_max_count_byte_range();
+        let range = self.feat_min_max_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of FeatMinMaxRecords, in alphabetical order by
     /// featureTableTag
     pub fn feat_min_max_records(&self) -> &'a [FeatMinMaxRecord] {
-        let range = self.shape.feat_min_max_records_byte_range();
+        let range = self.feat_min_max_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1073,19 +1074,7 @@ impl Format<u16> for BaseCoordFormat1Marker {
 #[doc(hidden)]
 pub struct BaseCoordFormat1Marker {}
 
-impl BaseCoordFormat1Marker {
-    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.base_coord_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for BaseCoordFormat1Marker {
+impl<'a> MinByteRange for BaseCoordFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.coordinate_byte_range().end
     }
@@ -1105,15 +1094,25 @@ pub type BaseCoordFormat1<'a> = TableRef<'a, BaseCoordFormat1Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseCoordFormat1<'a> {
+    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.base_coord_format_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
     /// Format identifier — format = 1
     pub fn base_coord_format(&self) -> u16 {
-        let range = self.shape.base_coord_format_byte_range();
+        let range = self.base_coord_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
-        let range = self.shape.coordinate_byte_range();
+        let range = self.coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -1149,29 +1148,7 @@ impl Format<u16> for BaseCoordFormat2Marker {
 #[doc(hidden)]
 pub struct BaseCoordFormat2Marker {}
 
-impl BaseCoordFormat2Marker {
-    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.base_coord_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn reference_glyph_byte_range(&self) -> Range<usize> {
-        let start = self.coordinate_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_coord_point_byte_range(&self) -> Range<usize> {
-        let start = self.reference_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for BaseCoordFormat2Marker {
+impl<'a> MinByteRange for BaseCoordFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.base_coord_point_byte_range().end
     }
@@ -1193,27 +1170,47 @@ pub type BaseCoordFormat2<'a> = TableRef<'a, BaseCoordFormat2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseCoordFormat2<'a> {
+    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.base_coord_format_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn reference_glyph_byte_range(&self) -> Range<usize> {
+        let start = self.coordinate_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_coord_point_byte_range(&self) -> Range<usize> {
+        let start = self.reference_glyph_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     /// Format identifier — format = 2
     pub fn base_coord_format(&self) -> u16 {
-        let range = self.shape.base_coord_format_byte_range();
+        let range = self.base_coord_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
-        let range = self.shape.coordinate_byte_range();
+        let range = self.coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Glyph ID of control glyph
     pub fn reference_glyph(&self) -> u16 {
-        let range = self.shape.reference_glyph_byte_range();
+        let range = self.reference_glyph_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Index of contour point on the reference glyph
     pub fn base_coord_point(&self) -> u16 {
-        let range = self.shape.base_coord_point_byte_range();
+        let range = self.base_coord_point_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -1251,24 +1248,7 @@ impl Format<u16> for BaseCoordFormat3Marker {
 #[doc(hidden)]
 pub struct BaseCoordFormat3Marker {}
 
-impl BaseCoordFormat3Marker {
-    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.base_coord_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn device_offset_byte_range(&self) -> Range<usize> {
-        let start = self.coordinate_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for BaseCoordFormat3Marker {
+impl<'a> MinByteRange for BaseCoordFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.device_offset_byte_range().end
     }
@@ -1289,15 +1269,30 @@ pub type BaseCoordFormat3<'a> = TableRef<'a, BaseCoordFormat3Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseCoordFormat3<'a> {
+    pub fn base_coord_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.base_coord_format_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn device_offset_byte_range(&self) -> Range<usize> {
+        let start = self.coordinate_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
     /// Format identifier — format = 3
     pub fn base_coord_format(&self) -> u16 {
-        let range = self.shape.base_coord_format_byte_range();
+        let range = self.base_coord_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
-        let range = self.shape.coordinate_byte_range();
+        let range = self.coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1305,7 +1300,7 @@ impl<'a> BaseCoordFormat3<'a> {
     /// table (variable font) for X or Y value, from beginning of
     /// BaseCoord table (may be NULL).
     pub fn device_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.device_offset_byte_range();
+        let range = self.device_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -742,9 +742,7 @@ impl<'a> SomeRecord<'a> for SmallGlyphMetrics {
 /// [IndexSubtableList](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtablelist) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct IndexSubtableListMarker {
-    number_of_index_subtables: u32,
-}
+pub struct IndexSubtableListMarker;
 
 impl<'a> MinByteRange for IndexSubtableList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -758,14 +756,11 @@ impl ReadArgs for IndexSubtableList<'_> {
 
 impl<'a> FontReadWithArgs<'a> for IndexSubtableList<'a> {
     fn read_with_args(data: FontData<'a>, args: &u32) -> Result<Self, ReadError> {
-        let number_of_index_subtables = *args;
-        let mut cursor = data.cursor();
-        let index_subtable_records_byte_len = (number_of_index_subtables as usize)
-            .checked_mul(IndexSubtableRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(index_subtable_records_byte_len);
-        cursor.finish(IndexSubtableListMarker {
-            number_of_index_subtables,
+        let args = *args;
+        Ok(TableRef {
+            shape: IndexSubtableListMarker,
+            args,
+            data,
         })
     }
 }
@@ -782,13 +777,13 @@ impl<'a> IndexSubtableList<'a> {
 }
 
 /// [IndexSubtableList](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtablelist) table.
-pub type IndexSubtableList<'a> = TableRef<'a, IndexSubtableListMarker>;
+pub type IndexSubtableList<'a> = TableRef<'a, IndexSubtableListMarker, u32>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtableList<'a> {
     fn index_subtable_records_byte_len(&self, start: usize) -> usize {
         let _ = start;
-        ((self.shape.number_of_index_subtables) as usize)
+        ((self.args) as usize)
             .checked_mul(IndexSubtableRecord::RAW_BYTE_LEN)
             .unwrap()
     }
@@ -805,7 +800,7 @@ impl<'a> IndexSubtableList<'a> {
     }
 
     pub(crate) fn number_of_index_subtables(&self) -> u32 {
-        self.shape.number_of_index_subtables
+        self.args
     }
 }
 
@@ -906,10 +901,7 @@ impl Format<u16> for IndexSubtable1Marker {
 /// [IndexSubTable1](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable1-variable-metrics-glyphs-with-4-byte-offsets): variable-metrics glyphs with 4-byte offsets.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct IndexSubtable1Marker {
-    last_glyph_index: GlyphId16,
-    first_glyph_index: GlyphId16,
-}
+pub struct IndexSubtable1Marker;
 
 impl<'a> MinByteRange for IndexSubtable1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -926,19 +918,11 @@ impl<'a> FontReadWithArgs<'a> for IndexSubtable1<'a> {
         data: FontData<'a>,
         args: &(GlyphId16, GlyphId16),
     ) -> Result<Self, ReadError> {
-        let (last_glyph_index, first_glyph_index) = *args;
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let sbit_offsets_byte_len =
-            (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
-                .checked_mul(u32::RAW_BYTE_LEN)
-                .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(sbit_offsets_byte_len);
-        cursor.finish(IndexSubtable1Marker {
-            last_glyph_index,
-            first_glyph_index,
+        let args = *args;
+        Ok(TableRef {
+            shape: IndexSubtable1Marker,
+            args,
+            data,
         })
     }
 }
@@ -959,13 +943,13 @@ impl<'a> IndexSubtable1<'a> {
 }
 
 /// [IndexSubTable1](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable1-variable-metrics-glyphs-with-4-byte-offsets): variable-metrics glyphs with 4-byte offsets.
-pub type IndexSubtable1<'a> = TableRef<'a, IndexSubtable1Marker>;
+pub type IndexSubtable1<'a> = TableRef<'a, IndexSubtable1Marker, (GlyphId16, GlyphId16)>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable1<'a> {
     fn sbit_offsets_byte_len(&self, start: usize) -> usize {
         let _ = start;
-        (transforms::subtract_add_two(self.shape.last_glyph_index, self.shape.first_glyph_index))
+        (transforms::subtract_add_two(self.args.0, self.args.1))
             .checked_mul(u32::RAW_BYTE_LEN)
             .unwrap()
     }
@@ -1014,11 +998,11 @@ impl<'a> IndexSubtable1<'a> {
     }
 
     pub(crate) fn last_glyph_index(&self) -> GlyphId16 {
-        self.shape.last_glyph_index
+        self.args.0
     }
 
     pub(crate) fn first_glyph_index(&self) -> GlyphId16 {
-        self.shape.first_glyph_index
+        self.args.1
     }
 }
 
@@ -1053,7 +1037,7 @@ impl Format<u16> for IndexSubtable2Marker {
 /// [IndexSubTable2](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable2-all-glyphs-have-identical-metrics): all glyphs have identical metrics.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct IndexSubtable2Marker {}
+pub struct IndexSubtable2Marker;
 
 impl<'a> MinByteRange for IndexSubtable2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1063,19 +1047,16 @@ impl<'a> MinByteRange for IndexSubtable2<'a> {
 
 impl<'a> FontRead<'a> for IndexSubtable2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let big_metrics_byte_len = BigGlyphMetrics::RAW_BYTE_LEN;
-        cursor.advance_by(big_metrics_byte_len);
-        cursor.finish(IndexSubtable2Marker {})
+        Ok(TableRef {
+            shape: IndexSubtable2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [IndexSubTable2](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable2-all-glyphs-have-identical-metrics): all glyphs have identical metrics.
-pub type IndexSubtable2<'a> = TableRef<'a, IndexSubtable2Marker>;
+pub type IndexSubtable2<'a> = TableRef<'a, IndexSubtable2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable2<'a> {
@@ -1179,10 +1160,7 @@ impl Format<u16> for IndexSubtable3Marker {
 /// [IndexSubTable3](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with 2-byte offsets.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct IndexSubtable3Marker {
-    last_glyph_index: GlyphId16,
-    first_glyph_index: GlyphId16,
-}
+pub struct IndexSubtable3Marker;
 
 impl<'a> MinByteRange for IndexSubtable3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1199,19 +1177,11 @@ impl<'a> FontReadWithArgs<'a> for IndexSubtable3<'a> {
         data: FontData<'a>,
         args: &(GlyphId16, GlyphId16),
     ) -> Result<Self, ReadError> {
-        let (last_glyph_index, first_glyph_index) = *args;
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let sbit_offsets_byte_len =
-            (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
-                .checked_mul(u16::RAW_BYTE_LEN)
-                .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(sbit_offsets_byte_len);
-        cursor.finish(IndexSubtable3Marker {
-            last_glyph_index,
-            first_glyph_index,
+        let args = *args;
+        Ok(TableRef {
+            shape: IndexSubtable3Marker,
+            args,
+            data,
         })
     }
 }
@@ -1232,13 +1202,13 @@ impl<'a> IndexSubtable3<'a> {
 }
 
 /// [IndexSubTable3](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with 2-byte offsets.
-pub type IndexSubtable3<'a> = TableRef<'a, IndexSubtable3Marker>;
+pub type IndexSubtable3<'a> = TableRef<'a, IndexSubtable3Marker, (GlyphId16, GlyphId16)>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable3<'a> {
     fn sbit_offsets_byte_len(&self, start: usize) -> usize {
         let _ = start;
-        (transforms::subtract_add_two(self.shape.last_glyph_index, self.shape.first_glyph_index))
+        (transforms::subtract_add_two(self.args.0, self.args.1))
             .checked_mul(u16::RAW_BYTE_LEN)
             .unwrap()
     }
@@ -1287,11 +1257,11 @@ impl<'a> IndexSubtable3<'a> {
     }
 
     pub(crate) fn last_glyph_index(&self) -> GlyphId16 {
-        self.shape.last_glyph_index
+        self.args.0
     }
 
     pub(crate) fn first_glyph_index(&self) -> GlyphId16 {
-        self.shape.first_glyph_index
+        self.args.1
     }
 }
 
@@ -1326,7 +1296,7 @@ impl Format<u16> for IndexSubtable4Marker {
 /// [IndexSubTable4](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with sparse glyph codes.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct IndexSubtable4Marker {}
+pub struct IndexSubtable4Marker;
 
 impl<'a> MinByteRange for IndexSubtable4<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1336,21 +1306,16 @@ impl<'a> MinByteRange for IndexSubtable4<'a> {
 
 impl<'a> FontRead<'a> for IndexSubtable4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let num_glyphs: u32 = cursor.read()?;
-        let glyph_array_byte_len = (transforms::add(num_glyphs, 1_usize))
-            .checked_mul(GlyphIdOffsetPair::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_array_byte_len);
-        cursor.finish(IndexSubtable4Marker {})
+        Ok(TableRef {
+            shape: IndexSubtable4Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [IndexSubTable4](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable3-variable-metrics-glyphs-with-2-byte-offsets): variable-metrics glyphs with sparse glyph codes.
-pub type IndexSubtable4<'a> = TableRef<'a, IndexSubtable4Marker>;
+pub type IndexSubtable4<'a> = TableRef<'a, IndexSubtable4Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable4<'a> {
@@ -1498,7 +1463,7 @@ impl Format<u16> for IndexSubtable5Marker {
 /// [IndexSubTable5](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable5-constant-metrics-glyphs-with-sparse-glyph-codes): constant-metrics glyphs with sparse glyph codes
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct IndexSubtable5Marker {}
+pub struct IndexSubtable5Marker;
 
 impl<'a> MinByteRange for IndexSubtable5<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1508,24 +1473,16 @@ impl<'a> MinByteRange for IndexSubtable5<'a> {
 
 impl<'a> FontRead<'a> for IndexSubtable5<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let big_metrics_byte_len = BigGlyphMetrics::RAW_BYTE_LEN;
-        cursor.advance_by(big_metrics_byte_len);
-        let num_glyphs: u32 = cursor.read()?;
-        let glyph_array_byte_len = (num_glyphs as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_array_byte_len);
-        cursor.finish(IndexSubtable5Marker {})
+        Ok(TableRef {
+            shape: IndexSubtable5Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [IndexSubTable5](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc#indexsubtable5-constant-metrics-glyphs-with-sparse-glyph-codes): constant-metrics glyphs with sparse glyph codes
-pub type IndexSubtable5<'a> = TableRef<'a, IndexSubtable5Marker>;
+pub type IndexSubtable5<'a> = TableRef<'a, IndexSubtable5Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> IndexSubtable5<'a> {

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -758,9 +758,9 @@ impl<'a> FontReadWithArgs<'a> for IndexSubtableList<'a> {
     fn read_with_args(data: FontData<'a>, args: &u32) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: IndexSubtableListMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -920,9 +920,9 @@ impl<'a> FontReadWithArgs<'a> for IndexSubtable1<'a> {
     ) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: IndexSubtable1Marker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1048,9 +1048,9 @@ impl<'a> MinByteRange for IndexSubtable2<'a> {
 impl<'a> FontRead<'a> for IndexSubtable2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: IndexSubtable2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1179,9 +1179,9 @@ impl<'a> FontReadWithArgs<'a> for IndexSubtable3<'a> {
     ) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: IndexSubtable3Marker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1307,9 +1307,9 @@ impl<'a> MinByteRange for IndexSubtable4<'a> {
 impl<'a> FontRead<'a> for IndexSubtable4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: IndexSubtable4Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1474,9 +1474,9 @@ impl<'a> MinByteRange for IndexSubtable5<'a> {
 impl<'a> FontRead<'a> for IndexSubtable5<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: IndexSubtable5Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -796,7 +796,7 @@ impl<'a> IndexSubtableList<'a> {
     /// Array of IndexSubtableRecords.
     pub fn index_subtable_records(&self) -> &'a [IndexSubtableRecord] {
         let range = self.index_subtable_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn number_of_index_subtables(&self) -> u32 {
@@ -977,24 +977,24 @@ impl<'a> IndexSubtable1<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn sbit_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.sbit_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn last_glyph_index(&self) -> GlyphId16 {
@@ -1093,31 +1093,31 @@ impl<'a> IndexSubtable2<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// All the glyphs are of the same size.
     pub fn image_size(&self) -> u32 {
         let range = self.image_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// All glyphs have the same metrics; glyph data may be compressed, byte-aligned, or bit-aligned.
     pub fn big_metrics(&self) -> &'a [BigGlyphMetrics] {
         let range = self.big_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1236,24 +1236,24 @@ impl<'a> IndexSubtable3<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn sbit_offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.sbit_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn last_glyph_index(&self) -> GlyphId16 {
@@ -1354,31 +1354,31 @@ impl<'a> IndexSubtable4<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array length.
     pub fn num_glyphs(&self) -> u32 {
         let range = self.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// One per glyph.
     pub fn glyph_array(&self) -> &'a [GlyphIdOffsetPair] {
         let range = self.glyph_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1535,43 +1535,43 @@ impl<'a> IndexSubtable5<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// All glyphs have the same data size.
     pub fn image_size(&self) -> u32 {
         let range = self.image_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// All glyphs have the same metrics.
     pub fn big_metrics(&self) -> &'a [BigGlyphMetrics] {
         let range = self.big_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Array length.
     pub fn num_glyphs(&self) -> u32 {
         let range = self.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// One per glyph, sorted by glyhph ID.
     pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.glyph_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [Color Bitmap Data](https://learn.microsoft.com/en-us/typography/opentype/spec/cbdt) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CbdtMarker {}
+pub struct CbdtMarker;
 
 impl<'a> MinByteRange for Cbdt<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,15 +23,16 @@ impl TopLevelTable for Cbdt<'_> {
 
 impl<'a> FontRead<'a> for Cbdt<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.finish(CbdtMarker {})
+        Ok(TableRef {
+            shape: CbdtMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [Color Bitmap Data](https://learn.microsoft.com/en-us/typography/opentype/spec/cbdt) table
-pub type Cbdt<'a> = TableRef<'a, CbdtMarker>;
+pub type Cbdt<'a> = TableRef<'a, CbdtMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cbdt<'a> {

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -49,13 +49,13 @@ impl<'a> Cbdt<'a> {
     /// Major version of the CBDT table, = 3.
     pub fn major_version(&self) -> u16 {
         let range = self.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minor version of CBDT table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Cbdt<'_> {
 impl<'a> FontRead<'a> for Cbdt<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CbdtMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -10,19 +10,7 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct CbdtMarker {}
 
-impl CbdtMarker {
-    pub fn major_version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn minor_version_byte_range(&self) -> Range<usize> {
-        let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for CbdtMarker {
+impl<'a> MinByteRange for Cbdt<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.minor_version_byte_range().end
     }
@@ -47,15 +35,25 @@ pub type Cbdt<'a> = TableRef<'a, CbdtMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cbdt<'a> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
+        let start = self.major_version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     /// Major version of the CBDT table, = 3.
     pub fn major_version(&self) -> u16 {
-        let range = self.shape.major_version_byte_range();
+        let range = self.major_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minor version of CBDT table, = 0.
     pub fn minor_version(&self) -> u16 {
-        let range = self.shape.minor_version_byte_range();
+        let range = self.minor_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -8,33 +8,9 @@ use crate::codegen_prelude::*;
 /// The [Color Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/cblc) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CblcMarker {
-    bitmap_sizes_byte_len: usize,
-}
+pub struct CblcMarker {}
 
-impl CblcMarker {
-    pub fn major_version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn minor_version_byte_range(&self) -> Range<usize> {
-        let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn num_sizes_byte_range(&self) -> Range<usize> {
-        let start = self.minor_version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
-        let start = self.num_sizes_byte_range().end;
-        start..start + self.bitmap_sizes_byte_len
-    }
-}
-
-impl MinByteRange for CblcMarker {
+impl<'a> MinByteRange for Cblc<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.bitmap_sizes_byte_range().end
     }
@@ -55,9 +31,7 @@ impl<'a> FontRead<'a> for Cblc<'a> {
             .checked_mul(BitmapSize::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(bitmap_sizes_byte_len);
-        cursor.finish(CblcMarker {
-            bitmap_sizes_byte_len,
-        })
+        cursor.finish(CblcMarker {})
     }
 }
 
@@ -66,27 +40,54 @@ pub type Cblc<'a> = TableRef<'a, CblcMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cblc<'a> {
+    fn bitmap_sizes_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_sizes()) as usize)
+            .checked_mul(BitmapSize::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn major_version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
+        let start = self.major_version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn num_sizes_byte_range(&self) -> Range<usize> {
+        let start = self.minor_version_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
+        let start = self.num_sizes_byte_range().end;
+        start..start + self.bitmap_sizes_byte_len(start)
+    }
+
     /// Major version of the CBLC table, = 3.
     pub fn major_version(&self) -> u16 {
-        let range = self.shape.major_version_byte_range();
+        let range = self.major_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minor version of CBLC table, = 0.
     pub fn minor_version(&self) -> u16 {
-        let range = self.shape.minor_version_byte_range();
+        let range = self.minor_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of BitmapSize records.
     pub fn num_sizes(&self) -> u32 {
-        let range = self.shape.num_sizes_byte_range();
+        let range = self.num_sizes_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// BitmapSize records array.
     pub fn bitmap_sizes(&self) -> &'a [BitmapSize] {
-        let range = self.shape.bitmap_sizes_byte_range();
+        let range = self.bitmap_sizes_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [Color Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/cblc) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CblcMarker {}
+pub struct CblcMarker;
 
 impl<'a> MinByteRange for Cblc<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,20 +23,16 @@ impl TopLevelTable for Cblc<'_> {
 
 impl<'a> FontRead<'a> for Cblc<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let num_sizes: u32 = cursor.read()?;
-        let bitmap_sizes_byte_len = (num_sizes as usize)
-            .checked_mul(BitmapSize::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(bitmap_sizes_byte_len);
-        cursor.finish(CblcMarker {})
+        Ok(TableRef {
+            shape: CblcMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [Color Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/cblc) table
-pub type Cblc<'a> = TableRef<'a, CblcMarker>;
+pub type Cblc<'a> = TableRef<'a, CblcMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cblc<'a> {

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -66,25 +66,25 @@ impl<'a> Cblc<'a> {
     /// Major version of the CBLC table, = 3.
     pub fn major_version(&self) -> u16 {
         let range = self.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minor version of CBLC table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of BitmapSize records.
     pub fn num_sizes(&self) -> u32 {
         let range = self.num_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// BitmapSize records array.
     pub fn bitmap_sizes(&self) -> &'a [BitmapSize] {
         let range = self.bitmap_sizes_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Cblc<'_> {
 impl<'a> FontRead<'a> for Cblc<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CblcMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -78,37 +78,37 @@ impl<'a> CffHeader<'a> {
     /// Format major version (starting at 1).
     pub fn major(&self) -> u8 {
         let range = self.major_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format minor version (starting at 0).
     pub fn minor(&self) -> u8 {
         let range = self.minor_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Header size (bytes).
     pub fn hdr_size(&self) -> u8 {
         let range = self.hdr_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Absolute offset size.
     pub fn off_size(&self) -> u8 {
         let range = self.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Padding bytes before the start of the Name INDEX.
     pub fn _padding(&self) -> &'a [u8] {
         let range = self._padding_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Remaining table data.
     pub fn trailing_data(&self) -> &'a [u8] {
         let range = self.trailing_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -19,9 +19,9 @@ impl<'a> MinByteRange for CffHeader<'a> {
 impl<'a> FontRead<'a> for CffHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CffHeaderMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -8,12 +8,50 @@ use crate::codegen_prelude::*;
 /// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CffHeaderMarker {
-    _padding_byte_len: usize,
-    trailing_data_byte_len: usize,
+pub struct CffHeaderMarker {}
+
+impl<'a> MinByteRange for CffHeader<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.trailing_data_byte_range().end
+    }
 }
 
-impl CffHeaderMarker {
+impl<'a> FontRead<'a> for CffHeader<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<u8>();
+        let hdr_size: u8 = cursor.read()?;
+        cursor.advance::<u8>();
+        let _padding_byte_len = (transforms::subtract(hdr_size, 4_usize))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(_padding_byte_len);
+        let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(trailing_data_byte_len);
+        cursor.finish(CffHeaderMarker {})
+    }
+}
+
+/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
+pub type CffHeader<'a> = TableRef<'a, CffHeaderMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> CffHeader<'a> {
+    fn _padding_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.hdr_size(), 4_usize))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn trailing_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn major_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -36,79 +74,47 @@ impl CffHeaderMarker {
 
     pub fn _padding_byte_range(&self) -> Range<usize> {
         let start = self.off_size_byte_range().end;
-        start..start + self._padding_byte_len
+        start..start + self._padding_byte_len(start)
     }
 
     pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self._padding_byte_range().end;
-        start..start + self.trailing_data_byte_len
+        start..start + self.trailing_data_byte_len(start)
     }
-}
 
-impl MinByteRange for CffHeaderMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.trailing_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for CffHeader<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<u8>();
-        let hdr_size: u8 = cursor.read()?;
-        cursor.advance::<u8>();
-        let _padding_byte_len = (transforms::subtract(hdr_size, 4_usize))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(_padding_byte_len);
-        let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(trailing_data_byte_len);
-        cursor.finish(CffHeaderMarker {
-            _padding_byte_len,
-            trailing_data_byte_len,
-        })
-    }
-}
-
-/// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
-pub type CffHeader<'a> = TableRef<'a, CffHeaderMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> CffHeader<'a> {
     /// Format major version (starting at 1).
     pub fn major(&self) -> u8 {
-        let range = self.shape.major_byte_range();
+        let range = self.major_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Format minor version (starting at 0).
     pub fn minor(&self) -> u8 {
-        let range = self.shape.minor_byte_range();
+        let range = self.minor_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Header size (bytes).
     pub fn hdr_size(&self) -> u8 {
-        let range = self.shape.hdr_size_byte_range();
+        let range = self.hdr_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Absolute offset size.
     pub fn off_size(&self) -> u8 {
-        let range = self.shape.off_size_byte_range();
+        let range = self.off_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Padding bytes before the start of the Name INDEX.
     pub fn _padding(&self) -> &'a [u8] {
-        let range = self.shape._padding_byte_range();
+        let range = self._padding_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Remaining table data.
     pub fn trailing_data(&self) -> &'a [u8] {
-        let range = self.shape.trailing_data_byte_range();
+        let range = self.trailing_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CffHeaderMarker {}
+pub struct CffHeaderMarker;
 
 impl<'a> MinByteRange for CffHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -18,23 +18,16 @@ impl<'a> MinByteRange for CffHeader<'a> {
 
 impl<'a> FontRead<'a> for CffHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<u8>();
-        let hdr_size: u8 = cursor.read()?;
-        cursor.advance::<u8>();
-        let _padding_byte_len = (transforms::subtract(hdr_size, 4_usize))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(_padding_byte_len);
-        let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(trailing_data_byte_len);
-        cursor.finish(CffHeaderMarker {})
+        Ok(TableRef {
+            shape: CffHeaderMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Compact Font Format](https://learn.microsoft.com/en-us/typography/opentype/spec/cff) table header
-pub type CffHeader<'a> = TableRef<'a, CffHeaderMarker>;
+pub type CffHeader<'a> = TableRef<'a, CffHeaderMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CffHeader<'a> {

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cff2HeaderMarker {}
+pub struct Cff2HeaderMarker;
 
 impl<'a> MinByteRange for Cff2Header<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -18,27 +18,16 @@ impl<'a> MinByteRange for Cff2Header<'a> {
 
 impl<'a> FontRead<'a> for Cff2Header<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<u8>();
-        let header_size: u8 = cursor.read()?;
-        let top_dict_length: u16 = cursor.read()?;
-        let _padding_byte_len = (transforms::subtract(header_size, 5_usize))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(_padding_byte_len);
-        let top_dict_data_byte_len = (top_dict_length as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(top_dict_data_byte_len);
-        let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(trailing_data_byte_len);
-        cursor.finish(Cff2HeaderMarker {})
+        Ok(TableRef {
+            shape: Cff2HeaderMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
-pub type Cff2Header<'a> = TableRef<'a, Cff2HeaderMarker>;
+pub type Cff2Header<'a> = TableRef<'a, Cff2HeaderMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cff2Header<'a> {

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -89,43 +89,43 @@ impl<'a> Cff2Header<'a> {
     /// Format major version (set to 2).
     pub fn major_version(&self) -> u8 {
         let range = self.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format minor version (set to 0).
     pub fn minor_version(&self) -> u8 {
         let range = self.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Header size (bytes).
     pub fn header_size(&self) -> u8 {
         let range = self.header_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Length of Top DICT structure in bytes.
     pub fn top_dict_length(&self) -> u16 {
         let range = self.top_dict_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Padding bytes before the start of the Top DICT.
     pub fn _padding(&self) -> &'a [u8] {
         let range = self._padding_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Data containing the Top DICT.
     pub fn top_dict_data(&self) -> &'a [u8] {
         let range = self.top_dict_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Remaining table data.
     pub fn trailing_data(&self) -> &'a [u8] {
         let range = self.trailing_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -19,9 +19,9 @@ impl<'a> MinByteRange for Cff2Header<'a> {
 impl<'a> FontRead<'a> for Cff2Header<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cff2HeaderMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -8,50 +8,9 @@ use crate::codegen_prelude::*;
 /// [Compact Font Format (CFF) version 2](https://learn.microsoft.com/en-us/typography/opentype/spec/cff2) table header
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cff2HeaderMarker {
-    _padding_byte_len: usize,
-    top_dict_data_byte_len: usize,
-    trailing_data_byte_len: usize,
-}
+pub struct Cff2HeaderMarker {}
 
-impl Cff2HeaderMarker {
-    pub fn major_version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn minor_version_byte_range(&self) -> Range<usize> {
-        let start = self.major_version_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn header_size_byte_range(&self) -> Range<usize> {
-        let start = self.minor_version_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn top_dict_length_byte_range(&self) -> Range<usize> {
-        let start = self.header_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn _padding_byte_range(&self) -> Range<usize> {
-        let start = self.top_dict_length_byte_range().end;
-        start..start + self._padding_byte_len
-    }
-
-    pub fn top_dict_data_byte_range(&self) -> Range<usize> {
-        let start = self._padding_byte_range().end;
-        start..start + self.top_dict_data_byte_len
-    }
-
-    pub fn trailing_data_byte_range(&self) -> Range<usize> {
-        let start = self.top_dict_data_byte_range().end;
-        start..start + self.trailing_data_byte_len
-    }
-}
-
-impl MinByteRange for Cff2HeaderMarker {
+impl<'a> MinByteRange for Cff2Header<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.trailing_data_byte_range().end
     }
@@ -74,11 +33,7 @@ impl<'a> FontRead<'a> for Cff2Header<'a> {
         cursor.advance_by(top_dict_data_byte_len);
         let trailing_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(trailing_data_byte_len);
-        cursor.finish(Cff2HeaderMarker {
-            _padding_byte_len,
-            top_dict_data_byte_len,
-            trailing_data_byte_len,
-        })
+        cursor.finish(Cff2HeaderMarker {})
     }
 }
 
@@ -87,45 +42,100 @@ pub type Cff2Header<'a> = TableRef<'a, Cff2HeaderMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cff2Header<'a> {
+    fn _padding_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.header_size(), 5_usize))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn top_dict_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.top_dict_length()) as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn trailing_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn major_version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
+        let start = self.major_version_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn header_size_byte_range(&self) -> Range<usize> {
+        let start = self.minor_version_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn top_dict_length_byte_range(&self) -> Range<usize> {
+        let start = self.header_size_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn _padding_byte_range(&self) -> Range<usize> {
+        let start = self.top_dict_length_byte_range().end;
+        start..start + self._padding_byte_len(start)
+    }
+
+    pub fn top_dict_data_byte_range(&self) -> Range<usize> {
+        let start = self._padding_byte_range().end;
+        start..start + self.top_dict_data_byte_len(start)
+    }
+
+    pub fn trailing_data_byte_range(&self) -> Range<usize> {
+        let start = self.top_dict_data_byte_range().end;
+        start..start + self.trailing_data_byte_len(start)
+    }
+
     /// Format major version (set to 2).
     pub fn major_version(&self) -> u8 {
-        let range = self.shape.major_version_byte_range();
+        let range = self.major_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Format minor version (set to 0).
     pub fn minor_version(&self) -> u8 {
-        let range = self.shape.minor_version_byte_range();
+        let range = self.minor_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Header size (bytes).
     pub fn header_size(&self) -> u8 {
-        let range = self.shape.header_size_byte_range();
+        let range = self.header_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Length of Top DICT structure in bytes.
     pub fn top_dict_length(&self) -> u16 {
-        let range = self.shape.top_dict_length_byte_range();
+        let range = self.top_dict_length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Padding bytes before the start of the Top DICT.
     pub fn _padding(&self) -> &'a [u8] {
-        let range = self.shape._padding_byte_range();
+        let range = self._padding_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Data containing the Top DICT.
     pub fn top_dict_data(&self) -> &'a [u8] {
-        let range = self.shape.top_dict_data_byte_range();
+        let range = self.top_dict_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Remaining table data.
     pub fn trailing_data(&self) -> &'a [u8] {
-        let range = self.shape.trailing_data_byte_range();
+        let range = self.trailing_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Cmap<'_> {
 impl<'a> FontRead<'a> for Cmap<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CmapMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -354,9 +354,9 @@ impl<'a> MinByteRange for Cmap0<'a> {
 impl<'a> FontRead<'a> for Cmap0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -459,9 +459,9 @@ impl<'a> MinByteRange for Cmap2<'a> {
 impl<'a> FontRead<'a> for Cmap2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -624,9 +624,9 @@ impl<'a> MinByteRange for Cmap4<'a> {
 impl<'a> FontRead<'a> for Cmap4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap4Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -861,9 +861,9 @@ impl<'a> MinByteRange for Cmap6<'a> {
 impl<'a> FontRead<'a> for Cmap6<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap6Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -992,9 +992,9 @@ impl<'a> MinByteRange for Cmap8<'a> {
 impl<'a> FontRead<'a> for Cmap8<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap8Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1199,9 +1199,9 @@ impl<'a> MinByteRange for Cmap10<'a> {
 impl<'a> FontRead<'a> for Cmap10<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap10Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1335,9 +1335,9 @@ impl<'a> MinByteRange for Cmap12<'a> {
 impl<'a> FontRead<'a> for Cmap12<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap12Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1466,9 +1466,9 @@ impl<'a> MinByteRange for Cmap13<'a> {
 impl<'a> FontRead<'a> for Cmap13<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap13Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1649,9 +1649,9 @@ impl<'a> MinByteRange for Cmap14<'a> {
 impl<'a> FontRead<'a> for Cmap14<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Cmap14Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1843,9 +1843,9 @@ impl<'a> MinByteRange for DefaultUvs<'a> {
 impl<'a> FontRead<'a> for DefaultUvs<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: DefaultUvsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1931,9 +1931,9 @@ impl<'a> MinByteRange for NonDefaultUvs<'a> {
 impl<'a> FontRead<'a> for NonDefaultUvs<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: NonDefaultUvsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CmapMarker {}
+pub struct CmapMarker;
 
 impl<'a> MinByteRange for Cmap<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,19 +23,16 @@ impl TopLevelTable for Cmap<'_> {
 
 impl<'a> FontRead<'a> for Cmap<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let num_tables: u16 = cursor.read()?;
-        let encoding_records_byte_len = (num_tables as usize)
-            .checked_mul(EncodingRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(encoding_records_byte_len);
-        cursor.finish(CmapMarker {})
+        Ok(TableRef {
+            shape: CmapMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
-pub type Cmap<'a> = TableRef<'a, CmapMarker>;
+pub type Cmap<'a> = TableRef<'a, CmapMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap<'a> {
@@ -346,7 +343,7 @@ impl Format<u16> for Cmap0Marker {
 /// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap0Marker {}
+pub struct Cmap0Marker;
 
 impl<'a> MinByteRange for Cmap0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -356,20 +353,16 @@ impl<'a> MinByteRange for Cmap0<'a> {
 
 impl<'a> FontRead<'a> for Cmap0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let glyph_id_array_byte_len = (256_usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap0Marker {})
+        Ok(TableRef {
+            shape: Cmap0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
-pub type Cmap0<'a> = TableRef<'a, Cmap0Marker>;
+pub type Cmap0<'a> = TableRef<'a, Cmap0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap0<'a> {
@@ -455,7 +448,7 @@ impl Format<u16> for Cmap2Marker {
 /// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap2Marker {}
+pub struct Cmap2Marker;
 
 impl<'a> MinByteRange for Cmap2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -465,20 +458,16 @@ impl<'a> MinByteRange for Cmap2<'a> {
 
 impl<'a> FontRead<'a> for Cmap2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let sub_header_keys_byte_len = (256_usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(sub_header_keys_byte_len);
-        cursor.finish(Cmap2Marker {})
+        Ok(TableRef {
+            shape: Cmap2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
-pub type Cmap2<'a> = TableRef<'a, Cmap2Marker>;
+pub type Cmap2<'a> = TableRef<'a, Cmap2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap2<'a> {
@@ -624,7 +613,7 @@ impl Format<u16> for Cmap4Marker {
 /// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap4Marker {}
+pub struct Cmap4Marker;
 
 impl<'a> MinByteRange for Cmap4<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -634,40 +623,16 @@ impl<'a> MinByteRange for Cmap4<'a> {
 
 impl<'a> FontRead<'a> for Cmap4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let seg_count_x2: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let end_code_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(end_code_byte_len);
-        cursor.advance::<u16>();
-        let start_code_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(start_code_byte_len);
-        let id_delta_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(i16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(id_delta_byte_len);
-        let id_range_offsets_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(id_range_offsets_byte_len);
-        let glyph_id_array_byte_len =
-            cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap4Marker {})
+        Ok(TableRef {
+            shape: Cmap4Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
-pub type Cmap4<'a> = TableRef<'a, Cmap4Marker>;
+pub type Cmap4<'a> = TableRef<'a, Cmap4Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap4<'a> {
@@ -885,7 +850,7 @@ impl Format<u16> for Cmap6Marker {
 /// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap6Marker {}
+pub struct Cmap6Marker;
 
 impl<'a> MinByteRange for Cmap6<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -895,22 +860,16 @@ impl<'a> MinByteRange for Cmap6<'a> {
 
 impl<'a> FontRead<'a> for Cmap6<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let entry_count: u16 = cursor.read()?;
-        let glyph_id_array_byte_len = (entry_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap6Marker {})
+        Ok(TableRef {
+            shape: Cmap6Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
-pub type Cmap6<'a> = TableRef<'a, Cmap6Marker>;
+pub type Cmap6<'a> = TableRef<'a, Cmap6Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap6<'a> {
@@ -1022,7 +981,7 @@ impl Format<u16> for Cmap8Marker {
 /// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap8Marker {}
+pub struct Cmap8Marker;
 
 impl<'a> MinByteRange for Cmap8<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1032,26 +991,16 @@ impl<'a> MinByteRange for Cmap8<'a> {
 
 impl<'a> FontRead<'a> for Cmap8<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let is32_byte_len = (8192_usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(is32_byte_len);
-        let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = (num_groups as usize)
-            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(groups_byte_len);
-        cursor.finish(Cmap8Marker {})
+        Ok(TableRef {
+            shape: Cmap8Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
-pub type Cmap8<'a> = TableRef<'a, Cmap8Marker>;
+pub type Cmap8<'a> = TableRef<'a, Cmap8Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap8<'a> {
@@ -1239,7 +1188,7 @@ impl Format<u16> for Cmap10Marker {
 /// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap10Marker {}
+pub struct Cmap10Marker;
 
 impl<'a> MinByteRange for Cmap10<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1249,23 +1198,16 @@ impl<'a> MinByteRange for Cmap10<'a> {
 
 impl<'a> FontRead<'a> for Cmap10<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_chars: u32 = cursor.read()?;
-        let glyph_id_array_byte_len = (num_chars as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap10Marker {})
+        Ok(TableRef {
+            shape: Cmap10Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
-pub type Cmap10<'a> = TableRef<'a, Cmap10Marker>;
+pub type Cmap10<'a> = TableRef<'a, Cmap10Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap10<'a> {
@@ -1382,7 +1324,7 @@ impl Format<u16> for Cmap12Marker {
 /// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap12Marker {}
+pub struct Cmap12Marker;
 
 impl<'a> MinByteRange for Cmap12<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1392,22 +1334,16 @@ impl<'a> MinByteRange for Cmap12<'a> {
 
 impl<'a> FontRead<'a> for Cmap12<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = (num_groups as usize)
-            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(groups_byte_len);
-        cursor.finish(Cmap12Marker {})
+        Ok(TableRef {
+            shape: Cmap12Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
-pub type Cmap12<'a> = TableRef<'a, Cmap12Marker>;
+pub type Cmap12<'a> = TableRef<'a, Cmap12Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap12<'a> {
@@ -1519,7 +1455,7 @@ impl Format<u16> for Cmap13Marker {
 /// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap13Marker {}
+pub struct Cmap13Marker;
 
 impl<'a> MinByteRange for Cmap13<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1529,22 +1465,16 @@ impl<'a> MinByteRange for Cmap13<'a> {
 
 impl<'a> FontRead<'a> for Cmap13<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = (num_groups as usize)
-            .checked_mul(ConstantMapGroup::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(groups_byte_len);
-        cursor.finish(Cmap13Marker {})
+        Ok(TableRef {
+            shape: Cmap13Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
-pub type Cmap13<'a> = TableRef<'a, Cmap13Marker>;
+pub type Cmap13<'a> = TableRef<'a, Cmap13Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap13<'a> {
@@ -1708,7 +1638,7 @@ impl Format<u16> for Cmap14Marker {
 /// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap14Marker {}
+pub struct Cmap14Marker;
 
 impl<'a> MinByteRange for Cmap14<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1718,20 +1648,16 @@ impl<'a> MinByteRange for Cmap14<'a> {
 
 impl<'a> FontRead<'a> for Cmap14<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let num_var_selector_records: u32 = cursor.read()?;
-        let var_selector_byte_len = (num_var_selector_records as usize)
-            .checked_mul(VariationSelector::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(var_selector_byte_len);
-        cursor.finish(Cmap14Marker {})
+        Ok(TableRef {
+            shape: Cmap14Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
-pub type Cmap14<'a> = TableRef<'a, Cmap14Marker>;
+pub type Cmap14<'a> = TableRef<'a, Cmap14Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap14<'a> {
@@ -1906,7 +1832,7 @@ impl<'a> SomeRecord<'a> for VariationSelector {
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DefaultUvsMarker {}
+pub struct DefaultUvsMarker;
 
 impl<'a> MinByteRange for DefaultUvs<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1916,18 +1842,16 @@ impl<'a> MinByteRange for DefaultUvs<'a> {
 
 impl<'a> FontRead<'a> for DefaultUvs<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let num_unicode_value_ranges: u32 = cursor.read()?;
-        let ranges_byte_len = (num_unicode_value_ranges as usize)
-            .checked_mul(UnicodeRange::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ranges_byte_len);
-        cursor.finish(DefaultUvsMarker {})
+        Ok(TableRef {
+            shape: DefaultUvsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
-pub type DefaultUvs<'a> = TableRef<'a, DefaultUvsMarker>;
+pub type DefaultUvs<'a> = TableRef<'a, DefaultUvsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> DefaultUvs<'a> {
@@ -1996,7 +1920,7 @@ impl<'a> std::fmt::Debug for DefaultUvs<'a> {
 /// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct NonDefaultUvsMarker {}
+pub struct NonDefaultUvsMarker;
 
 impl<'a> MinByteRange for NonDefaultUvs<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2006,18 +1930,16 @@ impl<'a> MinByteRange for NonDefaultUvs<'a> {
 
 impl<'a> FontRead<'a> for NonDefaultUvs<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let num_uvs_mappings: u32 = cursor.read()?;
-        let uvs_mapping_byte_len = (num_uvs_mappings as usize)
-            .checked_mul(UvsMapping::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(uvs_mapping_byte_len);
-        cursor.finish(NonDefaultUvsMarker {})
+        Ok(TableRef {
+            shape: NonDefaultUvsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
-pub type NonDefaultUvs<'a> = TableRef<'a, NonDefaultUvsMarker>;
+pub type NonDefaultUvs<'a> = TableRef<'a, NonDefaultUvsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> NonDefaultUvs<'a> {

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -8,28 +8,9 @@ use crate::codegen_prelude::*;
 /// [cmap](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#overview)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CmapMarker {
-    encoding_records_byte_len: usize,
-}
+pub struct CmapMarker {}
 
-impl CmapMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn num_tables_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn encoding_records_byte_range(&self) -> Range<usize> {
-        let start = self.num_tables_byte_range().end;
-        start..start + self.encoding_records_byte_len
-    }
-}
-
-impl MinByteRange for CmapMarker {
+impl<'a> MinByteRange for Cmap<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.encoding_records_byte_range().end
     }
@@ -49,9 +30,7 @@ impl<'a> FontRead<'a> for Cmap<'a> {
             .checked_mul(EncodingRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(encoding_records_byte_len);
-        cursor.finish(CmapMarker {
-            encoding_records_byte_len,
-        })
+        cursor.finish(CmapMarker {})
     }
 }
 
@@ -60,20 +39,42 @@ pub type Cmap<'a> = TableRef<'a, CmapMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cmap<'a> {
+    fn encoding_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_tables()) as usize)
+            .checked_mul(EncodingRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn num_tables_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn encoding_records_byte_range(&self) -> Range<usize> {
+        let start = self.num_tables_byte_range().end;
+        start..start + self.encoding_records_byte_len(start)
+    }
+
     /// Table version number (0).
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of encoding tables that follow.
     pub fn num_tables(&self) -> u16 {
-        let range = self.shape.num_tables_byte_range();
+        let range = self.num_tables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn encoding_records(&self) -> &'a [EncodingRecord] {
-        let range = self.shape.encoding_records_byte_range();
+        let range = self.encoding_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -345,11 +346,38 @@ impl Format<u16> for Cmap0Marker {
 /// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap0Marker {
-    glyph_id_array_byte_len: usize,
+pub struct Cmap0Marker {}
+
+impl<'a> MinByteRange for Cmap0<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_id_array_byte_range().end
+    }
 }
 
-impl Cmap0Marker {
+impl<'a> FontRead<'a> for Cmap0<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let glyph_id_array_byte_len = (256_usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(glyph_id_array_byte_len);
+        cursor.finish(Cmap0Marker {})
+    }
+}
+
+/// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
+pub type Cmap0<'a> = TableRef<'a, Cmap0Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap0<'a> {
+    fn glyph_id_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (256_usize).checked_mul(u8::RAW_BYTE_LEN).unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -367,59 +395,31 @@ impl Cmap0Marker {
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + self.glyph_id_array_byte_len
+        start..start + self.glyph_id_array_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap0Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.glyph_id_array_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap0<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let glyph_id_array_byte_len = (256_usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap0Marker {
-            glyph_id_array_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 0](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-0-byte-encoding-table): Byte encoding table
-pub type Cmap0<'a> = TableRef<'a, Cmap0Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap0<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// An array that maps character codes to glyph index values.
     pub fn glyph_id_array(&self) -> &'a [u8] {
-        let range = self.shape.glyph_id_array_byte_range();
+        let range = self.glyph_id_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -455,11 +455,38 @@ impl Format<u16> for Cmap2Marker {
 /// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap2Marker {
-    sub_header_keys_byte_len: usize,
+pub struct Cmap2Marker {}
+
+impl<'a> MinByteRange for Cmap2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.sub_header_keys_byte_range().end
+    }
 }
 
-impl Cmap2Marker {
+impl<'a> FontRead<'a> for Cmap2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let sub_header_keys_byte_len = (256_usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(sub_header_keys_byte_len);
+        cursor.finish(Cmap2Marker {})
+    }
+}
+
+/// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
+pub type Cmap2<'a> = TableRef<'a, Cmap2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap2<'a> {
+    fn sub_header_keys_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (256_usize).checked_mul(u16::RAW_BYTE_LEN).unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -477,60 +504,32 @@ impl Cmap2Marker {
 
     pub fn sub_header_keys_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + self.sub_header_keys_byte_len
+        start..start + self.sub_header_keys_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.sub_header_keys_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let sub_header_keys_byte_len = (256_usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(sub_header_keys_byte_len);
-        cursor.finish(Cmap2Marker {
-            sub_header_keys_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-2-high-byte-mapping-through-table): High-byte mapping through table
-pub type Cmap2<'a> = TableRef<'a, Cmap2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap2<'a> {
     /// Format number is set to 2.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array that maps high bytes to subHeaders: value is subHeader
     /// index × 8.
     pub fn sub_header_keys(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.sub_header_keys_byte_range();
+        let range = self.sub_header_keys_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -625,15 +624,85 @@ impl Format<u16> for Cmap4Marker {
 /// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap4Marker {
-    end_code_byte_len: usize,
-    start_code_byte_len: usize,
-    id_delta_byte_len: usize,
-    id_range_offsets_byte_len: usize,
-    glyph_id_array_byte_len: usize,
+pub struct Cmap4Marker {}
+
+impl<'a> MinByteRange for Cmap4<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_id_array_byte_range().end
+    }
 }
 
-impl Cmap4Marker {
+impl<'a> FontRead<'a> for Cmap4<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let seg_count_x2: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let end_code_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(end_code_byte_len);
+        cursor.advance::<u16>();
+        let start_code_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(start_code_byte_len);
+        let id_delta_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(i16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(id_delta_byte_len);
+        let id_range_offsets_byte_len = (transforms::half(seg_count_x2))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(id_range_offsets_byte_len);
+        let glyph_id_array_byte_len =
+            cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
+        cursor.advance_by(glyph_id_array_byte_len);
+        cursor.finish(Cmap4Marker {})
+    }
+}
+
+/// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
+pub type Cmap4<'a> = TableRef<'a, Cmap4Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap4<'a> {
+    fn end_code_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::half(self.seg_count_x2()))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn start_code_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::half(self.seg_count_x2()))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn id_delta_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::half(self.seg_count_x2()))
+            .checked_mul(i16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn id_range_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::half(self.seg_count_x2()))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn glyph_id_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        }
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -671,7 +740,7 @@ impl Cmap4Marker {
 
     pub fn end_code_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
-        start..start + self.end_code_byte_len
+        start..start + self.end_code_byte_len(start)
     }
 
     pub fn reserved_pad_byte_range(&self) -> Range<usize> {
@@ -681,98 +750,46 @@ impl Cmap4Marker {
 
     pub fn start_code_byte_range(&self) -> Range<usize> {
         let start = self.reserved_pad_byte_range().end;
-        start..start + self.start_code_byte_len
+        start..start + self.start_code_byte_len(start)
     }
 
     pub fn id_delta_byte_range(&self) -> Range<usize> {
         let start = self.start_code_byte_range().end;
-        start..start + self.id_delta_byte_len
+        start..start + self.id_delta_byte_len(start)
     }
 
     pub fn id_range_offsets_byte_range(&self) -> Range<usize> {
         let start = self.id_delta_byte_range().end;
-        start..start + self.id_range_offsets_byte_len
+        start..start + self.id_range_offsets_byte_len(start)
     }
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.id_range_offsets_byte_range().end;
-        start..start + self.glyph_id_array_byte_len
+        start..start + self.glyph_id_array_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap4Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.glyph_id_array_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap4<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let seg_count_x2: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let end_code_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(end_code_byte_len);
-        cursor.advance::<u16>();
-        let start_code_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(start_code_byte_len);
-        let id_delta_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(i16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(id_delta_byte_len);
-        let id_range_offsets_byte_len = (transforms::half(seg_count_x2))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(id_range_offsets_byte_len);
-        let glyph_id_array_byte_len =
-            cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap4Marker {
-            end_code_byte_len,
-            start_code_byte_len,
-            id_delta_byte_len,
-            id_range_offsets_byte_len,
-            glyph_id_array_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 4](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values): Segment mapping to delta values
-pub type Cmap4<'a> = TableRef<'a, Cmap4Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap4<'a> {
     /// Format number is set to 4.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 2 × segCount.
     pub fn seg_count_x2(&self) -> u16 {
-        let range = self.shape.seg_count_x2_byte_range();
+        let range = self.seg_count_x2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -780,51 +797,51 @@ impl<'a> Cmap4<'a> {
     /// ((2**floor(log2(segCount))) * 2, where “**” is an
     /// exponentiation operator)
     pub fn search_range(&self) -> u16 {
-        let range = self.shape.search_range_byte_range();
+        let range = self.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Log2 of the maximum power of 2 less than or equal to numTables
     /// (log2(searchRange/2), which is equal to floor(log2(segCount)))
     pub fn entry_selector(&self) -> u16 {
-        let range = self.shape.entry_selector_byte_range();
+        let range = self.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// segCount times 2, minus searchRange ((segCount * 2) -
     /// searchRange)
     pub fn range_shift(&self) -> u16 {
-        let range = self.shape.range_shift_byte_range();
+        let range = self.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End characterCode for each segment, last=0xFFFF.
     pub fn end_code(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.end_code_byte_range();
+        let range = self.end_code_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Start character code for each segment.
     pub fn start_code(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.start_code_byte_range();
+        let range = self.start_code_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Delta for all character codes in segment.
     pub fn id_delta(&self) -> &'a [BigEndian<i16>] {
-        let range = self.shape.id_delta_byte_range();
+        let range = self.id_delta_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Offsets into glyphIdArray or 0
     pub fn id_range_offsets(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.id_range_offsets_byte_range();
+        let range = self.id_range_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Glyph index array (arbitrary length)
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.glyph_id_array_byte_range();
+        let range = self.glyph_id_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -868,11 +885,42 @@ impl Format<u16> for Cmap6Marker {
 /// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap6Marker {
-    glyph_id_array_byte_len: usize,
+pub struct Cmap6Marker {}
+
+impl<'a> MinByteRange for Cmap6<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_id_array_byte_range().end
+    }
 }
 
-impl Cmap6Marker {
+impl<'a> FontRead<'a> for Cmap6<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let entry_count: u16 = cursor.read()?;
+        let glyph_id_array_byte_len = (entry_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(glyph_id_array_byte_len);
+        cursor.finish(Cmap6Marker {})
+    }
+}
+
+/// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
+pub type Cmap6<'a> = TableRef<'a, Cmap6Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap6<'a> {
+    fn glyph_id_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.entry_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -900,73 +948,43 @@ impl Cmap6Marker {
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.entry_count_byte_range().end;
-        start..start + self.glyph_id_array_byte_len
+        start..start + self.glyph_id_array_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap6Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.glyph_id_array_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap6<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let entry_count: u16 = cursor.read()?;
-        let glyph_id_array_byte_len = (entry_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap6Marker {
-            glyph_id_array_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 6](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-6-trimmed-table-mapping): Trimmed table mapping
-pub type Cmap6<'a> = TableRef<'a, Cmap6Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap6<'a> {
     /// Format number is set to 6.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// First character code of subrange.
     pub fn first_code(&self) -> u16 {
-        let range = self.shape.first_code_byte_range();
+        let range = self.first_code_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of character codes in subrange.
     pub fn entry_count(&self) -> u16 {
-        let range = self.shape.entry_count_byte_range();
+        let range = self.entry_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of glyph index values for character codes in the range.
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.glyph_id_array_byte_range();
+        let range = self.glyph_id_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1004,12 +1022,50 @@ impl Format<u16> for Cmap8Marker {
 /// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap8Marker {
-    is32_byte_len: usize,
-    groups_byte_len: usize,
+pub struct Cmap8Marker {}
+
+impl<'a> MinByteRange for Cmap8<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.groups_byte_range().end
+    }
 }
 
-impl Cmap8Marker {
+impl<'a> FontRead<'a> for Cmap8<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let is32_byte_len = (8192_usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(is32_byte_len);
+        let num_groups: u32 = cursor.read()?;
+        let groups_byte_len = (num_groups as usize)
+            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(groups_byte_len);
+        cursor.finish(Cmap8Marker {})
+    }
+}
+
+/// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
+pub type Cmap8<'a> = TableRef<'a, Cmap8Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap8<'a> {
+    fn is32_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (8192_usize).checked_mul(u8::RAW_BYTE_LEN).unwrap()
+    }
+    fn groups_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_groups()) as usize)
+            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1032,7 +1088,7 @@ impl Cmap8Marker {
 
     pub fn is32_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + self.is32_byte_len
+        start..start + self.is32_byte_len(start)
     }
 
     pub fn num_groups_byte_range(&self) -> Range<usize> {
@@ -1042,60 +1098,25 @@ impl Cmap8Marker {
 
     pub fn groups_byte_range(&self) -> Range<usize> {
         let start = self.num_groups_byte_range().end;
-        start..start + self.groups_byte_len
+        start..start + self.groups_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap8Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.groups_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap8<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let is32_byte_len = (8192_usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(is32_byte_len);
-        let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = (num_groups as usize)
-            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(groups_byte_len);
-        cursor.finish(Cmap8Marker {
-            is32_byte_len,
-            groups_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 8](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-8-mixed-16-bit-and-32-bit-coverage): mixed 16-bit and 32-bit coverage
-pub type Cmap8<'a> = TableRef<'a, Cmap8Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap8<'a> {
     /// Subtable format; set to 8.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1103,19 +1124,19 @@ impl<'a> Cmap8<'a> {
     /// whether the particular 16-bit (index) value is the start of a
     /// 32-bit character code
     pub fn is32(&self) -> &'a [u8] {
-        let range = self.shape.is32_byte_range();
+        let range = self.is32_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
-        let range = self.shape.num_groups_byte_range();
+        let range = self.num_groups_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of SequentialMapGroup records.
     pub fn groups(&self) -> &'a [SequentialMapGroup] {
-        let range = self.shape.groups_byte_range();
+        let range = self.groups_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1218,11 +1239,43 @@ impl Format<u16> for Cmap10Marker {
 /// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap10Marker {
-    glyph_id_array_byte_len: usize,
+pub struct Cmap10Marker {}
+
+impl<'a> MinByteRange for Cmap10<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_id_array_byte_range().end
+    }
 }
 
-impl Cmap10Marker {
+impl<'a> FontRead<'a> for Cmap10<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let num_chars: u32 = cursor.read()?;
+        let glyph_id_array_byte_len = (num_chars as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(glyph_id_array_byte_len);
+        cursor.finish(Cmap10Marker {})
+    }
+}
+
+/// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
+pub type Cmap10<'a> = TableRef<'a, Cmap10Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap10<'a> {
+    fn glyph_id_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_chars()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1255,74 +1308,43 @@ impl Cmap10Marker {
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.num_chars_byte_range().end;
-        start..start + self.glyph_id_array_byte_len
+        start..start + self.glyph_id_array_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap10Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.glyph_id_array_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap10<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_chars: u32 = cursor.read()?;
-        let glyph_id_array_byte_len = (num_chars as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_id_array_byte_len);
-        cursor.finish(Cmap10Marker {
-            glyph_id_array_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 10](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-10-trimmed-array): Tr
-pub type Cmap10<'a> = TableRef<'a, Cmap10Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap10<'a> {
     /// Subtable format; set to 10.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// First character code covered
     pub fn start_char_code(&self) -> u32 {
-        let range = self.shape.start_char_code_byte_range();
+        let range = self.start_char_code_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of character codes covered
     pub fn num_chars(&self) -> u32 {
-        let range = self.shape.num_chars_byte_range();
+        let range = self.num_chars_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of glyph indices for the character codes covered
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.glyph_id_array_byte_range();
+        let range = self.glyph_id_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1360,11 +1382,42 @@ impl Format<u16> for Cmap12Marker {
 /// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap12Marker {
-    groups_byte_len: usize,
+pub struct Cmap12Marker {}
+
+impl<'a> MinByteRange for Cmap12<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.groups_byte_range().end
+    }
 }
 
-impl Cmap12Marker {
+impl<'a> FontRead<'a> for Cmap12<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let num_groups: u32 = cursor.read()?;
+        let groups_byte_len = (num_groups as usize)
+            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(groups_byte_len);
+        cursor.finish(Cmap12Marker {})
+    }
+}
+
+/// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
+pub type Cmap12<'a> = TableRef<'a, Cmap12Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap12<'a> {
+    fn groups_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_groups()) as usize)
+            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1392,65 +1445,37 @@ impl Cmap12Marker {
 
     pub fn groups_byte_range(&self) -> Range<usize> {
         let start = self.num_groups_byte_range().end;
-        start..start + self.groups_byte_len
+        start..start + self.groups_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap12Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.groups_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap12<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = (num_groups as usize)
-            .checked_mul(SequentialMapGroup::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(groups_byte_len);
-        cursor.finish(Cmap12Marker { groups_byte_len })
-    }
-}
-
-/// [cmap Format 12](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage): Segmented coverage
-pub type Cmap12<'a> = TableRef<'a, Cmap12Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap12<'a> {
     /// Subtable format; set to 12.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
-        let range = self.shape.num_groups_byte_range();
+        let range = self.num_groups_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of SequentialMapGroup records.
     pub fn groups(&self) -> &'a [SequentialMapGroup] {
-        let range = self.shape.groups_byte_range();
+        let range = self.groups_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1494,11 +1519,42 @@ impl Format<u16> for Cmap13Marker {
 /// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap13Marker {
-    groups_byte_len: usize,
+pub struct Cmap13Marker {}
+
+impl<'a> MinByteRange for Cmap13<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.groups_byte_range().end
+    }
 }
 
-impl Cmap13Marker {
+impl<'a> FontRead<'a> for Cmap13<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let num_groups: u32 = cursor.read()?;
+        let groups_byte_len = (num_groups as usize)
+            .checked_mul(ConstantMapGroup::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(groups_byte_len);
+        cursor.finish(Cmap13Marker {})
+    }
+}
+
+/// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
+pub type Cmap13<'a> = TableRef<'a, Cmap13Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap13<'a> {
+    fn groups_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_groups()) as usize)
+            .checked_mul(ConstantMapGroup::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1526,65 +1582,37 @@ impl Cmap13Marker {
 
     pub fn groups_byte_range(&self) -> Range<usize> {
         let start = self.num_groups_byte_range().end;
-        start..start + self.groups_byte_len
+        start..start + self.groups_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap13Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.groups_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap13<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_groups: u32 = cursor.read()?;
-        let groups_byte_len = (num_groups as usize)
-            .checked_mul(ConstantMapGroup::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(groups_byte_len);
-        cursor.finish(Cmap13Marker { groups_byte_len })
-    }
-}
-
-/// [cmap Format 13](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-13-many-to-one-range-mappings): Many-to-one range mappings
-pub type Cmap13<'a> = TableRef<'a, Cmap13Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap13<'a> {
     /// Subtable format; set to 13.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
-        let range = self.shape.language_byte_range();
+        let range = self.language_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
-        let range = self.shape.num_groups_byte_range();
+        let range = self.num_groups_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of ConstantMapGroup records.
     pub fn groups(&self) -> &'a [ConstantMapGroup] {
-        let range = self.shape.groups_byte_range();
+        let range = self.groups_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1680,11 +1708,40 @@ impl Format<u16> for Cmap14Marker {
 /// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Cmap14Marker {
-    var_selector_byte_len: usize,
+pub struct Cmap14Marker {}
+
+impl<'a> MinByteRange for Cmap14<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_selector_byte_range().end
+    }
 }
 
-impl Cmap14Marker {
+impl<'a> FontRead<'a> for Cmap14<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
+        let num_var_selector_records: u32 = cursor.read()?;
+        let var_selector_byte_len = (num_var_selector_records as usize)
+            .checked_mul(VariationSelector::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(var_selector_byte_len);
+        cursor.finish(Cmap14Marker {})
+    }
+}
+
+/// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
+pub type Cmap14<'a> = TableRef<'a, Cmap14Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Cmap14<'a> {
+    fn var_selector_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_var_selector_records()) as usize)
+            .checked_mul(VariationSelector::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1702,58 +1759,30 @@ impl Cmap14Marker {
 
     pub fn var_selector_byte_range(&self) -> Range<usize> {
         let start = self.num_var_selector_records_byte_range().end;
-        start..start + self.var_selector_byte_len
+        start..start + self.var_selector_byte_len(start)
     }
-}
 
-impl MinByteRange for Cmap14Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_selector_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Cmap14<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let num_var_selector_records: u32 = cursor.read()?;
-        let var_selector_byte_len = (num_var_selector_records as usize)
-            .checked_mul(VariationSelector::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(var_selector_byte_len);
-        cursor.finish(Cmap14Marker {
-            var_selector_byte_len,
-        })
-    }
-}
-
-/// [cmap Format 14](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences): Unicode Variation Sequences
-pub type Cmap14<'a> = TableRef<'a, Cmap14Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Cmap14<'a> {
     /// Subtable format. Set to 14.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Byte length of this subtable (including this header)
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of variation Selector Records
     pub fn num_var_selector_records(&self) -> u32 {
-        let range = self.shape.num_var_selector_records_byte_range();
+        let range = self.num_var_selector_records_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of VariationSelector records.
     pub fn var_selector(&self) -> &'a [VariationSelector] {
-        let range = self.shape.var_selector_byte_range();
+        let range = self.var_selector_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1877,23 +1906,9 @@ impl<'a> SomeRecord<'a> for VariationSelector {
 /// [Default UVS table](https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#default-uvs-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DefaultUvsMarker {
-    ranges_byte_len: usize,
-}
+pub struct DefaultUvsMarker {}
 
-impl DefaultUvsMarker {
-    pub fn num_unicode_value_ranges_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn ranges_byte_range(&self) -> Range<usize> {
-        let start = self.num_unicode_value_ranges_byte_range().end;
-        start..start + self.ranges_byte_len
-    }
-}
-
-impl MinByteRange for DefaultUvsMarker {
+impl<'a> MinByteRange for DefaultUvs<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.ranges_byte_range().end
     }
@@ -1907,7 +1922,7 @@ impl<'a> FontRead<'a> for DefaultUvs<'a> {
             .checked_mul(UnicodeRange::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ranges_byte_len);
-        cursor.finish(DefaultUvsMarker { ranges_byte_len })
+        cursor.finish(DefaultUvsMarker {})
     }
 }
 
@@ -1916,15 +1931,32 @@ pub type DefaultUvs<'a> = TableRef<'a, DefaultUvsMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> DefaultUvs<'a> {
+    fn ranges_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_unicode_value_ranges()) as usize)
+            .checked_mul(UnicodeRange::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn num_unicode_value_ranges_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn ranges_byte_range(&self) -> Range<usize> {
+        let start = self.num_unicode_value_ranges_byte_range().end;
+        start..start + self.ranges_byte_len(start)
+    }
+
     /// Number of Unicode character ranges.
     pub fn num_unicode_value_ranges(&self) -> u32 {
-        let range = self.shape.num_unicode_value_ranges_byte_range();
+        let range = self.num_unicode_value_ranges_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of UnicodeRange records.
     pub fn ranges(&self) -> &'a [UnicodeRange] {
-        let range = self.shape.ranges_byte_range();
+        let range = self.ranges_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1964,23 +1996,9 @@ impl<'a> std::fmt::Debug for DefaultUvs<'a> {
 /// [Non-Default UVS table](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#non-default-uvs-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct NonDefaultUvsMarker {
-    uvs_mapping_byte_len: usize,
-}
+pub struct NonDefaultUvsMarker {}
 
-impl NonDefaultUvsMarker {
-    pub fn num_uvs_mappings_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn uvs_mapping_byte_range(&self) -> Range<usize> {
-        let start = self.num_uvs_mappings_byte_range().end;
-        start..start + self.uvs_mapping_byte_len
-    }
-}
-
-impl MinByteRange for NonDefaultUvsMarker {
+impl<'a> MinByteRange for NonDefaultUvs<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.uvs_mapping_byte_range().end
     }
@@ -1994,9 +2012,7 @@ impl<'a> FontRead<'a> for NonDefaultUvs<'a> {
             .checked_mul(UvsMapping::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(uvs_mapping_byte_len);
-        cursor.finish(NonDefaultUvsMarker {
-            uvs_mapping_byte_len,
-        })
+        cursor.finish(NonDefaultUvsMarker {})
     }
 }
 
@@ -2005,13 +2021,30 @@ pub type NonDefaultUvs<'a> = TableRef<'a, NonDefaultUvsMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> NonDefaultUvs<'a> {
+    fn uvs_mapping_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_uvs_mappings()) as usize)
+            .checked_mul(UvsMapping::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn num_uvs_mappings_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn uvs_mapping_byte_range(&self) -> Range<usize> {
+        let start = self.num_uvs_mappings_byte_range().end;
+        start..start + self.uvs_mapping_byte_len(start)
+    }
+
     pub fn num_uvs_mappings(&self) -> u32 {
-        let range = self.shape.num_uvs_mappings_byte_range();
+        let range = self.num_uvs_mappings_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn uvs_mapping(&self) -> &'a [UvsMapping] {
-        let range = self.shape.uvs_mapping_byte_range();
+        let range = self.uvs_mapping_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -61,18 +61,18 @@ impl<'a> Cmap<'a> {
     /// Table version number (0).
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of encoding tables that follow.
     pub fn num_tables(&self) -> u16 {
         let range = self.num_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn encoding_records(&self) -> &'a [EncodingRecord] {
         let range = self.encoding_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -394,26 +394,26 @@ impl<'a> Cmap0<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// An array that maps character codes to glyph index values.
     pub fn glyph_id_array(&self) -> &'a [u8] {
         let range = self.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -499,27 +499,27 @@ impl<'a> Cmap2<'a> {
     /// Format number is set to 2.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array that maps high bytes to subHeaders: value is subHeader
     /// index × 8.
     pub fn sub_header_keys(&self) -> &'a [BigEndian<u16>] {
         let range = self.sub_header_keys_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -736,26 +736,26 @@ impl<'a> Cmap4<'a> {
     /// Format number is set to 4.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 2 × segCount.
     pub fn seg_count_x2(&self) -> u16 {
         let range = self.seg_count_x2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum power of 2 less than or equal to segCount, times 2
@@ -763,51 +763,51 @@ impl<'a> Cmap4<'a> {
     /// exponentiation operator)
     pub fn search_range(&self) -> u16 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Log2 of the maximum power of 2 less than or equal to numTables
     /// (log2(searchRange/2), which is equal to floor(log2(segCount)))
     pub fn entry_selector(&self) -> u16 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// segCount times 2, minus searchRange ((segCount * 2) -
     /// searchRange)
     pub fn range_shift(&self) -> u16 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End characterCode for each segment, last=0xFFFF.
     pub fn end_code(&self) -> &'a [BigEndian<u16>] {
         let range = self.end_code_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Start character code for each segment.
     pub fn start_code(&self) -> &'a [BigEndian<u16>] {
         let range = self.start_code_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Delta for all character codes in segment.
     pub fn id_delta(&self) -> &'a [BigEndian<i16>] {
         let range = self.id_delta_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Offsets into glyphIdArray or 0
     pub fn id_range_offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.id_range_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Glyph index array (arbitrary length)
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -913,38 +913,38 @@ impl<'a> Cmap6<'a> {
     /// Format number is set to 6.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// First character code of subrange.
     pub fn first_code(&self) -> u16 {
         let range = self.first_code_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of character codes in subrange.
     pub fn entry_count(&self) -> u16 {
         let range = self.entry_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of glyph index values for character codes in the range.
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1053,20 +1053,20 @@ impl<'a> Cmap8<'a> {
     /// Subtable format; set to 8.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Tightly packed array of bits (8K bytes total) indicating
@@ -1074,19 +1074,19 @@ impl<'a> Cmap8<'a> {
     /// 32-bit character code
     pub fn is32(&self) -> &'a [u8] {
         let range = self.is32_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
         let range = self.num_groups_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of SequentialMapGroup records.
     pub fn groups(&self) -> &'a [SequentialMapGroup] {
         let range = self.groups_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1256,38 +1256,38 @@ impl<'a> Cmap10<'a> {
     /// Subtable format; set to 10.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// First character code covered
     pub fn start_char_code(&self) -> u32 {
         let range = self.start_char_code_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of character codes covered
     pub fn num_chars(&self) -> u32 {
         let range = self.num_chars_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of glyph indices for the character codes covered
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1387,32 +1387,32 @@ impl<'a> Cmap12<'a> {
     /// Subtable format; set to 12.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
         let range = self.num_groups_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of SequentialMapGroup records.
     pub fn groups(&self) -> &'a [SequentialMapGroup] {
         let range = self.groups_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1518,32 +1518,32 @@ impl<'a> Cmap13<'a> {
     /// Subtable format; set to 13.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
         let range = self.num_groups_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of ConstantMapGroup records.
     pub fn groups(&self) -> &'a [ConstantMapGroup] {
         let range = self.groups_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1691,25 +1691,25 @@ impl<'a> Cmap14<'a> {
     /// Subtable format. Set to 14.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Byte length of this subtable (including this header)
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of variation Selector Records
     pub fn num_var_selector_records(&self) -> u32 {
         let range = self.num_var_selector_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of VariationSelector records.
     pub fn var_selector(&self) -> &'a [VariationSelector] {
         let range = self.var_selector_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1875,13 +1875,13 @@ impl<'a> DefaultUvs<'a> {
     /// Number of Unicode character ranges.
     pub fn num_unicode_value_ranges(&self) -> u32 {
         let range = self.num_unicode_value_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of UnicodeRange records.
     pub fn ranges(&self) -> &'a [UnicodeRange] {
         let range = self.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1962,12 +1962,12 @@ impl<'a> NonDefaultUvs<'a> {
 
     pub fn num_uvs_mappings(&self) -> u32 {
         let range = self.num_uvs_mappings_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn uvs_mapping(&self) -> &'a [UvsMapping] {
         let range = self.uvs_mapping_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -145,19 +145,19 @@ impl<'a> Colr<'a> {
     /// Table version number - set to 0 or 1.
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of BaseGlyph records; may be 0 in a version 1 table.
     pub fn num_base_glyph_records(&self) -> u16 {
         let range = self.num_base_glyph_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to baseGlyphRecords array (may be NULL).
     pub fn base_glyph_records_offset(&self) -> Nullable<Offset32> {
         let range = self.base_glyph_records_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`base_glyph_records_offset`][Self::base_glyph_records_offset].
@@ -171,7 +171,7 @@ impl<'a> Colr<'a> {
     /// Offset to layerRecords array (may be NULL).
     pub fn layer_records_offset(&self) -> Nullable<Offset32> {
         let range = self.layer_records_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`layer_records_offset`][Self::layer_records_offset].
@@ -184,13 +184,13 @@ impl<'a> Colr<'a> {
     /// Number of Layer records; may be 0 in a version 1 table.
     pub fn num_layer_records(&self) -> u16 {
         let range = self.num_layer_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to BaseGlyphList table.
     pub fn base_glyph_list_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.base_glyph_list_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`base_glyph_list_offset`][Self::base_glyph_list_offset].
@@ -202,7 +202,7 @@ impl<'a> Colr<'a> {
     /// Offset to LayerList table (may be NULL).
     pub fn layer_list_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.layer_list_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`layer_list_offset`][Self::layer_list_offset].
@@ -214,7 +214,7 @@ impl<'a> Colr<'a> {
     /// Offset to ClipList table (may be NULL).
     pub fn clip_list_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.clip_list_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`clip_list_offset`][Self::clip_list_offset].
@@ -226,7 +226,7 @@ impl<'a> Colr<'a> {
     /// Offset to DeltaSetIndexMap table (may be NULL).
     pub fn var_index_map_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.var_index_map_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`var_index_map_offset`][Self::var_index_map_offset].
@@ -238,7 +238,7 @@ impl<'a> Colr<'a> {
     /// Offset to ItemVariationStore (may be NULL).
     pub fn item_variation_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.item_variation_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -457,12 +457,12 @@ impl<'a> BaseGlyphList<'a> {
 
     pub fn num_base_glyph_paint_records(&self) -> u32 {
         let range = self.num_base_glyph_paint_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn base_glyph_paint_records(&self) -> &'a [BaseGlyphPaint] {
         let range = self.base_glyph_paint_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -596,13 +596,13 @@ impl<'a> LayerList<'a> {
 
     pub fn num_layers(&self) -> u32 {
         let range = self.num_layers_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offsets to Paint tables.
     pub fn paint_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.paint_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`paint_offsets`][Self::paint_offsets].
@@ -699,19 +699,19 @@ impl<'a> ClipList<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of Clip records.
     pub fn num_clips(&self) -> u32 {
         let range = self.num_clips_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Clip records. Sorted by startGlyphID.
     pub fn clips(&self) -> &'a [Clip] {
         let range = self.clips_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -969,31 +969,31 @@ impl<'a> ClipBoxFormat1<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum x of clip box.
     pub fn x_min(&self) -> FWord {
         let range = self.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum y of clip box.
     pub fn y_min(&self) -> FWord {
         let range = self.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum x of clip box.
     pub fn x_max(&self) -> FWord {
         let range = self.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum y of clip box.
     pub fn y_max(&self) -> FWord {
         let range = self.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -1085,37 +1085,37 @@ impl<'a> ClipBoxFormat2<'a> {
     /// Set to 2.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum x of clip box. For variation, use varIndexBase + 0.
     pub fn x_min(&self) -> FWord {
         let range = self.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum y of clip box. For variation, use varIndexBase + 1.
     pub fn y_min(&self) -> FWord {
         let range = self.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum x of clip box. For variation, use varIndexBase + 2.
     pub fn x_max(&self) -> FWord {
         let range = self.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum y of clip box. For variation, use varIndexBase + 3.
     pub fn y_max(&self) -> FWord {
         let range = self.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -1397,18 +1397,18 @@ impl<'a> ColorLine<'a> {
     /// An Extend enum value.
     pub fn extend(&self) -> Extend {
         let range = self.extend_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of ColorStop records.
     pub fn num_stops(&self) -> u16 {
         let range = self.num_stops_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn color_stops(&self) -> &'a [ColorStop] {
         let range = self.color_stops_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1493,19 +1493,19 @@ impl<'a> VarColorLine<'a> {
     /// An Extend enum value.
     pub fn extend(&self) -> Extend {
         let range = self.extend_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of ColorStop records.
     pub fn num_stops(&self) -> u16 {
         let range = self.num_stops_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Allows for variations.
     pub fn color_stops(&self) -> &'a [VarColorStop] {
         let range = self.color_stops_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1908,19 +1908,19 @@ impl<'a> PaintColrLayers<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of offsets to paint tables to read from LayerList.
     pub fn num_layers(&self) -> u8 {
         let range = self.num_layers_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Index (base 0) into the LayerList.
     pub fn first_layer_index(&self) -> u32 {
         let range = self.first_layer_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -1995,19 +1995,19 @@ impl<'a> PaintSolid<'a> {
     /// Set to 2.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Index for a CPAL palette entry.
     pub fn palette_index(&self) -> u16 {
         let range = self.palette_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Alpha value.
     pub fn alpha(&self) -> F2Dot14 {
         let range = self.alpha_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2087,25 +2087,25 @@ impl<'a> PaintVarSolid<'a> {
     /// Set to 3.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Index for a CPAL palette entry.
     pub fn palette_index(&self) -> u16 {
         let range = self.palette_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Alpha value. For variation, use varIndexBase + 0.
     pub fn alpha(&self) -> F2Dot14 {
         let range = self.alpha_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2206,13 +2206,13 @@ impl<'a> PaintLinearGradient<'a> {
     /// Set to 4.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2224,37 +2224,37 @@ impl<'a> PaintLinearGradient<'a> {
     /// Start point (p₀) x coordinate.
     pub fn x0(&self) -> FWord {
         let range = self.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start point (p₀) y coordinate.
     pub fn y0(&self) -> FWord {
         let range = self.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End point (p₁) x coordinate.
     pub fn x1(&self) -> FWord {
         let range = self.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End point (p₁) y coordinate.
     pub fn y1(&self) -> FWord {
         let range = self.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Rotation point (p₂) x coordinate.
     pub fn x2(&self) -> FWord {
         let range = self.x2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Rotation point (p₂) y coordinate.
     pub fn y2(&self) -> FWord {
         let range = self.y2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2367,13 +2367,13 @@ impl<'a> PaintVarLinearGradient<'a> {
     /// Set to 5.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2386,48 +2386,48 @@ impl<'a> PaintVarLinearGradient<'a> {
     /// varIndexBase + 0.
     pub fn x0(&self) -> FWord {
         let range = self.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start point (p₀) y coordinate. For variation, use
     /// varIndexBase + 1.
     pub fn y0(&self) -> FWord {
         let range = self.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End point (p₁) x coordinate. For variation, use varIndexBase
     /// + 2.
     pub fn x1(&self) -> FWord {
         let range = self.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End point (p₁) y coordinate. For variation, use varIndexBase
     /// + 3.
     pub fn y1(&self) -> FWord {
         let range = self.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Rotation point (p₂) x coordinate. For variation, use
     /// varIndexBase + 4.
     pub fn x2(&self) -> FWord {
         let range = self.x2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Rotation point (p₂) y coordinate. For variation, use
     /// varIndexBase + 5.
     pub fn y2(&self) -> FWord {
         let range = self.y2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2536,13 +2536,13 @@ impl<'a> PaintRadialGradient<'a> {
     /// Set to 6.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2554,37 +2554,37 @@ impl<'a> PaintRadialGradient<'a> {
     /// Start circle center x coordinate.
     pub fn x0(&self) -> FWord {
         let range = self.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start circle center y coordinate.
     pub fn y0(&self) -> FWord {
         let range = self.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start circle radius.
     pub fn radius0(&self) -> UfWord {
         let range = self.radius0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End circle center x coordinate.
     pub fn x1(&self) -> FWord {
         let range = self.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End circle center y coordinate.
     pub fn y1(&self) -> FWord {
         let range = self.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End circle radius.
     pub fn radius1(&self) -> UfWord {
         let range = self.radius1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2697,13 +2697,13 @@ impl<'a> PaintVarRadialGradient<'a> {
     /// Set to 7.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2716,46 +2716,46 @@ impl<'a> PaintVarRadialGradient<'a> {
     /// varIndexBase + 0.
     pub fn x0(&self) -> FWord {
         let range = self.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start circle center y coordinate. For variation, use
     /// varIndexBase + 1.
     pub fn y0(&self) -> FWord {
         let range = self.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start circle radius. For variation, use varIndexBase + 2.
     pub fn radius0(&self) -> UfWord {
         let range = self.radius0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End circle center x coordinate. For variation, use varIndexBase
     /// + 3.
     pub fn x1(&self) -> FWord {
         let range = self.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End circle center y coordinate. For variation, use varIndexBase
     /// + 4.
     pub fn y1(&self) -> FWord {
         let range = self.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End circle radius. For variation, use varIndexBase + 5.
     pub fn radius1(&self) -> UfWord {
         let range = self.radius1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2854,13 +2854,13 @@ impl<'a> PaintSweepGradient<'a> {
     /// Set to 8.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2872,27 +2872,27 @@ impl<'a> PaintSweepGradient<'a> {
     /// Center x coordinate.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Center y coordinate.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn start_angle(&self) -> F2Dot14 {
         let range = self.start_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn end_angle(&self) -> F2Dot14 {
         let range = self.end_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -2993,13 +2993,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// Set to 9.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -3011,13 +3011,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// Center x coordinate. For variation, use varIndexBase + 0.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Center y coordinate. For variation, use varIndexBase + 1.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Start of the angular range of the gradient, 180° in
@@ -3025,7 +3025,7 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// varIndexBase + 2.
     pub fn start_angle(&self) -> F2Dot14 {
         let range = self.start_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// End of the angular range of the gradient, 180° in
@@ -3033,13 +3033,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// varIndexBase + 3.
     pub fn end_angle(&self) -> F2Dot14 {
         let range = self.end_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3121,13 +3121,13 @@ impl<'a> PaintGlyph<'a> {
     /// Set to 10.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint table.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3139,7 +3139,7 @@ impl<'a> PaintGlyph<'a> {
     /// Glyph ID for the source outline.
     pub fn glyph_id(&self) -> GlyphId16 {
         let range = self.glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3212,13 +3212,13 @@ impl<'a> PaintColrGlyph<'a> {
     /// Set to 11.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Glyph ID for a BaseGlyphList base glyph.
     pub fn glyph_id(&self) -> GlyphId16 {
         let range = self.glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3292,13 +3292,13 @@ impl<'a> PaintTransform<'a> {
     /// Set to 12.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3310,7 +3310,7 @@ impl<'a> PaintTransform<'a> {
     /// Offset to an Affine2x3 table.
     pub fn transform_offset(&self) -> Offset24 {
         let range = self.transform_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`transform_offset`][Self::transform_offset].
@@ -3397,13 +3397,13 @@ impl<'a> PaintVarTransform<'a> {
     /// Set to 13.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3415,7 +3415,7 @@ impl<'a> PaintVarTransform<'a> {
     /// Offset to a VarAffine2x3 table.
     pub fn transform_offset(&self) -> Offset24 {
         let range = self.transform_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`transform_offset`][Self::transform_offset].
@@ -3513,37 +3513,37 @@ impl<'a> Affine2x3<'a> {
     /// x-component of transformed x-basis vector.
     pub fn xx(&self) -> Fixed {
         let range = self.xx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y-component of transformed x-basis vector.
     pub fn yx(&self) -> Fixed {
         let range = self.yx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x-component of transformed y-basis vector.
     pub fn xy(&self) -> Fixed {
         let range = self.xy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y-component of transformed y-basis vector.
     pub fn yy(&self) -> Fixed {
         let range = self.yy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Translation in x direction.
     pub fn dx(&self) -> Fixed {
         let range = self.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Translation in y direction.
     pub fn dy(&self) -> Fixed {
         let range = self.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3638,46 +3638,46 @@ impl<'a> VarAffine2x3<'a> {
     /// varIndexBase + 0.
     pub fn xx(&self) -> Fixed {
         let range = self.xx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y-component of transformed x-basis vector. For variation, use
     /// varIndexBase + 1.
     pub fn yx(&self) -> Fixed {
         let range = self.yx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 2.
     pub fn xy(&self) -> Fixed {
         let range = self.xy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 3.
     pub fn yy(&self) -> Fixed {
         let range = self.yy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Translation in x direction. For variation, use varIndexBase + 4.
     pub fn dx(&self) -> Fixed {
         let range = self.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Translation in y direction. For variation, use varIndexBase + 5.
     pub fn dy(&self) -> Fixed {
         let range = self.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3761,13 +3761,13 @@ impl<'a> PaintTranslate<'a> {
     /// Set to 14.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3779,13 +3779,13 @@ impl<'a> PaintTranslate<'a> {
     /// Translation in x direction.
     pub fn dx(&self) -> FWord {
         let range = self.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Translation in y direction.
     pub fn dy(&self) -> FWord {
         let range = self.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3874,13 +3874,13 @@ impl<'a> PaintVarTranslate<'a> {
     /// Set to 15.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3892,19 +3892,19 @@ impl<'a> PaintVarTranslate<'a> {
     /// Translation in x direction. For variation, use varIndexBase + 0.
     pub fn dx(&self) -> FWord {
         let range = self.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Translation in y direction. For variation, use varIndexBase + 1.
     pub fn dy(&self) -> FWord {
         let range = self.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -3989,13 +3989,13 @@ impl<'a> PaintScale<'a> {
     /// Set to 16.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4007,13 +4007,13 @@ impl<'a> PaintScale<'a> {
     /// Scale factor in x direction.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Scale factor in y direction.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4102,13 +4102,13 @@ impl<'a> PaintVarScale<'a> {
     /// Set to 17.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4121,20 +4121,20 @@ impl<'a> PaintVarScale<'a> {
     /// 0.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4229,13 +4229,13 @@ impl<'a> PaintScaleAroundCenter<'a> {
     /// Set to 18.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4247,25 +4247,25 @@ impl<'a> PaintScaleAroundCenter<'a> {
     /// Scale factor in x direction.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Scale factor in y direction.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of scaling.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of scaling.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4366,13 +4366,13 @@ impl<'a> PaintVarScaleAroundCenter<'a> {
     /// Set to 19.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4385,34 +4385,34 @@ impl<'a> PaintVarScaleAroundCenter<'a> {
     /// 0.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 3.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4494,13 +4494,13 @@ impl<'a> PaintScaleUniform<'a> {
     /// Set to 20.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4512,7 +4512,7 @@ impl<'a> PaintScaleUniform<'a> {
     /// Scale factor in x and y directions.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4595,13 +4595,13 @@ impl<'a> PaintVarScaleUniform<'a> {
     /// Set to 21.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4614,13 +4614,13 @@ impl<'a> PaintVarScaleUniform<'a> {
     /// varIndexBase + 0.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4709,13 +4709,13 @@ impl<'a> PaintScaleUniformAroundCenter<'a> {
     /// Set to 22.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4727,19 +4727,19 @@ impl<'a> PaintScaleUniformAroundCenter<'a> {
     /// Scale factor in x and y directions.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of scaling.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of scaling.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4835,13 +4835,13 @@ impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     /// Set to 23.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4854,27 +4854,27 @@ impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     /// varIndexBase + 0.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 1.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4955,13 +4955,13 @@ impl<'a> PaintRotate<'a> {
     /// Set to 24.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4974,7 +4974,7 @@ impl<'a> PaintRotate<'a> {
     /// value.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5057,13 +5057,13 @@ impl<'a> PaintVarRotate<'a> {
     /// Set to 25.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5076,13 +5076,13 @@ impl<'a> PaintVarRotate<'a> {
     /// value. For variation, use varIndexBase + 0.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5171,13 +5171,13 @@ impl<'a> PaintRotateAroundCenter<'a> {
     /// Set to 26.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5190,19 +5190,19 @@ impl<'a> PaintRotateAroundCenter<'a> {
     /// value.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of rotation.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of rotation.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5297,13 +5297,13 @@ impl<'a> PaintVarRotateAroundCenter<'a> {
     /// Set to 27.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5316,27 +5316,27 @@ impl<'a> PaintVarRotateAroundCenter<'a> {
     /// value. For variation, use varIndexBase + 0.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 1.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5422,13 +5422,13 @@ impl<'a> PaintSkew<'a> {
     /// Set to 28.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5441,14 +5441,14 @@ impl<'a> PaintSkew<'a> {
     /// counter-clockwise degrees per 1.0 of value.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5537,13 +5537,13 @@ impl<'a> PaintVarSkew<'a> {
     /// Set to 29.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5557,7 +5557,7 @@ impl<'a> PaintVarSkew<'a> {
     /// varIndexBase + 0.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
@@ -5565,13 +5565,13 @@ impl<'a> PaintVarSkew<'a> {
     /// varIndexBase + 1.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5666,13 +5666,13 @@ impl<'a> PaintSkewAroundCenter<'a> {
     /// Set to 30.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5685,26 +5685,26 @@ impl<'a> PaintSkewAroundCenter<'a> {
     /// counter-clockwise degrees per 1.0 of value.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of rotation.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of rotation.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5805,13 +5805,13 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// Set to 31.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5825,7 +5825,7 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// varIndexBase + 0.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
@@ -5833,27 +5833,27 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// varIndexBase + 1.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
     pub fn center_x(&self) -> FWord {
         let range = self.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 3.
     pub fn center_y(&self) -> FWord {
         let range = self.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5940,13 +5940,13 @@ impl<'a> PaintComposite<'a> {
     /// Set to 32.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a source Paint table.
     pub fn source_paint_offset(&self) -> Offset24 {
         let range = self.source_paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`source_paint_offset`][Self::source_paint_offset].
@@ -5958,13 +5958,13 @@ impl<'a> PaintComposite<'a> {
     /// A CompositeMode enumeration value.
     pub fn composite_mode(&self) -> CompositeMode {
         let range = self.composite_mode_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to a backdrop Paint table.
     pub fn backdrop_paint_offset(&self) -> Offset24 {
         let range = self.backdrop_paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`backdrop_paint_offset`][Self::backdrop_paint_offset].

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Colr<'_> {
 impl<'a> FontRead<'a> for Colr<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ColrMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -426,9 +426,9 @@ impl<'a> MinByteRange for BaseGlyphList<'a> {
 impl<'a> FontRead<'a> for BaseGlyphList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BaseGlyphListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -565,9 +565,9 @@ impl<'a> MinByteRange for LayerList<'a> {
 impl<'a> FontRead<'a> for LayerList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LayerListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -662,9 +662,9 @@ impl<'a> MinByteRange for ClipList<'a> {
 impl<'a> FontRead<'a> for ClipList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClipListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -929,9 +929,9 @@ impl<'a> MinByteRange for ClipBoxFormat1<'a> {
 impl<'a> FontRead<'a> for ClipBoxFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClipBoxFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1040,9 +1040,9 @@ impl<'a> MinByteRange for ClipBoxFormat2<'a> {
 impl<'a> FontRead<'a> for ClipBoxFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClipBoxFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1360,9 +1360,9 @@ impl<'a> MinByteRange for ColorLine<'a> {
 impl<'a> FontRead<'a> for ColorLine<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ColorLineMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1456,9 +1456,9 @@ impl<'a> MinByteRange for VarColorLine<'a> {
 impl<'a> FontRead<'a> for VarColorLine<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VarColorLineMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1878,9 +1878,9 @@ impl<'a> MinByteRange for PaintColrLayers<'a> {
 impl<'a> FontRead<'a> for PaintColrLayers<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintColrLayersMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1965,9 +1965,9 @@ impl<'a> MinByteRange for PaintSolid<'a> {
 impl<'a> FontRead<'a> for PaintSolid<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintSolidMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2052,9 +2052,9 @@ impl<'a> MinByteRange for PaintVarSolid<'a> {
 impl<'a> FontRead<'a> for PaintVarSolid<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarSolidMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2151,9 +2151,9 @@ impl<'a> MinByteRange for PaintLinearGradient<'a> {
 impl<'a> FontRead<'a> for PaintLinearGradient<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintLinearGradientMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2307,9 +2307,9 @@ impl<'a> MinByteRange for PaintVarLinearGradient<'a> {
 impl<'a> FontRead<'a> for PaintVarLinearGradient<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarLinearGradientMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2481,9 +2481,9 @@ impl<'a> MinByteRange for PaintRadialGradient<'a> {
 impl<'a> FontRead<'a> for PaintRadialGradient<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintRadialGradientMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2637,9 +2637,9 @@ impl<'a> MinByteRange for PaintVarRadialGradient<'a> {
 impl<'a> FontRead<'a> for PaintVarRadialGradient<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarRadialGradientMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2809,9 +2809,9 @@ impl<'a> MinByteRange for PaintSweepGradient<'a> {
 impl<'a> FontRead<'a> for PaintSweepGradient<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintSweepGradientMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2943,9 +2943,9 @@ impl<'a> MinByteRange for PaintVarSweepGradient<'a> {
 impl<'a> FontRead<'a> for PaintVarSweepGradient<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarSweepGradientMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3091,9 +3091,9 @@ impl<'a> MinByteRange for PaintGlyph<'a> {
 impl<'a> FontRead<'a> for PaintGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintGlyphMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3187,9 +3187,9 @@ impl<'a> MinByteRange for PaintColrGlyph<'a> {
 impl<'a> FontRead<'a> for PaintColrGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintColrGlyphMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3262,9 +3262,9 @@ impl<'a> MinByteRange for PaintTransform<'a> {
 impl<'a> FontRead<'a> for PaintTransform<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintTransformMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3367,9 +3367,9 @@ impl<'a> MinByteRange for PaintVarTransform<'a> {
 impl<'a> FontRead<'a> for PaintVarTransform<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarTransformMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3468,9 +3468,9 @@ impl<'a> MinByteRange for Affine2x3<'a> {
 impl<'a> FontRead<'a> for Affine2x3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Affine2x3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3587,9 +3587,9 @@ impl<'a> MinByteRange for VarAffine2x3<'a> {
 impl<'a> FontRead<'a> for VarAffine2x3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VarAffine2x3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3726,9 +3726,9 @@ impl<'a> MinByteRange for PaintTranslate<'a> {
 impl<'a> FontRead<'a> for PaintTranslate<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintTranslateMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3834,9 +3834,9 @@ impl<'a> MinByteRange for PaintVarTranslate<'a> {
 impl<'a> FontRead<'a> for PaintVarTranslate<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarTranslateMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3954,9 +3954,9 @@ impl<'a> MinByteRange for PaintScale<'a> {
 impl<'a> FontRead<'a> for PaintScale<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintScaleMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4062,9 +4062,9 @@ impl<'a> MinByteRange for PaintVarScale<'a> {
 impl<'a> FontRead<'a> for PaintVarScale<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarScaleMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4184,9 +4184,9 @@ impl<'a> MinByteRange for PaintScaleAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintScaleAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintScaleAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4316,9 +4316,9 @@ impl<'a> MinByteRange for PaintVarScaleAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintVarScaleAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarScaleAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4464,9 +4464,9 @@ impl<'a> MinByteRange for PaintScaleUniform<'a> {
 impl<'a> FontRead<'a> for PaintScaleUniform<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintScaleUniformMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4560,9 +4560,9 @@ impl<'a> MinByteRange for PaintVarScaleUniform<'a> {
 impl<'a> FontRead<'a> for PaintVarScaleUniform<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarScaleUniformMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4669,9 +4669,9 @@ impl<'a> MinByteRange for PaintScaleUniformAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintScaleUniformAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintScaleUniformAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4789,9 +4789,9 @@ impl<'a> MinByteRange for PaintVarScaleUniformAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintVarScaleUniformAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarScaleUniformAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4925,9 +4925,9 @@ impl<'a> MinByteRange for PaintRotate<'a> {
 impl<'a> FontRead<'a> for PaintRotate<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintRotateMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5022,9 +5022,9 @@ impl<'a> MinByteRange for PaintVarRotate<'a> {
 impl<'a> FontRead<'a> for PaintVarRotate<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarRotateMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5131,9 +5131,9 @@ impl<'a> MinByteRange for PaintRotateAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintRotateAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintRotateAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5252,9 +5252,9 @@ impl<'a> MinByteRange for PaintVarRotateAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintVarRotateAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarRotateAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5387,9 +5387,9 @@ impl<'a> MinByteRange for PaintSkew<'a> {
 impl<'a> FontRead<'a> for PaintSkew<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintSkewMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5497,9 +5497,9 @@ impl<'a> MinByteRange for PaintVarSkew<'a> {
 impl<'a> FontRead<'a> for PaintVarSkew<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarSkewMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5621,9 +5621,9 @@ impl<'a> MinByteRange for PaintSkewAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintSkewAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintSkewAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5755,9 +5755,9 @@ impl<'a> MinByteRange for PaintVarSkewAroundCenter<'a> {
 impl<'a> FontRead<'a> for PaintVarSkewAroundCenter<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintVarSkewAroundCenterMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5905,9 +5905,9 @@ impl<'a> MinByteRange for PaintComposite<'a> {
 impl<'a> FontRead<'a> for PaintComposite<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PaintCompositeMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -16,59 +16,7 @@ pub struct ColrMarker {
     item_variation_store_offset_byte_start: Option<usize>,
 }
 
-impl ColrMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn num_base_glyph_records_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_glyph_records_offset_byte_range(&self) -> Range<usize> {
-        let start = self.num_base_glyph_records_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn layer_records_offset_byte_range(&self) -> Range<usize> {
-        let start = self.base_glyph_records_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn num_layer_records_byte_range(&self) -> Range<usize> {
-        let start = self.layer_records_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_glyph_list_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.base_glyph_list_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-
-    pub fn layer_list_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.layer_list_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-
-    pub fn clip_list_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.clip_list_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-
-    pub fn var_index_map_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.var_index_map_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-
-    pub fn item_variation_store_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.item_variation_store_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for ColrMarker {
+impl<'a> MinByteRange for Colr<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.num_layer_records_byte_range().end
     }
@@ -137,21 +85,71 @@ pub type Colr<'a> = TableRef<'a, ColrMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Colr<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn num_base_glyph_records_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_glyph_records_offset_byte_range(&self) -> Range<usize> {
+        let start = self.num_base_glyph_records_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn layer_records_offset_byte_range(&self) -> Range<usize> {
+        let start = self.base_glyph_records_offset_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn num_layer_records_byte_range(&self) -> Range<usize> {
+        let start = self.layer_records_offset_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_glyph_list_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.base_glyph_list_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
+    pub fn layer_list_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.layer_list_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
+    pub fn clip_list_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.clip_list_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
+    pub fn var_index_map_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.var_index_map_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
+    pub fn item_variation_store_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.item_variation_store_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
     /// Table version number - set to 0 or 1.
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of BaseGlyph records; may be 0 in a version 1 table.
     pub fn num_base_glyph_records(&self) -> u16 {
-        let range = self.shape.num_base_glyph_records_byte_range();
+        let range = self.num_base_glyph_records_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to baseGlyphRecords array (may be NULL).
     pub fn base_glyph_records_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.base_glyph_records_offset_byte_range();
+        let range = self.base_glyph_records_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -165,7 +163,7 @@ impl<'a> Colr<'a> {
 
     /// Offset to layerRecords array (may be NULL).
     pub fn layer_records_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.layer_records_offset_byte_range();
+        let range = self.layer_records_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -178,13 +176,13 @@ impl<'a> Colr<'a> {
 
     /// Number of Layer records; may be 0 in a version 1 table.
     pub fn num_layer_records(&self) -> u16 {
-        let range = self.shape.num_layer_records_byte_range();
+        let range = self.num_layer_records_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to BaseGlyphList table.
     pub fn base_glyph_list_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.base_glyph_list_offset_byte_range()?;
+        let range = self.base_glyph_list_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -196,7 +194,7 @@ impl<'a> Colr<'a> {
 
     /// Offset to LayerList table (may be NULL).
     pub fn layer_list_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.layer_list_offset_byte_range()?;
+        let range = self.layer_list_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -208,7 +206,7 @@ impl<'a> Colr<'a> {
 
     /// Offset to ClipList table (may be NULL).
     pub fn clip_list_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.clip_list_offset_byte_range()?;
+        let range = self.clip_list_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -220,7 +218,7 @@ impl<'a> Colr<'a> {
 
     /// Offset to DeltaSetIndexMap table (may be NULL).
     pub fn var_index_map_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.var_index_map_offset_byte_range()?;
+        let range = self.var_index_map_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -232,7 +230,7 @@ impl<'a> Colr<'a> {
 
     /// Offset to ItemVariationStore (may be NULL).
     pub fn item_variation_store_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.item_variation_store_offset_byte_range()?;
+        let range = self.item_variation_store_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -410,23 +408,9 @@ impl<'a> SomeRecord<'a> for Layer {
 /// [BaseGlyphList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BaseGlyphListMarker {
-    base_glyph_paint_records_byte_len: usize,
-}
+pub struct BaseGlyphListMarker {}
 
-impl BaseGlyphListMarker {
-    pub fn num_base_glyph_paint_records_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn base_glyph_paint_records_byte_range(&self) -> Range<usize> {
-        let start = self.num_base_glyph_paint_records_byte_range().end;
-        start..start + self.base_glyph_paint_records_byte_len
-    }
-}
-
-impl MinByteRange for BaseGlyphListMarker {
+impl<'a> MinByteRange for BaseGlyphList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.base_glyph_paint_records_byte_range().end
     }
@@ -440,9 +424,7 @@ impl<'a> FontRead<'a> for BaseGlyphList<'a> {
             .checked_mul(BaseGlyphPaint::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_glyph_paint_records_byte_len);
-        cursor.finish(BaseGlyphListMarker {
-            base_glyph_paint_records_byte_len,
-        })
+        cursor.finish(BaseGlyphListMarker {})
     }
 }
 
@@ -451,13 +433,30 @@ pub type BaseGlyphList<'a> = TableRef<'a, BaseGlyphListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseGlyphList<'a> {
+    fn base_glyph_paint_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_base_glyph_paint_records()) as usize)
+            .checked_mul(BaseGlyphPaint::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn num_base_glyph_paint_records_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn base_glyph_paint_records_byte_range(&self) -> Range<usize> {
+        let start = self.num_base_glyph_paint_records_byte_range().end;
+        start..start + self.base_glyph_paint_records_byte_len(start)
+    }
+
     pub fn num_base_glyph_paint_records(&self) -> u32 {
-        let range = self.shape.num_base_glyph_paint_records_byte_range();
+        let range = self.num_base_glyph_paint_records_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn base_glyph_paint_records(&self) -> &'a [BaseGlyphPaint] {
-        let range = self.shape.base_glyph_paint_records_byte_range();
+        let range = self.base_glyph_paint_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -550,23 +549,9 @@ impl<'a> SomeRecord<'a> for BaseGlyphPaint {
 /// [LayerList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LayerListMarker {
-    paint_offsets_byte_len: usize,
-}
+pub struct LayerListMarker {}
 
-impl LayerListMarker {
-    pub fn num_layers_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.num_layers_byte_range().end;
-        start..start + self.paint_offsets_byte_len
-    }
-}
-
-impl MinByteRange for LayerListMarker {
+impl<'a> MinByteRange for LayerList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.paint_offsets_byte_range().end
     }
@@ -580,9 +565,7 @@ impl<'a> FontRead<'a> for LayerList<'a> {
             .checked_mul(Offset32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(paint_offsets_byte_len);
-        cursor.finish(LayerListMarker {
-            paint_offsets_byte_len,
-        })
+        cursor.finish(LayerListMarker {})
     }
 }
 
@@ -591,14 +574,31 @@ pub type LayerList<'a> = TableRef<'a, LayerListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LayerList<'a> {
+    fn paint_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_layers()) as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn num_layers_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.num_layers_byte_range().end;
+        start..start + self.paint_offsets_byte_len(start)
+    }
+
     pub fn num_layers(&self) -> u32 {
-        let range = self.shape.num_layers_byte_range();
+        let range = self.num_layers_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offsets to Paint tables.
     pub fn paint_offsets(&self) -> &'a [BigEndian<Offset32>] {
-        let range = self.shape.paint_offsets_byte_range();
+        let range = self.paint_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -648,28 +648,9 @@ impl<'a> std::fmt::Debug for LayerList<'a> {
 /// [ClipList](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClipListMarker {
-    clips_byte_len: usize,
-}
+pub struct ClipListMarker {}
 
-impl ClipListMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn num_clips_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn clips_byte_range(&self) -> Range<usize> {
-        let start = self.num_clips_byte_range().end;
-        start..start + self.clips_byte_len
-    }
-}
-
-impl MinByteRange for ClipListMarker {
+impl<'a> MinByteRange for ClipList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.clips_byte_range().end
     }
@@ -684,7 +665,7 @@ impl<'a> FontRead<'a> for ClipList<'a> {
             .checked_mul(Clip::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(clips_byte_len);
-        cursor.finish(ClipListMarker { clips_byte_len })
+        cursor.finish(ClipListMarker {})
     }
 }
 
@@ -693,21 +674,43 @@ pub type ClipList<'a> = TableRef<'a, ClipListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClipList<'a> {
+    fn clips_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_clips()) as usize)
+            .checked_mul(Clip::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn num_clips_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn clips_byte_range(&self) -> Range<usize> {
+        let start = self.num_clips_byte_range().end;
+        start..start + self.clips_byte_len(start)
+    }
+
     /// Set to 1.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of Clip records.
     pub fn num_clips(&self) -> u32 {
-        let range = self.shape.num_clips_byte_range();
+        let range = self.num_clips_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Clip records. Sorted by startGlyphID.
     pub fn clips(&self) -> &'a [Clip] {
-        let range = self.shape.clips_byte_range();
+        let range = self.clips_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -917,7 +920,29 @@ impl Format<u8> for ClipBoxFormat1Marker {
 #[doc(hidden)]
 pub struct ClipBoxFormat1Marker {}
 
-impl ClipBoxFormat1Marker {
+impl<'a> MinByteRange for ClipBoxFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.y_max_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for ClipBoxFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.finish(ClipBoxFormat1Marker {})
+    }
+}
+
+/// [ClipBoxFormat1](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
+pub type ClipBoxFormat1<'a> = TableRef<'a, ClipBoxFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ClipBoxFormat1<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -942,58 +967,34 @@ impl ClipBoxFormat1Marker {
         let start = self.x_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for ClipBoxFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.y_max_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for ClipBoxFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.finish(ClipBoxFormat1Marker {})
-    }
-}
-
-/// [ClipBoxFormat1](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
-pub type ClipBoxFormat1<'a> = TableRef<'a, ClipBoxFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> ClipBoxFormat1<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum x of clip box.
     pub fn x_min(&self) -> FWord {
-        let range = self.shape.x_min_byte_range();
+        let range = self.x_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum y of clip box.
     pub fn y_min(&self) -> FWord {
-        let range = self.shape.y_min_byte_range();
+        let range = self.y_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum x of clip box.
     pub fn x_max(&self) -> FWord {
-        let range = self.shape.x_max_byte_range();
+        let range = self.x_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum y of clip box.
     pub fn y_max(&self) -> FWord {
-        let range = self.shape.y_max_byte_range();
+        let range = self.y_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -1032,7 +1033,30 @@ impl Format<u8> for ClipBoxFormat2Marker {
 #[doc(hidden)]
 pub struct ClipBoxFormat2Marker {}
 
-impl ClipBoxFormat2Marker {
+impl<'a> MinByteRange for ClipBoxFormat2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for ClipBoxFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(ClipBoxFormat2Marker {})
+    }
+}
+
+/// [ClipBoxFormat2](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
+pub type ClipBoxFormat2<'a> = TableRef<'a, ClipBoxFormat2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ClipBoxFormat2<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -1062,65 +1086,40 @@ impl ClipBoxFormat2Marker {
         let start = self.y_max_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for ClipBoxFormat2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for ClipBoxFormat2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(ClipBoxFormat2Marker {})
-    }
-}
-
-/// [ClipBoxFormat2](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyphlist-layerlist-and-cliplist) record
-pub type ClipBoxFormat2<'a> = TableRef<'a, ClipBoxFormat2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> ClipBoxFormat2<'a> {
     /// Set to 2.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum x of clip box. For variation, use varIndexBase + 0.
     pub fn x_min(&self) -> FWord {
-        let range = self.shape.x_min_byte_range();
+        let range = self.x_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum y of clip box. For variation, use varIndexBase + 1.
     pub fn y_min(&self) -> FWord {
-        let range = self.shape.y_min_byte_range();
+        let range = self.y_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum x of clip box. For variation, use varIndexBase + 2.
     pub fn x_max(&self) -> FWord {
-        let range = self.shape.x_max_byte_range();
+        let range = self.x_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum y of clip box. For variation, use varIndexBase + 3.
     pub fn y_max(&self) -> FWord {
-        let range = self.shape.y_max_byte_range();
+        let range = self.y_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -1355,28 +1354,9 @@ impl<'a> SomeRecord<'a> for VarColorStop {
 /// [ColorLine](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ColorLineMarker {
-    color_stops_byte_len: usize,
-}
+pub struct ColorLineMarker {}
 
-impl ColorLineMarker {
-    pub fn extend_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + Extend::RAW_BYTE_LEN
-    }
-
-    pub fn num_stops_byte_range(&self) -> Range<usize> {
-        let start = self.extend_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn color_stops_byte_range(&self) -> Range<usize> {
-        let start = self.num_stops_byte_range().end;
-        start..start + self.color_stops_byte_len
-    }
-}
-
-impl MinByteRange for ColorLineMarker {
+impl<'a> MinByteRange for ColorLine<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.color_stops_byte_range().end
     }
@@ -1391,9 +1371,7 @@ impl<'a> FontRead<'a> for ColorLine<'a> {
             .checked_mul(ColorStop::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(color_stops_byte_len);
-        cursor.finish(ColorLineMarker {
-            color_stops_byte_len,
-        })
+        cursor.finish(ColorLineMarker {})
     }
 }
 
@@ -1402,20 +1380,42 @@ pub type ColorLine<'a> = TableRef<'a, ColorLineMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ColorLine<'a> {
+    fn color_stops_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_stops()) as usize)
+            .checked_mul(ColorStop::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn extend_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Extend::RAW_BYTE_LEN
+    }
+
+    pub fn num_stops_byte_range(&self) -> Range<usize> {
+        let start = self.extend_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn color_stops_byte_range(&self) -> Range<usize> {
+        let start = self.num_stops_byte_range().end;
+        start..start + self.color_stops_byte_len(start)
+    }
+
     /// An Extend enum value.
     pub fn extend(&self) -> Extend {
-        let range = self.shape.extend_byte_range();
+        let range = self.extend_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of ColorStop records.
     pub fn num_stops(&self) -> u16 {
-        let range = self.shape.num_stops_byte_range();
+        let range = self.num_stops_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn color_stops(&self) -> &'a [ColorStop] {
-        let range = self.shape.color_stops_byte_range();
+        let range = self.color_stops_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1453,28 +1453,9 @@ impl<'a> std::fmt::Debug for ColorLine<'a> {
 /// [VarColorLine](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#color-references-colorstop-and-colorline) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VarColorLineMarker {
-    color_stops_byte_len: usize,
-}
+pub struct VarColorLineMarker {}
 
-impl VarColorLineMarker {
-    pub fn extend_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + Extend::RAW_BYTE_LEN
-    }
-
-    pub fn num_stops_byte_range(&self) -> Range<usize> {
-        let start = self.extend_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn color_stops_byte_range(&self) -> Range<usize> {
-        let start = self.num_stops_byte_range().end;
-        start..start + self.color_stops_byte_len
-    }
-}
-
-impl MinByteRange for VarColorLineMarker {
+impl<'a> MinByteRange for VarColorLine<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.color_stops_byte_range().end
     }
@@ -1489,9 +1470,7 @@ impl<'a> FontRead<'a> for VarColorLine<'a> {
             .checked_mul(VarColorStop::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(color_stops_byte_len);
-        cursor.finish(VarColorLineMarker {
-            color_stops_byte_len,
-        })
+        cursor.finish(VarColorLineMarker {})
     }
 }
 
@@ -1500,21 +1479,43 @@ pub type VarColorLine<'a> = TableRef<'a, VarColorLineMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VarColorLine<'a> {
+    fn color_stops_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_stops()) as usize)
+            .checked_mul(VarColorStop::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn extend_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Extend::RAW_BYTE_LEN
+    }
+
+    pub fn num_stops_byte_range(&self) -> Range<usize> {
+        let start = self.extend_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn color_stops_byte_range(&self) -> Range<usize> {
+        let start = self.num_stops_byte_range().end;
+        start..start + self.color_stops_byte_len(start)
+    }
+
     /// An Extend enum value.
     pub fn extend(&self) -> Extend {
-        let range = self.shape.extend_byte_range();
+        let range = self.extend_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of ColorStop records.
     pub fn num_stops(&self) -> u16 {
-        let range = self.shape.num_stops_byte_range();
+        let range = self.num_stops_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Allows for variations.
     pub fn color_stops(&self) -> &'a [VarColorStop] {
-        let range = self.shape.color_stops_byte_range();
+        let range = self.color_stops_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1879,24 +1880,7 @@ impl Format<u8> for PaintColrLayersMarker {
 #[doc(hidden)]
 pub struct PaintColrLayersMarker {}
 
-impl PaintColrLayersMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn num_layers_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn first_layer_index_byte_range(&self) -> Range<usize> {
-        let start = self.num_layers_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintColrLayersMarker {
+impl<'a> MinByteRange for PaintColrLayers<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.first_layer_index_byte_range().end
     }
@@ -1917,21 +1901,36 @@ pub type PaintColrLayers<'a> = TableRef<'a, PaintColrLayersMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintColrLayers<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn num_layers_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn first_layer_index_byte_range(&self) -> Range<usize> {
+        let start = self.num_layers_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
     /// Set to 1.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of offsets to paint tables to read from LayerList.
     pub fn num_layers(&self) -> u8 {
-        let range = self.shape.num_layers_byte_range();
+        let range = self.num_layers_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Index (base 0) into the LayerList.
     pub fn first_layer_index(&self) -> u32 {
-        let range = self.shape.first_layer_index_byte_range();
+        let range = self.first_layer_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -1968,24 +1967,7 @@ impl Format<u8> for PaintSolidMarker {
 #[doc(hidden)]
 pub struct PaintSolidMarker {}
 
-impl PaintSolidMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn palette_index_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn alpha_byte_range(&self) -> Range<usize> {
-        let start = self.palette_index_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintSolidMarker {
+impl<'a> MinByteRange for PaintSolid<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.alpha_byte_range().end
     }
@@ -2006,21 +1988,36 @@ pub type PaintSolid<'a> = TableRef<'a, PaintSolidMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintSolid<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn palette_index_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn alpha_byte_range(&self) -> Range<usize> {
+        let start = self.palette_index_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
     /// Set to 2.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Index for a CPAL palette entry.
     pub fn palette_index(&self) -> u16 {
-        let range = self.shape.palette_index_byte_range();
+        let range = self.palette_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Alpha value.
     pub fn alpha(&self) -> F2Dot14 {
-        let range = self.shape.alpha_byte_range();
+        let range = self.alpha_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2057,29 +2054,7 @@ impl Format<u8> for PaintVarSolidMarker {
 #[doc(hidden)]
 pub struct PaintVarSolidMarker {}
 
-impl PaintVarSolidMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn palette_index_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn alpha_byte_range(&self) -> Range<usize> {
-        let start = self.palette_index_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-
-    pub fn var_index_base_byte_range(&self) -> Range<usize> {
-        let start = self.alpha_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintVarSolidMarker {
+impl<'a> MinByteRange for PaintVarSolid<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.var_index_base_byte_range().end
     }
@@ -2101,27 +2076,47 @@ pub type PaintVarSolid<'a> = TableRef<'a, PaintVarSolidMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintVarSolid<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn palette_index_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn alpha_byte_range(&self) -> Range<usize> {
+        let start = self.palette_index_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
+        let start = self.alpha_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
     /// Set to 3.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Index for a CPAL palette entry.
     pub fn palette_index(&self) -> u16 {
-        let range = self.shape.palette_index_byte_range();
+        let range = self.palette_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Alpha value. For variation, use varIndexBase + 0.
     pub fn alpha(&self) -> F2Dot14 {
-        let range = self.shape.alpha_byte_range();
+        let range = self.alpha_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2159,7 +2154,32 @@ impl Format<u8> for PaintLinearGradientMarker {
 #[doc(hidden)]
 pub struct PaintLinearGradientMarker {}
 
-impl PaintLinearGradientMarker {
+impl<'a> MinByteRange for PaintLinearGradient<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.y2_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintLinearGradient<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.finish(PaintLinearGradientMarker {})
+    }
+}
+
+/// [PaintLinearGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-4-and-5-paintlineargradient-paintvarlineargradient) table
+pub type PaintLinearGradient<'a> = TableRef<'a, PaintLinearGradientMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintLinearGradient<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -2199,43 +2219,16 @@ impl PaintLinearGradientMarker {
         let start = self.x2_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintLinearGradientMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.y2_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintLinearGradient<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.finish(PaintLinearGradientMarker {})
-    }
-}
-
-/// [PaintLinearGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-4-and-5-paintlineargradient-paintvarlineargradient) table
-pub type PaintLinearGradient<'a> = TableRef<'a, PaintLinearGradientMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintLinearGradient<'a> {
     /// Set to 4.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
-        let range = self.shape.color_line_offset_byte_range();
+        let range = self.color_line_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2247,37 +2240,37 @@ impl<'a> PaintLinearGradient<'a> {
 
     /// Start point (p₀) x coordinate.
     pub fn x0(&self) -> FWord {
-        let range = self.shape.x0_byte_range();
+        let range = self.x0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start point (p₀) y coordinate.
     pub fn y0(&self) -> FWord {
-        let range = self.shape.y0_byte_range();
+        let range = self.y0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End point (p₁) x coordinate.
     pub fn x1(&self) -> FWord {
-        let range = self.shape.x1_byte_range();
+        let range = self.x1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End point (p₁) y coordinate.
     pub fn y1(&self) -> FWord {
-        let range = self.shape.y1_byte_range();
+        let range = self.y1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Rotation point (p₂) x coordinate.
     pub fn x2(&self) -> FWord {
-        let range = self.shape.x2_byte_range();
+        let range = self.x2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Rotation point (p₂) y coordinate.
     pub fn y2(&self) -> FWord {
-        let range = self.shape.y2_byte_range();
+        let range = self.y2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2322,7 +2315,33 @@ impl Format<u8> for PaintVarLinearGradientMarker {
 #[doc(hidden)]
 pub struct PaintVarLinearGradientMarker {}
 
-impl PaintVarLinearGradientMarker {
+impl<'a> MinByteRange for PaintVarLinearGradient<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarLinearGradient<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarLinearGradientMarker {})
+    }
+}
+
+/// [PaintVarLinearGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-4-and-5-paintlineargradient-paintvarlineargradient) table
+pub type PaintVarLinearGradient<'a> = TableRef<'a, PaintVarLinearGradientMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarLinearGradient<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -2367,44 +2386,16 @@ impl PaintVarLinearGradientMarker {
         let start = self.y2_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarLinearGradientMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarLinearGradient<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarLinearGradientMarker {})
-    }
-}
-
-/// [PaintVarLinearGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-4-and-5-paintlineargradient-paintvarlineargradient) table
-pub type PaintVarLinearGradient<'a> = TableRef<'a, PaintVarLinearGradientMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarLinearGradient<'a> {
     /// Set to 5.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
-        let range = self.shape.color_line_offset_byte_range();
+        let range = self.color_line_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2417,48 +2408,48 @@ impl<'a> PaintVarLinearGradient<'a> {
     /// Start point (p₀) x coordinate. For variation, use
     /// varIndexBase + 0.
     pub fn x0(&self) -> FWord {
-        let range = self.shape.x0_byte_range();
+        let range = self.x0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start point (p₀) y coordinate. For variation, use
     /// varIndexBase + 1.
     pub fn y0(&self) -> FWord {
-        let range = self.shape.y0_byte_range();
+        let range = self.y0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End point (p₁) x coordinate. For variation, use varIndexBase
     /// + 2.
     pub fn x1(&self) -> FWord {
-        let range = self.shape.x1_byte_range();
+        let range = self.x1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End point (p₁) y coordinate. For variation, use varIndexBase
     /// + 3.
     pub fn y1(&self) -> FWord {
-        let range = self.shape.y1_byte_range();
+        let range = self.y1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Rotation point (p₂) x coordinate. For variation, use
     /// varIndexBase + 4.
     pub fn x2(&self) -> FWord {
-        let range = self.shape.x2_byte_range();
+        let range = self.x2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Rotation point (p₂) y coordinate. For variation, use
     /// varIndexBase + 5.
     pub fn y2(&self) -> FWord {
-        let range = self.shape.y2_byte_range();
+        let range = self.y2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2504,7 +2495,32 @@ impl Format<u8> for PaintRadialGradientMarker {
 #[doc(hidden)]
 pub struct PaintRadialGradientMarker {}
 
-impl PaintRadialGradientMarker {
+impl<'a> MinByteRange for PaintRadialGradient<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.radius1_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintRadialGradient<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<UfWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<UfWord>();
+        cursor.finish(PaintRadialGradientMarker {})
+    }
+}
+
+/// [PaintRadialGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-6-and-7-paintradialgradient-paintvarradialgradient) table
+pub type PaintRadialGradient<'a> = TableRef<'a, PaintRadialGradientMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintRadialGradient<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -2544,43 +2560,16 @@ impl PaintRadialGradientMarker {
         let start = self.y1_byte_range().end;
         start..start + UfWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintRadialGradientMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.radius1_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintRadialGradient<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.finish(PaintRadialGradientMarker {})
-    }
-}
-
-/// [PaintRadialGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-6-and-7-paintradialgradient-paintvarradialgradient) table
-pub type PaintRadialGradient<'a> = TableRef<'a, PaintRadialGradientMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintRadialGradient<'a> {
     /// Set to 6.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
-        let range = self.shape.color_line_offset_byte_range();
+        let range = self.color_line_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2592,37 +2581,37 @@ impl<'a> PaintRadialGradient<'a> {
 
     /// Start circle center x coordinate.
     pub fn x0(&self) -> FWord {
-        let range = self.shape.x0_byte_range();
+        let range = self.x0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start circle center y coordinate.
     pub fn y0(&self) -> FWord {
-        let range = self.shape.y0_byte_range();
+        let range = self.y0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start circle radius.
     pub fn radius0(&self) -> UfWord {
-        let range = self.shape.radius0_byte_range();
+        let range = self.radius0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End circle center x coordinate.
     pub fn x1(&self) -> FWord {
-        let range = self.shape.x1_byte_range();
+        let range = self.x1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End circle center y coordinate.
     pub fn y1(&self) -> FWord {
-        let range = self.shape.y1_byte_range();
+        let range = self.y1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End circle radius.
     pub fn radius1(&self) -> UfWord {
-        let range = self.shape.radius1_byte_range();
+        let range = self.radius1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2667,7 +2656,33 @@ impl Format<u8> for PaintVarRadialGradientMarker {
 #[doc(hidden)]
 pub struct PaintVarRadialGradientMarker {}
 
-impl PaintVarRadialGradientMarker {
+impl<'a> MinByteRange for PaintVarRadialGradient<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarRadialGradient<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<UfWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<UfWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarRadialGradientMarker {})
+    }
+}
+
+/// [PaintVarRadialGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-6-and-7-paintradialgradient-paintvarradialgradient) table
+pub type PaintVarRadialGradient<'a> = TableRef<'a, PaintVarRadialGradientMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarRadialGradient<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -2712,44 +2727,16 @@ impl PaintVarRadialGradientMarker {
         let start = self.radius1_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarRadialGradientMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarRadialGradient<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarRadialGradientMarker {})
-    }
-}
-
-/// [PaintVarRadialGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-6-and-7-paintradialgradient-paintvarradialgradient) table
-pub type PaintVarRadialGradient<'a> = TableRef<'a, PaintVarRadialGradientMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarRadialGradient<'a> {
     /// Set to 7.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
-        let range = self.shape.color_line_offset_byte_range();
+        let range = self.color_line_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2762,46 +2749,46 @@ impl<'a> PaintVarRadialGradient<'a> {
     /// Start circle center x coordinate. For variation, use
     /// varIndexBase + 0.
     pub fn x0(&self) -> FWord {
-        let range = self.shape.x0_byte_range();
+        let range = self.x0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start circle center y coordinate. For variation, use
     /// varIndexBase + 1.
     pub fn y0(&self) -> FWord {
-        let range = self.shape.y0_byte_range();
+        let range = self.y0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start circle radius. For variation, use varIndexBase + 2.
     pub fn radius0(&self) -> UfWord {
-        let range = self.shape.radius0_byte_range();
+        let range = self.radius0_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End circle center x coordinate. For variation, use varIndexBase
     /// + 3.
     pub fn x1(&self) -> FWord {
-        let range = self.shape.x1_byte_range();
+        let range = self.x1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End circle center y coordinate. For variation, use varIndexBase
     /// + 4.
     pub fn y1(&self) -> FWord {
-        let range = self.shape.y1_byte_range();
+        let range = self.y1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End circle radius. For variation, use varIndexBase + 5.
     pub fn radius1(&self) -> UfWord {
-        let range = self.shape.radius1_byte_range();
+        let range = self.radius1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2847,7 +2834,30 @@ impl Format<u8> for PaintSweepGradientMarker {
 #[doc(hidden)]
 pub struct PaintSweepGradientMarker {}
 
-impl PaintSweepGradientMarker {
+impl<'a> MinByteRange for PaintSweepGradient<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.end_angle_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintSweepGradient<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.finish(PaintSweepGradientMarker {})
+    }
+}
+
+/// [PaintSweepGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-8-and-9-paintsweepgradient-paintvarsweepgradient) table
+pub type PaintSweepGradient<'a> = TableRef<'a, PaintSweepGradientMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintSweepGradient<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -2877,41 +2887,16 @@ impl PaintSweepGradientMarker {
         let start = self.start_angle_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintSweepGradientMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.end_angle_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintSweepGradient<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.finish(PaintSweepGradientMarker {})
-    }
-}
-
-/// [PaintSweepGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-8-and-9-paintsweepgradient-paintvarsweepgradient) table
-pub type PaintSweepGradient<'a> = TableRef<'a, PaintSweepGradientMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintSweepGradient<'a> {
     /// Set to 8.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
-        let range = self.shape.color_line_offset_byte_range();
+        let range = self.color_line_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2923,27 +2908,27 @@ impl<'a> PaintSweepGradient<'a> {
 
     /// Center x coordinate.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Center y coordinate.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Start of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn start_angle(&self) -> F2Dot14 {
-        let range = self.shape.start_angle_byte_range();
+        let range = self.start_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// End of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn end_angle(&self) -> F2Dot14 {
-        let range = self.shape.end_angle_byte_range();
+        let range = self.end_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -2986,7 +2971,31 @@ impl Format<u8> for PaintVarSweepGradientMarker {
 #[doc(hidden)]
 pub struct PaintVarSweepGradientMarker {}
 
-impl PaintVarSweepGradientMarker {
+impl<'a> MinByteRange for PaintVarSweepGradient<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarSweepGradient<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarSweepGradientMarker {})
+    }
+}
+
+/// [PaintVarSweepGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-8-and-9-paintsweepgradient-paintvarsweepgradient) table
+pub type PaintVarSweepGradient<'a> = TableRef<'a, PaintVarSweepGradientMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarSweepGradient<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -3021,42 +3030,16 @@ impl PaintVarSweepGradientMarker {
         let start = self.end_angle_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarSweepGradientMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarSweepGradient<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarSweepGradientMarker {})
-    }
-}
-
-/// [PaintVarSweepGradient](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-8-and-9-paintsweepgradient-paintvarsweepgradient) table
-pub type PaintVarSweepGradient<'a> = TableRef<'a, PaintVarSweepGradientMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarSweepGradient<'a> {
     /// Set to 9.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
-        let range = self.shape.color_line_offset_byte_range();
+        let range = self.color_line_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3068,13 +3051,13 @@ impl<'a> PaintVarSweepGradient<'a> {
 
     /// Center x coordinate. For variation, use varIndexBase + 0.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Center y coordinate. For variation, use varIndexBase + 1.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3082,7 +3065,7 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 2.
     pub fn start_angle(&self) -> F2Dot14 {
-        let range = self.shape.start_angle_byte_range();
+        let range = self.start_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3090,13 +3073,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 3.
     pub fn end_angle(&self) -> F2Dot14 {
-        let range = self.shape.end_angle_byte_range();
+        let range = self.end_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -3140,24 +3123,7 @@ impl Format<u8> for PaintGlyphMarker {
 #[doc(hidden)]
 pub struct PaintGlyphMarker {}
 
-impl PaintGlyphMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn glyph_id_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + GlyphId16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintGlyphMarker {
+impl<'a> MinByteRange for PaintGlyph<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.glyph_id_byte_range().end
     }
@@ -3178,15 +3144,30 @@ pub type PaintGlyph<'a> = TableRef<'a, PaintGlyphMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintGlyph<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_id_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + GlyphId16::RAW_BYTE_LEN
+    }
+
     /// Set to 10.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint table.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3198,7 +3179,7 @@ impl<'a> PaintGlyph<'a> {
 
     /// Glyph ID for the source outline.
     pub fn glyph_id(&self) -> GlyphId16 {
-        let range = self.shape.glyph_id_byte_range();
+        let range = self.glyph_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -3238,19 +3219,7 @@ impl Format<u8> for PaintColrGlyphMarker {
 #[doc(hidden)]
 pub struct PaintColrGlyphMarker {}
 
-impl PaintColrGlyphMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn glyph_id_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + GlyphId16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintColrGlyphMarker {
+impl<'a> MinByteRange for PaintColrGlyph<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.glyph_id_byte_range().end
     }
@@ -3270,15 +3239,25 @@ pub type PaintColrGlyph<'a> = TableRef<'a, PaintColrGlyphMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintColrGlyph<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_id_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + GlyphId16::RAW_BYTE_LEN
+    }
+
     /// Set to 11.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Glyph ID for a BaseGlyphList base glyph.
     pub fn glyph_id(&self) -> GlyphId16 {
-        let range = self.shape.glyph_id_byte_range();
+        let range = self.glyph_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -3314,24 +3293,7 @@ impl Format<u8> for PaintTransformMarker {
 #[doc(hidden)]
 pub struct PaintTransformMarker {}
 
-impl PaintTransformMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn transform_offset_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintTransformMarker {
+impl<'a> MinByteRange for PaintTransform<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.transform_offset_byte_range().end
     }
@@ -3352,15 +3314,30 @@ pub type PaintTransform<'a> = TableRef<'a, PaintTransformMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintTransform<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn transform_offset_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
     /// Set to 12.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3372,7 +3349,7 @@ impl<'a> PaintTransform<'a> {
 
     /// Offset to an Affine2x3 table.
     pub fn transform_offset(&self) -> Offset24 {
-        let range = self.shape.transform_offset_byte_range();
+        let range = self.transform_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3421,24 +3398,7 @@ impl Format<u8> for PaintVarTransformMarker {
 #[doc(hidden)]
 pub struct PaintVarTransformMarker {}
 
-impl PaintVarTransformMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn transform_offset_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintVarTransformMarker {
+impl<'a> MinByteRange for PaintVarTransform<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.transform_offset_byte_range().end
     }
@@ -3459,15 +3419,30 @@ pub type PaintVarTransform<'a> = TableRef<'a, PaintVarTransformMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintVarTransform<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn transform_offset_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
     /// Set to 13.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3479,7 +3454,7 @@ impl<'a> PaintVarTransform<'a> {
 
     /// Offset to a VarAffine2x3 table.
     pub fn transform_offset(&self) -> Offset24 {
-        let range = self.shape.transform_offset_byte_range();
+        let range = self.transform_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3524,7 +3499,30 @@ impl<'a> std::fmt::Debug for PaintVarTransform<'a> {
 #[doc(hidden)]
 pub struct Affine2x3Marker {}
 
-impl Affine2x3Marker {
+impl<'a> MinByteRange for Affine2x3<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.dy_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for Affine2x3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.finish(Affine2x3Marker {})
+    }
+}
+
+/// [Affine2x3](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) record
+pub type Affine2x3<'a> = TableRef<'a, Affine2x3Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Affine2x3<'a> {
     pub fn xx_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Fixed::RAW_BYTE_LEN
@@ -3554,65 +3552,40 @@ impl Affine2x3Marker {
         let start = self.dx_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for Affine2x3Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.dy_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Affine2x3<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.finish(Affine2x3Marker {})
-    }
-}
-
-/// [Affine2x3](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) record
-pub type Affine2x3<'a> = TableRef<'a, Affine2x3Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Affine2x3<'a> {
     /// x-component of transformed x-basis vector.
     pub fn xx(&self) -> Fixed {
-        let range = self.shape.xx_byte_range();
+        let range = self.xx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y-component of transformed x-basis vector.
     pub fn yx(&self) -> Fixed {
-        let range = self.shape.yx_byte_range();
+        let range = self.yx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x-component of transformed y-basis vector.
     pub fn xy(&self) -> Fixed {
-        let range = self.shape.xy_byte_range();
+        let range = self.xy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y-component of transformed y-basis vector.
     pub fn yy(&self) -> Fixed {
-        let range = self.shape.yy_byte_range();
+        let range = self.yy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Translation in x direction.
     pub fn dx(&self) -> Fixed {
-        let range = self.shape.dx_byte_range();
+        let range = self.dx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Translation in y direction.
     pub fn dy(&self) -> Fixed {
-        let range = self.shape.dy_byte_range();
+        let range = self.dy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -3648,7 +3621,31 @@ impl<'a> std::fmt::Debug for Affine2x3<'a> {
 #[doc(hidden)]
 pub struct VarAffine2x3Marker {}
 
-impl VarAffine2x3Marker {
+impl<'a> MinByteRange for VarAffine2x3<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for VarAffine2x3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<u32>();
+        cursor.finish(VarAffine2x3Marker {})
+    }
+}
+
+/// [VarAffine2x3](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) record
+pub type VarAffine2x3<'a> = TableRef<'a, VarAffine2x3Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> VarAffine2x3<'a> {
     pub fn xx_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Fixed::RAW_BYTE_LEN
@@ -3683,76 +3680,50 @@ impl VarAffine2x3Marker {
         let start = self.dy_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for VarAffine2x3Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for VarAffine2x3<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<u32>();
-        cursor.finish(VarAffine2x3Marker {})
-    }
-}
-
-/// [VarAffine2x3](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-12-and-13-painttransform-paintvartransform) record
-pub type VarAffine2x3<'a> = TableRef<'a, VarAffine2x3Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> VarAffine2x3<'a> {
     /// x-component of transformed x-basis vector. For variation, use
     /// varIndexBase + 0.
     pub fn xx(&self) -> Fixed {
-        let range = self.shape.xx_byte_range();
+        let range = self.xx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y-component of transformed x-basis vector. For variation, use
     /// varIndexBase + 1.
     pub fn yx(&self) -> Fixed {
-        let range = self.shape.yx_byte_range();
+        let range = self.yx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 2.
     pub fn xy(&self) -> Fixed {
-        let range = self.shape.xy_byte_range();
+        let range = self.xy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 3.
     pub fn yy(&self) -> Fixed {
-        let range = self.shape.yy_byte_range();
+        let range = self.yy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Translation in x direction. For variation, use varIndexBase + 4.
     pub fn dx(&self) -> Fixed {
-        let range = self.shape.dx_byte_range();
+        let range = self.dx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Translation in y direction. For variation, use varIndexBase + 5.
     pub fn dy(&self) -> Fixed {
-        let range = self.shape.dy_byte_range();
+        let range = self.dy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -3793,29 +3764,7 @@ impl Format<u8> for PaintTranslateMarker {
 #[doc(hidden)]
 pub struct PaintTranslateMarker {}
 
-impl PaintTranslateMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn dx_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
-    }
-
-    pub fn dy_byte_range(&self) -> Range<usize> {
-        let start = self.dx_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintTranslateMarker {
+impl<'a> MinByteRange for PaintTranslate<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.dy_byte_range().end
     }
@@ -3837,15 +3786,35 @@ pub type PaintTranslate<'a> = TableRef<'a, PaintTranslateMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintTranslate<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn dx_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + FWord::RAW_BYTE_LEN
+    }
+
+    pub fn dy_byte_range(&self) -> Range<usize> {
+        let start = self.dx_byte_range().end;
+        start..start + FWord::RAW_BYTE_LEN
+    }
+
     /// Set to 14.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3857,13 +3826,13 @@ impl<'a> PaintTranslate<'a> {
 
     /// Translation in x direction.
     pub fn dx(&self) -> FWord {
-        let range = self.shape.dx_byte_range();
+        let range = self.dx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Translation in y direction.
     pub fn dy(&self) -> FWord {
-        let range = self.shape.dy_byte_range();
+        let range = self.dy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -3904,7 +3873,29 @@ impl Format<u8> for PaintVarTranslateMarker {
 #[doc(hidden)]
 pub struct PaintVarTranslateMarker {}
 
-impl PaintVarTranslateMarker {
+impl<'a> MinByteRange for PaintVarTranslate<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarTranslate<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarTranslateMarker {})
+    }
+}
+
+/// [PaintVarTranslate](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-14-and-15-painttranslate-paintvartranslate) table
+pub type PaintVarTranslate<'a> = TableRef<'a, PaintVarTranslateMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarTranslate<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -3929,40 +3920,16 @@ impl PaintVarTranslateMarker {
         let start = self.dy_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarTranslateMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarTranslate<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarTranslateMarker {})
-    }
-}
-
-/// [PaintVarTranslate](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-14-and-15-painttranslate-paintvartranslate) table
-pub type PaintVarTranslate<'a> = TableRef<'a, PaintVarTranslateMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarTranslate<'a> {
     /// Set to 15.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3974,19 +3941,19 @@ impl<'a> PaintVarTranslate<'a> {
 
     /// Translation in x direction. For variation, use varIndexBase + 0.
     pub fn dx(&self) -> FWord {
-        let range = self.shape.dx_byte_range();
+        let range = self.dx_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Translation in y direction. For variation, use varIndexBase + 1.
     pub fn dy(&self) -> FWord {
-        let range = self.shape.dy_byte_range();
+        let range = self.dy_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4028,29 +3995,7 @@ impl Format<u8> for PaintScaleMarker {
 #[doc(hidden)]
 pub struct PaintScaleMarker {}
 
-impl PaintScaleMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn scale_x_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-
-    pub fn scale_y_byte_range(&self) -> Range<usize> {
-        let start = self.scale_x_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintScaleMarker {
+impl<'a> MinByteRange for PaintScale<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.scale_y_byte_range().end
     }
@@ -4072,15 +4017,35 @@ pub type PaintScale<'a> = TableRef<'a, PaintScaleMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintScale<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn scale_x_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
+    pub fn scale_y_byte_range(&self) -> Range<usize> {
+        let start = self.scale_x_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
     /// Set to 16.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4092,13 +4057,13 @@ impl<'a> PaintScale<'a> {
 
     /// Scale factor in x direction.
     pub fn scale_x(&self) -> F2Dot14 {
-        let range = self.shape.scale_x_byte_range();
+        let range = self.scale_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Scale factor in y direction.
     pub fn scale_y(&self) -> F2Dot14 {
-        let range = self.shape.scale_y_byte_range();
+        let range = self.scale_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4139,7 +4104,29 @@ impl Format<u8> for PaintVarScaleMarker {
 #[doc(hidden)]
 pub struct PaintVarScaleMarker {}
 
-impl PaintVarScaleMarker {
+impl<'a> MinByteRange for PaintVarScale<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarScale<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarScaleMarker {})
+    }
+}
+
+/// [PaintVarScale](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
+pub type PaintVarScale<'a> = TableRef<'a, PaintVarScaleMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarScale<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -4164,40 +4151,16 @@ impl PaintVarScaleMarker {
         let start = self.scale_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarScaleMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarScale<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarScaleMarker {})
-    }
-}
-
-/// [PaintVarScale](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
-pub type PaintVarScale<'a> = TableRef<'a, PaintVarScaleMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarScale<'a> {
     /// Set to 17.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4210,20 +4173,20 @@ impl<'a> PaintVarScale<'a> {
     /// Scale factor in x direction. For variation, use varIndexBase +
     /// 0.
     pub fn scale_x(&self) -> F2Dot14 {
-        let range = self.shape.scale_x_byte_range();
+        let range = self.scale_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
     pub fn scale_y(&self) -> F2Dot14 {
-        let range = self.shape.scale_y_byte_range();
+        let range = self.scale_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4265,7 +4228,30 @@ impl Format<u8> for PaintScaleAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintScaleAroundCenterMarker {}
 
-impl PaintScaleAroundCenterMarker {
+impl<'a> MinByteRange for PaintScaleAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.center_y_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintScaleAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.finish(PaintScaleAroundCenterMarker {})
+    }
+}
+
+/// [PaintScaleAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
+pub type PaintScaleAroundCenter<'a> = TableRef<'a, PaintScaleAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintScaleAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -4295,41 +4281,16 @@ impl PaintScaleAroundCenterMarker {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintScaleAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.center_y_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintScaleAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.finish(PaintScaleAroundCenterMarker {})
-    }
-}
-
-/// [PaintScaleAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
-pub type PaintScaleAroundCenter<'a> = TableRef<'a, PaintScaleAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintScaleAroundCenter<'a> {
     /// Set to 18.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4341,25 +4302,25 @@ impl<'a> PaintScaleAroundCenter<'a> {
 
     /// Scale factor in x direction.
     pub fn scale_x(&self) -> F2Dot14 {
-        let range = self.shape.scale_x_byte_range();
+        let range = self.scale_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Scale factor in y direction.
     pub fn scale_y(&self) -> F2Dot14 {
-        let range = self.shape.scale_y_byte_range();
+        let range = self.scale_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of scaling.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of scaling.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4402,7 +4363,31 @@ impl Format<u8> for PaintVarScaleAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintVarScaleAroundCenterMarker {}
 
-impl PaintVarScaleAroundCenterMarker {
+impl<'a> MinByteRange for PaintVarScaleAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarScaleAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarScaleAroundCenterMarker {})
+    }
+}
+
+/// [PaintVarScaleAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
+pub type PaintVarScaleAroundCenter<'a> = TableRef<'a, PaintVarScaleAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarScaleAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -4437,42 +4422,16 @@ impl PaintVarScaleAroundCenterMarker {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarScaleAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarScaleAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarScaleAroundCenterMarker {})
-    }
-}
-
-/// [PaintVarScaleAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
-pub type PaintVarScaleAroundCenter<'a> = TableRef<'a, PaintVarScaleAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarScaleAroundCenter<'a> {
     /// Set to 19.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4485,34 +4444,34 @@ impl<'a> PaintVarScaleAroundCenter<'a> {
     /// Scale factor in x direction. For variation, use varIndexBase +
     /// 0.
     pub fn scale_x(&self) -> F2Dot14 {
-        let range = self.shape.scale_x_byte_range();
+        let range = self.scale_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
     pub fn scale_y(&self) -> F2Dot14 {
-        let range = self.shape.scale_y_byte_range();
+        let range = self.scale_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 3.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4556,24 +4515,7 @@ impl Format<u8> for PaintScaleUniformMarker {
 #[doc(hidden)]
 pub struct PaintScaleUniformMarker {}
 
-impl PaintScaleUniformMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn scale_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintScaleUniformMarker {
+impl<'a> MinByteRange for PaintScaleUniform<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.scale_byte_range().end
     }
@@ -4594,15 +4536,30 @@ pub type PaintScaleUniform<'a> = TableRef<'a, PaintScaleUniformMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintScaleUniform<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn scale_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
     /// Set to 20.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4614,7 +4571,7 @@ impl<'a> PaintScaleUniform<'a> {
 
     /// Scale factor in x and y directions.
     pub fn scale(&self) -> F2Dot14 {
-        let range = self.shape.scale_byte_range();
+        let range = self.scale_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4654,29 +4611,7 @@ impl Format<u8> for PaintVarScaleUniformMarker {
 #[doc(hidden)]
 pub struct PaintVarScaleUniformMarker {}
 
-impl PaintVarScaleUniformMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn scale_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-
-    pub fn var_index_base_byte_range(&self) -> Range<usize> {
-        let start = self.scale_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintVarScaleUniformMarker {
+impl<'a> MinByteRange for PaintVarScaleUniform<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.var_index_base_byte_range().end
     }
@@ -4698,15 +4633,35 @@ pub type PaintVarScaleUniform<'a> = TableRef<'a, PaintVarScaleUniformMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintVarScaleUniform<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn scale_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
+        let start = self.scale_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
     /// Set to 21.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4719,13 +4674,13 @@ impl<'a> PaintVarScaleUniform<'a> {
     /// Scale factor in x and y directions. For variation, use
     /// varIndexBase + 0.
     pub fn scale(&self) -> F2Dot14 {
-        let range = self.shape.scale_byte_range();
+        let range = self.scale_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4766,7 +4721,29 @@ impl Format<u8> for PaintScaleUniformAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintScaleUniformAroundCenterMarker {}
 
-impl PaintScaleUniformAroundCenterMarker {
+impl<'a> MinByteRange for PaintScaleUniformAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.center_y_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintScaleUniformAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.finish(PaintScaleUniformAroundCenterMarker {})
+    }
+}
+
+/// [PaintScaleUniformAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
+pub type PaintScaleUniformAroundCenter<'a> = TableRef<'a, PaintScaleUniformAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintScaleUniformAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -4791,40 +4768,16 @@ impl PaintScaleUniformAroundCenterMarker {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintScaleUniformAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.center_y_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintScaleUniformAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.finish(PaintScaleUniformAroundCenterMarker {})
-    }
-}
-
-/// [PaintScaleUniformAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
-pub type PaintScaleUniformAroundCenter<'a> = TableRef<'a, PaintScaleUniformAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintScaleUniformAroundCenter<'a> {
     /// Set to 22.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4836,19 +4789,19 @@ impl<'a> PaintScaleUniformAroundCenter<'a> {
 
     /// Scale factor in x and y directions.
     pub fn scale(&self) -> F2Dot14 {
-        let range = self.shape.scale_byte_range();
+        let range = self.scale_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of scaling.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of scaling.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4890,7 +4843,31 @@ impl Format<u8> for PaintVarScaleUniformAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintVarScaleUniformAroundCenterMarker {}
 
-impl PaintVarScaleUniformAroundCenterMarker {
+impl<'a> MinByteRange for PaintVarScaleUniformAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarScaleUniformAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarScaleUniformAroundCenterMarker {})
+    }
+}
+
+/// [PaintVarScaleUniformAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
+pub type PaintVarScaleUniformAroundCenter<'a> =
+    TableRef<'a, PaintVarScaleUniformAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -4920,42 +4897,16 @@ impl PaintVarScaleUniformAroundCenterMarker {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarScaleUniformAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarScaleUniformAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarScaleUniformAroundCenterMarker {})
-    }
-}
-
-/// [PaintVarScaleUniformAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-16-to-23-paintscale-and-variant-scaling-formats) table
-pub type PaintVarScaleUniformAroundCenter<'a> =
-    TableRef<'a, PaintVarScaleUniformAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     /// Set to 23.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -4968,27 +4919,27 @@ impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     /// Scale factor in x and y directions. For variation, use
     /// varIndexBase + 0.
     pub fn scale(&self) -> F2Dot14 {
-        let range = self.shape.scale_byte_range();
+        let range = self.scale_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 1.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5031,24 +4982,7 @@ impl Format<u8> for PaintRotateMarker {
 #[doc(hidden)]
 pub struct PaintRotateMarker {}
 
-impl PaintRotateMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn angle_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintRotateMarker {
+impl<'a> MinByteRange for PaintRotate<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.angle_byte_range().end
     }
@@ -5069,15 +5003,30 @@ pub type PaintRotate<'a> = TableRef<'a, PaintRotateMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintRotate<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn angle_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
     /// Set to 24.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5090,7 +5039,7 @@ impl<'a> PaintRotate<'a> {
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value.
     pub fn angle(&self) -> F2Dot14 {
-        let range = self.shape.angle_byte_range();
+        let range = self.angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5130,29 +5079,7 @@ impl Format<u8> for PaintVarRotateMarker {
 #[doc(hidden)]
 pub struct PaintVarRotateMarker {}
 
-impl PaintVarRotateMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn angle_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-
-    pub fn var_index_base_byte_range(&self) -> Range<usize> {
-        let start = self.angle_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintVarRotateMarker {
+impl<'a> MinByteRange for PaintVarRotate<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.var_index_base_byte_range().end
     }
@@ -5174,15 +5101,35 @@ pub type PaintVarRotate<'a> = TableRef<'a, PaintVarRotateMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintVarRotate<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn angle_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
+    pub fn var_index_base_byte_range(&self) -> Range<usize> {
+        let start = self.angle_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
     /// Set to 25.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5195,13 +5142,13 @@ impl<'a> PaintVarRotate<'a> {
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value. For variation, use varIndexBase + 0.
     pub fn angle(&self) -> F2Dot14 {
-        let range = self.shape.angle_byte_range();
+        let range = self.angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5242,7 +5189,29 @@ impl Format<u8> for PaintRotateAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintRotateAroundCenterMarker {}
 
-impl PaintRotateAroundCenterMarker {
+impl<'a> MinByteRange for PaintRotateAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.center_y_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintRotateAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.finish(PaintRotateAroundCenterMarker {})
+    }
+}
+
+/// [PaintRotateAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
+pub type PaintRotateAroundCenter<'a> = TableRef<'a, PaintRotateAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintRotateAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -5267,40 +5236,16 @@ impl PaintRotateAroundCenterMarker {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintRotateAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.center_y_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintRotateAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.finish(PaintRotateAroundCenterMarker {})
-    }
-}
-
-/// [PaintRotateAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
-pub type PaintRotateAroundCenter<'a> = TableRef<'a, PaintRotateAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintRotateAroundCenter<'a> {
     /// Set to 26.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5313,19 +5258,19 @@ impl<'a> PaintRotateAroundCenter<'a> {
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value.
     pub fn angle(&self) -> F2Dot14 {
-        let range = self.shape.angle_byte_range();
+        let range = self.angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of rotation.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of rotation.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5367,7 +5312,30 @@ impl Format<u8> for PaintVarRotateAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintVarRotateAroundCenterMarker {}
 
-impl PaintVarRotateAroundCenterMarker {
+impl<'a> MinByteRange for PaintVarRotateAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarRotateAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarRotateAroundCenterMarker {})
+    }
+}
+
+/// [PaintVarRotateAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
+pub type PaintVarRotateAroundCenter<'a> = TableRef<'a, PaintVarRotateAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarRotateAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -5397,41 +5365,16 @@ impl PaintVarRotateAroundCenterMarker {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarRotateAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarRotateAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarRotateAroundCenterMarker {})
-    }
-}
-
-/// [PaintVarRotateAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-24-to-27-paintrotate-paintvarrotate-paintrotatearoundcenter-paintvarrotatearoundcenter) table
-pub type PaintVarRotateAroundCenter<'a> = TableRef<'a, PaintVarRotateAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarRotateAroundCenter<'a> {
     /// Set to 27.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5444,27 +5387,27 @@ impl<'a> PaintVarRotateAroundCenter<'a> {
     /// Rotation angle, 180° in counter-clockwise degrees per 1.0 of
     /// value. For variation, use varIndexBase + 0.
     pub fn angle(&self) -> F2Dot14 {
-        let range = self.shape.angle_byte_range();
+        let range = self.angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 1.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5507,29 +5450,7 @@ impl Format<u8> for PaintSkewMarker {
 #[doc(hidden)]
 pub struct PaintSkewMarker {}
 
-impl PaintSkewMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
-        let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-
-    pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
-        let start = self.x_skew_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintSkewMarker {
+impl<'a> MinByteRange for PaintSkew<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.y_skew_angle_byte_range().end
     }
@@ -5551,15 +5472,35 @@ pub type PaintSkew<'a> = TableRef<'a, PaintSkewMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintSkew<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
+        let start = self.paint_offset_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
+    pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
+        let start = self.x_skew_angle_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
     /// Set to 28.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5572,14 +5513,14 @@ impl<'a> PaintSkew<'a> {
     /// Angle of skew in the direction of the x-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn x_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.x_skew_angle_byte_range();
+        let range = self.x_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn y_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.y_skew_angle_byte_range();
+        let range = self.y_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5620,7 +5561,29 @@ impl Format<u8> for PaintVarSkewMarker {
 #[doc(hidden)]
 pub struct PaintVarSkewMarker {}
 
-impl PaintVarSkewMarker {
+impl<'a> MinByteRange for PaintVarSkew<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarSkew<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarSkewMarker {})
+    }
+}
+
+/// [PaintVarSkew](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
+pub type PaintVarSkew<'a> = TableRef<'a, PaintVarSkewMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarSkew<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -5645,40 +5608,16 @@ impl PaintVarSkewMarker {
         let start = self.y_skew_angle_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarSkewMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarSkew<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarSkewMarker {})
-    }
-}
-
-/// [PaintVarSkew](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
-pub type PaintVarSkew<'a> = TableRef<'a, PaintVarSkewMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarSkew<'a> {
     /// Set to 29.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5692,7 +5631,7 @@ impl<'a> PaintVarSkew<'a> {
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 0.
     pub fn x_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.x_skew_angle_byte_range();
+        let range = self.x_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5700,13 +5639,13 @@ impl<'a> PaintVarSkew<'a> {
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 1.
     pub fn y_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.y_skew_angle_byte_range();
+        let range = self.y_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5748,7 +5687,30 @@ impl Format<u8> for PaintSkewAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintSkewAroundCenterMarker {}
 
-impl PaintSkewAroundCenterMarker {
+impl<'a> MinByteRange for PaintSkewAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.center_y_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintSkewAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.finish(PaintSkewAroundCenterMarker {})
+    }
+}
+
+/// [PaintSkewAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
+pub type PaintSkewAroundCenter<'a> = TableRef<'a, PaintSkewAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintSkewAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -5778,41 +5740,16 @@ impl PaintSkewAroundCenterMarker {
         let start = self.center_x_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintSkewAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.center_y_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintSkewAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.finish(PaintSkewAroundCenterMarker {})
-    }
-}
-
-/// [PaintSkewAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
-pub type PaintSkewAroundCenter<'a> = TableRef<'a, PaintSkewAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintSkewAroundCenter<'a> {
     /// Set to 30.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5825,26 +5762,26 @@ impl<'a> PaintSkewAroundCenter<'a> {
     /// Angle of skew in the direction of the x-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn x_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.x_skew_angle_byte_range();
+        let range = self.x_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn y_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.y_skew_angle_byte_range();
+        let range = self.y_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of rotation.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of rotation.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5887,7 +5824,31 @@ impl Format<u8> for PaintVarSkewAroundCenterMarker {
 #[doc(hidden)]
 pub struct PaintVarSkewAroundCenterMarker {}
 
-impl PaintVarSkewAroundCenterMarker {
+impl<'a> MinByteRange for PaintVarSkewAroundCenter<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.var_index_base_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for PaintVarSkewAroundCenter<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        cursor.advance::<Offset24>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<F2Dot14>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<u32>();
+        cursor.finish(PaintVarSkewAroundCenterMarker {})
+    }
+}
+
+/// [PaintVarSkewAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
+pub type PaintVarSkewAroundCenter<'a> = TableRef<'a, PaintVarSkewAroundCenterMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PaintVarSkewAroundCenter<'a> {
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -5922,42 +5883,16 @@ impl PaintVarSkewAroundCenterMarker {
         let start = self.center_y_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for PaintVarSkewAroundCenterMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.var_index_base_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PaintVarSkewAroundCenter<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        cursor.advance::<Offset24>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<u32>();
-        cursor.finish(PaintVarSkewAroundCenterMarker {})
-    }
-}
-
-/// [PaintVarSkewAroundCenter](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#formats-28-to-31-paintskew-paintvarskew-paintskewaroundcenter-paintvarskewaroundcenter) table
-pub type PaintVarSkewAroundCenter<'a> = TableRef<'a, PaintVarSkewAroundCenterMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PaintVarSkewAroundCenter<'a> {
     /// Set to 31.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
-        let range = self.shape.paint_offset_byte_range();
+        let range = self.paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5971,7 +5906,7 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 0.
     pub fn x_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.x_skew_angle_byte_range();
+        let range = self.x_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5979,27 +5914,27 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// counter-clockwise degrees per 1.0 of value. For variation, use
     /// varIndexBase + 1.
     pub fn y_skew_angle(&self) -> F2Dot14 {
-        let range = self.shape.y_skew_angle_byte_range();
+        let range = self.y_skew_angle_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
     pub fn center_x(&self) -> FWord {
-        let range = self.shape.center_x_byte_range();
+        let range = self.center_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 3.
     pub fn center_y(&self) -> FWord {
-        let range = self.shape.center_y_byte_range();
+        let range = self.center_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
-        let range = self.shape.var_index_base_byte_range();
+        let range = self.var_index_base_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -6043,29 +5978,7 @@ impl Format<u8> for PaintCompositeMarker {
 #[doc(hidden)]
 pub struct PaintCompositeMarker {}
 
-impl PaintCompositeMarker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn source_paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-
-    pub fn composite_mode_byte_range(&self) -> Range<usize> {
-        let start = self.source_paint_offset_byte_range().end;
-        start..start + CompositeMode::RAW_BYTE_LEN
-    }
-
-    pub fn backdrop_paint_offset_byte_range(&self) -> Range<usize> {
-        let start = self.composite_mode_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for PaintCompositeMarker {
+impl<'a> MinByteRange for PaintComposite<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.backdrop_paint_offset_byte_range().end
     }
@@ -6087,15 +6000,35 @@ pub type PaintComposite<'a> = TableRef<'a, PaintCompositeMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PaintComposite<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn source_paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
+    pub fn composite_mode_byte_range(&self) -> Range<usize> {
+        let start = self.source_paint_offset_byte_range().end;
+        start..start + CompositeMode::RAW_BYTE_LEN
+    }
+
+    pub fn backdrop_paint_offset_byte_range(&self) -> Range<usize> {
+        let start = self.composite_mode_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
     /// Set to 32.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a source Paint table.
     pub fn source_paint_offset(&self) -> Offset24 {
-        let range = self.shape.source_paint_offset_byte_range();
+        let range = self.source_paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -6107,13 +6040,13 @@ impl<'a> PaintComposite<'a> {
 
     /// A CompositeMode enumeration value.
     pub fn composite_mode(&self) -> CompositeMode {
-        let range = self.shape.composite_mode_byte_range();
+        let range = self.composite_mode_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to a backdrop Paint table.
     pub fn backdrop_paint_offset(&self) -> Offset24 {
-        let range = self.shape.backdrop_paint_offset_byte_range();
+        let range = self.backdrop_paint_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -113,32 +113,32 @@ impl<'a> Cpal<'a> {
     /// Table version number (=0).
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of palette entries in each palette.
     pub fn num_palette_entries(&self) -> u16 {
         let range = self.num_palette_entries_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of palettes in the table.
     pub fn num_palettes(&self) -> u16 {
         let range = self.num_palettes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Total number of color records, combined for all palettes.
     pub fn num_color_records(&self) -> u16 {
         let range = self.num_color_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the beginning of CPAL table to the first
     /// ColorRecord.
     pub fn color_records_array_offset(&self) -> Nullable<Offset32> {
         let range = self.color_records_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`color_records_array_offset`][Self::color_records_array_offset].
@@ -153,7 +153,7 @@ impl<'a> Cpal<'a> {
     /// color record array.
     pub fn color_record_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.color_record_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Offset from the beginning of CPAL table to the [Palette Types Array][].
@@ -163,7 +163,7 @@ impl<'a> Cpal<'a> {
     /// [Palette Types Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-type-array
     pub fn palette_types_array_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.palette_types_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`palette_types_array_offset`][Self::palette_types_array_offset].
@@ -183,7 +183,7 @@ impl<'a> Cpal<'a> {
     /// [Palette Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-labels-array
     pub fn palette_labels_array_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.palette_labels_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`palette_labels_array_offset`][Self::palette_labels_array_offset].
@@ -205,7 +205,7 @@ impl<'a> Cpal<'a> {
     /// [Palette Entry Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entry-label-array
     pub fn palette_entry_labels_array_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.palette_entry_labels_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`palette_entry_labels_array_offset`][Self::palette_entry_labels_array_offset].

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Cpal<'_> {
 impl<'a> FontRead<'a> for Cpal<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CpalMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -8,33 +8,9 @@ use crate::codegen_prelude::*;
 /// The [cvar](https://learn.microsoft.com/en-us/typography/opentype/spec/cvar) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CvarMarker {
-    tuple_variation_headers_byte_len: usize,
-}
+pub struct CvarMarker {}
 
-impl CvarMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn tuple_variation_count_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + TupleVariationCount::RAW_BYTE_LEN
-    }
-
-    pub fn data_offset_byte_range(&self) -> Range<usize> {
-        let start = self.tuple_variation_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
-        let start = self.data_offset_byte_range().end;
-        start..start + self.tuple_variation_headers_byte_len
-    }
-}
-
-impl MinByteRange for CvarMarker {
+impl<'a> MinByteRange for Cvar<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.tuple_variation_headers_byte_range().end
     }
@@ -53,9 +29,7 @@ impl<'a> FontRead<'a> for Cvar<'a> {
         cursor.advance::<Offset16>();
         let tuple_variation_headers_byte_len = cursor.remaining_bytes();
         cursor.advance_by(tuple_variation_headers_byte_len);
-        cursor.finish(CvarMarker {
-            tuple_variation_headers_byte_len,
-        })
+        cursor.finish(CvarMarker {})
     }
 }
 
@@ -64,9 +38,34 @@ pub type Cvar<'a> = TableRef<'a, CvarMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cvar<'a> {
+    fn tuple_variation_headers_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        self.data.len().saturating_sub(start)
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn tuple_variation_count_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + TupleVariationCount::RAW_BYTE_LEN
+    }
+
+    pub fn data_offset_byte_range(&self) -> Range<usize> {
+        let start = self.tuple_variation_count_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
+        let start = self.data_offset_byte_range().end;
+        start..start + self.tuple_variation_headers_byte_len(start)
+    }
+
     /// Major/minor version number of the CVT variations table — set to (1,0).
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -75,13 +74,13 @@ impl<'a> Cvar<'a> {
     /// number of tuple variation tables can be any number between 1
     /// and 4095.
     pub fn tuple_variation_count(&self) -> TupleVariationCount {
-        let range = self.shape.tuple_variation_count_byte_range();
+        let range = self.tuple_variation_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset from the start of the 'cvar' table to the serialized data.
     pub fn data_offset(&self) -> Offset16 {
-        let range = self.shape.data_offset_byte_range();
+        let range = self.data_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -93,7 +92,7 @@ impl<'a> Cvar<'a> {
 
     /// Array of tuple variation headers.
     pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader<'a>> {
-        let range = self.shape.tuple_variation_headers_byte_range();
+        let range = self.tuple_variation_headers_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
     }
 }

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Cvar<'_> {
 impl<'a> FontRead<'a> for Cvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -64,7 +64,7 @@ impl<'a> Cvar<'a> {
     /// Major/minor version number of the CVT variations table — set to (1,0).
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A packed field. The high 4 bits are flags, and the low 12 bits
@@ -73,13 +73,13 @@ impl<'a> Cvar<'a> {
     /// and 4095.
     pub fn tuple_variation_count(&self) -> TupleVariationCount {
         let range = self.tuple_variation_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the start of the 'cvar' table to the serialized data.
     pub fn data_offset(&self) -> Offset16 {
         let range = self.data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`data_offset`][Self::data_offset].
@@ -91,7 +91,7 @@ impl<'a> Cvar<'a> {
     /// Array of tuple variation headers.
     pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader<'a>> {
         let range = self.tuple_variation_headers_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 }
 

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [cvar](https://learn.microsoft.com/en-us/typography/opentype/spec/cvar) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CvarMarker {}
+pub struct CvarMarker;
 
 impl<'a> MinByteRange for Cvar<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,18 +23,16 @@ impl TopLevelTable for Cvar<'_> {
 
 impl<'a> FontRead<'a> for Cvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<TupleVariationCount>();
-        cursor.advance::<Offset16>();
-        let tuple_variation_headers_byte_len = cursor.remaining_bytes();
-        cursor.advance_by(tuple_variation_headers_byte_len);
-        cursor.finish(CvarMarker {})
+        Ok(TableRef {
+            shape: CvarMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [cvar](https://learn.microsoft.com/en-us/typography/opentype/spec/cvar) table.
-pub type Cvar<'a> = TableRef<'a, CvarMarker>;
+pub type Cvar<'a> = TableRef<'a, CvarMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Cvar<'a> {

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -66,25 +66,25 @@ impl<'a> Dsig<'a> {
     /// Version number of the DSIG table (0x00000001)
     pub fn version(&self) -> u32 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of signatures in the table
     pub fn num_signatures(&self) -> u16 {
         let range = self.num_signatures_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Permission flags
     pub fn flags(&self) -> PermissionFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of signature records
     pub fn signature_records(&self) -> &'a [SignatureRecord] {
         let range = self.signature_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -532,13 +532,13 @@ impl<'a> SignatureBlockFormat1<'a> {
     /// Length (in bytes) of the PKCS#7 packet in the signature field.
     pub fn signature_length(&self) -> u32 {
         let range = self.signature_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// PKCS#7 packet
     pub fn signature(&self) -> &'a [u8] {
         let range = self.signature_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -8,33 +8,9 @@ use crate::codegen_prelude::*;
 /// [DSIG (Digital Signature Table)](https://docs.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DsigMarker {
-    signature_records_byte_len: usize,
-}
+pub struct DsigMarker {}
 
-impl DsigMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn num_signatures_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn flags_byte_range(&self) -> Range<usize> {
-        let start = self.num_signatures_byte_range().end;
-        start..start + PermissionFlags::RAW_BYTE_LEN
-    }
-
-    pub fn signature_records_byte_range(&self) -> Range<usize> {
-        let start = self.flags_byte_range().end;
-        start..start + self.signature_records_byte_len
-    }
-}
-
-impl MinByteRange for DsigMarker {
+impl<'a> MinByteRange for Dsig<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.signature_records_byte_range().end
     }
@@ -55,9 +31,7 @@ impl<'a> FontRead<'a> for Dsig<'a> {
             .checked_mul(SignatureRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(signature_records_byte_len);
-        cursor.finish(DsigMarker {
-            signature_records_byte_len,
-        })
+        cursor.finish(DsigMarker {})
     }
 }
 
@@ -66,27 +40,54 @@ pub type Dsig<'a> = TableRef<'a, DsigMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Dsig<'a> {
+    fn signature_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_signatures()) as usize)
+            .checked_mul(SignatureRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn num_signatures_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
+        let start = self.num_signatures_byte_range().end;
+        start..start + PermissionFlags::RAW_BYTE_LEN
+    }
+
+    pub fn signature_records_byte_range(&self) -> Range<usize> {
+        let start = self.flags_byte_range().end;
+        start..start + self.signature_records_byte_len(start)
+    }
+
     /// Version number of the DSIG table (0x00000001)
     pub fn version(&self) -> u32 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of signatures in the table
     pub fn num_signatures(&self) -> u16 {
-        let range = self.shape.num_signatures_byte_range();
+        let range = self.num_signatures_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Permission flags
     pub fn flags(&self) -> PermissionFlags {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of signature records
     pub fn signature_records(&self) -> &'a [SignatureRecord] {
-        let range = self.shape.signature_records_byte_range();
+        let range = self.signature_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -482,11 +483,40 @@ impl<'a> SomeRecord<'a> for SignatureRecord {
 /// [Signature Block Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SignatureBlockFormat1Marker {
-    signature_byte_len: usize,
+pub struct SignatureBlockFormat1Marker {}
+
+impl<'a> MinByteRange for SignatureBlockFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.signature_byte_range().end
+    }
 }
 
-impl SignatureBlockFormat1Marker {
+impl<'a> FontRead<'a> for SignatureBlockFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let signature_length: u32 = cursor.read()?;
+        let signature_byte_len = (signature_length as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(signature_byte_len);
+        cursor.finish(SignatureBlockFormat1Marker {})
+    }
+}
+
+/// [Signature Block Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
+pub type SignatureBlockFormat1<'a> = TableRef<'a, SignatureBlockFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SignatureBlockFormat1<'a> {
+    fn signature_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.signature_length()) as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn _reserved1_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -504,44 +534,18 @@ impl SignatureBlockFormat1Marker {
 
     pub fn signature_byte_range(&self) -> Range<usize> {
         let start = self.signature_length_byte_range().end;
-        start..start + self.signature_byte_len
+        start..start + self.signature_byte_len(start)
     }
-}
 
-impl MinByteRange for SignatureBlockFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.signature_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SignatureBlockFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let signature_length: u32 = cursor.read()?;
-        let signature_byte_len = (signature_length as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(signature_byte_len);
-        cursor.finish(SignatureBlockFormat1Marker { signature_byte_len })
-    }
-}
-
-/// [Signature Block Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
-pub type SignatureBlockFormat1<'a> = TableRef<'a, SignatureBlockFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SignatureBlockFormat1<'a> {
     /// Length (in bytes) of the PKCS#7 packet in the signature field.
     pub fn signature_length(&self) -> u32 {
-        let range = self.shape.signature_length_byte_range();
+        let range = self.signature_length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// PKCS#7 packet
     pub fn signature(&self) -> &'a [u8] {
-        let range = self.shape.signature_byte_range();
+        let range = self.signature_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [DSIG (Digital Signature Table)](https://docs.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DsigMarker {}
+pub struct DsigMarker;
 
 impl<'a> MinByteRange for Dsig<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,20 +23,16 @@ impl TopLevelTable for Dsig<'_> {
 
 impl<'a> FontRead<'a> for Dsig<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        let num_signatures: u16 = cursor.read()?;
-        cursor.advance::<PermissionFlags>();
-        let signature_records_byte_len = (num_signatures as usize)
-            .checked_mul(SignatureRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(signature_records_byte_len);
-        cursor.finish(DsigMarker {})
+        Ok(TableRef {
+            shape: DsigMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [DSIG (Digital Signature Table)](https://docs.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure) table
-pub type Dsig<'a> = TableRef<'a, DsigMarker>;
+pub type Dsig<'a> = TableRef<'a, DsigMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Dsig<'a> {
@@ -483,7 +479,7 @@ impl<'a> SomeRecord<'a> for SignatureRecord {
 /// [Signature Block Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SignatureBlockFormat1Marker {}
+pub struct SignatureBlockFormat1Marker;
 
 impl<'a> MinByteRange for SignatureBlockFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -493,20 +489,16 @@ impl<'a> MinByteRange for SignatureBlockFormat1<'a> {
 
 impl<'a> FontRead<'a> for SignatureBlockFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let signature_length: u32 = cursor.read()?;
-        let signature_byte_len = (signature_length as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(signature_byte_len);
-        cursor.finish(SignatureBlockFormat1Marker {})
+        Ok(TableRef {
+            shape: SignatureBlockFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Signature Block Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/dsig#table-structure)
-pub type SignatureBlockFormat1<'a> = TableRef<'a, SignatureBlockFormat1Marker>;
+pub type SignatureBlockFormat1<'a> = TableRef<'a, SignatureBlockFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SignatureBlockFormat1<'a> {

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Dsig<'_> {
 impl<'a> FontRead<'a> for Dsig<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: DsigMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -490,9 +490,9 @@ impl<'a> MinByteRange for SignatureBlockFormat1<'a> {
 impl<'a> FontRead<'a> for SignatureBlockFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SignatureBlockFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -49,13 +49,13 @@ impl<'a> Ebdt<'a> {
     /// Major version of the EBDT table, = 2.
     pub fn major_version(&self) -> u16 {
         let range = self.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minor version of EBDT table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Ebdt<'_> {
 impl<'a> FontRead<'a> for Ebdt<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: EbdtMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [Embedded Bitmap Data](https://learn.microsoft.com/en-us/typography/opentype/spec/ebdt) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct EbdtMarker {}
+pub struct EbdtMarker;
 
 impl<'a> MinByteRange for Ebdt<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,15 +23,16 @@ impl TopLevelTable for Ebdt<'_> {
 
 impl<'a> FontRead<'a> for Ebdt<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.finish(EbdtMarker {})
+        Ok(TableRef {
+            shape: EbdtMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [Embedded Bitmap Data](https://learn.microsoft.com/en-us/typography/opentype/spec/ebdt) table
-pub type Ebdt<'a> = TableRef<'a, EbdtMarker>;
+pub type Ebdt<'a> = TableRef<'a, EbdtMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Ebdt<'a> {

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -10,19 +10,7 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct EbdtMarker {}
 
-impl EbdtMarker {
-    pub fn major_version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn minor_version_byte_range(&self) -> Range<usize> {
-        let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for EbdtMarker {
+impl<'a> MinByteRange for Ebdt<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.minor_version_byte_range().end
     }
@@ -47,15 +35,25 @@ pub type Ebdt<'a> = TableRef<'a, EbdtMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Ebdt<'a> {
+    pub fn major_version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn minor_version_byte_range(&self) -> Range<usize> {
+        let start = self.major_version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     /// Major version of the EBDT table, = 2.
     pub fn major_version(&self) -> u16 {
-        let range = self.shape.major_version_byte_range();
+        let range = self.major_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minor version of EBDT table, = 0.
     pub fn minor_version(&self) -> u16 {
-        let range = self.shape.minor_version_byte_range();
+        let range = self.minor_version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [Embedded Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct EblcMarker {}
+pub struct EblcMarker;
 
 impl<'a> MinByteRange for Eblc<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,20 +23,16 @@ impl TopLevelTable for Eblc<'_> {
 
 impl<'a> FontRead<'a> for Eblc<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let num_sizes: u32 = cursor.read()?;
-        let bitmap_sizes_byte_len = (num_sizes as usize)
-            .checked_mul(BitmapSize::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(bitmap_sizes_byte_len);
-        cursor.finish(EblcMarker {})
+        Ok(TableRef {
+            shape: EblcMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [Embedded Bitmap Location](https://learn.microsoft.com/en-us/typography/opentype/spec/eblc) table
-pub type Eblc<'a> = TableRef<'a, EblcMarker>;
+pub type Eblc<'a> = TableRef<'a, EblcMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Eblc<'a> {

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -66,25 +66,25 @@ impl<'a> Eblc<'a> {
     /// Major version of the EBLC table, = 2.
     pub fn major_version(&self) -> u16 {
         let range = self.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minor version of EBLC table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of BitmapSize records.
     pub fn num_sizes(&self) -> u32 {
         let range = self.num_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// BitmapSize records array.
     pub fn bitmap_sizes(&self) -> &'a [BitmapSize] {
         let range = self.bitmap_sizes_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Eblc<'_> {
 impl<'a> FontRead<'a> for Eblc<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: EblcMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -72,19 +72,19 @@ impl<'a> Feat<'a> {
     /// version).
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of entries in the feature name array.
     pub fn feature_name_count(&self) -> u16 {
         let range = self.feature_name_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The feature name array, sorted by feature type.
     pub fn names(&self) -> &'a [FeatureName] {
         let range = self.names_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -261,7 +261,7 @@ impl<'a> SettingNameArray<'a> {
     /// List of setting names for a feature.
     pub fn settings(&self) -> &'a [SettingName] {
         let range = self.settings_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn n_settings(&self) -> u16 {

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Feat<'_> {
 impl<'a> FontRead<'a> for Feat<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FeatMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -224,9 +224,9 @@ impl<'a> FontReadWithArgs<'a> for SettingNameArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: SettingNameArrayMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Fvar<'_> {
 impl<'a> FontRead<'a> for Fvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -173,9 +173,9 @@ impl<'a> FontReadWithArgs<'a> for AxisInstanceArrays<'a> {
     fn read_with_args(data: FontData<'a>, args: &(u16, u16, u16)) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: AxisInstanceArraysMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -75,14 +75,14 @@ impl<'a> Fvar<'a> {
     /// Minor version number of the font variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the beginning of the table to the start of the VariationAxisRecord array. The
     /// InstanceRecord array directly follows.
     pub fn axis_instance_arrays_offset(&self) -> Offset16 {
         let range = self.axis_instance_arrays_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`axis_instance_arrays_offset`][Self::axis_instance_arrays_offset].
@@ -100,25 +100,25 @@ impl<'a> Fvar<'a> {
     /// The number of variation axes in the font (the number of records in the axes array).
     pub fn axis_count(&self) -> u16 {
         let range = self.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The size in bytes of each VariationAxisRecord — set to 20 (0x0014) for this version.
     pub fn axis_size(&self) -> u16 {
         let range = self.axis_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of named instances defined in the font (the number of records in the instances array).
     pub fn instance_count(&self) -> u16 {
         let range = self.instance_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The size in bytes of each InstanceRecord — set to either axisCount * sizeof(Fixed) + 4, or to axisCount * sizeof(Fixed) + 6.
     pub fn instance_size(&self) -> u16 {
         let range = self.instance_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -229,15 +229,13 @@ impl<'a> AxisInstanceArrays<'a> {
     /// Variation axis record array.
     pub fn axes(&self) -> &'a [VariationAxisRecord] {
         let range = self.axes_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Instance record array.
     pub fn instances(&self) -> ComputedArray<'a, InstanceRecord<'a>> {
         let range = self.instances_byte_range();
-        self.data
-            .read_with_args(range, &(self.axis_count(), self.instance_size()))
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &(self.axis_count(), self.instance_size()))
     }
 
     pub(crate) fn axis_count(&self) -> u16 {

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [gasp](https://learn.microsoft.com/en-us/typography/opentype/spec/gasp#gasp-table-formats)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GaspMarker {}
+pub struct GaspMarker;
 
 impl<'a> MinByteRange for Gasp<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,19 +23,16 @@ impl TopLevelTable for Gasp<'_> {
 
 impl<'a> FontRead<'a> for Gasp<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let num_ranges: u16 = cursor.read()?;
-        let gasp_ranges_byte_len = (num_ranges as usize)
-            .checked_mul(GaspRange::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(gasp_ranges_byte_len);
-        cursor.finish(GaspMarker {})
+        Ok(TableRef {
+            shape: GaspMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [gasp](https://learn.microsoft.com/en-us/typography/opentype/spec/gasp#gasp-table-formats)
-pub type Gasp<'a> = TableRef<'a, GaspMarker>;
+pub type Gasp<'a> = TableRef<'a, GaspMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gasp<'a> {

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -61,19 +61,19 @@ impl<'a> Gasp<'a> {
     /// Version number (set to 1)
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of records to follow
     pub fn num_ranges(&self) -> u16 {
         let range = self.num_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Sorted by ppem
     pub fn gasp_ranges(&self) -> &'a [GaspRange] {
         let range = self.gasp_ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -8,28 +8,9 @@ use crate::codegen_prelude::*;
 /// [gasp](https://learn.microsoft.com/en-us/typography/opentype/spec/gasp#gasp-table-formats)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GaspMarker {
-    gasp_ranges_byte_len: usize,
-}
+pub struct GaspMarker {}
 
-impl GaspMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn num_ranges_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn gasp_ranges_byte_range(&self) -> Range<usize> {
-        let start = self.num_ranges_byte_range().end;
-        start..start + self.gasp_ranges_byte_len
-    }
-}
-
-impl MinByteRange for GaspMarker {
+impl<'a> MinByteRange for Gasp<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.gasp_ranges_byte_range().end
     }
@@ -49,9 +30,7 @@ impl<'a> FontRead<'a> for Gasp<'a> {
             .checked_mul(GaspRange::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(gasp_ranges_byte_len);
-        cursor.finish(GaspMarker {
-            gasp_ranges_byte_len,
-        })
+        cursor.finish(GaspMarker {})
     }
 }
 
@@ -60,21 +39,43 @@ pub type Gasp<'a> = TableRef<'a, GaspMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gasp<'a> {
+    fn gasp_ranges_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_ranges()) as usize)
+            .checked_mul(GaspRange::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn num_ranges_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn gasp_ranges_byte_range(&self) -> Range<usize> {
+        let start = self.num_ranges_byte_range().end;
+        start..start + self.gasp_ranges_byte_len(start)
+    }
+
     /// Version number (set to 1)
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of records to follow
     pub fn num_ranges(&self) -> u16 {
-        let range = self.shape.num_ranges_byte_range();
+        let range = self.num_ranges_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Sorted by ppem
     pub fn gasp_ranges(&self) -> &'a [GaspRange] {
-        let range = self.shape.gasp_ranges_byte_range();
+        let range = self.gasp_ranges_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Gasp<'_> {
 impl<'a> FontRead<'a> for Gasp<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GaspMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -85,14 +85,14 @@ impl<'a> Gdef<'a> {
     /// The major/minor version of the GDEF table
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
     pub fn glyph_class_def_offset(&self) -> Nullable<Offset16> {
         let range = self.glyph_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`glyph_class_def_offset`][Self::glyph_class_def_offset].
@@ -105,7 +105,7 @@ impl<'a> Gdef<'a> {
     /// header (may be NULL)
     pub fn attach_list_offset(&self) -> Nullable<Offset16> {
         let range = self.attach_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`attach_list_offset`][Self::attach_list_offset].
@@ -118,7 +118,7 @@ impl<'a> Gdef<'a> {
     /// header (may be NULL)
     pub fn lig_caret_list_offset(&self) -> Nullable<Offset16> {
         let range = self.lig_caret_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`lig_caret_list_offset`][Self::lig_caret_list_offset].
@@ -131,7 +131,7 @@ impl<'a> Gdef<'a> {
     /// beginning of GDEF header (may be NULL)
     pub fn mark_attach_class_def_offset(&self) -> Nullable<Offset16> {
         let range = self.mark_attach_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark_attach_class_def_offset`][Self::mark_attach_class_def_offset].
@@ -144,7 +144,7 @@ impl<'a> Gdef<'a> {
     /// beginning of GDEF header (may be NULL)
     pub fn mark_glyph_sets_def_offset(&self) -> Option<Nullable<Offset16>> {
         let range = self.mark_glyph_sets_def_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`mark_glyph_sets_def_offset`][Self::mark_glyph_sets_def_offset].
@@ -157,7 +157,7 @@ impl<'a> Gdef<'a> {
     /// GDEF header (may be NULL)
     pub fn item_var_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.item_var_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`item_var_store_offset`][Self::item_var_store_offset].
@@ -319,7 +319,7 @@ impl<'a> AttachList<'a> {
     /// Offset to Coverage table - from beginning of AttachList table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -331,14 +331,14 @@ impl<'a> AttachList<'a> {
     /// Number of glyphs with attachment points
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to AttachPoint tables-from beginning of
     /// AttachList table-in Coverage Index order
     pub fn attach_point_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.attach_point_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`attach_point_offsets`][Self::attach_point_offsets].
@@ -434,13 +434,13 @@ impl<'a> AttachPoint<'a> {
     /// Number of attachment points on this glyph
     pub fn point_count(&self) -> u16 {
         let range = self.point_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of contour point indices -in increasing numerical order
     pub fn point_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.point_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -517,7 +517,7 @@ impl<'a> LigCaretList<'a> {
     /// Offset to Coverage table - from beginning of LigCaretList table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -529,14 +529,14 @@ impl<'a> LigCaretList<'a> {
     /// Number of ligature glyphs
     pub fn lig_glyph_count(&self) -> u16 {
         let range = self.lig_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to LigGlyph tables, from beginning of
     /// LigCaretList table —in Coverage Index order
     pub fn lig_glyph_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.lig_glyph_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`lig_glyph_offsets`][Self::lig_glyph_offsets].
@@ -632,14 +632,14 @@ impl<'a> LigGlyph<'a> {
     /// Number of CaretValue tables for this ligature (components - 1)
     pub fn caret_count(&self) -> u16 {
         let range = self.caret_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
     pub fn caret_value_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.caret_value_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`caret_value_offsets`][Self::caret_value_offsets].
@@ -806,13 +806,13 @@ impl<'a> CaretValueFormat1<'a> {
     /// Format identifier: format = 1
     pub fn caret_value_format(&self) -> u16 {
         let range = self.caret_value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -881,13 +881,13 @@ impl<'a> CaretValueFormat2<'a> {
     /// Format identifier: format = 2
     pub fn caret_value_format(&self) -> u16 {
         let range = self.caret_value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Contour point index on glyph
     pub fn caret_value_point_index(&self) -> u16 {
         let range = self.caret_value_point_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -964,13 +964,13 @@ impl<'a> CaretValueFormat3<'a> {
     /// Format identifier-format = 3
     pub fn caret_value_format(&self) -> u16 {
         let range = self.caret_value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Device table (non-variable font) / Variation Index
@@ -978,7 +978,7 @@ impl<'a> CaretValueFormat3<'a> {
     /// CaretValue table
     pub fn device_offset(&self) -> Offset16 {
         let range = self.device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].
@@ -1069,20 +1069,20 @@ impl<'a> MarkGlyphSets<'a> {
     /// Format identifier == 1
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of mark glyph sets defined
     pub fn mark_glyph_set_count(&self) -> u16 {
         let range = self.mark_glyph_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.
     pub fn coverage_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Gdef<'_> {
 impl<'a> FontRead<'a> for Gdef<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GdefMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -282,9 +282,9 @@ impl<'a> MinByteRange for AttachList<'a> {
 impl<'a> FontRead<'a> for AttachList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AttachListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -402,9 +402,9 @@ impl<'a> MinByteRange for AttachPoint<'a> {
 impl<'a> FontRead<'a> for AttachPoint<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AttachPointMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -480,9 +480,9 @@ impl<'a> MinByteRange for LigCaretList<'a> {
 impl<'a> FontRead<'a> for LigCaretList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LigCaretListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -600,9 +600,9 @@ impl<'a> MinByteRange for LigGlyph<'a> {
 impl<'a> FontRead<'a> for LigGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LigGlyphMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -781,9 +781,9 @@ impl<'a> MinByteRange for CaretValueFormat1<'a> {
 impl<'a> FontRead<'a> for CaretValueFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CaretValueFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -856,9 +856,9 @@ impl<'a> MinByteRange for CaretValueFormat2<'a> {
 impl<'a> FontRead<'a> for CaretValueFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CaretValueFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -934,9 +934,9 @@ impl<'a> MinByteRange for CaretValueFormat3<'a> {
 impl<'a> FontRead<'a> for CaretValueFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CaretValueFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1032,9 +1032,9 @@ impl<'a> MinByteRange for MarkGlyphSets<'a> {
 impl<'a> FontRead<'a> for MarkGlyphSets<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MarkGlyphSetsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [glyf (Glyph Data)](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GlyfMarker {}
+pub struct GlyfMarker;
 
 impl TopLevelTable for Glyf<'_> {
     /// `glyf`
@@ -17,13 +17,16 @@ impl TopLevelTable for Glyf<'_> {
 
 impl<'a> FontRead<'a> for Glyf<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let cursor = data.cursor();
-        cursor.finish(GlyfMarker {})
+        Ok(TableRef {
+            shape: GlyfMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [glyf (Glyph Data)](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf) table
-pub type Glyf<'a> = TableRef<'a, GlyfMarker>;
+pub type Glyf<'a> = TableRef<'a, GlyfMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Glyf<'a> {}
@@ -54,7 +57,7 @@ impl<'a> std::fmt::Debug for Glyf<'a> {
 /// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SimpleGlyphMarker {}
+pub struct SimpleGlyphMarker;
 
 impl<'a> MinByteRange for SimpleGlyph<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -64,29 +67,16 @@ impl<'a> MinByteRange for SimpleGlyph<'a> {
 
 impl<'a> FontRead<'a> for SimpleGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let number_of_contours: i16 = cursor.read()?;
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        let end_pts_of_contours_byte_len = (number_of_contours as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(end_pts_of_contours_byte_len);
-        let instruction_length: u16 = cursor.read()?;
-        let instructions_byte_len = (instruction_length as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(instructions_byte_len);
-        let glyph_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(glyph_data_byte_len);
-        cursor.finish(SimpleGlyphMarker {})
+        Ok(TableRef {
+            shape: SimpleGlyphMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
-pub type SimpleGlyph<'a> = TableRef<'a, SimpleGlyphMarker>;
+pub type SimpleGlyph<'a> = TableRef<'a, SimpleGlyphMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SimpleGlyph<'a> {
@@ -648,7 +638,7 @@ impl<'a> From<SimpleGlyphFlags> for FieldType<'a> {
 /// [CompositeGlyph](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CompositeGlyphMarker {}
+pub struct CompositeGlyphMarker;
 
 impl<'a> MinByteRange for CompositeGlyph<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -658,21 +648,16 @@ impl<'a> MinByteRange for CompositeGlyph<'a> {
 
 impl<'a> FontRead<'a> for CompositeGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        let component_data_byte_len =
-            cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(component_data_byte_len);
-        cursor.finish(CompositeGlyphMarker {})
+        Ok(TableRef {
+            shape: CompositeGlyphMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [CompositeGlyph](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
-pub type CompositeGlyph<'a> = TableRef<'a, CompositeGlyphMarker>;
+pub type CompositeGlyph<'a> = TableRef<'a, CompositeGlyphMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CompositeGlyph<'a> {

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -10,8 +10,6 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct GlyfMarker {}
 
-impl GlyfMarker {}
-
 impl TopLevelTable for Glyf<'_> {
     /// `glyf`
     const TAG: Tag = Tag::new(b"glyf");
@@ -56,13 +54,62 @@ impl<'a> std::fmt::Debug for Glyf<'a> {
 /// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SimpleGlyphMarker {
-    end_pts_of_contours_byte_len: usize,
-    instructions_byte_len: usize,
-    glyph_data_byte_len: usize,
+pub struct SimpleGlyphMarker {}
+
+impl<'a> MinByteRange for SimpleGlyph<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_data_byte_range().end
+    }
 }
 
-impl SimpleGlyphMarker {
+impl<'a> FontRead<'a> for SimpleGlyph<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let number_of_contours: i16 = cursor.read()?;
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        let end_pts_of_contours_byte_len = (number_of_contours as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(end_pts_of_contours_byte_len);
+        let instruction_length: u16 = cursor.read()?;
+        let instructions_byte_len = (instruction_length as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(instructions_byte_len);
+        let glyph_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(glyph_data_byte_len);
+        cursor.finish(SimpleGlyphMarker {})
+    }
+}
+
+/// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
+pub type SimpleGlyph<'a> = TableRef<'a, SimpleGlyphMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SimpleGlyph<'a> {
+    fn end_pts_of_contours_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.number_of_contours()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn instructions_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.instruction_length()) as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn glyph_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn number_of_contours_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + i16::RAW_BYTE_LEN
@@ -90,7 +137,7 @@ impl SimpleGlyphMarker {
 
     pub fn end_pts_of_contours_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
-        start..start + self.end_pts_of_contours_byte_len
+        start..start + self.end_pts_of_contours_byte_len(start)
     }
 
     pub fn instruction_length_byte_range(&self) -> Range<usize> {
@@ -100,89 +147,50 @@ impl SimpleGlyphMarker {
 
     pub fn instructions_byte_range(&self) -> Range<usize> {
         let start = self.instruction_length_byte_range().end;
-        start..start + self.instructions_byte_len
+        start..start + self.instructions_byte_len(start)
     }
 
     pub fn glyph_data_byte_range(&self) -> Range<usize> {
         let start = self.instructions_byte_range().end;
-        start..start + self.glyph_data_byte_len
+        start..start + self.glyph_data_byte_len(start)
     }
-}
 
-impl MinByteRange for SimpleGlyphMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.glyph_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SimpleGlyph<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let number_of_contours: i16 = cursor.read()?;
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        let end_pts_of_contours_byte_len = (number_of_contours as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(end_pts_of_contours_byte_len);
-        let instruction_length: u16 = cursor.read()?;
-        let instructions_byte_len = (instruction_length as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(instructions_byte_len);
-        let glyph_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(glyph_data_byte_len);
-        cursor.finish(SimpleGlyphMarker {
-            end_pts_of_contours_byte_len,
-            instructions_byte_len,
-            glyph_data_byte_len,
-        })
-    }
-}
-
-/// The [Glyph Header](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
-pub type SimpleGlyph<'a> = TableRef<'a, SimpleGlyphMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SimpleGlyph<'a> {
     /// If the number of contours is greater than or equal to zero,
     /// this is a simple glyph. If negative, this is a composite glyph
     /// — the value -1 should be used for composite glyphs.
     pub fn number_of_contours(&self) -> i16 {
-        let range = self.shape.number_of_contours_byte_range();
+        let range = self.number_of_contours_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum x for coordinate data.
     pub fn x_min(&self) -> i16 {
-        let range = self.shape.x_min_byte_range();
+        let range = self.x_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum y for coordinate data.
     pub fn y_min(&self) -> i16 {
-        let range = self.shape.y_min_byte_range();
+        let range = self.y_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum x for coordinate data.
     pub fn x_max(&self) -> i16 {
-        let range = self.shape.x_max_byte_range();
+        let range = self.x_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum y for coordinate data.
     pub fn y_max(&self) -> i16 {
-        let range = self.shape.y_max_byte_range();
+        let range = self.y_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of point indices for the last point of each contour,
     /// in increasing numeric order
     pub fn end_pts_of_contours(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.end_pts_of_contours_byte_range();
+        let range = self.end_pts_of_contours_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -190,19 +198,19 @@ impl<'a> SimpleGlyph<'a> {
     /// zero, no instructions are present for this glyph, and this
     /// field is followed directly by the flags field.
     pub fn instruction_length(&self) -> u16 {
-        let range = self.shape.instruction_length_byte_range();
+        let range = self.instruction_length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of instruction byte code for the glyph.
     pub fn instructions(&self) -> &'a [u8] {
-        let range = self.shape.instructions_byte_range();
+        let range = self.instructions_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// the raw data for flags & x/y coordinates
     pub fn glyph_data(&self) -> &'a [u8] {
-        let range = self.shape.glyph_data_byte_range();
+        let range = self.glyph_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -640,11 +648,42 @@ impl<'a> From<SimpleGlyphFlags> for FieldType<'a> {
 /// [CompositeGlyph](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CompositeGlyphMarker {
-    component_data_byte_len: usize,
+pub struct CompositeGlyphMarker {}
+
+impl<'a> MinByteRange for CompositeGlyph<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.component_data_byte_range().end
+    }
 }
 
-impl CompositeGlyphMarker {
+impl<'a> FontRead<'a> for CompositeGlyph<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        let component_data_byte_len =
+            cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(component_data_byte_len);
+        cursor.finish(CompositeGlyphMarker {})
+    }
+}
+
+/// [CompositeGlyph](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
+pub type CompositeGlyph<'a> = TableRef<'a, CompositeGlyphMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> CompositeGlyph<'a> {
+    fn component_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn number_of_contours_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + i16::RAW_BYTE_LEN
@@ -672,74 +711,45 @@ impl CompositeGlyphMarker {
 
     pub fn component_data_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
-        start..start + self.component_data_byte_len
+        start..start + self.component_data_byte_len(start)
     }
-}
 
-impl MinByteRange for CompositeGlyphMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.component_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for CompositeGlyph<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        let component_data_byte_len =
-            cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(component_data_byte_len);
-        cursor.finish(CompositeGlyphMarker {
-            component_data_byte_len,
-        })
-    }
-}
-
-/// [CompositeGlyph](https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#glyph-headers)
-pub type CompositeGlyph<'a> = TableRef<'a, CompositeGlyphMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> CompositeGlyph<'a> {
     /// If the number of contours is greater than or equal to zero,
     /// this is a simple glyph. If negative, this is a composite glyph
     /// — the value -1 should be used for composite glyphs.
     pub fn number_of_contours(&self) -> i16 {
-        let range = self.shape.number_of_contours_byte_range();
+        let range = self.number_of_contours_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum x for coordinate data.
     pub fn x_min(&self) -> i16 {
-        let range = self.shape.x_min_byte_range();
+        let range = self.x_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum y for coordinate data.
     pub fn y_min(&self) -> i16 {
-        let range = self.shape.y_min_byte_range();
+        let range = self.y_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum x for coordinate data.
     pub fn x_max(&self) -> i16 {
-        let range = self.shape.x_max_byte_range();
+        let range = self.x_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum y for coordinate data.
     pub fn y_max(&self) -> i16 {
-        let range = self.shape.y_max_byte_range();
+        let range = self.y_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// component flag
     /// glyph index of component
     pub fn component_data(&self) -> &'a [u8] {
-        let range = self.shape.component_data_byte_range();
+        let range = self.component_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -18,9 +18,9 @@ impl TopLevelTable for Glyf<'_> {
 impl<'a> FontRead<'a> for Glyf<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GlyfMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -68,9 +68,9 @@ impl<'a> MinByteRange for SimpleGlyph<'a> {
 impl<'a> FontRead<'a> for SimpleGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SimpleGlyphMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -649,9 +649,9 @@ impl<'a> MinByteRange for CompositeGlyph<'a> {
 impl<'a> FontRead<'a> for CompositeGlyph<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CompositeGlyphMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -150,38 +150,38 @@ impl<'a> SimpleGlyph<'a> {
     /// — the value -1 should be used for composite glyphs.
     pub fn number_of_contours(&self) -> i16 {
         let range = self.number_of_contours_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum x for coordinate data.
     pub fn x_min(&self) -> i16 {
         let range = self.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum y for coordinate data.
     pub fn y_min(&self) -> i16 {
         let range = self.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum x for coordinate data.
     pub fn x_max(&self) -> i16 {
         let range = self.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum y for coordinate data.
     pub fn y_max(&self) -> i16 {
         let range = self.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of point indices for the last point of each contour,
     /// in increasing numeric order
     pub fn end_pts_of_contours(&self) -> &'a [BigEndian<u16>] {
         let range = self.end_pts_of_contours_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Total number of bytes for instructions. If instructionLength is
@@ -189,19 +189,19 @@ impl<'a> SimpleGlyph<'a> {
     /// field is followed directly by the flags field.
     pub fn instruction_length(&self) -> u16 {
         let range = self.instruction_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of instruction byte code for the glyph.
     pub fn instructions(&self) -> &'a [u8] {
         let range = self.instructions_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// the raw data for flags & x/y coordinates
     pub fn glyph_data(&self) -> &'a [u8] {
         let range = self.glyph_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -704,38 +704,38 @@ impl<'a> CompositeGlyph<'a> {
     /// — the value -1 should be used for composite glyphs.
     pub fn number_of_contours(&self) -> i16 {
         let range = self.number_of_contours_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum x for coordinate data.
     pub fn x_min(&self) -> i16 {
         let range = self.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum y for coordinate data.
     pub fn y_min(&self) -> i16 {
         let range = self.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum x for coordinate data.
     pub fn x_max(&self) -> i16 {
         let range = self.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum y for coordinate data.
     pub fn y_max(&self) -> i16 {
         let range = self.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// component flag
     /// glyph index of component
     pub fn component_data(&self) -> &'a [u8] {
         let range = self.component_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -13,34 +13,7 @@ pub struct GposMarker {
     feature_variations_offset_byte_start: Option<usize>,
 }
 
-impl GposMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn script_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.script_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.feature_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.feature_variations_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for GposMarker {
+impl<'a> MinByteRange for Gpos<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.lookup_list_offset_byte_range().end
     }
@@ -77,15 +50,40 @@ pub type Gpos<'a> = TableRef<'a, GposMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gpos<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn script_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.script_list_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.feature_list_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.feature_variations_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to ScriptList table, from beginning of GPOS table
     pub fn script_list_offset(&self) -> Offset16 {
-        let range = self.shape.script_list_offset_byte_range();
+        let range = self.script_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -97,7 +95,7 @@ impl<'a> Gpos<'a> {
 
     /// Offset to FeatureList table, from beginning of GPOS table
     pub fn feature_list_offset(&self) -> Offset16 {
-        let range = self.shape.feature_list_offset_byte_range();
+        let range = self.feature_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -109,7 +107,7 @@ impl<'a> Gpos<'a> {
 
     /// Offset to LookupList table, from beginning of GPOS table
     pub fn lookup_list_offset(&self) -> Offset16 {
-        let range = self.shape.lookup_list_offset_byte_range();
+        let range = self.lookup_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -120,7 +118,7 @@ impl<'a> Gpos<'a> {
     }
 
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.feature_variations_offset_byte_range()?;
+        let range = self.feature_variations_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -706,24 +704,7 @@ impl Format<u16> for AnchorFormat1Marker {
 #[doc(hidden)]
 pub struct AnchorFormat1Marker {}
 
-impl AnchorFormat1Marker {
-    pub fn anchor_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.anchor_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.x_coordinate_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for AnchorFormat1Marker {
+impl<'a> MinByteRange for AnchorFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.y_coordinate_byte_range().end
     }
@@ -744,21 +725,36 @@ pub type AnchorFormat1<'a> = TableRef<'a, AnchorFormat1Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat1<'a> {
+    pub fn anchor_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.anchor_format_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.x_coordinate_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
     /// Format identifier, = 1
     pub fn anchor_format(&self) -> u16 {
-        let range = self.shape.anchor_format_byte_range();
+        let range = self.anchor_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
-        let range = self.shape.x_coordinate_byte_range();
+        let range = self.x_coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
-        let range = self.shape.y_coordinate_byte_range();
+        let range = self.y_coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -795,29 +791,7 @@ impl Format<u16> for AnchorFormat2Marker {
 #[doc(hidden)]
 pub struct AnchorFormat2Marker {}
 
-impl AnchorFormat2Marker {
-    pub fn anchor_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.anchor_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
-        let start = self.x_coordinate_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn anchor_point_byte_range(&self) -> Range<usize> {
-        let start = self.y_coordinate_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for AnchorFormat2Marker {
+impl<'a> MinByteRange for AnchorFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.anchor_point_byte_range().end
     }
@@ -839,27 +813,47 @@ pub type AnchorFormat2<'a> = TableRef<'a, AnchorFormat2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat2<'a> {
+    pub fn anchor_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn x_coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.anchor_format_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_coordinate_byte_range(&self) -> Range<usize> {
+        let start = self.x_coordinate_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn anchor_point_byte_range(&self) -> Range<usize> {
+        let start = self.y_coordinate_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     /// Format identifier, = 2
     pub fn anchor_format(&self) -> u16 {
-        let range = self.shape.anchor_format_byte_range();
+        let range = self.anchor_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
-        let range = self.shape.x_coordinate_byte_range();
+        let range = self.x_coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
-        let range = self.shape.y_coordinate_byte_range();
+        let range = self.y_coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Index to glyph contour point
     pub fn anchor_point(&self) -> u16 {
-        let range = self.shape.anchor_point_byte_range();
+        let range = self.anchor_point_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -897,7 +891,29 @@ impl Format<u16> for AnchorFormat3Marker {
 #[doc(hidden)]
 pub struct AnchorFormat3Marker {}
 
-impl AnchorFormat3Marker {
+impl<'a> MinByteRange for AnchorFormat3<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.y_device_offset_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for AnchorFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.finish(AnchorFormat3Marker {})
+    }
+}
+
+/// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
+pub type AnchorFormat3<'a> = TableRef<'a, AnchorFormat3Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> AnchorFormat3<'a> {
     pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -922,46 +938,22 @@ impl AnchorFormat3Marker {
         let start = self.x_device_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for AnchorFormat3Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.y_device_offset_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for AnchorFormat3<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(AnchorFormat3Marker {})
-    }
-}
-
-/// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
-pub type AnchorFormat3<'a> = TableRef<'a, AnchorFormat3Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> AnchorFormat3<'a> {
     /// Format identifier, = 3
     pub fn anchor_format(&self) -> u16 {
-        let range = self.shape.anchor_format_byte_range();
+        let range = self.anchor_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
-        let range = self.shape.x_coordinate_byte_range();
+        let range = self.x_coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
-        let range = self.shape.y_coordinate_byte_range();
+        let range = self.y_coordinate_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -969,7 +961,7 @@ impl<'a> AnchorFormat3<'a> {
     /// table (variable font) for X coordinate, from beginning of
     /// Anchor table (may be NULL)
     pub fn x_device_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.x_device_offset_byte_range();
+        let range = self.x_device_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -983,7 +975,7 @@ impl<'a> AnchorFormat3<'a> {
     /// table (variable font) for Y coordinate, from beginning of
     /// Anchor table (may be NULL)
     pub fn y_device_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.y_device_offset_byte_range();
+        let range = self.y_device_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1028,23 +1020,9 @@ impl<'a> std::fmt::Debug for AnchorFormat3<'a> {
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MarkArrayMarker {
-    mark_records_byte_len: usize,
-}
+pub struct MarkArrayMarker {}
 
-impl MarkArrayMarker {
-    pub fn mark_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn mark_records_byte_range(&self) -> Range<usize> {
-        let start = self.mark_count_byte_range().end;
-        start..start + self.mark_records_byte_len
-    }
-}
-
-impl MinByteRange for MarkArrayMarker {
+impl<'a> MinByteRange for MarkArray<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.mark_records_byte_range().end
     }
@@ -1058,9 +1036,7 @@ impl<'a> FontRead<'a> for MarkArray<'a> {
             .checked_mul(MarkRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(mark_records_byte_len);
-        cursor.finish(MarkArrayMarker {
-            mark_records_byte_len,
-        })
+        cursor.finish(MarkArrayMarker {})
     }
 }
 
@@ -1069,16 +1045,33 @@ pub type MarkArray<'a> = TableRef<'a, MarkArrayMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkArray<'a> {
+    fn mark_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.mark_count()) as usize)
+            .checked_mul(MarkRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn mark_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn mark_records_byte_range(&self) -> Range<usize> {
+        let start = self.mark_count_byte_range().end;
+        start..start + self.mark_records_byte_len(start)
+    }
+
     /// Number of MarkRecords
     pub fn mark_count(&self) -> u16 {
-        let range = self.shape.mark_count_byte_range();
+        let range = self.mark_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
     pub fn mark_records(&self) -> &'a [MarkRecord] {
-        let range = self.shape.mark_records_byte_range();
+        let range = self.mark_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1260,11 +1253,36 @@ impl Format<u16> for SinglePosFormat1Marker {
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SinglePosFormat1Marker {
-    value_record_byte_len: usize,
+pub struct SinglePosFormat1Marker {}
+
+impl<'a> MinByteRange for SinglePosFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.value_record_byte_range().end
+    }
 }
 
-impl SinglePosFormat1Marker {
+impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let value_format: ValueFormat = cursor.read()?;
+        let value_record_byte_len = <ValueRecord as ComputeSize>::compute_size(&value_format)?;
+        cursor.advance_by(value_record_byte_len);
+        cursor.finish(SinglePosFormat1Marker {})
+    }
+}
+
+/// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
+pub type SinglePosFormat1<'a> = TableRef<'a, SinglePosFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SinglePosFormat1<'a> {
+    fn value_record_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap()
+    }
+
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1282,44 +1300,18 @@ impl SinglePosFormat1Marker {
 
     pub fn value_record_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
-        start..start + self.value_record_byte_len
+        start..start + self.value_record_byte_len(start)
     }
-}
 
-impl MinByteRange for SinglePosFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.value_record_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let value_format: ValueFormat = cursor.read()?;
-        let value_record_byte_len = <ValueRecord as ComputeSize>::compute_size(&value_format)?;
-        cursor.advance_by(value_record_byte_len);
-        cursor.finish(SinglePosFormat1Marker {
-            value_record_byte_len,
-        })
-    }
-}
-
-/// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
-pub type SinglePosFormat1<'a> = TableRef<'a, SinglePosFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SinglePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1331,14 +1323,14 @@ impl<'a> SinglePosFormat1<'a> {
 
     /// Defines the types of data in the ValueRecord.
     pub fn value_format(&self) -> ValueFormat {
-        let range = self.shape.value_format_byte_range();
+        let range = self.value_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Defines positioning value(s) — applied to all glyphs in the
     /// Coverage table.
     pub fn value_record(&self) -> ValueRecord {
-        let range = self.shape.value_record_byte_range();
+        let range = self.value_record_byte_range();
         self.data
             .read_with_args(range, &self.value_format())
             .unwrap()
@@ -1382,11 +1374,41 @@ impl Format<u16> for SinglePosFormat2Marker {
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SinglePosFormat2Marker {
-    value_records_byte_len: usize,
+pub struct SinglePosFormat2Marker {}
+
+impl<'a> MinByteRange for SinglePosFormat2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.value_records_byte_range().end
+    }
 }
 
-impl SinglePosFormat2Marker {
+impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let value_format: ValueFormat = cursor.read()?;
+        let value_count: u16 = cursor.read()?;
+        let value_records_byte_len = (value_count as usize)
+            .checked_mul(<ValueRecord as ComputeSize>::compute_size(&value_format)?)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(value_records_byte_len);
+        cursor.finish(SinglePosFormat2Marker {})
+    }
+}
+
+/// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
+pub type SinglePosFormat2<'a> = TableRef<'a, SinglePosFormat2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SinglePosFormat2<'a> {
+    fn value_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.value_count()) as usize)
+            .checked_mul(<ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap())
+            .unwrap()
+    }
+
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1409,47 +1431,18 @@ impl SinglePosFormat2Marker {
 
     pub fn value_records_byte_range(&self) -> Range<usize> {
         let start = self.value_count_byte_range().end;
-        start..start + self.value_records_byte_len
+        start..start + self.value_records_byte_len(start)
     }
-}
 
-impl MinByteRange for SinglePosFormat2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.value_records_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let value_format: ValueFormat = cursor.read()?;
-        let value_count: u16 = cursor.read()?;
-        let value_records_byte_len = (value_count as usize)
-            .checked_mul(<ValueRecord as ComputeSize>::compute_size(&value_format)?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(value_records_byte_len);
-        cursor.finish(SinglePosFormat2Marker {
-            value_records_byte_len,
-        })
-    }
-}
-
-/// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
-pub type SinglePosFormat2<'a> = TableRef<'a, SinglePosFormat2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SinglePosFormat2<'a> {
     /// Format identifier: format = 2
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1461,20 +1454,20 @@ impl<'a> SinglePosFormat2<'a> {
 
     /// Defines the types of data in the ValueRecords.
     pub fn value_format(&self) -> ValueFormat {
-        let range = self.shape.value_format_byte_range();
+        let range = self.value_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of ValueRecords — must equal glyphCount in the
     /// Coverage table.
     pub fn value_count(&self) -> u16 {
-        let range = self.shape.value_count_byte_range();
+        let range = self.value_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of ValueRecords — positioning values applied to glyphs.
     pub fn value_records(&self) -> ComputedArray<'a, ValueRecord> {
-        let range = self.shape.value_records_byte_range();
+        let range = self.value_records_byte_range();
         self.data
             .read_with_args(range, &self.value_format())
             .unwrap()
@@ -1621,11 +1614,42 @@ impl Format<u16> for PairPosFormat1Marker {
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct PairPosFormat1Marker {
-    pair_set_offsets_byte_len: usize,
+pub struct PairPosFormat1Marker {}
+
+impl<'a> MinByteRange for PairPosFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.pair_set_offsets_byte_range().end
+    }
 }
 
-impl PairPosFormat1Marker {
+impl<'a> FontRead<'a> for PairPosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<ValueFormat>();
+        cursor.advance::<ValueFormat>();
+        let pair_set_count: u16 = cursor.read()?;
+        let pair_set_offsets_byte_len = (pair_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(pair_set_offsets_byte_len);
+        cursor.finish(PairPosFormat1Marker {})
+    }
+}
+
+/// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
+pub type PairPosFormat1<'a> = TableRef<'a, PairPosFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PairPosFormat1<'a> {
+    fn pair_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.pair_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1653,48 +1677,18 @@ impl PairPosFormat1Marker {
 
     pub fn pair_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.pair_set_count_byte_range().end;
-        start..start + self.pair_set_offsets_byte_len
+        start..start + self.pair_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for PairPosFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.pair_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PairPosFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<ValueFormat>();
-        cursor.advance::<ValueFormat>();
-        let pair_set_count: u16 = cursor.read()?;
-        let pair_set_offsets_byte_len = (pair_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pair_set_offsets_byte_len);
-        cursor.finish(PairPosFormat1Marker {
-            pair_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
-pub type PairPosFormat1<'a> = TableRef<'a, PairPosFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PairPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1707,27 +1701,27 @@ impl<'a> PairPosFormat1<'a> {
     /// Defines the types of data in valueRecord1 — for the first
     /// glyph in the pair (may be zero).
     pub fn value_format1(&self) -> ValueFormat {
-        let range = self.shape.value_format1_byte_range();
+        let range = self.value_format1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Defines the types of data in valueRecord2 — for the second
     /// glyph in the pair (may be zero).
     pub fn value_format2(&self) -> ValueFormat {
-        let range = self.shape.value_format2_byte_range();
+        let range = self.value_format2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of PairSet tables
     pub fn pair_set_count(&self) -> u16 {
-        let range = self.shape.pair_set_count_byte_range();
+        let range = self.pair_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to PairSet tables. Offsets are from beginning
     /// of PairPos subtable, ordered by Coverage Index.
     pub fn pair_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.pair_set_offsets_byte_range();
+        let range = self.pair_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1789,22 +1783,9 @@ impl<'a> std::fmt::Debug for PairPosFormat1<'a> {
 pub struct PairSetMarker {
     value_format1: ValueFormat,
     value_format2: ValueFormat,
-    pair_value_records_byte_len: usize,
 }
 
-impl PairSetMarker {
-    pub fn pair_value_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn pair_value_records_byte_range(&self) -> Range<usize> {
-        let start = self.pair_value_count_byte_range().end;
-        start..start + self.pair_value_records_byte_len
-    }
-}
-
-impl MinByteRange for PairSetMarker {
+impl<'a> MinByteRange for PairSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.pair_value_records_byte_range().end
     }
@@ -1832,7 +1813,6 @@ impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
         cursor.finish(PairSetMarker {
             value_format1,
             value_format2,
-            pair_value_records_byte_len,
         })
     }
 }
@@ -1857,16 +1837,39 @@ pub type PairSet<'a> = TableRef<'a, PairSetMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairSet<'a> {
+    fn pair_value_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.pair_value_count()) as usize)
+            .checked_mul(
+                <PairValueRecord as ComputeSize>::compute_size(&(
+                    self.shape.value_format1,
+                    self.shape.value_format2,
+                ))
+                .unwrap(),
+            )
+            .unwrap()
+    }
+
+    pub fn pair_value_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn pair_value_records_byte_range(&self) -> Range<usize> {
+        let start = self.pair_value_count_byte_range().end;
+        start..start + self.pair_value_records_byte_len(start)
+    }
+
     /// Number of PairValueRecords
     pub fn pair_value_count(&self) -> u16 {
-        let range = self.shape.pair_value_count_byte_range();
+        let range = self.pair_value_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
     pub fn pair_value_records(&self) -> ComputedArray<'a, PairValueRecord> {
-        let range = self.shape.pair_value_records_byte_range();
+        let range = self.pair_value_records_byte_range();
         self.data
             .read_with_args(range, &(self.value_format1(), self.value_format2()))
             .unwrap()
@@ -2022,11 +2025,56 @@ impl Format<u16> for PairPosFormat2Marker {
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct PairPosFormat2Marker {
-    class1_records_byte_len: usize,
+pub struct PairPosFormat2Marker {}
+
+impl<'a> MinByteRange for PairPosFormat2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.class1_records_byte_range().end
+    }
 }
 
-impl PairPosFormat2Marker {
+impl<'a> FontRead<'a> for PairPosFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let value_format1: ValueFormat = cursor.read()?;
+        let value_format2: ValueFormat = cursor.read()?;
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        let class1_count: u16 = cursor.read()?;
+        let class2_count: u16 = cursor.read()?;
+        let class1_records_byte_len = (class1_count as usize)
+            .checked_mul(<Class1Record as ComputeSize>::compute_size(&(
+                class2_count,
+                value_format1,
+                value_format2,
+            ))?)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(class1_records_byte_len);
+        cursor.finish(PairPosFormat2Marker {})
+    }
+}
+
+/// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
+pub type PairPosFormat2<'a> = TableRef<'a, PairPosFormat2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> PairPosFormat2<'a> {
+    fn class1_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.class1_count()) as usize)
+            .checked_mul(
+                <Class1Record as ComputeSize>::compute_size(&(
+                    self.class2_count(),
+                    self.value_format1(),
+                    self.value_format2(),
+                ))
+                .unwrap(),
+            )
+            .unwrap()
+    }
+
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -2069,55 +2117,18 @@ impl PairPosFormat2Marker {
 
     pub fn class1_records_byte_range(&self) -> Range<usize> {
         let start = self.class2_count_byte_range().end;
-        start..start + self.class1_records_byte_len
+        start..start + self.class1_records_byte_len(start)
     }
-}
 
-impl MinByteRange for PairPosFormat2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.class1_records_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for PairPosFormat2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let value_format1: ValueFormat = cursor.read()?;
-        let value_format2: ValueFormat = cursor.read()?;
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let class1_count: u16 = cursor.read()?;
-        let class2_count: u16 = cursor.read()?;
-        let class1_records_byte_len = (class1_count as usize)
-            .checked_mul(<Class1Record as ComputeSize>::compute_size(&(
-                class2_count,
-                value_format1,
-                value_format2,
-            ))?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class1_records_byte_len);
-        cursor.finish(PairPosFormat2Marker {
-            class1_records_byte_len,
-        })
-    }
-}
-
-/// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
-pub type PairPosFormat2<'a> = TableRef<'a, PairPosFormat2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> PairPosFormat2<'a> {
     /// Format identifier: format = 2
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2130,21 +2141,21 @@ impl<'a> PairPosFormat2<'a> {
     /// ValueRecord definition — for the first glyph of the pair (may
     /// be zero).
     pub fn value_format1(&self) -> ValueFormat {
-        let range = self.shape.value_format1_byte_range();
+        let range = self.value_format1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// ValueRecord definition — for the second glyph of the pair
     /// (may be zero).
     pub fn value_format2(&self) -> ValueFormat {
-        let range = self.shape.value_format2_byte_range();
+        let range = self.value_format2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the first glyph of the pair.
     pub fn class_def1_offset(&self) -> Offset16 {
-        let range = self.shape.class_def1_offset_byte_range();
+        let range = self.class_def1_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2157,7 +2168,7 @@ impl<'a> PairPosFormat2<'a> {
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the second glyph of the pair.
     pub fn class_def2_offset(&self) -> Offset16 {
-        let range = self.shape.class_def2_offset_byte_range();
+        let range = self.class_def2_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2169,19 +2180,19 @@ impl<'a> PairPosFormat2<'a> {
 
     /// Number of classes in classDef1 table — includes Class 0.
     pub fn class1_count(&self) -> u16 {
-        let range = self.shape.class1_count_byte_range();
+        let range = self.class1_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of classes in classDef2 table — includes Class 0.
     pub fn class2_count(&self) -> u16 {
-        let range = self.shape.class2_count_byte_range();
+        let range = self.class2_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of Class1 records, ordered by classes in classDef1.
     pub fn class1_records(&self) -> ComputedArray<'a, Class1Record<'a>> {
-        let range = self.shape.class1_records_byte_range();
+        let range = self.class1_records_byte_range();
         self.data
             .read_with_args(
                 range,
@@ -2421,11 +2432,40 @@ impl Format<u16> for CursivePosFormat1Marker {
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CursivePosFormat1Marker {
-    entry_exit_record_byte_len: usize,
+pub struct CursivePosFormat1Marker {}
+
+impl<'a> MinByteRange for CursivePosFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.entry_exit_record_byte_range().end
+    }
 }
 
-impl CursivePosFormat1Marker {
+impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let entry_exit_count: u16 = cursor.read()?;
+        let entry_exit_record_byte_len = (entry_exit_count as usize)
+            .checked_mul(EntryExitRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(entry_exit_record_byte_len);
+        cursor.finish(CursivePosFormat1Marker {})
+    }
+}
+
+/// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
+pub type CursivePosFormat1<'a> = TableRef<'a, CursivePosFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> CursivePosFormat1<'a> {
+    fn entry_exit_record_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.entry_exit_count()) as usize)
+            .checked_mul(EntryExitRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -2443,46 +2483,18 @@ impl CursivePosFormat1Marker {
 
     pub fn entry_exit_record_byte_range(&self) -> Range<usize> {
         let start = self.entry_exit_count_byte_range().end;
-        start..start + self.entry_exit_record_byte_len
+        start..start + self.entry_exit_record_byte_len(start)
     }
-}
 
-impl MinByteRange for CursivePosFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.entry_exit_record_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let entry_exit_count: u16 = cursor.read()?;
-        let entry_exit_record_byte_len = (entry_exit_count as usize)
-            .checked_mul(EntryExitRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(entry_exit_record_byte_len);
-        cursor.finish(CursivePosFormat1Marker {
-            entry_exit_record_byte_len,
-        })
-    }
-}
-
-/// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
-pub type CursivePosFormat1<'a> = TableRef<'a, CursivePosFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> CursivePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of CursivePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2494,13 +2506,13 @@ impl<'a> CursivePosFormat1<'a> {
 
     /// Number of EntryExit records
     pub fn entry_exit_count(&self) -> u16 {
-        let range = self.shape.entry_exit_count_byte_range();
+        let range = self.entry_exit_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of EntryExit records, in Coverage index order.
     pub fn entry_exit_record(&self) -> &'a [EntryExitRecord] {
-        let range = self.shape.entry_exit_record_byte_range();
+        let range = self.entry_exit_record_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -2624,7 +2636,30 @@ impl Format<u16> for MarkBasePosFormat1Marker {
 #[doc(hidden)]
 pub struct MarkBasePosFormat1Marker {}
 
-impl MarkBasePosFormat1Marker {
+impl<'a> MinByteRange for MarkBasePosFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.base_array_offset_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.finish(MarkBasePosFormat1Marker {})
+    }
+}
+
+/// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
+pub type MarkBasePosFormat1<'a> = TableRef<'a, MarkBasePosFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> MarkBasePosFormat1<'a> {
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -2654,42 +2689,17 @@ impl MarkBasePosFormat1Marker {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for MarkBasePosFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.base_array_offset_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkBasePosFormat1Marker {})
-    }
-}
-
-/// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
-pub type MarkBasePosFormat1<'a> = TableRef<'a, MarkBasePosFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> MarkBasePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
     pub fn mark_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark_coverage_offset_byte_range();
+        let range = self.mark_coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2702,7 +2712,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Offset to baseCoverage table, from beginning of MarkBasePos
     /// subtable.
     pub fn base_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.base_coverage_offset_byte_range();
+        let range = self.base_coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2714,14 +2724,14 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     /// Number of classes defined for marks
     pub fn mark_class_count(&self) -> u16 {
-        let range = self.shape.mark_class_count_byte_range();
+        let range = self.mark_class_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to MarkArray table, from beginning of MarkBasePos
     /// subtable.
     pub fn mark_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark_array_offset_byte_range();
+        let range = self.mark_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2734,7 +2744,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Offset to BaseArray table, from beginning of MarkBasePos
     /// subtable.
     pub fn base_array_offset(&self) -> Offset16 {
-        let range = self.shape.base_array_offset_byte_range();
+        let range = self.base_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2789,22 +2799,9 @@ impl<'a> std::fmt::Debug for MarkBasePosFormat1<'a> {
 #[doc(hidden)]
 pub struct BaseArrayMarker {
     mark_class_count: u16,
-    base_records_byte_len: usize,
 }
 
-impl BaseArrayMarker {
-    pub fn base_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn base_records_byte_range(&self) -> Range<usize> {
-        let start = self.base_count_byte_range().end;
-        start..start + self.base_records_byte_len
-    }
-}
-
-impl MinByteRange for BaseArrayMarker {
+impl<'a> MinByteRange for BaseArray<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.base_records_byte_range().end
     }
@@ -2825,10 +2822,7 @@ impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
             )?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(base_records_byte_len);
-        cursor.finish(BaseArrayMarker {
-            mark_class_count,
-            base_records_byte_len,
-        })
+        cursor.finish(BaseArrayMarker { mark_class_count })
     }
 }
 
@@ -2848,15 +2842,34 @@ pub type BaseArray<'a> = TableRef<'a, BaseArrayMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseArray<'a> {
+    fn base_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.base_count()) as usize)
+            .checked_mul(
+                <BaseRecord as ComputeSize>::compute_size(&self.shape.mark_class_count).unwrap(),
+            )
+            .unwrap()
+    }
+
+    pub fn base_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn base_records_byte_range(&self) -> Range<usize> {
+        let start = self.base_count_byte_range().end;
+        start..start + self.base_records_byte_len(start)
+    }
+
     /// Number of BaseRecords
     pub fn base_count(&self) -> u16 {
-        let range = self.shape.base_count_byte_range();
+        let range = self.base_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of BaseRecords, in order of baseCoverage Index.
     pub fn base_records(&self) -> ComputedArray<'a, BaseRecord<'a>> {
-        let range = self.shape.base_records_byte_range();
+        let range = self.base_records_byte_range();
         self.data
             .read_with_args(range, &self.mark_class_count())
             .unwrap()
@@ -2999,7 +3012,30 @@ impl Format<u16> for MarkLigPosFormat1Marker {
 #[doc(hidden)]
 pub struct MarkLigPosFormat1Marker {}
 
-impl MarkLigPosFormat1Marker {
+impl<'a> MinByteRange for MarkLigPosFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.ligature_array_offset_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.finish(MarkLigPosFormat1Marker {})
+    }
+}
+
+/// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
+pub type MarkLigPosFormat1<'a> = TableRef<'a, MarkLigPosFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> MarkLigPosFormat1<'a> {
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -3029,42 +3065,17 @@ impl MarkLigPosFormat1Marker {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for MarkLigPosFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.ligature_array_offset_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkLigPosFormat1Marker {})
-    }
-}
-
-/// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
-pub type MarkLigPosFormat1<'a> = TableRef<'a, MarkLigPosFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> MarkLigPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
     pub fn mark_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark_coverage_offset_byte_range();
+        let range = self.mark_coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3077,7 +3088,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Offset to ligatureCoverage table, from beginning of MarkLigPos
     /// subtable.
     pub fn ligature_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.ligature_coverage_offset_byte_range();
+        let range = self.ligature_coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3089,14 +3100,14 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     /// Number of defined mark classes
     pub fn mark_class_count(&self) -> u16 {
-        let range = self.shape.mark_class_count_byte_range();
+        let range = self.mark_class_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to MarkArray table, from beginning of MarkLigPos
     /// subtable.
     pub fn mark_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark_array_offset_byte_range();
+        let range = self.mark_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3109,7 +3120,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Offset to LigatureArray table, from beginning of MarkLigPos
     /// subtable.
     pub fn ligature_array_offset(&self) -> Offset16 {
-        let range = self.shape.ligature_array_offset_byte_range();
+        let range = self.ligature_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3164,22 +3175,9 @@ impl<'a> std::fmt::Debug for MarkLigPosFormat1<'a> {
 #[doc(hidden)]
 pub struct LigatureArrayMarker {
     mark_class_count: u16,
-    ligature_attach_offsets_byte_len: usize,
 }
 
-impl LigatureArrayMarker {
-    pub fn ligature_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn ligature_attach_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.ligature_count_byte_range().end;
-        start..start + self.ligature_attach_offsets_byte_len
-    }
-}
-
-impl MinByteRange for LigatureArrayMarker {
+impl<'a> MinByteRange for LigatureArray<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.ligature_attach_offsets_byte_range().end
     }
@@ -3198,10 +3196,7 @@ impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ligature_attach_offsets_byte_len);
-        cursor.finish(LigatureArrayMarker {
-            mark_class_count,
-            ligature_attach_offsets_byte_len,
-        })
+        cursor.finish(LigatureArrayMarker { mark_class_count })
     }
 }
 
@@ -3221,9 +3216,26 @@ pub type LigatureArray<'a> = TableRef<'a, LigatureArrayMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureArray<'a> {
+    fn ligature_attach_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.ligature_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn ligature_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn ligature_attach_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.ligature_count_byte_range().end;
+        start..start + self.ligature_attach_offsets_byte_len(start)
+    }
+
     /// Number of LigatureAttach table offsets
     pub fn ligature_count(&self) -> u16 {
-        let range = self.shape.ligature_count_byte_range();
+        let range = self.ligature_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3231,7 +3243,7 @@ impl<'a> LigatureArray<'a> {
     /// beginning of LigatureArray table, ordered by ligatureCoverage
     /// index.
     pub fn ligature_attach_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.ligature_attach_offsets_byte_range();
+        let range = self.ligature_attach_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -3289,22 +3301,9 @@ impl<'a> std::fmt::Debug for LigatureArray<'a> {
 #[doc(hidden)]
 pub struct LigatureAttachMarker {
     mark_class_count: u16,
-    component_records_byte_len: usize,
 }
 
-impl LigatureAttachMarker {
-    pub fn component_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn component_records_byte_range(&self) -> Range<usize> {
-        let start = self.component_count_byte_range().end;
-        start..start + self.component_records_byte_len
-    }
-}
-
-impl MinByteRange for LigatureAttachMarker {
+impl<'a> MinByteRange for LigatureAttach<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.component_records_byte_range().end
     }
@@ -3325,10 +3324,7 @@ impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
             )?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(component_records_byte_len);
-        cursor.finish(LigatureAttachMarker {
-            mark_class_count,
-            component_records_byte_len,
-        })
+        cursor.finish(LigatureAttachMarker { mark_class_count })
     }
 }
 
@@ -3348,15 +3344,35 @@ pub type LigatureAttach<'a> = TableRef<'a, LigatureAttachMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureAttach<'a> {
+    fn component_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.component_count()) as usize)
+            .checked_mul(
+                <ComponentRecord as ComputeSize>::compute_size(&self.shape.mark_class_count)
+                    .unwrap(),
+            )
+            .unwrap()
+    }
+
+    pub fn component_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn component_records_byte_range(&self) -> Range<usize> {
+        let start = self.component_count_byte_range().end;
+        start..start + self.component_records_byte_len(start)
+    }
+
     /// Number of ComponentRecords in this ligature
     pub fn component_count(&self) -> u16 {
-        let range = self.shape.component_count_byte_range();
+        let range = self.component_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of Component records, ordered in writing direction.
     pub fn component_records(&self) -> ComputedArray<'a, ComponentRecord<'a>> {
-        let range = self.shape.component_records_byte_range();
+        let range = self.component_records_byte_range();
         self.data
             .read_with_args(range, &self.mark_class_count())
             .unwrap()
@@ -3499,7 +3515,30 @@ impl Format<u16> for MarkMarkPosFormat1Marker {
 #[doc(hidden)]
 pub struct MarkMarkPosFormat1Marker {}
 
-impl MarkMarkPosFormat1Marker {
+impl<'a> MinByteRange for MarkMarkPosFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.mark2_array_offset_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.finish(MarkMarkPosFormat1Marker {})
+    }
+}
+
+/// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
+pub type MarkMarkPosFormat1<'a> = TableRef<'a, MarkMarkPosFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> MarkMarkPosFormat1<'a> {
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -3529,42 +3568,17 @@ impl MarkMarkPosFormat1Marker {
         let start = self.mark1_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for MarkMarkPosFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.mark2_array_offset_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkMarkPosFormat1Marker {})
-    }
-}
-
-/// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
-pub type MarkMarkPosFormat1<'a> = TableRef<'a, MarkMarkPosFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> MarkMarkPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark1_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark1_coverage_offset_byte_range();
+        let range = self.mark1_coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3577,7 +3591,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Offset to Base Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark2_coverage_offset(&self) -> Offset16 {
-        let range = self.shape.mark2_coverage_offset_byte_range();
+        let range = self.mark2_coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3589,14 +3603,14 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     /// Number of Combining Mark classes defined
     pub fn mark_class_count(&self) -> u16 {
-        let range = self.shape.mark_class_count_byte_range();
+        let range = self.mark_class_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to MarkArray table for mark1, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark1_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark1_array_offset_byte_range();
+        let range = self.mark1_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3609,7 +3623,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Offset to Mark2Array table for mark2, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark2_array_offset(&self) -> Offset16 {
-        let range = self.shape.mark2_array_offset_byte_range();
+        let range = self.mark2_array_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3664,22 +3678,9 @@ impl<'a> std::fmt::Debug for MarkMarkPosFormat1<'a> {
 #[doc(hidden)]
 pub struct Mark2ArrayMarker {
     mark_class_count: u16,
-    mark2_records_byte_len: usize,
 }
 
-impl Mark2ArrayMarker {
-    pub fn mark2_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn mark2_records_byte_range(&self) -> Range<usize> {
-        let start = self.mark2_count_byte_range().end;
-        start..start + self.mark2_records_byte_len
-    }
-}
-
-impl MinByteRange for Mark2ArrayMarker {
+impl<'a> MinByteRange for Mark2Array<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.mark2_records_byte_range().end
     }
@@ -3700,10 +3701,7 @@ impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
             )?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(mark2_records_byte_len);
-        cursor.finish(Mark2ArrayMarker {
-            mark_class_count,
-            mark2_records_byte_len,
-        })
+        cursor.finish(Mark2ArrayMarker { mark_class_count })
     }
 }
 
@@ -3723,15 +3721,34 @@ pub type Mark2Array<'a> = TableRef<'a, Mark2ArrayMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Mark2Array<'a> {
+    fn mark2_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.mark2_count()) as usize)
+            .checked_mul(
+                <Mark2Record as ComputeSize>::compute_size(&self.shape.mark_class_count).unwrap(),
+            )
+            .unwrap()
+    }
+
+    pub fn mark2_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn mark2_records_byte_range(&self) -> Range<usize> {
+        let start = self.mark2_count_byte_range().end;
+        start..start + self.mark2_records_byte_len(start)
+    }
+
     /// Number of Mark2 records
     pub fn mark2_count(&self) -> u16 {
-        let range = self.shape.mark2_count_byte_range();
+        let range = self.mark2_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of Mark2Records, in Coverage order.
     pub fn mark2_records(&self) -> ComputedArray<'a, Mark2Record<'a>> {
-        let range = self.shape.mark2_records_byte_range();
+        let range = self.mark2_records_byte_range();
         self.data
             .read_with_args(range, &self.mark_class_count())
             .unwrap()
@@ -3876,24 +3893,7 @@ pub struct ExtensionPosFormat1Marker<T = ()> {
     offset_type: std::marker::PhantomData<*const T>,
 }
 
-impl<T> ExtensionPosFormat1Marker<T> {
-    pub fn pos_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
-        let start = self.pos_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn extension_offset_byte_range(&self) -> Range<usize> {
-        let start = self.extension_lookup_type_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for ExtensionPosFormat1Marker {
+impl<'a, T> MinByteRange for ExtensionPosFormat1<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.extension_offset_byte_range().end
     }
@@ -3951,16 +3951,31 @@ pub type ExtensionPosFormat1<'a, T> = TableRef<'a, ExtensionPosFormat1Marker<T>>
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> ExtensionPosFormat1<'a, T> {
+    pub fn pos_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
+        let start = self.pos_format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn extension_offset_byte_range(&self) -> Range<usize> {
+        let start = self.extension_lookup_type_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
-        let range = self.shape.pos_format_byte_range();
+        let range = self.pos_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
     pub fn extension_lookup_type(&self) -> u16 {
-        let range = self.shape.extension_lookup_type_byte_range();
+        let range = self.extension_lookup_type_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3968,7 +3983,7 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// extensionLookupType, relative to the start of the
     /// ExtensionPosFormat1 subtable.
     pub fn extension_offset(&self) -> Offset32 {
-        let range = self.shape.extension_offset_byte_range();
+        let range = self.extension_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -25,9 +25,9 @@ impl TopLevelTable for Gpos<'_> {
 impl<'a> FontRead<'a> for Gpos<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GposMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -705,9 +705,9 @@ impl<'a> MinByteRange for AnchorFormat1<'a> {
 impl<'a> FontRead<'a> for AnchorFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AnchorFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -792,9 +792,9 @@ impl<'a> MinByteRange for AnchorFormat2<'a> {
 impl<'a> FontRead<'a> for AnchorFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AnchorFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -891,9 +891,9 @@ impl<'a> MinByteRange for AnchorFormat3<'a> {
 impl<'a> FontRead<'a> for AnchorFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AnchorFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1020,9 +1020,9 @@ impl<'a> MinByteRange for MarkArray<'a> {
 impl<'a> FontRead<'a> for MarkArray<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MarkArrayMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1251,9 +1251,9 @@ impl<'a> MinByteRange for SinglePosFormat1<'a> {
 impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SinglePosFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1370,9 +1370,9 @@ impl<'a> MinByteRange for SinglePosFormat2<'a> {
 impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SinglePosFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1605,9 +1605,9 @@ impl<'a> MinByteRange for PairPosFormat1<'a> {
 impl<'a> FontRead<'a> for PairPosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PairPosFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1773,9 +1773,9 @@ impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
     ) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: PairSetMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1996,9 +1996,9 @@ impl<'a> MinByteRange for PairPosFormat2<'a> {
 impl<'a> FontRead<'a> for PairPosFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PairPosFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2390,9 +2390,9 @@ impl<'a> MinByteRange for CursivePosFormat1<'a> {
 impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CursivePosFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2588,9 +2588,9 @@ impl<'a> MinByteRange for MarkBasePosFormat1<'a> {
 impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MarkBasePosFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2753,9 +2753,9 @@ impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: BaseArrayMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2953,9 +2953,9 @@ impl<'a> MinByteRange for MarkLigPosFormat1<'a> {
 impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MarkLigPosFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3118,9 +3118,9 @@ impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: LigatureArrayMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3240,9 +3240,9 @@ impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: LigatureAttachMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3440,9 +3440,9 @@ impl<'a> MinByteRange for MarkMarkPosFormat1<'a> {
 impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MarkMarkPosFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3605,9 +3605,9 @@ impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: Mark2ArrayMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3805,9 +3805,9 @@ impl<'a, T> MinByteRange for ExtensionPosFormat1<'a, T> {
 impl<'a, T> FontRead<'a> for ExtensionPosFormat1<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ExtensionPosFormat1Marker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3817,9 +3817,9 @@ impl<'a> ExtensionPosFormat1<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> ExtensionPosFormat1<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionPosFormat1Marker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -3830,9 +3830,9 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     pub(crate) fn of_unit_type(&self) -> ExtensionPosFormat1<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionPosFormat1Marker,
             args: std::marker::PhantomData,
             data: *data,
+            _marker: std::marker::PhantomData,
         }
     }
 }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -9,9 +9,7 @@ use crate::codegen_prelude::*;
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GposMarker {
-    feature_variations_offset_byte_start: Option<usize>,
-}
+pub struct GposMarker;
 
 impl<'a> MinByteRange for Gpos<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -26,27 +24,17 @@ impl TopLevelTable for Gpos<'_> {
 
 impl<'a> FontRead<'a> for Gpos<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let version: MajorMinor = cursor.read()?;
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let feature_variations_offset_byte_start = version
-            .compatible((1u16, 1u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 1u16))
-            .then(|| cursor.advance::<Offset32>());
-        cursor.finish(GposMarker {
-            feature_variations_offset_byte_start,
+        Ok(TableRef {
+            shape: GposMarker,
+            args: (),
+            data,
         })
     }
 }
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 /// [GPOS Version 1.0](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header)
-pub type Gpos<'a> = TableRef<'a, GposMarker>;
+pub type Gpos<'a> = TableRef<'a, GposMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gpos<'a> {
@@ -71,8 +59,12 @@ impl<'a> Gpos<'a> {
     }
 
     pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.feature_variations_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 1u16)) {
+            let start = self.lookup_list_offset_byte_range().end;
+            Some(start..start + Offset32::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
@@ -702,7 +694,7 @@ impl Format<u16> for AnchorFormat1Marker {
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AnchorFormat1Marker {}
+pub struct AnchorFormat1Marker;
 
 impl<'a> MinByteRange for AnchorFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -712,16 +704,16 @@ impl<'a> MinByteRange for AnchorFormat1<'a> {
 
 impl<'a> FontRead<'a> for AnchorFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.finish(AnchorFormat1Marker {})
+        Ok(TableRef {
+            shape: AnchorFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Anchor Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-1-design-units): Design Units
-pub type AnchorFormat1<'a> = TableRef<'a, AnchorFormat1Marker>;
+pub type AnchorFormat1<'a> = TableRef<'a, AnchorFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat1<'a> {
@@ -789,7 +781,7 @@ impl Format<u16> for AnchorFormat2Marker {
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AnchorFormat2Marker {}
+pub struct AnchorFormat2Marker;
 
 impl<'a> MinByteRange for AnchorFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -799,17 +791,16 @@ impl<'a> MinByteRange for AnchorFormat2<'a> {
 
 impl<'a> FontRead<'a> for AnchorFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(AnchorFormat2Marker {})
+        Ok(TableRef {
+            shape: AnchorFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Anchor Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-2-design-units-plus-contour-point): Design Units Plus Contour Point
-pub type AnchorFormat2<'a> = TableRef<'a, AnchorFormat2Marker>;
+pub type AnchorFormat2<'a> = TableRef<'a, AnchorFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat2<'a> {
@@ -889,7 +880,7 @@ impl Format<u16> for AnchorFormat3Marker {
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AnchorFormat3Marker {}
+pub struct AnchorFormat3Marker;
 
 impl<'a> MinByteRange for AnchorFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -899,18 +890,16 @@ impl<'a> MinByteRange for AnchorFormat3<'a> {
 
 impl<'a> FontRead<'a> for AnchorFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(AnchorFormat3Marker {})
+        Ok(TableRef {
+            shape: AnchorFormat3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Anchor Table Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#anchor-table-format-3-design-units-plus-device-or-variationindex-tables): Design Units Plus Device or VariationIndex Tables
-pub type AnchorFormat3<'a> = TableRef<'a, AnchorFormat3Marker>;
+pub type AnchorFormat3<'a> = TableRef<'a, AnchorFormat3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AnchorFormat3<'a> {
@@ -1020,7 +1009,7 @@ impl<'a> std::fmt::Debug for AnchorFormat3<'a> {
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MarkArrayMarker {}
+pub struct MarkArrayMarker;
 
 impl<'a> MinByteRange for MarkArray<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1030,18 +1019,16 @@ impl<'a> MinByteRange for MarkArray<'a> {
 
 impl<'a> FontRead<'a> for MarkArray<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let mark_count: u16 = cursor.read()?;
-        let mark_records_byte_len = (mark_count as usize)
-            .checked_mul(MarkRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(mark_records_byte_len);
-        cursor.finish(MarkArrayMarker {})
+        Ok(TableRef {
+            shape: MarkArrayMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Mark Array Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-array-table)
-pub type MarkArray<'a> = TableRef<'a, MarkArrayMarker>;
+pub type MarkArray<'a> = TableRef<'a, MarkArrayMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkArray<'a> {
@@ -1253,7 +1240,7 @@ impl Format<u16> for SinglePosFormat1Marker {
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SinglePosFormat1Marker {}
+pub struct SinglePosFormat1Marker;
 
 impl<'a> MinByteRange for SinglePosFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1263,18 +1250,16 @@ impl<'a> MinByteRange for SinglePosFormat1<'a> {
 
 impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let value_format: ValueFormat = cursor.read()?;
-        let value_record_byte_len = <ValueRecord as ComputeSize>::compute_size(&value_format)?;
-        cursor.advance_by(value_record_byte_len);
-        cursor.finish(SinglePosFormat1Marker {})
+        Ok(TableRef {
+            shape: SinglePosFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Single Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-1-single-positioning-value): Single Positioning Value
-pub type SinglePosFormat1<'a> = TableRef<'a, SinglePosFormat1Marker>;
+pub type SinglePosFormat1<'a> = TableRef<'a, SinglePosFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SinglePosFormat1<'a> {
@@ -1374,7 +1359,7 @@ impl Format<u16> for SinglePosFormat2Marker {
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SinglePosFormat2Marker {}
+pub struct SinglePosFormat2Marker;
 
 impl<'a> MinByteRange for SinglePosFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1384,21 +1369,16 @@ impl<'a> MinByteRange for SinglePosFormat2<'a> {
 
 impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let value_format: ValueFormat = cursor.read()?;
-        let value_count: u16 = cursor.read()?;
-        let value_records_byte_len = (value_count as usize)
-            .checked_mul(<ValueRecord as ComputeSize>::compute_size(&value_format)?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(value_records_byte_len);
-        cursor.finish(SinglePosFormat2Marker {})
+        Ok(TableRef {
+            shape: SinglePosFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Single Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#single-adjustment-positioning-format-2-array-of-positioning-values): Array of Positioning Values
-pub type SinglePosFormat2<'a> = TableRef<'a, SinglePosFormat2Marker>;
+pub type SinglePosFormat2<'a> = TableRef<'a, SinglePosFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SinglePosFormat2<'a> {
@@ -1614,7 +1594,7 @@ impl Format<u16> for PairPosFormat1Marker {
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct PairPosFormat1Marker {}
+pub struct PairPosFormat1Marker;
 
 impl<'a> MinByteRange for PairPosFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1624,22 +1604,16 @@ impl<'a> MinByteRange for PairPosFormat1<'a> {
 
 impl<'a> FontRead<'a> for PairPosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<ValueFormat>();
-        cursor.advance::<ValueFormat>();
-        let pair_set_count: u16 = cursor.read()?;
-        let pair_set_offsets_byte_len = (pair_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pair_set_offsets_byte_len);
-        cursor.finish(PairPosFormat1Marker {})
+        Ok(TableRef {
+            shape: PairPosFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Pair Adjustment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-1-adjustments-for-glyph-pairs): Adjustments for Glyph Pairs
-pub type PairPosFormat1<'a> = TableRef<'a, PairPosFormat1Marker>;
+pub type PairPosFormat1<'a> = TableRef<'a, PairPosFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairPosFormat1<'a> {
@@ -1780,10 +1754,7 @@ impl<'a> std::fmt::Debug for PairPosFormat1<'a> {
 /// Part of [PairPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct PairSetMarker {
-    value_format1: ValueFormat,
-    value_format2: ValueFormat,
-}
+pub struct PairSetMarker;
 
 impl<'a> MinByteRange for PairSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1800,19 +1771,11 @@ impl<'a> FontReadWithArgs<'a> for PairSet<'a> {
         data: FontData<'a>,
         args: &(ValueFormat, ValueFormat),
     ) -> Result<Self, ReadError> {
-        let (value_format1, value_format2) = *args;
-        let mut cursor = data.cursor();
-        let pair_value_count: u16 = cursor.read()?;
-        let pair_value_records_byte_len = (pair_value_count as usize)
-            .checked_mul(<PairValueRecord as ComputeSize>::compute_size(&(
-                value_format1,
-                value_format2,
-            ))?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pair_value_records_byte_len);
-        cursor.finish(PairSetMarker {
-            value_format1,
-            value_format2,
+        let args = *args;
+        Ok(TableRef {
+            shape: PairSetMarker,
+            args,
+            data,
         })
     }
 }
@@ -1833,7 +1796,7 @@ impl<'a> PairSet<'a> {
 }
 
 /// Part of [PairPosFormat1]
-pub type PairSet<'a> = TableRef<'a, PairSetMarker>;
+pub type PairSet<'a> = TableRef<'a, PairSetMarker, (ValueFormat, ValueFormat)>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairSet<'a> {
@@ -1841,11 +1804,8 @@ impl<'a> PairSet<'a> {
         let _ = start;
         ((self.pair_value_count()) as usize)
             .checked_mul(
-                <PairValueRecord as ComputeSize>::compute_size(&(
-                    self.shape.value_format1,
-                    self.shape.value_format2,
-                ))
-                .unwrap(),
+                <PairValueRecord as ComputeSize>::compute_size(&(self.args.0, self.args.1))
+                    .unwrap(),
             )
             .unwrap()
     }
@@ -1876,11 +1836,11 @@ impl<'a> PairSet<'a> {
     }
 
     pub(crate) fn value_format1(&self) -> ValueFormat {
-        self.shape.value_format1
+        self.args.0
     }
 
     pub(crate) fn value_format2(&self) -> ValueFormat {
-        self.shape.value_format2
+        self.args.1
     }
 }
 
@@ -2025,7 +1985,7 @@ impl Format<u16> for PairPosFormat2Marker {
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct PairPosFormat2Marker {}
+pub struct PairPosFormat2Marker;
 
 impl<'a> MinByteRange for PairPosFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2035,29 +1995,16 @@ impl<'a> MinByteRange for PairPosFormat2<'a> {
 
 impl<'a> FontRead<'a> for PairPosFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let value_format1: ValueFormat = cursor.read()?;
-        let value_format2: ValueFormat = cursor.read()?;
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let class1_count: u16 = cursor.read()?;
-        let class2_count: u16 = cursor.read()?;
-        let class1_records_byte_len = (class1_count as usize)
-            .checked_mul(<Class1Record as ComputeSize>::compute_size(&(
-                class2_count,
-                value_format1,
-                value_format2,
-            ))?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class1_records_byte_len);
-        cursor.finish(PairPosFormat2Marker {})
+        Ok(TableRef {
+            shape: PairPosFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Pair Adjustment Positioning Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#pair-adjustment-positioning-format-2-class-pair-adjustment): Class Pair Adjustment
-pub type PairPosFormat2<'a> = TableRef<'a, PairPosFormat2Marker>;
+pub type PairPosFormat2<'a> = TableRef<'a, PairPosFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> PairPosFormat2<'a> {
@@ -2432,7 +2379,7 @@ impl Format<u16> for CursivePosFormat1Marker {
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CursivePosFormat1Marker {}
+pub struct CursivePosFormat1Marker;
 
 impl<'a> MinByteRange for CursivePosFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2442,20 +2389,16 @@ impl<'a> MinByteRange for CursivePosFormat1<'a> {
 
 impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let entry_exit_count: u16 = cursor.read()?;
-        let entry_exit_record_byte_len = (entry_exit_count as usize)
-            .checked_mul(EntryExitRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(entry_exit_record_byte_len);
-        cursor.finish(CursivePosFormat1Marker {})
+        Ok(TableRef {
+            shape: CursivePosFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Cursive Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#cursive-attachment-positioning-format1-cursive-attachment): Cursvie attachment
-pub type CursivePosFormat1<'a> = TableRef<'a, CursivePosFormat1Marker>;
+pub type CursivePosFormat1<'a> = TableRef<'a, CursivePosFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CursivePosFormat1<'a> {
@@ -2634,7 +2577,7 @@ impl Format<u16> for MarkBasePosFormat1Marker {
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MarkBasePosFormat1Marker {}
+pub struct MarkBasePosFormat1Marker;
 
 impl<'a> MinByteRange for MarkBasePosFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2644,19 +2587,16 @@ impl<'a> MinByteRange for MarkBasePosFormat1<'a> {
 
 impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkBasePosFormat1Marker {})
+        Ok(TableRef {
+            shape: MarkBasePosFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Mark-to-Base Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-base-attachment-positioning-format-1-mark-to-base-attachment-point): Mark-to-base Attachment Point
-pub type MarkBasePosFormat1<'a> = TableRef<'a, MarkBasePosFormat1Marker>;
+pub type MarkBasePosFormat1<'a> = TableRef<'a, MarkBasePosFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkBasePosFormat1<'a> {
@@ -2797,9 +2737,7 @@ impl<'a> std::fmt::Debug for MarkBasePosFormat1<'a> {
 /// Part of [MarkBasePosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BaseArrayMarker {
-    mark_class_count: u16,
-}
+pub struct BaseArrayMarker;
 
 impl<'a> MinByteRange for BaseArray<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2813,16 +2751,12 @@ impl ReadArgs for BaseArray<'_> {
 
 impl<'a> FontReadWithArgs<'a> for BaseArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let mark_class_count = *args;
-        let mut cursor = data.cursor();
-        let base_count: u16 = cursor.read()?;
-        let base_records_byte_len = (base_count as usize)
-            .checked_mul(<BaseRecord as ComputeSize>::compute_size(
-                &mark_class_count,
-            )?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(base_records_byte_len);
-        cursor.finish(BaseArrayMarker { mark_class_count })
+        let args = *args;
+        Ok(TableRef {
+            shape: BaseArrayMarker,
+            args,
+            data,
+        })
     }
 }
 
@@ -2838,16 +2772,14 @@ impl<'a> BaseArray<'a> {
 }
 
 /// Part of [MarkBasePosFormat1]
-pub type BaseArray<'a> = TableRef<'a, BaseArrayMarker>;
+pub type BaseArray<'a> = TableRef<'a, BaseArrayMarker, u16>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BaseArray<'a> {
     fn base_records_byte_len(&self, start: usize) -> usize {
         let _ = start;
         ((self.base_count()) as usize)
-            .checked_mul(
-                <BaseRecord as ComputeSize>::compute_size(&self.shape.mark_class_count).unwrap(),
-            )
+            .checked_mul(<BaseRecord as ComputeSize>::compute_size(&self.args).unwrap())
             .unwrap()
     }
 
@@ -2876,7 +2808,7 @@ impl<'a> BaseArray<'a> {
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
-        self.shape.mark_class_count
+        self.args
     }
 }
 
@@ -3010,7 +2942,7 @@ impl Format<u16> for MarkLigPosFormat1Marker {
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MarkLigPosFormat1Marker {}
+pub struct MarkLigPosFormat1Marker;
 
 impl<'a> MinByteRange for MarkLigPosFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3020,19 +2952,16 @@ impl<'a> MinByteRange for MarkLigPosFormat1<'a> {
 
 impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkLigPosFormat1Marker {})
+        Ok(TableRef {
+            shape: MarkLigPosFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Mark-to-Ligature Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-ligature-attachment-positioning-format-1-mark-to-ligature-attachment): Mark-to-Ligature Attachment
-pub type MarkLigPosFormat1<'a> = TableRef<'a, MarkLigPosFormat1Marker>;
+pub type MarkLigPosFormat1<'a> = TableRef<'a, MarkLigPosFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkLigPosFormat1<'a> {
@@ -3173,9 +3102,7 @@ impl<'a> std::fmt::Debug for MarkLigPosFormat1<'a> {
 /// Part of [MarkLigPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureArrayMarker {
-    mark_class_count: u16,
-}
+pub struct LigatureArrayMarker;
 
 impl<'a> MinByteRange for LigatureArray<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3189,14 +3116,12 @@ impl ReadArgs for LigatureArray<'_> {
 
 impl<'a> FontReadWithArgs<'a> for LigatureArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let mark_class_count = *args;
-        let mut cursor = data.cursor();
-        let ligature_count: u16 = cursor.read()?;
-        let ligature_attach_offsets_byte_len = (ligature_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ligature_attach_offsets_byte_len);
-        cursor.finish(LigatureArrayMarker { mark_class_count })
+        let args = *args;
+        Ok(TableRef {
+            shape: LigatureArrayMarker,
+            args,
+            data,
+        })
     }
 }
 
@@ -3212,7 +3137,7 @@ impl<'a> LigatureArray<'a> {
 }
 
 /// Part of [MarkLigPosFormat1]
-pub type LigatureArray<'a> = TableRef<'a, LigatureArrayMarker>;
+pub type LigatureArray<'a> = TableRef<'a, LigatureArrayMarker, u16>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureArray<'a> {
@@ -3256,7 +3181,7 @@ impl<'a> LigatureArray<'a> {
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
-        self.shape.mark_class_count
+        self.args
     }
 }
 
@@ -3299,9 +3224,7 @@ impl<'a> std::fmt::Debug for LigatureArray<'a> {
 /// Part of [MarkLigPosFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureAttachMarker {
-    mark_class_count: u16,
-}
+pub struct LigatureAttachMarker;
 
 impl<'a> MinByteRange for LigatureAttach<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3315,16 +3238,12 @@ impl ReadArgs for LigatureAttach<'_> {
 
 impl<'a> FontReadWithArgs<'a> for LigatureAttach<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let mark_class_count = *args;
-        let mut cursor = data.cursor();
-        let component_count: u16 = cursor.read()?;
-        let component_records_byte_len = (component_count as usize)
-            .checked_mul(<ComponentRecord as ComputeSize>::compute_size(
-                &mark_class_count,
-            )?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(component_records_byte_len);
-        cursor.finish(LigatureAttachMarker { mark_class_count })
+        let args = *args;
+        Ok(TableRef {
+            shape: LigatureAttachMarker,
+            args,
+            data,
+        })
     }
 }
 
@@ -3340,17 +3259,14 @@ impl<'a> LigatureAttach<'a> {
 }
 
 /// Part of [MarkLigPosFormat1]
-pub type LigatureAttach<'a> = TableRef<'a, LigatureAttachMarker>;
+pub type LigatureAttach<'a> = TableRef<'a, LigatureAttachMarker, u16>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureAttach<'a> {
     fn component_records_byte_len(&self, start: usize) -> usize {
         let _ = start;
         ((self.component_count()) as usize)
-            .checked_mul(
-                <ComponentRecord as ComputeSize>::compute_size(&self.shape.mark_class_count)
-                    .unwrap(),
-            )
+            .checked_mul(<ComponentRecord as ComputeSize>::compute_size(&self.args).unwrap())
             .unwrap()
     }
 
@@ -3379,7 +3295,7 @@ impl<'a> LigatureAttach<'a> {
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
-        self.shape.mark_class_count
+        self.args
     }
 }
 
@@ -3513,7 +3429,7 @@ impl Format<u16> for MarkMarkPosFormat1Marker {
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MarkMarkPosFormat1Marker {}
+pub struct MarkMarkPosFormat1Marker;
 
 impl<'a> MinByteRange for MarkMarkPosFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3523,19 +3439,16 @@ impl<'a> MinByteRange for MarkMarkPosFormat1<'a> {
 
 impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.finish(MarkMarkPosFormat1Marker {})
+        Ok(TableRef {
+            shape: MarkMarkPosFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Mark-to-Mark Attachment Positioning Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#mark-to-mark-attachment-positioning-format-1-mark-to-mark-attachment): Mark-to-Mark Attachment
-pub type MarkMarkPosFormat1<'a> = TableRef<'a, MarkMarkPosFormat1Marker>;
+pub type MarkMarkPosFormat1<'a> = TableRef<'a, MarkMarkPosFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MarkMarkPosFormat1<'a> {
@@ -3676,9 +3589,7 @@ impl<'a> std::fmt::Debug for MarkMarkPosFormat1<'a> {
 /// Part of [MarkMarkPosFormat1]Class2Record
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Mark2ArrayMarker {
-    mark_class_count: u16,
-}
+pub struct Mark2ArrayMarker;
 
 impl<'a> MinByteRange for Mark2Array<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3692,16 +3603,12 @@ impl ReadArgs for Mark2Array<'_> {
 
 impl<'a> FontReadWithArgs<'a> for Mark2Array<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let mark_class_count = *args;
-        let mut cursor = data.cursor();
-        let mark2_count: u16 = cursor.read()?;
-        let mark2_records_byte_len = (mark2_count as usize)
-            .checked_mul(<Mark2Record as ComputeSize>::compute_size(
-                &mark_class_count,
-            )?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(mark2_records_byte_len);
-        cursor.finish(Mark2ArrayMarker { mark_class_count })
+        let args = *args;
+        Ok(TableRef {
+            shape: Mark2ArrayMarker,
+            args,
+            data,
+        })
     }
 }
 
@@ -3717,16 +3624,14 @@ impl<'a> Mark2Array<'a> {
 }
 
 /// Part of [MarkMarkPosFormat1]Class2Record
-pub type Mark2Array<'a> = TableRef<'a, Mark2ArrayMarker>;
+pub type Mark2Array<'a> = TableRef<'a, Mark2ArrayMarker, u16>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Mark2Array<'a> {
     fn mark2_records_byte_len(&self, start: usize) -> usize {
         let _ = start;
         ((self.mark2_count()) as usize)
-            .checked_mul(
-                <Mark2Record as ComputeSize>::compute_size(&self.shape.mark_class_count).unwrap(),
-            )
+            .checked_mul(<Mark2Record as ComputeSize>::compute_size(&self.args).unwrap())
             .unwrap()
     }
 
@@ -3755,7 +3660,7 @@ impl<'a> Mark2Array<'a> {
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
-        self.shape.mark_class_count
+        self.args
     }
 }
 
@@ -3887,11 +3792,9 @@ impl Format<u16> for ExtensionPosFormat1Marker {
 }
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ExtensionPosFormat1Marker<T = ()> {
-    offset_type: std::marker::PhantomData<*const T>,
-}
+pub struct ExtensionPosFormat1Marker;
 
 impl<'a, T> MinByteRange for ExtensionPosFormat1<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3899,22 +3802,12 @@ impl<'a, T> MinByteRange for ExtensionPosFormat1<'a, T> {
     }
 }
 
-impl<T> Clone for ExtensionPosFormat1Marker<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T> Copy for ExtensionPosFormat1Marker<T> {}
-
 impl<'a, T> FontRead<'a> for ExtensionPosFormat1<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        cursor.finish(ExtensionPosFormat1Marker {
-            offset_type: std::marker::PhantomData,
+        Ok(TableRef {
+            shape: ExtensionPosFormat1Marker,
+            args: std::marker::PhantomData,
+            data,
         })
     }
 }
@@ -3924,9 +3817,8 @@ impl<'a> ExtensionPosFormat1<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> ExtensionPosFormat1<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionPosFormat1Marker {
-                offset_type: std::marker::PhantomData,
-            },
+            shape: ExtensionPosFormat1Marker,
+            args: std::marker::PhantomData,
             data,
         }
     }
@@ -3938,16 +3830,16 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     pub(crate) fn of_unit_type(&self) -> ExtensionPosFormat1<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionPosFormat1Marker {
-                offset_type: std::marker::PhantomData,
-            },
+            shape: ExtensionPosFormat1Marker,
+            args: std::marker::PhantomData,
             data: *data,
         }
     }
 }
 
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
-pub type ExtensionPosFormat1<'a, T> = TableRef<'a, ExtensionPosFormat1Marker<T>>;
+pub type ExtensionPosFormat1<'a, T = ()> =
+    TableRef<'a, ExtensionPosFormat1Marker, std::marker::PhantomData<*const T>>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> ExtensionPosFormat1<'a, T> {

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -70,13 +70,13 @@ impl<'a> Gpos<'a> {
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to ScriptList table, from beginning of GPOS table
     pub fn script_list_offset(&self) -> Offset16 {
         let range = self.script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
@@ -88,7 +88,7 @@ impl<'a> Gpos<'a> {
     /// Offset to FeatureList table, from beginning of GPOS table
     pub fn feature_list_offset(&self) -> Offset16 {
         let range = self.feature_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
@@ -100,7 +100,7 @@ impl<'a> Gpos<'a> {
     /// Offset to LookupList table, from beginning of GPOS table
     pub fn lookup_list_offset(&self) -> Offset16 {
         let range = self.lookup_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
@@ -111,7 +111,7 @@ impl<'a> Gpos<'a> {
 
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.feature_variations_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
@@ -735,19 +735,19 @@ impl<'a> AnchorFormat1<'a> {
     /// Format identifier, = 1
     pub fn anchor_format(&self) -> u16 {
         let range = self.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
         let range = self.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
         let range = self.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -827,25 +827,25 @@ impl<'a> AnchorFormat2<'a> {
     /// Format identifier, = 2
     pub fn anchor_format(&self) -> u16 {
         let range = self.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
         let range = self.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
         let range = self.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Index to glyph contour point
     pub fn anchor_point(&self) -> u16 {
         let range = self.anchor_point_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -931,19 +931,19 @@ impl<'a> AnchorFormat3<'a> {
     /// Format identifier, = 3
     pub fn anchor_format(&self) -> u16 {
         let range = self.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
         let range = self.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
         let range = self.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Device table (non-variable font) / VariationIndex
@@ -951,7 +951,7 @@ impl<'a> AnchorFormat3<'a> {
     /// Anchor table (may be NULL)
     pub fn x_device_offset(&self) -> Nullable<Offset16> {
         let range = self.x_device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`x_device_offset`][Self::x_device_offset].
@@ -965,7 +965,7 @@ impl<'a> AnchorFormat3<'a> {
     /// Anchor table (may be NULL)
     pub fn y_device_offset(&self) -> Nullable<Offset16> {
         let range = self.y_device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`y_device_offset`][Self::y_device_offset].
@@ -1052,14 +1052,14 @@ impl<'a> MarkArray<'a> {
     /// Number of MarkRecords
     pub fn mark_count(&self) -> u16 {
         let range = self.mark_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
     pub fn mark_records(&self) -> &'a [MarkRecord] {
         let range = self.mark_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1291,13 +1291,13 @@ impl<'a> SinglePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1309,16 +1309,14 @@ impl<'a> SinglePosFormat1<'a> {
     /// Defines the types of data in the ValueRecord.
     pub fn value_format(&self) -> ValueFormat {
         let range = self.value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Defines positioning value(s) — applied to all glyphs in the
     /// Coverage table.
     pub fn value_record(&self) -> ValueRecord {
         let range = self.value_record_byte_range();
-        self.data
-            .read_with_args(range, &self.value_format())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.value_format())
     }
 }
 
@@ -1417,13 +1415,13 @@ impl<'a> SinglePosFormat2<'a> {
     /// Format identifier: format = 2
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1435,22 +1433,20 @@ impl<'a> SinglePosFormat2<'a> {
     /// Defines the types of data in the ValueRecords.
     pub fn value_format(&self) -> ValueFormat {
         let range = self.value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of ValueRecords — must equal glyphCount in the
     /// Coverage table.
     pub fn value_count(&self) -> u16 {
         let range = self.value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of ValueRecords — positioning values applied to glyphs.
     pub fn value_records(&self) -> ComputedArray<'a, ValueRecord> {
         let range = self.value_records_byte_range();
-        self.data
-            .read_with_args(range, &self.value_format())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.value_format())
     }
 }
 
@@ -1657,13 +1653,13 @@ impl<'a> PairPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1676,27 +1672,27 @@ impl<'a> PairPosFormat1<'a> {
     /// glyph in the pair (may be zero).
     pub fn value_format1(&self) -> ValueFormat {
         let range = self.value_format1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Defines the types of data in valueRecord2 — for the second
     /// glyph in the pair (may be zero).
     pub fn value_format2(&self) -> ValueFormat {
         let range = self.value_format2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of PairSet tables
     pub fn pair_set_count(&self) -> u16 {
         let range = self.pair_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to PairSet tables. Offsets are from beginning
     /// of PairPos subtable, ordered by Coverage Index.
     pub fn pair_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.pair_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`pair_set_offsets`][Self::pair_set_offsets].
@@ -1823,16 +1819,18 @@ impl<'a> PairSet<'a> {
     /// Number of PairValueRecords
     pub fn pair_value_count(&self) -> u16 {
         let range = self.pair_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of PairValueRecords, ordered by glyph ID of the second
     /// glyph.
     pub fn pair_value_records(&self) -> ComputedArray<'a, PairValueRecord> {
         let range = self.pair_value_records_byte_range();
-        self.data
-            .read_with_args(range, &(self.value_format1(), self.value_format2()))
-            .unwrap()
+        unchecked::read_with_args(
+            self.data,
+            range,
+            &(self.value_format1(), self.value_format2()),
+        )
     }
 
     pub(crate) fn value_format1(&self) -> ValueFormat {
@@ -2070,13 +2068,13 @@ impl<'a> PairPosFormat2<'a> {
     /// Format identifier: format = 2
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2089,21 +2087,21 @@ impl<'a> PairPosFormat2<'a> {
     /// be zero).
     pub fn value_format1(&self) -> ValueFormat {
         let range = self.value_format1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// ValueRecord definition — for the second glyph of the pair
     /// (may be zero).
     pub fn value_format2(&self) -> ValueFormat {
         let range = self.value_format2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the first glyph of the pair.
     pub fn class_def1_offset(&self) -> Offset16 {
         let range = self.class_def1_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`class_def1_offset`][Self::class_def1_offset].
@@ -2116,7 +2114,7 @@ impl<'a> PairPosFormat2<'a> {
     /// — for the second glyph of the pair.
     pub fn class_def2_offset(&self) -> Offset16 {
         let range = self.class_def2_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`class_def2_offset`][Self::class_def2_offset].
@@ -2128,28 +2126,27 @@ impl<'a> PairPosFormat2<'a> {
     /// Number of classes in classDef1 table — includes Class 0.
     pub fn class1_count(&self) -> u16 {
         let range = self.class1_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of classes in classDef2 table — includes Class 0.
     pub fn class2_count(&self) -> u16 {
         let range = self.class2_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of Class1 records, ordered by classes in classDef1.
     pub fn class1_records(&self) -> ComputedArray<'a, Class1Record<'a>> {
         let range = self.class1_records_byte_range();
-        self.data
-            .read_with_args(
-                range,
-                &(
-                    self.class2_count(),
-                    self.value_format1(),
-                    self.value_format2(),
-                ),
-            )
-            .unwrap()
+        unchecked::read_with_args(
+            self.data,
+            range,
+            &(
+                self.class2_count(),
+                self.value_format1(),
+                self.value_format2(),
+            ),
+        )
     }
 }
 
@@ -2432,13 +2429,13 @@ impl<'a> CursivePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of CursivePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2450,13 +2447,13 @@ impl<'a> CursivePosFormat1<'a> {
     /// Number of EntryExit records
     pub fn entry_exit_count(&self) -> u16 {
         let range = self.entry_exit_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of EntryExit records, in Coverage index order.
     pub fn entry_exit_record(&self) -> &'a [EntryExitRecord] {
         let range = self.entry_exit_record_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2633,14 +2630,14 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
     pub fn mark_coverage_offset(&self) -> Offset16 {
         let range = self.mark_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
@@ -2653,7 +2650,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// subtable.
     pub fn base_coverage_offset(&self) -> Offset16 {
         let range = self.base_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`base_coverage_offset`][Self::base_coverage_offset].
@@ -2665,14 +2662,14 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Number of classes defined for marks
     pub fn mark_class_count(&self) -> u16 {
         let range = self.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to MarkArray table, from beginning of MarkBasePos
     /// subtable.
     pub fn mark_array_offset(&self) -> Offset16 {
         let range = self.mark_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
@@ -2685,7 +2682,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// subtable.
     pub fn base_array_offset(&self) -> Offset16 {
         let range = self.base_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`base_array_offset`][Self::base_array_offset].
@@ -2796,15 +2793,13 @@ impl<'a> BaseArray<'a> {
     /// Number of BaseRecords
     pub fn base_count(&self) -> u16 {
         let range = self.base_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of BaseRecords, in order of baseCoverage Index.
     pub fn base_records(&self) -> ComputedArray<'a, BaseRecord<'a>> {
         let range = self.base_records_byte_range();
-        self.data
-            .read_with_args(range, &self.mark_class_count())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.mark_class_count())
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
@@ -2998,14 +2993,14 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
     pub fn mark_coverage_offset(&self) -> Offset16 {
         let range = self.mark_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
@@ -3018,7 +3013,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// subtable.
     pub fn ligature_coverage_offset(&self) -> Offset16 {
         let range = self.ligature_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`ligature_coverage_offset`][Self::ligature_coverage_offset].
@@ -3030,14 +3025,14 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Number of defined mark classes
     pub fn mark_class_count(&self) -> u16 {
         let range = self.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to MarkArray table, from beginning of MarkLigPos
     /// subtable.
     pub fn mark_array_offset(&self) -> Offset16 {
         let range = self.mark_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
@@ -3050,7 +3045,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// subtable.
     pub fn ligature_array_offset(&self) -> Offset16 {
         let range = self.ligature_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`ligature_array_offset`][Self::ligature_array_offset].
@@ -3161,7 +3156,7 @@ impl<'a> LigatureArray<'a> {
     /// Number of LigatureAttach table offsets
     pub fn ligature_count(&self) -> u16 {
         let range = self.ligature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to LigatureAttach tables. Offsets are from
@@ -3169,7 +3164,7 @@ impl<'a> LigatureArray<'a> {
     /// index.
     pub fn ligature_attach_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.ligature_attach_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`ligature_attach_offsets`][Self::ligature_attach_offsets].
@@ -3283,15 +3278,13 @@ impl<'a> LigatureAttach<'a> {
     /// Number of ComponentRecords in this ligature
     pub fn component_count(&self) -> u16 {
         let range = self.component_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of Component records, ordered in writing direction.
     pub fn component_records(&self) -> ComputedArray<'a, ComponentRecord<'a>> {
         let range = self.component_records_byte_range();
-        self.data
-            .read_with_args(range, &self.mark_class_count())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.mark_class_count())
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
@@ -3485,14 +3478,14 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark1_coverage_offset(&self) -> Offset16 {
         let range = self.mark1_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark1_coverage_offset`][Self::mark1_coverage_offset].
@@ -3505,7 +3498,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// MarkMarkPos subtable.
     pub fn mark2_coverage_offset(&self) -> Offset16 {
         let range = self.mark2_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark2_coverage_offset`][Self::mark2_coverage_offset].
@@ -3517,14 +3510,14 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Number of Combining Mark classes defined
     pub fn mark_class_count(&self) -> u16 {
         let range = self.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to MarkArray table for mark1, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark1_array_offset(&self) -> Offset16 {
         let range = self.mark1_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark1_array_offset`][Self::mark1_array_offset].
@@ -3537,7 +3530,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// MarkMarkPos subtable.
     pub fn mark2_array_offset(&self) -> Offset16 {
         let range = self.mark2_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`mark2_array_offset`][Self::mark2_array_offset].
@@ -3648,15 +3641,13 @@ impl<'a> Mark2Array<'a> {
     /// Number of Mark2 records
     pub fn mark2_count(&self) -> u16 {
         let range = self.mark2_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of Mark2Records, in Coverage order.
     pub fn mark2_records(&self) -> ComputedArray<'a, Mark2Record<'a>> {
         let range = self.mark2_records_byte_range();
-        self.data
-            .read_with_args(range, &self.mark_class_count())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.mark_class_count())
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
@@ -3861,14 +3852,14 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
     pub fn extension_lookup_type(&self) -> u16 {
         let range = self.extension_lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to the extension subtable, of lookup type
@@ -3876,7 +3867,7 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// ExtensionPosFormat1 subtable.
     pub fn extension_offset(&self) -> Offset32 {
         let range = self.extension_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -8,9 +8,7 @@ use crate::codegen_prelude::*;
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GsubMarker {
-    feature_variations_offset_byte_start: Option<usize>,
-}
+pub struct GsubMarker;
 
 impl<'a> MinByteRange for Gsub<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -25,26 +23,16 @@ impl TopLevelTable for Gsub<'_> {
 
 impl<'a> FontRead<'a> for Gsub<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let version: MajorMinor = cursor.read()?;
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let feature_variations_offset_byte_start = version
-            .compatible((1u16, 1u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 1u16))
-            .then(|| cursor.advance::<Offset32>());
-        cursor.finish(GsubMarker {
-            feature_variations_offset_byte_start,
+        Ok(TableRef {
+            shape: GsubMarker,
+            args: (),
+            data,
         })
     }
 }
 
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
-pub type Gsub<'a> = TableRef<'a, GsubMarker>;
+pub type Gsub<'a> = TableRef<'a, GsubMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gsub<'a> {
@@ -69,8 +57,12 @@ impl<'a> Gsub<'a> {
     }
 
     pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.feature_variations_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 1u16)) {
+            let start = self.lookup_list_offset_byte_range().end;
+            Some(start..start + Offset32::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     /// The major and minor version of the GSUB table, as a tuple (u16, u16)
@@ -339,7 +331,7 @@ impl Format<u16> for SingleSubstFormat1Marker {
 /// [Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SingleSubstFormat1Marker {}
+pub struct SingleSubstFormat1Marker;
 
 impl<'a> MinByteRange for SingleSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -349,16 +341,16 @@ impl<'a> MinByteRange for SingleSubstFormat1<'a> {
 
 impl<'a> FontRead<'a> for SingleSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<i16>();
-        cursor.finish(SingleSubstFormat1Marker {})
+        Ok(TableRef {
+            shape: SingleSubstFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1)
-pub type SingleSubstFormat1<'a> = TableRef<'a, SingleSubstFormat1Marker>;
+pub type SingleSubstFormat1<'a> = TableRef<'a, SingleSubstFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SingleSubstFormat1<'a> {
@@ -436,7 +428,7 @@ impl Format<u16> for SingleSubstFormat2Marker {
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SingleSubstFormat2Marker {}
+pub struct SingleSubstFormat2Marker;
 
 impl<'a> MinByteRange for SingleSubstFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -446,20 +438,16 @@ impl<'a> MinByteRange for SingleSubstFormat2<'a> {
 
 impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = (glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(substitute_glyph_ids_byte_len);
-        cursor.finish(SingleSubstFormat2Marker {})
+        Ok(TableRef {
+            shape: SingleSubstFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
-pub type SingleSubstFormat2<'a> = TableRef<'a, SingleSubstFormat2Marker>;
+pub type SingleSubstFormat2<'a> = TableRef<'a, SingleSubstFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SingleSubstFormat2<'a> {
@@ -559,7 +547,7 @@ impl Format<u16> for MultipleSubstFormat1Marker {
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MultipleSubstFormat1Marker {}
+pub struct MultipleSubstFormat1Marker;
 
 impl<'a> MinByteRange for MultipleSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -569,20 +557,16 @@ impl<'a> MinByteRange for MultipleSubstFormat1<'a> {
 
 impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let sequence_count: u16 = cursor.read()?;
-        let sequence_offsets_byte_len = (sequence_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(sequence_offsets_byte_len);
-        cursor.finish(MultipleSubstFormat1Marker {})
+        Ok(TableRef {
+            shape: MultipleSubstFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
-pub type MultipleSubstFormat1<'a> = TableRef<'a, MultipleSubstFormat1Marker>;
+pub type MultipleSubstFormat1<'a> = TableRef<'a, MultipleSubstFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MultipleSubstFormat1<'a> {
@@ -696,7 +680,7 @@ impl<'a> std::fmt::Debug for MultipleSubstFormat1<'a> {
 /// Part of [MultipleSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceMarker {}
+pub struct SequenceMarker;
 
 impl<'a> MinByteRange for Sequence<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -706,18 +690,16 @@ impl<'a> MinByteRange for Sequence<'a> {
 
 impl<'a> FontRead<'a> for Sequence<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = (glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(substitute_glyph_ids_byte_len);
-        cursor.finish(SequenceMarker {})
+        Ok(TableRef {
+            shape: SequenceMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [MultipleSubstFormat1]
-pub type Sequence<'a> = TableRef<'a, SequenceMarker>;
+pub type Sequence<'a> = TableRef<'a, SequenceMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Sequence<'a> {
@@ -784,7 +766,7 @@ impl Format<u16> for AlternateSubstFormat1Marker {
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AlternateSubstFormat1Marker {}
+pub struct AlternateSubstFormat1Marker;
 
 impl<'a> MinByteRange for AlternateSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -794,20 +776,16 @@ impl<'a> MinByteRange for AlternateSubstFormat1<'a> {
 
 impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let alternate_set_count: u16 = cursor.read()?;
-        let alternate_set_offsets_byte_len = (alternate_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(alternate_set_offsets_byte_len);
-        cursor.finish(AlternateSubstFormat1Marker {})
+        Ok(TableRef {
+            shape: AlternateSubstFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
-pub type AlternateSubstFormat1<'a> = TableRef<'a, AlternateSubstFormat1Marker>;
+pub type AlternateSubstFormat1<'a> = TableRef<'a, AlternateSubstFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AlternateSubstFormat1<'a> {
@@ -924,7 +902,7 @@ impl<'a> std::fmt::Debug for AlternateSubstFormat1<'a> {
 /// Part of [AlternateSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AlternateSetMarker {}
+pub struct AlternateSetMarker;
 
 impl<'a> MinByteRange for AlternateSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -934,18 +912,16 @@ impl<'a> MinByteRange for AlternateSet<'a> {
 
 impl<'a> FontRead<'a> for AlternateSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let glyph_count: u16 = cursor.read()?;
-        let alternate_glyph_ids_byte_len = (glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(alternate_glyph_ids_byte_len);
-        cursor.finish(AlternateSetMarker {})
+        Ok(TableRef {
+            shape: AlternateSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [AlternateSubstFormat1]
-pub type AlternateSet<'a> = TableRef<'a, AlternateSetMarker>;
+pub type AlternateSet<'a> = TableRef<'a, AlternateSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AlternateSet<'a> {
@@ -1011,7 +987,7 @@ impl Format<u16> for LigatureSubstFormat1Marker {
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureSubstFormat1Marker {}
+pub struct LigatureSubstFormat1Marker;
 
 impl<'a> MinByteRange for LigatureSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1021,20 +997,16 @@ impl<'a> MinByteRange for LigatureSubstFormat1<'a> {
 
 impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let ligature_set_count: u16 = cursor.read()?;
-        let ligature_set_offsets_byte_len = (ligature_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ligature_set_offsets_byte_len);
-        cursor.finish(LigatureSubstFormat1Marker {})
+        Ok(TableRef {
+            shape: LigatureSubstFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
-pub type LigatureSubstFormat1<'a> = TableRef<'a, LigatureSubstFormat1Marker>;
+pub type LigatureSubstFormat1<'a> = TableRef<'a, LigatureSubstFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureSubstFormat1<'a> {
@@ -1148,7 +1120,7 @@ impl<'a> std::fmt::Debug for LigatureSubstFormat1<'a> {
 /// Part of [LigatureSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureSetMarker {}
+pub struct LigatureSetMarker;
 
 impl<'a> MinByteRange for LigatureSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1158,18 +1130,16 @@ impl<'a> MinByteRange for LigatureSet<'a> {
 
 impl<'a> FontRead<'a> for LigatureSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let ligature_count: u16 = cursor.read()?;
-        let ligature_offsets_byte_len = (ligature_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ligature_offsets_byte_len);
-        cursor.finish(LigatureSetMarker {})
+        Ok(TableRef {
+            shape: LigatureSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [LigatureSubstFormat1]
-pub type LigatureSet<'a> = TableRef<'a, LigatureSetMarker>;
+pub type LigatureSet<'a> = TableRef<'a, LigatureSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureSet<'a> {
@@ -1249,7 +1219,7 @@ impl<'a> std::fmt::Debug for LigatureSet<'a> {
 /// Part of [LigatureSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureMarker {}
+pub struct LigatureMarker;
 
 impl<'a> MinByteRange for Ligature<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1259,19 +1229,16 @@ impl<'a> MinByteRange for Ligature<'a> {
 
 impl<'a> FontRead<'a> for Ligature<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<GlyphId16>();
-        let component_count: u16 = cursor.read()?;
-        let component_glyph_ids_byte_len = (transforms::subtract(component_count, 1_usize))
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(component_glyph_ids_byte_len);
-        cursor.finish(LigatureMarker {})
+        Ok(TableRef {
+            shape: LigatureMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [LigatureSubstFormat1]
-pub type Ligature<'a> = TableRef<'a, LigatureMarker>;
+pub type Ligature<'a> = TableRef<'a, LigatureMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Ligature<'a> {
@@ -1348,11 +1315,9 @@ impl Format<u16> for ExtensionSubstFormat1Marker {
 }
 
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ExtensionSubstFormat1Marker<T = ()> {
-    offset_type: std::marker::PhantomData<*const T>,
-}
+pub struct ExtensionSubstFormat1Marker;
 
 impl<'a, T> MinByteRange for ExtensionSubstFormat1<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1360,22 +1325,12 @@ impl<'a, T> MinByteRange for ExtensionSubstFormat1<'a, T> {
     }
 }
 
-impl<T> Clone for ExtensionSubstFormat1Marker<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T> Copy for ExtensionSubstFormat1Marker<T> {}
-
 impl<'a, T> FontRead<'a> for ExtensionSubstFormat1<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        cursor.finish(ExtensionSubstFormat1Marker {
-            offset_type: std::marker::PhantomData,
+        Ok(TableRef {
+            shape: ExtensionSubstFormat1Marker,
+            args: std::marker::PhantomData,
+            data,
         })
     }
 }
@@ -1385,9 +1340,8 @@ impl<'a> ExtensionSubstFormat1<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> ExtensionSubstFormat1<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionSubstFormat1Marker {
-                offset_type: std::marker::PhantomData,
-            },
+            shape: ExtensionSubstFormat1Marker,
+            args: std::marker::PhantomData,
             data,
         }
     }
@@ -1399,16 +1353,16 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     pub(crate) fn of_unit_type(&self) -> ExtensionSubstFormat1<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionSubstFormat1Marker {
-                offset_type: std::marker::PhantomData,
-            },
+            shape: ExtensionSubstFormat1Marker,
+            args: std::marker::PhantomData,
             data: *data,
         }
     }
 }
 
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
-pub type ExtensionSubstFormat1<'a, T> = TableRef<'a, ExtensionSubstFormat1Marker<T>>;
+pub type ExtensionSubstFormat1<'a, T = ()> =
+    TableRef<'a, ExtensionSubstFormat1Marker, std::marker::PhantomData<*const T>>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> ExtensionSubstFormat1<'a, T> {
@@ -1571,7 +1525,7 @@ impl Format<u16> for ReverseChainSingleSubstFormat1Marker {
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ReverseChainSingleSubstFormat1Marker {}
+pub struct ReverseChainSingleSubstFormat1Marker;
 
 impl<'a> MinByteRange for ReverseChainSingleSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1581,30 +1535,17 @@ impl<'a> MinByteRange for ReverseChainSingleSubstFormat1<'a> {
 
 impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_coverage_offsets_byte_len = (backtrack_glyph_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(backtrack_coverage_offsets_byte_len);
-        let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_coverage_offsets_byte_len = (lookahead_glyph_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lookahead_coverage_offsets_byte_len);
-        let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = (glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(substitute_glyph_ids_byte_len);
-        cursor.finish(ReverseChainSingleSubstFormat1Marker {})
+        Ok(TableRef {
+            shape: ReverseChainSingleSubstFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
-pub type ReverseChainSingleSubstFormat1<'a> = TableRef<'a, ReverseChainSingleSubstFormat1Marker>;
+pub type ReverseChainSingleSubstFormat1<'a> =
+    TableRef<'a, ReverseChainSingleSubstFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ReverseChainSingleSubstFormat1<'a> {

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -68,13 +68,13 @@ impl<'a> Gsub<'a> {
     /// The major and minor version of the GSUB table, as a tuple (u16, u16)
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to ScriptList table, from beginning of GSUB table
     pub fn script_list_offset(&self) -> Offset16 {
         let range = self.script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
@@ -86,7 +86,7 @@ impl<'a> Gsub<'a> {
     /// Offset to FeatureList table, from beginning of GSUB table
     pub fn feature_list_offset(&self) -> Offset16 {
         let range = self.feature_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
@@ -98,7 +98,7 @@ impl<'a> Gsub<'a> {
     /// Offset to LookupList table, from beginning of GSUB table
     pub fn lookup_list_offset(&self) -> Offset16 {
         let range = self.lookup_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
@@ -111,7 +111,7 @@ impl<'a> Gsub<'a> {
     /// table (may be NULL)
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.feature_variations_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
@@ -372,14 +372,14 @@ impl<'a> SingleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -391,7 +391,7 @@ impl<'a> SingleSubstFormat1<'a> {
     /// Add to original glyph ID to get substitute glyph ID
     pub fn delta_glyph_id(&self) -> i16 {
         let range = self.delta_glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -481,14 +481,14 @@ impl<'a> SingleSubstFormat2<'a> {
     /// Format identifier: format = 2
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -500,13 +500,13 @@ impl<'a> SingleSubstFormat2<'a> {
     /// Number of glyph IDs in the substituteGlyphIDs array
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of substitute glyph IDs — ordered by Coverage index
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.substitute_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -600,14 +600,14 @@ impl<'a> MultipleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -619,14 +619,14 @@ impl<'a> MultipleSubstFormat1<'a> {
     /// Number of Sequence table offsets in the sequenceOffsets array
     pub fn sequence_count(&self) -> u16 {
         let range = self.sequence_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to Sequence tables. Offsets are from beginning
     /// of substitution subtable, ordered by Coverage index
     pub fn sequence_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.sequence_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`sequence_offsets`][Self::sequence_offsets].
@@ -724,13 +724,13 @@ impl<'a> Sequence<'a> {
     /// always be greater than 0.
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// String of glyph IDs to substitute
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.substitute_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -819,14 +819,14 @@ impl<'a> AlternateSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -838,14 +838,14 @@ impl<'a> AlternateSubstFormat1<'a> {
     /// Number of AlternateSet tables
     pub fn alternate_set_count(&self) -> u16 {
         let range = self.alternate_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to AlternateSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     pub fn alternate_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.alternate_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`alternate_set_offsets`][Self::alternate_set_offsets].
@@ -945,13 +945,13 @@ impl<'a> AlternateSet<'a> {
     /// Number of glyph IDs in the alternateGlyphIDs array
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of alternate glyph IDs, in arbitrary order
     pub fn alternate_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.alternate_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1040,14 +1040,14 @@ impl<'a> LigatureSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1059,14 +1059,14 @@ impl<'a> LigatureSubstFormat1<'a> {
     /// Number of LigatureSet tables
     pub fn ligature_set_count(&self) -> u16 {
         let range = self.ligature_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to LigatureSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     pub fn ligature_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.ligature_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`ligature_set_offsets`][Self::ligature_set_offsets].
@@ -1163,14 +1163,14 @@ impl<'a> LigatureSet<'a> {
     /// Number of Ligature tables
     pub fn ligature_count(&self) -> u16 {
         let range = self.ligature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
     pub fn ligature_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.ligature_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`ligature_offsets`][Self::ligature_offsets].
@@ -1267,20 +1267,20 @@ impl<'a> Ligature<'a> {
     /// glyph ID of ligature to substitute
     pub fn ligature_glyph(&self) -> GlyphId16 {
         let range = self.ligature_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of components in the ligature
     pub fn component_count(&self) -> u16 {
         let range = self.component_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of component glyph IDs — start with the second
     /// component, ordered in writing direction
     pub fn component_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.component_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1384,14 +1384,14 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     /// Format identifier. Set to 1.
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
     pub fn extension_lookup_type(&self) -> u16 {
         let range = self.extension_lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to the extension subtable, of lookup type
@@ -1399,7 +1399,7 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     /// ExtensionSubstFormat1 subtable.
     pub fn extension_offset(&self) -> Offset32 {
         let range = self.extension_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].
@@ -1611,14 +1611,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1630,14 +1630,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Number of glyphs in the backtrack sequence.
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to coverage tables in backtrack sequence, in
     /// glyph sequence order.
     pub fn backtrack_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.backtrack_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
@@ -1650,14 +1650,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Number of glyphs in lookahead sequence.
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to coverage tables in lookahead sequence, in
     /// glyph sequence order.
     pub fn lookahead_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.lookahead_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
@@ -1670,13 +1670,13 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Number of glyph IDs in the substituteGlyphIDs array.
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of substitute glyph IDs — ordered by Coverage index.
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.substitute_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Gsub<'_> {
 impl<'a> FontRead<'a> for Gsub<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GsubMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -342,9 +342,9 @@ impl<'a> MinByteRange for SingleSubstFormat1<'a> {
 impl<'a> FontRead<'a> for SingleSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SingleSubstFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -439,9 +439,9 @@ impl<'a> MinByteRange for SingleSubstFormat2<'a> {
 impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SingleSubstFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -558,9 +558,9 @@ impl<'a> MinByteRange for MultipleSubstFormat1<'a> {
 impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MultipleSubstFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -691,9 +691,9 @@ impl<'a> MinByteRange for Sequence<'a> {
 impl<'a> FontRead<'a> for Sequence<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SequenceMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -777,9 +777,9 @@ impl<'a> MinByteRange for AlternateSubstFormat1<'a> {
 impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AlternateSubstFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -913,9 +913,9 @@ impl<'a> MinByteRange for AlternateSet<'a> {
 impl<'a> FontRead<'a> for AlternateSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AlternateSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -998,9 +998,9 @@ impl<'a> MinByteRange for LigatureSubstFormat1<'a> {
 impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LigatureSubstFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1131,9 +1131,9 @@ impl<'a> MinByteRange for LigatureSet<'a> {
 impl<'a> FontRead<'a> for LigatureSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LigatureSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1230,9 +1230,9 @@ impl<'a> MinByteRange for Ligature<'a> {
 impl<'a> FontRead<'a> for Ligature<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LigatureMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1328,9 +1328,9 @@ impl<'a, T> MinByteRange for ExtensionSubstFormat1<'a, T> {
 impl<'a, T> FontRead<'a> for ExtensionSubstFormat1<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ExtensionSubstFormat1Marker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1340,9 +1340,9 @@ impl<'a> ExtensionSubstFormat1<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> ExtensionSubstFormat1<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionSubstFormat1Marker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -1353,9 +1353,9 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     pub(crate) fn of_unit_type(&self) -> ExtensionSubstFormat1<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: ExtensionSubstFormat1Marker,
             args: std::marker::PhantomData,
             data: *data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -1536,9 +1536,9 @@ impl<'a> MinByteRange for ReverseChainSingleSubstFormat1<'a> {
 impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ReverseChainSingleSubstFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -12,34 +12,7 @@ pub struct GsubMarker {
     feature_variations_offset_byte_start: Option<usize>,
 }
 
-impl GsubMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn script_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.script_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
-        let start = self.feature_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.feature_variations_offset_byte_start?;
-        Some(start..start + Offset32::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for GsubMarker {
+impl<'a> MinByteRange for Gsub<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.lookup_list_offset_byte_range().end
     }
@@ -75,15 +48,40 @@ pub type Gsub<'a> = TableRef<'a, GsubMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Gsub<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn script_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.script_list_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
+        let start = self.feature_list_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn feature_variations_offset_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.feature_variations_offset_byte_start?;
+        Some(start..start + Offset32::RAW_BYTE_LEN)
+    }
+
     /// The major and minor version of the GSUB table, as a tuple (u16, u16)
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to ScriptList table, from beginning of GSUB table
     pub fn script_list_offset(&self) -> Offset16 {
-        let range = self.shape.script_list_offset_byte_range();
+        let range = self.script_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -95,7 +93,7 @@ impl<'a> Gsub<'a> {
 
     /// Offset to FeatureList table, from beginning of GSUB table
     pub fn feature_list_offset(&self) -> Offset16 {
-        let range = self.shape.feature_list_offset_byte_range();
+        let range = self.feature_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -107,7 +105,7 @@ impl<'a> Gsub<'a> {
 
     /// Offset to LookupList table, from beginning of GSUB table
     pub fn lookup_list_offset(&self) -> Offset16 {
-        let range = self.shape.lookup_list_offset_byte_range();
+        let range = self.lookup_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -120,7 +118,7 @@ impl<'a> Gsub<'a> {
     /// Offset to FeatureVariations table, from beginning of the GSUB
     /// table (may be NULL)
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
-        let range = self.shape.feature_variations_offset_byte_range()?;
+        let range = self.feature_variations_offset_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -343,24 +341,7 @@ impl Format<u16> for SingleSubstFormat1Marker {
 #[doc(hidden)]
 pub struct SingleSubstFormat1Marker {}
 
-impl SingleSubstFormat1Marker {
-    pub fn subst_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
-        let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn delta_glyph_id_byte_range(&self) -> Range<usize> {
-        let start = self.coverage_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for SingleSubstFormat1Marker {
+impl<'a> MinByteRange for SingleSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.delta_glyph_id_byte_range().end
     }
@@ -381,16 +362,31 @@ pub type SingleSubstFormat1<'a> = TableRef<'a, SingleSubstFormat1Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SingleSubstFormat1<'a> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
+        let start = self.subst_format_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn delta_glyph_id_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_offset_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -402,7 +398,7 @@ impl<'a> SingleSubstFormat1<'a> {
 
     /// Add to original glyph ID to get substitute glyph ID
     pub fn delta_glyph_id(&self) -> i16 {
-        let range = self.shape.delta_glyph_id_byte_range();
+        let range = self.delta_glyph_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -440,11 +436,40 @@ impl Format<u16> for SingleSubstFormat2Marker {
 /// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SingleSubstFormat2Marker {
-    substitute_glyph_ids_byte_len: usize,
+pub struct SingleSubstFormat2Marker {}
+
+impl<'a> MinByteRange for SingleSubstFormat2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.substitute_glyph_ids_byte_range().end
+    }
 }
 
-impl SingleSubstFormat2Marker {
+impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let glyph_count: u16 = cursor.read()?;
+        let substitute_glyph_ids_byte_len = (glyph_count as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(substitute_glyph_ids_byte_len);
+        cursor.finish(SingleSubstFormat2Marker {})
+    }
+}
+
+/// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
+pub type SingleSubstFormat2<'a> = TableRef<'a, SingleSubstFormat2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SingleSubstFormat2<'a> {
+    fn substitute_glyph_ids_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -462,47 +487,19 @@ impl SingleSubstFormat2Marker {
 
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + self.substitute_glyph_ids_byte_len
+        start..start + self.substitute_glyph_ids_byte_len(start)
     }
-}
 
-impl MinByteRange for SingleSubstFormat2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.substitute_glyph_ids_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let glyph_count: u16 = cursor.read()?;
-        let substitute_glyph_ids_byte_len = (glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(substitute_glyph_ids_byte_len);
-        cursor.finish(SingleSubstFormat2Marker {
-            substitute_glyph_ids_byte_len,
-        })
-    }
-}
-
-/// [Single Substitution Format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#12-single-substitution-format-2)
-pub type SingleSubstFormat2<'a> = TableRef<'a, SingleSubstFormat2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SingleSubstFormat2<'a> {
     /// Format identifier: format = 2
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -514,13 +511,13 @@ impl<'a> SingleSubstFormat2<'a> {
 
     /// Number of glyph IDs in the substituteGlyphIDs array
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of substitute glyph IDs — ordered by Coverage index
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.substitute_glyph_ids_byte_range();
+        let range = self.substitute_glyph_ids_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -562,11 +559,40 @@ impl Format<u16> for MultipleSubstFormat1Marker {
 /// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MultipleSubstFormat1Marker {
-    sequence_offsets_byte_len: usize,
+pub struct MultipleSubstFormat1Marker {}
+
+impl<'a> MinByteRange for MultipleSubstFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.sequence_offsets_byte_range().end
+    }
 }
 
-impl MultipleSubstFormat1Marker {
+impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let sequence_count: u16 = cursor.read()?;
+        let sequence_offsets_byte_len = (sequence_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(sequence_offsets_byte_len);
+        cursor.finish(MultipleSubstFormat1Marker {})
+    }
+}
+
+/// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
+pub type MultipleSubstFormat1<'a> = TableRef<'a, MultipleSubstFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> MultipleSubstFormat1<'a> {
+    fn sequence_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.sequence_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -584,47 +610,19 @@ impl MultipleSubstFormat1Marker {
 
     pub fn sequence_offsets_byte_range(&self) -> Range<usize> {
         let start = self.sequence_count_byte_range().end;
-        start..start + self.sequence_offsets_byte_len
+        start..start + self.sequence_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for MultipleSubstFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.sequence_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let sequence_count: u16 = cursor.read()?;
-        let sequence_offsets_byte_len = (sequence_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(sequence_offsets_byte_len);
-        cursor.finish(MultipleSubstFormat1Marker {
-            sequence_offsets_byte_len,
-        })
-    }
-}
-
-/// [Multiple Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#21-multiple-substitution-format-1)
-pub type MultipleSubstFormat1<'a> = TableRef<'a, MultipleSubstFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> MultipleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -636,14 +634,14 @@ impl<'a> MultipleSubstFormat1<'a> {
 
     /// Number of Sequence table offsets in the sequenceOffsets array
     pub fn sequence_count(&self) -> u16 {
-        let range = self.shape.sequence_count_byte_range();
+        let range = self.sequence_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to Sequence tables. Offsets are from beginning
     /// of substitution subtable, ordered by Coverage index
     pub fn sequence_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.sequence_offsets_byte_range();
+        let range = self.sequence_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -698,23 +696,9 @@ impl<'a> std::fmt::Debug for MultipleSubstFormat1<'a> {
 /// Part of [MultipleSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceMarker {
-    substitute_glyph_ids_byte_len: usize,
-}
+pub struct SequenceMarker {}
 
-impl SequenceMarker {
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + self.substitute_glyph_ids_byte_len
-    }
-}
-
-impl MinByteRange for SequenceMarker {
+impl<'a> MinByteRange for Sequence<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.substitute_glyph_ids_byte_range().end
     }
@@ -728,9 +712,7 @@ impl<'a> FontRead<'a> for Sequence<'a> {
             .checked_mul(GlyphId16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitute_glyph_ids_byte_len);
-        cursor.finish(SequenceMarker {
-            substitute_glyph_ids_byte_len,
-        })
+        cursor.finish(SequenceMarker {})
     }
 }
 
@@ -739,16 +721,33 @@ pub type Sequence<'a> = TableRef<'a, SequenceMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Sequence<'a> {
+    fn substitute_glyph_ids_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + self.substitute_glyph_ids_byte_len(start)
+    }
+
     /// Number of glyph IDs in the substituteGlyphIDs array. This must
     /// always be greater than 0.
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// String of glyph IDs to substitute
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.substitute_glyph_ids_byte_range();
+        let range = self.substitute_glyph_ids_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -785,11 +784,40 @@ impl Format<u16> for AlternateSubstFormat1Marker {
 /// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AlternateSubstFormat1Marker {
-    alternate_set_offsets_byte_len: usize,
+pub struct AlternateSubstFormat1Marker {}
+
+impl<'a> MinByteRange for AlternateSubstFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.alternate_set_offsets_byte_range().end
+    }
 }
 
-impl AlternateSubstFormat1Marker {
+impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let alternate_set_count: u16 = cursor.read()?;
+        let alternate_set_offsets_byte_len = (alternate_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(alternate_set_offsets_byte_len);
+        cursor.finish(AlternateSubstFormat1Marker {})
+    }
+}
+
+/// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
+pub type AlternateSubstFormat1<'a> = TableRef<'a, AlternateSubstFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> AlternateSubstFormat1<'a> {
+    fn alternate_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.alternate_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -807,47 +835,19 @@ impl AlternateSubstFormat1Marker {
 
     pub fn alternate_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.alternate_set_count_byte_range().end;
-        start..start + self.alternate_set_offsets_byte_len
+        start..start + self.alternate_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for AlternateSubstFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.alternate_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let alternate_set_count: u16 = cursor.read()?;
-        let alternate_set_offsets_byte_len = (alternate_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(alternate_set_offsets_byte_len);
-        cursor.finish(AlternateSubstFormat1Marker {
-            alternate_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Alternate Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#31-alternate-substitution-format-1)
-pub type AlternateSubstFormat1<'a> = TableRef<'a, AlternateSubstFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> AlternateSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -859,14 +859,14 @@ impl<'a> AlternateSubstFormat1<'a> {
 
     /// Number of AlternateSet tables
     pub fn alternate_set_count(&self) -> u16 {
-        let range = self.shape.alternate_set_count_byte_range();
+        let range = self.alternate_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to AlternateSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     pub fn alternate_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.alternate_set_offsets_byte_range();
+        let range = self.alternate_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -924,23 +924,9 @@ impl<'a> std::fmt::Debug for AlternateSubstFormat1<'a> {
 /// Part of [AlternateSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AlternateSetMarker {
-    alternate_glyph_ids_byte_len: usize,
-}
+pub struct AlternateSetMarker {}
 
-impl AlternateSetMarker {
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn alternate_glyph_ids_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + self.alternate_glyph_ids_byte_len
-    }
-}
-
-impl MinByteRange for AlternateSetMarker {
+impl<'a> MinByteRange for AlternateSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.alternate_glyph_ids_byte_range().end
     }
@@ -954,9 +940,7 @@ impl<'a> FontRead<'a> for AlternateSet<'a> {
             .checked_mul(GlyphId16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(alternate_glyph_ids_byte_len);
-        cursor.finish(AlternateSetMarker {
-            alternate_glyph_ids_byte_len,
-        })
+        cursor.finish(AlternateSetMarker {})
     }
 }
 
@@ -965,15 +949,32 @@ pub type AlternateSet<'a> = TableRef<'a, AlternateSetMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AlternateSet<'a> {
+    fn alternate_glyph_ids_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn alternate_glyph_ids_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + self.alternate_glyph_ids_byte_len(start)
+    }
+
     /// Number of glyph IDs in the alternateGlyphIDs array
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of alternate glyph IDs, in arbitrary order
     pub fn alternate_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.alternate_glyph_ids_byte_range();
+        let range = self.alternate_glyph_ids_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1010,11 +1011,40 @@ impl Format<u16> for LigatureSubstFormat1Marker {
 /// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureSubstFormat1Marker {
-    ligature_set_offsets_byte_len: usize,
+pub struct LigatureSubstFormat1Marker {}
+
+impl<'a> MinByteRange for LigatureSubstFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.ligature_set_offsets_byte_range().end
+    }
 }
 
-impl LigatureSubstFormat1Marker {
+impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let ligature_set_count: u16 = cursor.read()?;
+        let ligature_set_offsets_byte_len = (ligature_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(ligature_set_offsets_byte_len);
+        cursor.finish(LigatureSubstFormat1Marker {})
+    }
+}
+
+/// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
+pub type LigatureSubstFormat1<'a> = TableRef<'a, LigatureSubstFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> LigatureSubstFormat1<'a> {
+    fn ligature_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.ligature_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1032,47 +1062,19 @@ impl LigatureSubstFormat1Marker {
 
     pub fn ligature_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.ligature_set_count_byte_range().end;
-        start..start + self.ligature_set_offsets_byte_len
+        start..start + self.ligature_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for LigatureSubstFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.ligature_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let ligature_set_count: u16 = cursor.read()?;
-        let ligature_set_offsets_byte_len = (ligature_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ligature_set_offsets_byte_len);
-        cursor.finish(LigatureSubstFormat1Marker {
-            ligature_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Ligature Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#41-ligature-substitution-format-1)
-pub type LigatureSubstFormat1<'a> = TableRef<'a, LigatureSubstFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> LigatureSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1084,14 +1086,14 @@ impl<'a> LigatureSubstFormat1<'a> {
 
     /// Number of LigatureSet tables
     pub fn ligature_set_count(&self) -> u16 {
-        let range = self.shape.ligature_set_count_byte_range();
+        let range = self.ligature_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to LigatureSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     pub fn ligature_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.ligature_set_offsets_byte_range();
+        let range = self.ligature_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1146,23 +1148,9 @@ impl<'a> std::fmt::Debug for LigatureSubstFormat1<'a> {
 /// Part of [LigatureSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureSetMarker {
-    ligature_offsets_byte_len: usize,
-}
+pub struct LigatureSetMarker {}
 
-impl LigatureSetMarker {
-    pub fn ligature_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn ligature_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.ligature_count_byte_range().end;
-        start..start + self.ligature_offsets_byte_len
-    }
-}
-
-impl MinByteRange for LigatureSetMarker {
+impl<'a> MinByteRange for LigatureSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.ligature_offsets_byte_range().end
     }
@@ -1176,9 +1164,7 @@ impl<'a> FontRead<'a> for LigatureSet<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(ligature_offsets_byte_len);
-        cursor.finish(LigatureSetMarker {
-            ligature_offsets_byte_len,
-        })
+        cursor.finish(LigatureSetMarker {})
     }
 }
 
@@ -1187,16 +1173,33 @@ pub type LigatureSet<'a> = TableRef<'a, LigatureSetMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LigatureSet<'a> {
+    fn ligature_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.ligature_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn ligature_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn ligature_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.ligature_count_byte_range().end;
+        start..start + self.ligature_offsets_byte_len(start)
+    }
+
     /// Number of Ligature tables
     pub fn ligature_count(&self) -> u16 {
-        let range = self.shape.ligature_count_byte_range();
+        let range = self.ligature_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
     pub fn ligature_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.ligature_offsets_byte_range();
+        let range = self.ligature_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1246,28 +1249,9 @@ impl<'a> std::fmt::Debug for LigatureSet<'a> {
 /// Part of [LigatureSubstFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LigatureMarker {
-    component_glyph_ids_byte_len: usize,
-}
+pub struct LigatureMarker {}
 
-impl LigatureMarker {
-    pub fn ligature_glyph_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + GlyphId16::RAW_BYTE_LEN
-    }
-
-    pub fn component_count_byte_range(&self) -> Range<usize> {
-        let start = self.ligature_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn component_glyph_ids_byte_range(&self) -> Range<usize> {
-        let start = self.component_count_byte_range().end;
-        start..start + self.component_glyph_ids_byte_len
-    }
-}
-
-impl MinByteRange for LigatureMarker {
+impl<'a> MinByteRange for Ligature<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.component_glyph_ids_byte_range().end
     }
@@ -1282,9 +1266,7 @@ impl<'a> FontRead<'a> for Ligature<'a> {
             .checked_mul(GlyphId16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(component_glyph_ids_byte_len);
-        cursor.finish(LigatureMarker {
-            component_glyph_ids_byte_len,
-        })
+        cursor.finish(LigatureMarker {})
     }
 }
 
@@ -1293,22 +1275,44 @@ pub type Ligature<'a> = TableRef<'a, LigatureMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Ligature<'a> {
+    fn component_glyph_ids_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.component_count(), 1_usize))
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn ligature_glyph_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + GlyphId16::RAW_BYTE_LEN
+    }
+
+    pub fn component_count_byte_range(&self) -> Range<usize> {
+        let start = self.ligature_glyph_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn component_glyph_ids_byte_range(&self) -> Range<usize> {
+        let start = self.component_count_byte_range().end;
+        start..start + self.component_glyph_ids_byte_len(start)
+    }
+
     /// glyph ID of ligature to substitute
     pub fn ligature_glyph(&self) -> GlyphId16 {
-        let range = self.shape.ligature_glyph_byte_range();
+        let range = self.ligature_glyph_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of components in the ligature
     pub fn component_count(&self) -> u16 {
-        let range = self.shape.component_count_byte_range();
+        let range = self.component_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of component glyph IDs — start with the second
     /// component, ordered in writing direction
     pub fn component_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.component_glyph_ids_byte_range();
+        let range = self.component_glyph_ids_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1350,24 +1354,7 @@ pub struct ExtensionSubstFormat1Marker<T = ()> {
     offset_type: std::marker::PhantomData<*const T>,
 }
 
-impl<T> ExtensionSubstFormat1Marker<T> {
-    pub fn subst_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
-        let start = self.subst_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn extension_offset_byte_range(&self) -> Range<usize> {
-        let start = self.extension_lookup_type_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for ExtensionSubstFormat1Marker {
+impl<'a, T> MinByteRange for ExtensionSubstFormat1<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.extension_offset_byte_range().end
     }
@@ -1425,16 +1412,31 @@ pub type ExtensionSubstFormat1<'a, T> = TableRef<'a, ExtensionSubstFormat1Marker
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> ExtensionSubstFormat1<'a, T> {
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
+        let start = self.subst_format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn extension_offset_byte_range(&self) -> Range<usize> {
+        let start = self.extension_lookup_type_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
     /// Format identifier. Set to 1.
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
     pub fn extension_lookup_type(&self) -> u16 {
-        let range = self.shape.extension_lookup_type_byte_range();
+        let range = self.extension_lookup_type_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1442,7 +1444,7 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     /// extensionLookupType, relative to the start of the
     /// ExtensionSubstFormat1 subtable.
     pub fn extension_offset(&self) -> Offset32 {
-        let range = self.shape.extension_offset_byte_range();
+        let range = self.extension_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1569,55 +1571,9 @@ impl Format<u16> for ReverseChainSingleSubstFormat1Marker {
 /// [Reverse Chaining Contextual Single Substitution Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#81-reverse-chaining-contextual-single-substitution-format-1-coverage-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ReverseChainSingleSubstFormat1Marker {
-    backtrack_coverage_offsets_byte_len: usize,
-    lookahead_coverage_offsets_byte_len: usize,
-    substitute_glyph_ids_byte_len: usize,
-}
+pub struct ReverseChainSingleSubstFormat1Marker {}
 
-impl ReverseChainSingleSubstFormat1Marker {
-    pub fn subst_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
-        let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + self.backtrack_coverage_offsets_byte_len
-    }
-
-    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + self.lookahead_coverage_offsets_byte_len
-    }
-
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + self.substitute_glyph_ids_byte_len
-    }
-}
-
-impl MinByteRange for ReverseChainSingleSubstFormat1Marker {
+impl<'a> MinByteRange for ReverseChainSingleSubstFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.substitute_glyph_ids_byte_range().end
     }
@@ -1643,11 +1599,7 @@ impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1<'a> {
             .checked_mul(GlyphId16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitute_glyph_ids_byte_len);
-        cursor.finish(ReverseChainSingleSubstFormat1Marker {
-            backtrack_coverage_offsets_byte_len,
-            lookahead_coverage_offsets_byte_len,
-            substitute_glyph_ids_byte_len,
-        })
+        cursor.finish(ReverseChainSingleSubstFormat1Marker {})
     }
 }
 
@@ -1656,16 +1608,75 @@ pub type ReverseChainSingleSubstFormat1<'a> = TableRef<'a, ReverseChainSingleSub
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ReverseChainSingleSubstFormat1<'a> {
+    fn backtrack_coverage_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.backtrack_glyph_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn lookahead_coverage_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lookahead_glyph_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn substitute_glyph_ids_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn subst_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn coverage_offset_byte_range(&self) -> Range<usize> {
+        let start = self.subst_format_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_offset_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_glyph_count_byte_range().end;
+        start..start + self.backtrack_coverage_offsets_byte_len(start)
+    }
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_coverage_offsets_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_glyph_count_byte_range().end;
+        start..start + self.lookahead_coverage_offsets_byte_len(start)
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_coverage_offsets_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + self.substitute_glyph_ids_byte_len(start)
+    }
+
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
-        let range = self.shape.subst_format_byte_range();
+        let range = self.subst_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1677,14 +1688,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
 
     /// Number of glyphs in the backtrack sequence.
     pub fn backtrack_glyph_count(&self) -> u16 {
-        let range = self.shape.backtrack_glyph_count_byte_range();
+        let range = self.backtrack_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to coverage tables in backtrack sequence, in
     /// glyph sequence order.
     pub fn backtrack_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.backtrack_coverage_offsets_byte_range();
+        let range = self.backtrack_coverage_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1697,14 +1708,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
 
     /// Number of glyphs in lookahead sequence.
     pub fn lookahead_glyph_count(&self) -> u16 {
-        let range = self.shape.lookahead_glyph_count_byte_range();
+        let range = self.lookahead_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to coverage tables in lookahead sequence, in
     /// glyph sequence order.
     pub fn lookahead_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.lookahead_coverage_offsets_byte_range();
+        let range = self.lookahead_coverage_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1717,13 +1728,13 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
 
     /// Number of glyph IDs in the substituteGlyphIDs array.
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of substitute glyph IDs — ordered by Coverage index.
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.substitute_glyph_ids_byte_range();
+        let range = self.substitute_glyph_ids_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Gvar<'_> {
 impl<'a> FontRead<'a> for Gvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -505,9 +505,9 @@ impl<'a> FontReadWithArgs<'a> for SharedTuples<'a> {
     fn read_with_args(data: FontData<'a>, args: &(u16, u16)) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: SharedTuplesMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -596,9 +596,9 @@ impl<'a> MinByteRange for GlyphVariationDataHeader<'a> {
 impl<'a> FontRead<'a> for GlyphVariationDataHeader<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GlyphVariationDataHeaderMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -86,14 +86,14 @@ impl<'a> Gvar<'a> {
     /// Major/minor version number of the glyph variations table — set to (1,0).
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
         let range = self.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of shared tuple records. Shared tuple records can be
@@ -102,13 +102,13 @@ impl<'a> Gvar<'a> {
     /// within a glyph variation data table.
     pub fn shared_tuple_count(&self) -> u16 {
         let range = self.shared_tuple_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the start of this table to the shared tuple records.
     pub fn shared_tuples_offset(&self) -> Offset32 {
         let range = self.shared_tuples_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`shared_tuples_offset`][Self::shared_tuples_offset].
@@ -122,7 +122,7 @@ impl<'a> Gvar<'a> {
     /// of glyphs stored elsewhere in the font.
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Bit-field that gives the format of the offset array that
@@ -130,21 +130,21 @@ impl<'a> Gvar<'a> {
     /// set, the offsets are uint32.
     pub fn flags(&self) -> GvarFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the start of this table to the array of
     /// GlyphVariationData tables.
     pub fn glyph_variation_data_array_offset(&self) -> u32 {
         let range = self.glyph_variation_data_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offsets from the start of the GlyphVariationData array to each
     /// GlyphVariationData table.
     pub fn glyph_variation_data_offsets(&self) -> ComputedArray<'a, U16Or32> {
         let range = self.glyph_variation_data_offsets_byte_range();
-        self.data.read_with_args(range, &self.flags()).unwrap()
+        unchecked::read_with_args(self.data, range, &self.flags())
     }
 }
 
@@ -546,7 +546,7 @@ impl<'a> SharedTuples<'a> {
 
     pub fn tuples(&self) -> ComputedArray<'a, Tuple<'a>> {
         let range = self.tuples_byte_range();
-        self.data.read_with_args(range, &self.axis_count()).unwrap()
+        unchecked::read_with_args(self.data, range, &self.axis_count())
     }
 
     pub(crate) fn shared_tuple_count(&self) -> u16 {
@@ -634,14 +634,14 @@ impl<'a> GlyphVariationDataHeader<'a> {
     /// and 4095.
     pub fn tuple_variation_count(&self) -> TupleVariationCount {
         let range = self.tuple_variation_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the start of the GlyphVariationData table to the
     /// serialized data
     pub fn serialized_data_offset(&self) -> Offset16 {
         let range = self.serialized_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`serialized_data_offset`][Self::serialized_data_offset].
@@ -653,7 +653,7 @@ impl<'a> GlyphVariationDataHeader<'a> {
     /// Array of tuple variation headers.
     pub fn tuple_variation_headers(&self) -> VarLenArray<'a, TupleVariationHeader<'a>> {
         let range = self.tuple_variation_headers_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 }
 

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -88,27 +88,29 @@ impl<'a> Hdmx<'a> {
     /// Table version number (set to 0).
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of device records.
     pub fn num_records(&self) -> u16 {
         let range = self.num_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Size of device record, 32-bit aligned.
     pub fn size_device_record(&self) -> u32 {
         let range = self.size_device_record_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of device records.
     pub fn records(&self) -> ComputedArray<'a, DeviceRecord<'a>> {
         let range = self.records_byte_range();
-        self.data
-            .read_with_args(range, &(self.num_glyphs(), self.size_device_record()))
-            .unwrap()
+        unchecked::read_with_args(
+            self.data,
+            range,
+            &(self.num_glyphs(), self.size_device_record()),
+        )
     }
 
     pub(crate) fn num_glyphs(&self) -> u16 {

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -29,9 +29,9 @@ impl<'a> FontReadWithArgs<'a> for Hdmx<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: HdmxMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -698,7 +698,47 @@ impl<'a> From<Flags> for FieldType<'a> {
 #[doc(hidden)]
 pub struct HeadMarker {}
 
-impl HeadMarker {
+impl<'a> MinByteRange for Head<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_data_format_byte_range().end
+    }
+}
+
+impl TopLevelTable for Head<'_> {
+    /// `head`
+    const TAG: Tag = Tag::new(b"head");
+}
+
+impl<'a> FontRead<'a> for Head<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<MajorMinor>();
+        cursor.advance::<Fixed>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        cursor.advance::<Flags>();
+        cursor.advance::<u16>();
+        cursor.advance::<LongDateTime>();
+        cursor.advance::<LongDateTime>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<MacStyle>();
+        cursor.advance::<u16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.finish(HeadMarker {})
+    }
+}
+
+/// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
+/// (font header) table.
+pub type Head<'a> = TableRef<'a, HeadMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Head<'a> {
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
@@ -783,58 +823,16 @@ impl HeadMarker {
         let start = self.index_to_loc_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for HeadMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.glyph_data_format_byte_range().end
-    }
-}
-
-impl TopLevelTable for Head<'_> {
-    /// `head`
-    const TAG: Tag = Tag::new(b"head");
-}
-
-impl<'a> FontRead<'a> for Head<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<Flags>();
-        cursor.advance::<u16>();
-        cursor.advance::<LongDateTime>();
-        cursor.advance::<LongDateTime>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<MacStyle>();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.finish(HeadMarker {})
-    }
-}
-
-/// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
-/// (font header) table.
-pub type Head<'a> = TableRef<'a, HeadMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Head<'a> {
     /// Version number of the font header table, set to (1, 0)
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Set by font manufacturer.
     pub fn font_revision(&self) -> Fixed {
-        let range = self.shape.font_revision_byte_range();
+        let range = self.font_revision_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -844,19 +842,19 @@ impl<'a> Head<'a> {
     /// invalidated by changes to the file structure and font table
     /// directory, and must be ignored.
     pub fn checksum_adjustment(&self) -> u32 {
-        let range = self.shape.checksum_adjustment_byte_range();
+        let range = self.checksum_adjustment_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Set to 0x5F0F3CF5.
     pub fn magic_number(&self) -> u32 {
-        let range = self.shape.magic_number_byte_range();
+        let range = self.magic_number_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// See the flags enum.
     pub fn flags(&self) -> Flags {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -865,75 +863,75 @@ impl<'a> Head<'a> {
     /// recommended as this allows performance optimizations in some
     /// rasterizers.
     pub fn units_per_em(&self) -> u16 {
-        let range = self.shape.units_per_em_byte_range();
+        let range = self.units_per_em_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
     pub fn created(&self) -> LongDateTime {
-        let range = self.shape.created_byte_range();
+        let range = self.created_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
     pub fn modified(&self) -> LongDateTime {
-        let range = self.shape.modified_byte_range();
+        let range = self.modified_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum x coordinate across all glyph bounding boxes.
     pub fn x_min(&self) -> i16 {
-        let range = self.shape.x_min_byte_range();
+        let range = self.x_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum y coordinate across all glyph bounding boxes.
     pub fn y_min(&self) -> i16 {
-        let range = self.shape.y_min_byte_range();
+        let range = self.y_min_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum x coordinate across all glyph bounding boxes.
     pub fn x_max(&self) -> i16 {
-        let range = self.shape.x_max_byte_range();
+        let range = self.x_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum y coordinate across all glyph bounding boxes.
     pub fn y_max(&self) -> i16 {
-        let range = self.shape.y_max_byte_range();
+        let range = self.y_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Bits identifying the font's style; see [MacStyle]
     pub fn mac_style(&self) -> MacStyle {
-        let range = self.shape.mac_style_byte_range();
+        let range = self.mac_style_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Smallest readable size in pixels.
     pub fn lowest_rec_ppem(&self) -> u16 {
-        let range = self.shape.lowest_rec_ppem_byte_range();
+        let range = self.lowest_rec_ppem_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Deprecated (Set to 2).
     pub fn font_direction_hint(&self) -> i16 {
-        let range = self.shape.font_direction_hint_byte_range();
+        let range = self.font_direction_hint_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for short offsets (Offset16), 1 for long (Offset32).
     pub fn index_to_loc_format(&self) -> i16 {
-        let range = self.shape.index_to_loc_format_byte_range();
+        let range = self.index_to_loc_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for current format.
     pub fn glyph_data_format(&self) -> i16 {
-        let range = self.shape.glyph_data_format_byte_range();
+        let range = self.glyph_data_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -813,13 +813,13 @@ impl<'a> Head<'a> {
     /// Version number of the font header table, set to (1, 0)
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Set by font manufacturer.
     pub fn font_revision(&self) -> Fixed {
         let range = self.font_revision_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// To compute: set it to 0, sum the entire font as uint32, then
@@ -829,19 +829,19 @@ impl<'a> Head<'a> {
     /// directory, and must be ignored.
     pub fn checksum_adjustment(&self) -> u32 {
         let range = self.checksum_adjustment_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Set to 0x5F0F3CF5.
     pub fn magic_number(&self) -> u32 {
         let range = self.magic_number_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// See the flags enum.
     pub fn flags(&self) -> Flags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Set to a value from 16 to 16384. Any value in this range is
@@ -850,75 +850,75 @@ impl<'a> Head<'a> {
     /// rasterizers.
     pub fn units_per_em(&self) -> u16 {
         let range = self.units_per_em_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
     pub fn created(&self) -> LongDateTime {
         let range = self.created_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
     pub fn modified(&self) -> LongDateTime {
         let range = self.modified_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum x coordinate across all glyph bounding boxes.
     pub fn x_min(&self) -> i16 {
         let range = self.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum y coordinate across all glyph bounding boxes.
     pub fn y_min(&self) -> i16 {
         let range = self.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum x coordinate across all glyph bounding boxes.
     pub fn x_max(&self) -> i16 {
         let range = self.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum y coordinate across all glyph bounding boxes.
     pub fn y_max(&self) -> i16 {
         let range = self.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Bits identifying the font's style; see [MacStyle]
     pub fn mac_style(&self) -> MacStyle {
         let range = self.mac_style_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Smallest readable size in pixels.
     pub fn lowest_rec_ppem(&self) -> u16 {
         let range = self.lowest_rec_ppem_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Deprecated (Set to 2).
     pub fn font_direction_hint(&self) -> i16 {
         let range = self.font_direction_hint_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 0 for short offsets (Offset16), 1 for long (Offset32).
     pub fn index_to_loc_format(&self) -> i16 {
         let range = self.index_to_loc_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 0 for current format.
     pub fn glyph_data_format(&self) -> i16 {
         let range = self.glyph_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -712,9 +712,9 @@ impl TopLevelTable for Head<'_> {
 impl<'a> FontRead<'a> for Head<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: HeadMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -696,7 +696,7 @@ impl<'a> From<Flags> for FieldType<'a> {
 /// (font header) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct HeadMarker {}
+pub struct HeadMarker;
 
 impl<'a> MinByteRange for Head<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -711,31 +711,17 @@ impl TopLevelTable for Head<'_> {
 
 impl<'a> FontRead<'a> for Head<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<Fixed>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<Flags>();
-        cursor.advance::<u16>();
-        cursor.advance::<LongDateTime>();
-        cursor.advance::<LongDateTime>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<MacStyle>();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.finish(HeadMarker {})
+        Ok(TableRef {
+            shape: HeadMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [head](https://docs.microsoft.com/en-us/typography/opentype/spec/head)
 /// (font header) table.
-pub type Head<'a> = TableRef<'a, HeadMarker>;
+pub type Head<'a> = TableRef<'a, HeadMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Head<'a> {

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Hhea<'_> {
 impl<'a> FontRead<'a> for Hhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: HheaMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct HheaMarker {}
+pub struct HheaMarker;
 
 impl<'a> MinByteRange for Hhea<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,30 +23,16 @@ impl TopLevelTable for Hhea<'_> {
 
 impl<'a> FontRead<'a> for Hhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(HheaMarker {})
+        Ok(TableRef {
+            shape: HheaMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-pub type Hhea<'a> = TableRef<'a, HheaMarker>;
+pub type Hhea<'a> = TableRef<'a, HheaMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Hhea<'a> {

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -124,65 +124,65 @@ impl<'a> Hhea<'a> {
     /// The major/minor version (1, 0)
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Typographic ascent.
     pub fn ascender(&self) -> FWord {
         let range = self.ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Typographic descent.
     pub fn descender(&self) -> FWord {
         let range = self.descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
     pub fn line_gap(&self) -> FWord {
         let range = self.line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum advance width value in 'hmtx' table.
     pub fn advance_width_max(&self) -> UfWord {
         let range = self.advance_width_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum left sidebearing value in 'hmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
     pub fn min_left_side_bearing(&self) -> FWord {
         let range = self.min_left_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum right sidebearing value; calculated as min(aw - (lsb +
     /// xMax - xMin)) for glyphs with contours (empty glyphs should be ignored).
     pub fn min_right_side_bearing(&self) -> FWord {
         let range = self.min_right_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Max(lsb + (xMax-xMin))
     pub fn x_max_extent(&self) -> FWord {
         let range = self.x_max_extent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
     pub fn caret_slope_rise(&self) -> i16 {
         let range = self.caret_slope_rise_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 0 for vertical caret, 1 for horizontal.
     pub fn caret_slope_run(&self) -> i16 {
         let range = self.caret_slope_run_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The amount by which a slanted highlight on a glyph needs to be
@@ -190,19 +190,19 @@ impl<'a> Hhea<'a> {
     /// non-slanted fonts
     pub fn caret_offset(&self) -> i16 {
         let range = self.caret_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 0 for current format.
     pub fn metric_data_format(&self) -> i16 {
         let range = self.metric_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of hMetric entries in 'hmtx' table
     pub fn number_of_h_metrics(&self) -> u16 {
         let range = self.number_of_h_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -10,7 +10,46 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct HheaMarker {}
 
-impl HheaMarker {
+impl<'a> MinByteRange for Hhea<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.number_of_h_metrics_byte_range().end
+    }
+}
+
+impl TopLevelTable for Hhea<'_> {
+    /// `hhea`
+    const TAG: Tag = Tag::new(b"hhea");
+}
+
+impl<'a> FontRead<'a> for Hhea<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<MajorMinor>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<UfWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<u16>();
+        cursor.finish(HheaMarker {})
+    }
+}
+
+/// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
+pub type Hhea<'a> = TableRef<'a, HheaMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Hhea<'a> {
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
@@ -95,109 +134,68 @@ impl HheaMarker {
         let start = self.metric_data_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for HheaMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.number_of_h_metrics_byte_range().end
-    }
-}
-
-impl TopLevelTable for Hhea<'_> {
-    /// `hhea`
-    const TAG: Tag = Tag::new(b"hhea");
-}
-
-impl<'a> FontRead<'a> for Hhea<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(HheaMarker {})
-    }
-}
-
-/// [hhea](https://docs.microsoft.com/en-us/typography/opentype/spec/hhea) Horizontal Header Table
-pub type Hhea<'a> = TableRef<'a, HheaMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Hhea<'a> {
     /// The major/minor version (1, 0)
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Typographic ascent.
     pub fn ascender(&self) -> FWord {
-        let range = self.shape.ascender_byte_range();
+        let range = self.ascender_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Typographic descent.
     pub fn descender(&self) -> FWord {
-        let range = self.shape.descender_byte_range();
+        let range = self.descender_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
     pub fn line_gap(&self) -> FWord {
-        let range = self.shape.line_gap_byte_range();
+        let range = self.line_gap_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum advance width value in 'hmtx' table.
     pub fn advance_width_max(&self) -> UfWord {
-        let range = self.shape.advance_width_max_byte_range();
+        let range = self.advance_width_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum left sidebearing value in 'hmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
     pub fn min_left_side_bearing(&self) -> FWord {
-        let range = self.shape.min_left_side_bearing_byte_range();
+        let range = self.min_left_side_bearing_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum right sidebearing value; calculated as min(aw - (lsb +
     /// xMax - xMin)) for glyphs with contours (empty glyphs should be ignored).
     pub fn min_right_side_bearing(&self) -> FWord {
-        let range = self.shape.min_right_side_bearing_byte_range();
+        let range = self.min_right_side_bearing_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Max(lsb + (xMax-xMin))
     pub fn x_max_extent(&self) -> FWord {
-        let range = self.shape.x_max_extent_byte_range();
+        let range = self.x_max_extent_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
     pub fn caret_slope_rise(&self) -> i16 {
-        let range = self.shape.caret_slope_rise_byte_range();
+        let range = self.caret_slope_rise_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for vertical caret, 1 for horizontal.
     pub fn caret_slope_run(&self) -> i16 {
-        let range = self.shape.caret_slope_run_byte_range();
+        let range = self.caret_slope_run_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -205,19 +203,19 @@ impl<'a> Hhea<'a> {
     /// shifted to produce the best appearance. Set to 0 for
     /// non-slanted fonts
     pub fn caret_offset(&self) -> i16 {
-        let range = self.shape.caret_offset_byte_range();
+        let range = self.caret_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for current format.
     pub fn metric_data_format(&self) -> i16 {
-        let range = self.shape.metric_data_format_byte_range();
+        let range = self.metric_data_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of hMetric entries in 'hmtx' table
     pub fn number_of_h_metrics(&self) -> u16 {
-        let range = self.shape.number_of_h_metrics_byte_range();
+        let range = self.number_of_h_metrics_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -80,14 +80,14 @@ impl<'a> Hmtx<'a> {
     /// glyph. Records are indexed by glyph ID.
     pub fn h_metrics(&self) -> &'a [LongMetric] {
         let range = self.h_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Leading (left/top) side bearings for glyph IDs greater than or equal to
     /// numberOfLongMetrics.
     pub fn left_side_bearings(&self) -> &'a [BigEndian<i16>] {
         let range = self.left_side_bearings_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn number_of_h_metrics(&self) -> u16 {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -29,9 +29,9 @@ impl<'a> FontReadWithArgs<'a> for Hmtx<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: HmtxMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [HVAR (Horizontal Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/hvar) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct HvarMarker {}
+pub struct HvarMarker;
 
 impl<'a> MinByteRange for Hvar<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,18 +23,16 @@ impl TopLevelTable for Hvar<'_> {
 
 impl<'a> FontRead<'a> for Hvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.finish(HvarMarker {})
+        Ok(TableRef {
+            shape: HvarMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [HVAR (Horizontal Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/hvar) table
-pub type Hvar<'a> = TableRef<'a, HvarMarker>;
+pub type Hvar<'a> = TableRef<'a, HvarMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Hvar<'a> {

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Hvar<'_> {
 impl<'a> FontRead<'a> for Hvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: HvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -65,13 +65,13 @@ impl<'a> Hvar<'a> {
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the start of this table to the item variation store table.
     pub fn item_variation_store_offset(&self) -> Offset32 {
         let range = self.item_variation_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -83,7 +83,7 @@ impl<'a> Hvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for advance widths (may be NULL).
     pub fn advance_width_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.advance_width_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`advance_width_mapping_offset`][Self::advance_width_mapping_offset].
@@ -95,7 +95,7 @@ impl<'a> Hvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for left side bearings (may be NULL).
     pub fn lsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.lsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`lsb_mapping_offset`][Self::lsb_mapping_offset].
@@ -107,7 +107,7 @@ impl<'a> Hvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for right side bearings (may be NULL).
     pub fn rsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.rsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`rsb_mapping_offset`][Self::rsb_mapping_offset].

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -10,34 +10,7 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct HvarMarker {}
 
-impl HvarMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn advance_width_mapping_offset_byte_range(&self) -> Range<usize> {
-        let start = self.item_variation_store_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn lsb_mapping_offset_byte_range(&self) -> Range<usize> {
-        let start = self.advance_width_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-
-    pub fn rsb_mapping_offset_byte_range(&self) -> Range<usize> {
-        let start = self.lsb_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for HvarMarker {
+impl<'a> MinByteRange for Hvar<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.rsb_mapping_offset_byte_range().end
     }
@@ -65,16 +38,41 @@ pub type Hvar<'a> = TableRef<'a, HvarMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Hvar<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn advance_width_mapping_offset_byte_range(&self) -> Range<usize> {
+        let start = self.item_variation_store_offset_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn lsb_mapping_offset_byte_range(&self) -> Range<usize> {
+        let start = self.advance_width_mapping_offset_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
+    pub fn rsb_mapping_offset_byte_range(&self) -> Range<usize> {
+        let start = self.lsb_mapping_offset_byte_range().end;
+        start..start + Offset32::RAW_BYTE_LEN
+    }
+
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset in bytes from the start of this table to the item variation store table.
     pub fn item_variation_store_offset(&self) -> Offset32 {
-        let range = self.shape.item_variation_store_offset_byte_range();
+        let range = self.item_variation_store_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -86,7 +84,7 @@ impl<'a> Hvar<'a> {
 
     /// Offset in bytes from the start of this table to the delta-set index mapping for advance widths (may be NULL).
     pub fn advance_width_mapping_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.advance_width_mapping_offset_byte_range();
+        let range = self.advance_width_mapping_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -98,7 +96,7 @@ impl<'a> Hvar<'a> {
 
     /// Offset in bytes from the start of this table to the delta-set index mapping for left side bearings (may be NULL).
     pub fn lsb_mapping_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.lsb_mapping_offset_byte_range();
+        let range = self.lsb_mapping_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -110,7 +108,7 @@ impl<'a> Hvar<'a> {
 
     /// Offset in bytes from the start of this table to the delta-set index mapping for right side bearings (may be NULL).
     pub fn rsb_mapping_offset(&self) -> Nullable<Offset32> {
-        let range = self.shape.rsb_mapping_offset_byte_range();
+        let range = self.rsb_mapping_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -442,9 +442,9 @@ impl<'a> MinByteRange for PatchMapFormat1<'a> {
 impl<'a> FontRead<'a> for PatchMapFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PatchMapFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -744,9 +744,9 @@ impl<'a> FontReadWithArgs<'a> for GlyphMap<'a> {
     fn read_with_args(data: FontData<'a>, args: &(Uint24, u16)) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: GlyphMapMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -848,9 +848,9 @@ impl<'a> FontReadWithArgs<'a> for FeatureMap<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: FeatureMapMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1127,9 +1127,9 @@ impl<'a> MinByteRange for PatchMapFormat2<'a> {
 impl<'a> FontRead<'a> for PatchMapFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PatchMapFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1379,9 +1379,9 @@ impl<'a> MinByteRange for MappingEntries<'a> {
 impl<'a> FontRead<'a> for MappingEntries<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MappingEntriesMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1443,9 +1443,9 @@ impl<'a> MinByteRange for EntryData<'a> {
 impl<'a> FontRead<'a> for EntryData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: EntryDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2120,9 +2120,9 @@ impl<'a> MinByteRange for IdStringData<'a> {
 impl<'a> FontRead<'a> for IdStringData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: IdStringDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2185,9 +2185,9 @@ impl<'a> MinByteRange for TableKeyedPatch<'a> {
 impl<'a> FontRead<'a> for TableKeyedPatch<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: TableKeyedPatchMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2312,9 +2312,9 @@ impl<'a> MinByteRange for TablePatch<'a> {
 impl<'a> FontRead<'a> for TablePatch<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: TablePatchMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2719,9 +2719,9 @@ impl<'a> MinByteRange for GlyphKeyedPatch<'a> {
 impl<'a> FontRead<'a> for GlyphKeyedPatch<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GlyphKeyedPatchMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3150,9 +3150,9 @@ impl<'a> FontReadWithArgs<'a> for GlyphPatches<'a> {
     fn read_with_args(data: FontData<'a>, args: &GlyphKeyedFlags) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: GlyphPatchesMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3305,9 +3305,9 @@ impl<'a> MinByteRange for GlyphData<'a> {
 impl<'a> FontRead<'a> for GlyphData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GlyphDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -572,41 +572,41 @@ impl<'a> PatchMapFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn field_flags(&self) -> PatchMapFieldPresenceFlags {
         let range = self.field_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Unique ID that identifies compatible patches.
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Largest entry index which appears in either the glyph map or feature map.
     pub fn max_entry_index(&self) -> u16 {
         let range = self.max_entry_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Largest entry index which appears in the glyph map.
     pub fn max_glyph_map_entry_index(&self) -> u16 {
         let range = self.max_glyph_map_entry_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn glyph_count(&self) -> Uint24 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Sub table that maps glyph ids to entry indices.
     pub fn glyph_map_offset(&self) -> Offset32 {
         let range = self.glyph_map_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`glyph_map_offset`][Self::glyph_map_offset].
@@ -619,7 +619,7 @@ impl<'a> PatchMapFormat1<'a> {
     /// Sub table that maps feature and glyph ids to entry indices.
     pub fn feature_map_offset(&self) -> Nullable<Offset32> {
         let range = self.feature_map_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`feature_map_offset`][Self::feature_map_offset].
@@ -631,33 +631,33 @@ impl<'a> PatchMapFormat1<'a> {
 
     pub fn applied_entries_bitmap(&self) -> &'a [u8] {
         let range = self.applied_entries_bitmap_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub fn url_template_length(&self) -> u16 {
         let range = self.url_template_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn url_template(&self) -> &'a [u8] {
         let range = self.url_template_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Patch format number for patches referenced by this mapping.
     pub fn patch_format(&self) -> u8 {
         let range = self.patch_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn cff_charstrings_offset(&self) -> Option<u32> {
         let range = self.cff_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn cff2_charstrings_offset(&self) -> Option<u32> {
         let range = self.cff2_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 
@@ -789,14 +789,12 @@ impl<'a> GlyphMap<'a> {
 
     pub fn first_mapped_glyph(&self) -> u16 {
         let range = self.first_mapped_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn entry_index(&self) -> ComputedArray<'a, U8Or16> {
         let range = self.entry_index_byte_range();
-        self.data
-            .read_with_args(range, &self.max_entry_index())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.max_entry_index())
     }
 
     pub(crate) fn glyph_count(&self) -> Uint24 {
@@ -901,19 +899,17 @@ impl<'a> FeatureMap<'a> {
 
     pub fn feature_count(&self) -> u16 {
         let range = self.feature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn feature_records(&self) -> ComputedArray<'a, FeatureRecord> {
         let range = self.feature_records_byte_range();
-        self.data
-            .read_with_args(range, &self.max_entry_index())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.max_entry_index())
     }
 
     pub fn entry_map_data(&self) -> &'a [u8] {
         let range = self.entry_map_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn max_entry_index(&self) -> u16 {
@@ -1236,34 +1232,34 @@ impl<'a> PatchMapFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn field_flags(&self) -> PatchMapFieldPresenceFlags {
         let range = self.field_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Unique ID that identifies compatible patches.
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Patch format number for patches referenced by this mapping.
     pub fn default_patch_format(&self) -> u8 {
         let range = self.default_patch_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn entry_count(&self) -> Uint24 {
         let range = self.entry_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn entries_offset(&self) -> Offset32 {
         let range = self.entries_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`entries_offset`][Self::entries_offset].
@@ -1274,7 +1270,7 @@ impl<'a> PatchMapFormat2<'a> {
 
     pub fn entry_id_string_data_offset(&self) -> Nullable<Offset32> {
         let range = self.entry_id_string_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`entry_id_string_data_offset`][Self::entry_id_string_data_offset].
@@ -1285,22 +1281,22 @@ impl<'a> PatchMapFormat2<'a> {
 
     pub fn url_template_length(&self) -> u16 {
         let range = self.url_template_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn url_template(&self) -> &'a [u8] {
         let range = self.url_template_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub fn cff_charstrings_offset(&self) -> Option<u32> {
         let range = self.cff_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn cff2_charstrings_offset(&self) -> Option<u32> {
         let range = self.cff2_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 
@@ -1405,7 +1401,7 @@ impl<'a> MappingEntries<'a> {
 
     pub fn entry_data(&self) -> &'a [u8] {
         let range = self.entry_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1646,42 +1642,42 @@ impl<'a> EntryData<'a> {
 
     pub fn format_flags(&self) -> EntryFormatFlags {
         let range = self.format_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn feature_count(&self) -> Option<u8> {
         let range = self.feature_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn feature_tags(&self) -> Option<&'a [BigEndian<Tag>]> {
         let range = self.feature_tags_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     pub fn design_space_count(&self) -> Option<u16> {
         let range = self.design_space_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn design_space_segments(&self) -> Option<&'a [DesignSpaceSegment]> {
         let range = self.design_space_segments_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     pub fn match_mode_and_count(&self) -> Option<MatchModeAndCount> {
         let range = self.match_mode_and_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn child_indices(&self) -> Option<&'a [BigEndian<Uint24>]> {
         let range = self.child_indices_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     pub fn trailing_data(&self) -> &'a [u8] {
         let range = self.trailing_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2146,7 +2142,7 @@ impl<'a> IdStringData<'a> {
 
     pub fn id_data(&self) -> &'a [u8] {
         let range = self.id_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2231,23 +2227,23 @@ impl<'a> TableKeyedPatch<'a> {
 
     pub fn format(&self) -> Tag {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Unique ID that identifies compatible patches.
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn patches_count(&self) -> u16 {
         let range = self.patches_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn patch_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.patch_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`patch_offsets`][Self::patch_offsets].
@@ -2354,22 +2350,22 @@ impl<'a> TablePatch<'a> {
 
     pub fn tag(&self) -> Tag {
         let range = self.tag_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn flags(&self) -> TablePatchFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn max_uncompressed_length(&self) -> u32 {
         let range = self.max_uncompressed_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn brotli_stream(&self) -> &'a [u8] {
         let range = self.brotli_stream_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2771,27 +2767,27 @@ impl<'a> GlyphKeyedPatch<'a> {
 
     pub fn format(&self) -> Tag {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn flags(&self) -> GlyphKeyedFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn max_uncompressed_length(&self) -> u32 {
         let range = self.max_uncompressed_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn brotli_stream(&self) -> &'a [u8] {
         let range = self.brotli_stream_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -3219,27 +3215,27 @@ impl<'a> GlyphPatches<'a> {
 
     pub fn glyph_count(&self) -> u32 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn table_count(&self) -> u8 {
         let range = self.table_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn glyph_ids(&self) -> ComputedArray<'a, U16Or24> {
         let range = self.glyph_ids_byte_range();
-        self.data.read_with_args(range, &self.flags()).unwrap()
+        unchecked::read_with_args(self.data, range, &self.flags())
     }
 
     pub fn tables(&self) -> &'a [BigEndian<Tag>] {
         let range = self.tables_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub fn glyph_data_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.glyph_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`glyph_data_offsets`][Self::glyph_data_offsets].
@@ -3331,7 +3327,7 @@ impl<'a> GlyphData<'a> {
 
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The OpenType [kerning](https://learn.microsoft.com/en-us/typography/opentype/spec/kern) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct OtKernMarker {}
+pub struct OtKernMarker;
 
 impl<'a> MinByteRange for OtKern<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -18,17 +18,16 @@ impl<'a> MinByteRange for OtKern<'a> {
 
 impl<'a> FontRead<'a> for OtKern<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let subtable_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(subtable_data_byte_len);
-        cursor.finish(OtKernMarker {})
+        Ok(TableRef {
+            shape: OtKernMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The OpenType [kerning](https://learn.microsoft.com/en-us/typography/opentype/spec/kern) table.
-pub type OtKern<'a> = TableRef<'a, OtKernMarker>;
+pub type OtKern<'a> = TableRef<'a, OtKernMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> OtKern<'a> {
@@ -100,7 +99,7 @@ impl<'a> std::fmt::Debug for OtKern<'a> {
 /// The Apple Advanced Typography [kerning](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6kern.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AatKernMarker {}
+pub struct AatKernMarker;
 
 impl<'a> MinByteRange for AatKern<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -110,17 +109,16 @@ impl<'a> MinByteRange for AatKern<'a> {
 
 impl<'a> FontRead<'a> for AatKern<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<u32>();
-        let subtable_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(subtable_data_byte_len);
-        cursor.finish(AatKernMarker {})
+        Ok(TableRef {
+            shape: AatKernMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The Apple Advanced Typography [kerning](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6kern.html) table.
-pub type AatKern<'a> = TableRef<'a, AatKernMarker>;
+pub type AatKern<'a> = TableRef<'a, AatKernMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AatKern<'a> {
@@ -192,7 +190,7 @@ impl<'a> std::fmt::Debug for AatKern<'a> {
 /// A subtable in an OT `kern` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct OtSubtableMarker {}
+pub struct OtSubtableMarker;
 
 impl<'a> MinByteRange for OtSubtable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -202,18 +200,16 @@ impl<'a> MinByteRange for OtSubtable<'a> {
 
 impl<'a> FontRead<'a> for OtSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(OtSubtableMarker {})
+        Ok(TableRef {
+            shape: OtSubtableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// A subtable in an OT `kern` table.
-pub type OtSubtable<'a> = TableRef<'a, OtSubtableMarker>;
+pub type OtSubtable<'a> = TableRef<'a, OtSubtableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> OtSubtable<'a> {
@@ -297,7 +293,7 @@ impl<'a> std::fmt::Debug for OtSubtable<'a> {
 /// A subtable in an AAT `kern` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AatSubtableMarker {}
+pub struct AatSubtableMarker;
 
 impl<'a> MinByteRange for AatSubtable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -307,18 +303,16 @@ impl<'a> MinByteRange for AatSubtable<'a> {
 
 impl<'a> FontRead<'a> for AatSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(AatSubtableMarker {})
+        Ok(TableRef {
+            shape: AatSubtableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// A subtable in an AAT `kern` table.
-pub type AatSubtable<'a> = TableRef<'a, AatSubtableMarker>;
+pub type AatSubtable<'a> = TableRef<'a, AatSubtableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AatSubtable<'a> {
@@ -402,7 +396,7 @@ impl<'a> std::fmt::Debug for AatSubtable<'a> {
 /// The type 0 `kern` subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable0Marker {}
+pub struct Subtable0Marker;
 
 impl<'a> MinByteRange for Subtable0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -412,21 +406,16 @@ impl<'a> MinByteRange for Subtable0<'a> {
 
 impl<'a> FontRead<'a> for Subtable0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let n_pairs: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let pairs_byte_len = (n_pairs as usize)
-            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pairs_byte_len);
-        cursor.finish(Subtable0Marker {})
+        Ok(TableRef {
+            shape: Subtable0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The type 0 `kern` subtable.
-pub type Subtable0<'a> = TableRef<'a, Subtable0Marker>;
+pub type Subtable0<'a> = TableRef<'a, Subtable0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable0<'a> {
@@ -528,7 +517,7 @@ impl<'a> std::fmt::Debug for Subtable0<'a> {
 /// Class table for the type 2 `kern` subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable2ClassTableMarker {}
+pub struct Subtable2ClassTableMarker;
 
 impl<'a> MinByteRange for Subtable2ClassTable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -538,19 +527,16 @@ impl<'a> MinByteRange for Subtable2ClassTable<'a> {
 
 impl<'a> FontRead<'a> for Subtable2ClassTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<GlyphId16>();
-        let n_glyphs: u16 = cursor.read()?;
-        let offsets_byte_len = (n_glyphs as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(offsets_byte_len);
-        cursor.finish(Subtable2ClassTableMarker {})
+        Ok(TableRef {
+            shape: Subtable2ClassTableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Class table for the type 2 `kern` subtable.
-pub type Subtable2ClassTable<'a> = TableRef<'a, Subtable2ClassTableMarker>;
+pub type Subtable2ClassTable<'a> = TableRef<'a, Subtable2ClassTableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable2ClassTable<'a> {
@@ -621,7 +607,7 @@ impl<'a> std::fmt::Debug for Subtable2ClassTable<'a> {
 /// The type 3 'kern' subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable3Marker {}
+pub struct Subtable3Marker;
 
 impl<'a> MinByteRange for Subtable3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -631,35 +617,16 @@ impl<'a> MinByteRange for Subtable3<'a> {
 
 impl<'a> FontRead<'a> for Subtable3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let glyph_count: u16 = cursor.read()?;
-        let kern_value_count: u8 = cursor.read()?;
-        let left_class_count: u8 = cursor.read()?;
-        let right_class_count: u8 = cursor.read()?;
-        cursor.advance::<u8>();
-        let kern_value_byte_len = (kern_value_count as usize)
-            .checked_mul(i16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(kern_value_byte_len);
-        let left_class_byte_len = (glyph_count as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(left_class_byte_len);
-        let right_class_byte_len = (glyph_count as usize)
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(right_class_byte_len);
-        let kern_index_byte_len =
-            (transforms::add_multiply(left_class_count, 0_usize, right_class_count))
-                .checked_mul(u8::RAW_BYTE_LEN)
-                .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(kern_index_byte_len);
-        cursor.finish(Subtable3Marker {})
+        Ok(TableRef {
+            shape: Subtable3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The type 3 'kern' subtable.
-pub type Subtable3<'a> = TableRef<'a, Subtable3Marker>;
+pub type Subtable3<'a> = TableRef<'a, Subtable3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable3<'a> {

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -57,19 +57,19 @@ impl<'a> OtKern<'a> {
     /// Table version number—set to 0.
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of subtables in the kerning table.
     pub fn n_tables(&self) -> u16 {
         let range = self.n_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Data for subtables, immediately following the header.
     pub fn subtable_data(&self) -> &'a [u8] {
         let range = self.subtable_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -148,19 +148,19 @@ impl<'a> AatKern<'a> {
     /// The version number of the kerning table (0x00010000 for the current version).
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of subtables included in the kerning table.
     pub fn n_tables(&self) -> u32 {
         let range = self.n_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Data for subtables, immediately following the header.    
     pub fn subtable_data(&self) -> &'a [u8] {
         let range = self.subtable_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -244,25 +244,25 @@ impl<'a> OtSubtable<'a> {
     /// Kern subtable version number-- set to 0.
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u16 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u16 {
         let range = self.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -347,25 +347,25 @@ impl<'a> AatSubtable<'a> {
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u16 {
         let range = self.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The tuple index (used for variations fonts). This value specifies which tuple this subtable covers.
     pub fn tuple_index(&self) -> u16 {
         let range = self.tuple_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -454,31 +454,31 @@ impl<'a> Subtable0<'a> {
     /// The number of kerning pairs in this subtable.
     pub fn n_pairs(&self) -> u16 {
         let range = self.n_pairs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The largest power of two less than or equal to the value of nPairs, multiplied by the size in bytes of an entry in the subtable.
     pub fn search_range(&self) -> u16 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is calculated as log2 of the largest power of two less than or equal to the value of nPairs. This value indicates how many iterations of the search loop have to be made. For example, in a list of eight items, there would be three iterations of the loop.
     pub fn entry_selector(&self) -> u16 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of nPairs minus the largest power of two less than or equal to nPairs. This is multiplied by the size in bytes of an entry in the table.
     pub fn range_shift(&self) -> u16 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Kerning records.
     pub fn pairs(&self) -> &'a [Subtable0Pair] {
         let range = self.pairs_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -565,19 +565,19 @@ impl<'a> Subtable2ClassTable<'a> {
     /// First glyph in class range.
     pub fn first_glyph(&self) -> GlyphId16 {
         let range = self.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of glyph in class range.
     pub fn n_glyphs(&self) -> u16 {
         let range = self.n_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The offsets array for all of the glyphs in the range.
     pub fn offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -703,55 +703,55 @@ impl<'a> Subtable3<'a> {
     /// The number of glyphs in this font.
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of kerning values.
     pub fn kern_value_count(&self) -> u8 {
         let range = self.kern_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of left-hand classes.
     pub fn left_class_count(&self) -> u8 {
         let range = self.left_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of right-hand classes.
     pub fn right_class_count(&self) -> u8 {
         let range = self.right_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Set to zero (reserved for future use).
     pub fn flags(&self) -> u8 {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The kerning values.
     pub fn kern_value(&self) -> &'a [BigEndian<i16>] {
         let range = self.kern_value_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// The left-hand classes.
     pub fn left_class(&self) -> &'a [u8] {
         let range = self.left_class_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// The right-hand classes.
     pub fn right_class(&self) -> &'a [u8] {
         let range = self.right_class_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// The indices into the kernValue array.
     pub fn kern_index(&self) -> &'a [u8] {
         let range = self.kern_index_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -19,9 +19,9 @@ impl<'a> MinByteRange for OtKern<'a> {
 impl<'a> FontRead<'a> for OtKern<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: OtKernMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -110,9 +110,9 @@ impl<'a> MinByteRange for AatKern<'a> {
 impl<'a> FontRead<'a> for AatKern<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AatKernMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -201,9 +201,9 @@ impl<'a> MinByteRange for OtSubtable<'a> {
 impl<'a> FontRead<'a> for OtSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: OtSubtableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -304,9 +304,9 @@ impl<'a> MinByteRange for AatSubtable<'a> {
 impl<'a> FontRead<'a> for AatSubtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AatSubtableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -407,9 +407,9 @@ impl<'a> MinByteRange for Subtable0<'a> {
 impl<'a> FontRead<'a> for Subtable0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Subtable0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -528,9 +528,9 @@ impl<'a> MinByteRange for Subtable2ClassTable<'a> {
 impl<'a> FontRead<'a> for Subtable2ClassTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Subtable2ClassTableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -618,9 +618,9 @@ impl<'a> MinByteRange for Subtable3<'a> {
 impl<'a> FontRead<'a> for Subtable3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Subtable3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -8,28 +8,9 @@ use crate::codegen_prelude::*;
 /// The OpenType [kerning](https://learn.microsoft.com/en-us/typography/opentype/spec/kern) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct OtKernMarker {
-    subtable_data_byte_len: usize,
-}
+pub struct OtKernMarker {}
 
-impl OtKernMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn n_tables_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn subtable_data_byte_range(&self) -> Range<usize> {
-        let start = self.n_tables_byte_range().end;
-        start..start + self.subtable_data_byte_len
-    }
-}
-
-impl MinByteRange for OtKernMarker {
+impl<'a> MinByteRange for OtKern<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.subtable_data_byte_range().end
     }
@@ -42,9 +23,7 @@ impl<'a> FontRead<'a> for OtKern<'a> {
         cursor.advance::<u16>();
         let subtable_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(subtable_data_byte_len);
-        cursor.finish(OtKernMarker {
-            subtable_data_byte_len,
-        })
+        cursor.finish(OtKernMarker {})
     }
 }
 
@@ -53,21 +32,44 @@ pub type OtKern<'a> = TableRef<'a, OtKernMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> OtKern<'a> {
+    fn subtable_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn n_tables_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn subtable_data_byte_range(&self) -> Range<usize> {
+        let start = self.n_tables_byte_range().end;
+        start..start + self.subtable_data_byte_len(start)
+    }
+
     /// Table version number—set to 0.
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of subtables in the kerning table.
     pub fn n_tables(&self) -> u16 {
-        let range = self.shape.n_tables_byte_range();
+        let range = self.n_tables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Data for subtables, immediately following the header.
     pub fn subtable_data(&self) -> &'a [u8] {
-        let range = self.shape.subtable_data_byte_range();
+        let range = self.subtable_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -98,28 +100,9 @@ impl<'a> std::fmt::Debug for OtKern<'a> {
 /// The Apple Advanced Typography [kerning](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6kern.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AatKernMarker {
-    subtable_data_byte_len: usize,
-}
+pub struct AatKernMarker {}
 
-impl AatKernMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn n_tables_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn subtable_data_byte_range(&self) -> Range<usize> {
-        let start = self.n_tables_byte_range().end;
-        start..start + self.subtable_data_byte_len
-    }
-}
-
-impl MinByteRange for AatKernMarker {
+impl<'a> MinByteRange for AatKern<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.subtable_data_byte_range().end
     }
@@ -132,9 +115,7 @@ impl<'a> FontRead<'a> for AatKern<'a> {
         cursor.advance::<u32>();
         let subtable_data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
         cursor.advance_by(subtable_data_byte_len);
-        cursor.finish(AatKernMarker {
-            subtable_data_byte_len,
-        })
+        cursor.finish(AatKernMarker {})
     }
 }
 
@@ -143,21 +124,44 @@ pub type AatKern<'a> = TableRef<'a, AatKernMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> AatKern<'a> {
+    fn subtable_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn n_tables_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn subtable_data_byte_range(&self) -> Range<usize> {
+        let start = self.n_tables_byte_range().end;
+        start..start + self.subtable_data_byte_len(start)
+    }
+
     /// The version number of the kerning table (0x00010000 for the current version).
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of subtables included in the kerning table.
     pub fn n_tables(&self) -> u32 {
-        let range = self.shape.n_tables_byte_range();
+        let range = self.n_tables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Data for subtables, immediately following the header.    
     pub fn subtable_data(&self) -> &'a [u8] {
-        let range = self.shape.subtable_data_byte_range();
+        let range = self.subtable_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -188,11 +192,39 @@ impl<'a> std::fmt::Debug for AatKern<'a> {
 /// A subtable in an OT `kern` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct OtSubtableMarker {
-    data_byte_len: usize,
+pub struct OtSubtableMarker {}
+
+impl<'a> MinByteRange for OtSubtable<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.data_byte_range().end
+    }
 }
 
-impl OtSubtableMarker {
+impl<'a> FontRead<'a> for OtSubtable<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(data_byte_len);
+        cursor.finish(OtSubtableMarker {})
+    }
+}
+
+/// A subtable in an OT `kern` table.
+pub type OtSubtable<'a> = TableRef<'a, OtSubtableMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> OtSubtable<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -210,54 +242,30 @@ impl OtSubtableMarker {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.coverage_byte_range().end;
-        start..start + self.data_byte_len
+        start..start + self.data_byte_len(start)
     }
-}
 
-impl MinByteRange for OtSubtableMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for OtSubtable<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(OtSubtableMarker { data_byte_len })
-    }
-}
-
-/// A subtable in an OT `kern` table.
-pub type OtSubtable<'a> = TableRef<'a, OtSubtableMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> OtSubtable<'a> {
     /// Kern subtable version number-- set to 0.
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u16 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u16 {
-        let range = self.shape.coverage_byte_range();
+        let range = self.coverage_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -289,11 +297,39 @@ impl<'a> std::fmt::Debug for OtSubtable<'a> {
 /// A subtable in an AAT `kern` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct AatSubtableMarker {
-    data_byte_len: usize,
+pub struct AatSubtableMarker {}
+
+impl<'a> MinByteRange for AatSubtable<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.data_byte_range().end
+    }
 }
 
-impl AatSubtableMarker {
+impl<'a> FontRead<'a> for AatSubtable<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u32>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(data_byte_len);
+        cursor.finish(AatSubtableMarker {})
+    }
+}
+
+/// A subtable in an AAT `kern` table.
+pub type AatSubtable<'a> = TableRef<'a, AatSubtableMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> AatSubtable<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
@@ -311,54 +347,30 @@ impl AatSubtableMarker {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_index_byte_range().end;
-        start..start + self.data_byte_len
+        start..start + self.data_byte_len(start)
     }
-}
 
-impl MinByteRange for AatSubtableMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for AatSubtable<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(AatSubtableMarker { data_byte_len })
-    }
-}
-
-/// A subtable in an AAT `kern` table.
-pub type AatSubtable<'a> = TableRef<'a, AatSubtableMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> AatSubtable<'a> {
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u16 {
-        let range = self.shape.coverage_byte_range();
+        let range = self.coverage_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The tuple index (used for variations fonts). This value specifies which tuple this subtable covers.
     pub fn tuple_index(&self) -> u16 {
-        let range = self.shape.tuple_index_byte_range();
+        let range = self.tuple_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -390,11 +402,41 @@ impl<'a> std::fmt::Debug for AatSubtable<'a> {
 /// The type 0 `kern` subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable0Marker {
-    pairs_byte_len: usize,
+pub struct Subtable0Marker {}
+
+impl<'a> MinByteRange for Subtable0<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.pairs_byte_range().end
+    }
 }
 
-impl Subtable0Marker {
+impl<'a> FontRead<'a> for Subtable0<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let n_pairs: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let pairs_byte_len = (n_pairs as usize)
+            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(pairs_byte_len);
+        cursor.finish(Subtable0Marker {})
+    }
+}
+
+/// The type 0 `kern` subtable.
+pub type Subtable0<'a> = TableRef<'a, Subtable0Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Subtable0<'a> {
+    fn pairs_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_pairs()) as usize)
+            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn n_pairs_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -417,63 +459,36 @@ impl Subtable0Marker {
 
     pub fn pairs_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
-        start..start + self.pairs_byte_len
+        start..start + self.pairs_byte_len(start)
     }
-}
 
-impl MinByteRange for Subtable0Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.pairs_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Subtable0<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let n_pairs: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let pairs_byte_len = (n_pairs as usize)
-            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pairs_byte_len);
-        cursor.finish(Subtable0Marker { pairs_byte_len })
-    }
-}
-
-/// The type 0 `kern` subtable.
-pub type Subtable0<'a> = TableRef<'a, Subtable0Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Subtable0<'a> {
     /// The number of kerning pairs in this subtable.
     pub fn n_pairs(&self) -> u16 {
-        let range = self.shape.n_pairs_byte_range();
+        let range = self.n_pairs_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The largest power of two less than or equal to the value of nPairs, multiplied by the size in bytes of an entry in the subtable.
     pub fn search_range(&self) -> u16 {
-        let range = self.shape.search_range_byte_range();
+        let range = self.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// This is calculated as log2 of the largest power of two less than or equal to the value of nPairs. This value indicates how many iterations of the search loop have to be made. For example, in a list of eight items, there would be three iterations of the loop.
     pub fn entry_selector(&self) -> u16 {
-        let range = self.shape.entry_selector_byte_range();
+        let range = self.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of nPairs minus the largest power of two less than or equal to nPairs. This is multiplied by the size in bytes of an entry in the table.
     pub fn range_shift(&self) -> u16 {
-        let range = self.shape.range_shift_byte_range();
+        let range = self.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Kerning records.
     pub fn pairs(&self) -> &'a [Subtable0Pair] {
-        let range = self.shape.pairs_byte_range();
+        let range = self.pairs_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -513,28 +528,9 @@ impl<'a> std::fmt::Debug for Subtable0<'a> {
 /// Class table for the type 2 `kern` subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable2ClassTableMarker {
-    offsets_byte_len: usize,
-}
+pub struct Subtable2ClassTableMarker {}
 
-impl Subtable2ClassTableMarker {
-    pub fn first_glyph_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + GlyphId16::RAW_BYTE_LEN
-    }
-
-    pub fn n_glyphs_byte_range(&self) -> Range<usize> {
-        let start = self.first_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn offsets_byte_range(&self) -> Range<usize> {
-        let start = self.n_glyphs_byte_range().end;
-        start..start + self.offsets_byte_len
-    }
-}
-
-impl MinByteRange for Subtable2ClassTableMarker {
+impl<'a> MinByteRange for Subtable2ClassTable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.offsets_byte_range().end
     }
@@ -549,7 +545,7 @@ impl<'a> FontRead<'a> for Subtable2ClassTable<'a> {
             .checked_mul(u16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(offsets_byte_len);
-        cursor.finish(Subtable2ClassTableMarker { offsets_byte_len })
+        cursor.finish(Subtable2ClassTableMarker {})
     }
 }
 
@@ -558,21 +554,43 @@ pub type Subtable2ClassTable<'a> = TableRef<'a, Subtable2ClassTableMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable2ClassTable<'a> {
+    fn offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_glyphs()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn first_glyph_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + GlyphId16::RAW_BYTE_LEN
+    }
+
+    pub fn n_glyphs_byte_range(&self) -> Range<usize> {
+        let start = self.first_glyph_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn offsets_byte_range(&self) -> Range<usize> {
+        let start = self.n_glyphs_byte_range().end;
+        start..start + self.offsets_byte_len(start)
+    }
+
     /// First glyph in class range.
     pub fn first_glyph(&self) -> GlyphId16 {
-        let range = self.shape.first_glyph_byte_range();
+        let range = self.first_glyph_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of glyph in class range.
     pub fn n_glyphs(&self) -> u16 {
-        let range = self.shape.n_glyphs_byte_range();
+        let range = self.n_glyphs_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The offsets array for all of the glyphs in the range.
     pub fn offsets(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.offsets_byte_range();
+        let range = self.offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -603,61 +621,9 @@ impl<'a> std::fmt::Debug for Subtable2ClassTable<'a> {
 /// The type 3 'kern' subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable3Marker {
-    kern_value_byte_len: usize,
-    left_class_byte_len: usize,
-    right_class_byte_len: usize,
-    kern_index_byte_len: usize,
-}
+pub struct Subtable3Marker {}
 
-impl Subtable3Marker {
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn kern_value_count_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn left_class_count_byte_range(&self) -> Range<usize> {
-        let start = self.kern_value_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn right_class_count_byte_range(&self) -> Range<usize> {
-        let start = self.left_class_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn flags_byte_range(&self) -> Range<usize> {
-        let start = self.right_class_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn kern_value_byte_range(&self) -> Range<usize> {
-        let start = self.flags_byte_range().end;
-        start..start + self.kern_value_byte_len
-    }
-
-    pub fn left_class_byte_range(&self) -> Range<usize> {
-        let start = self.kern_value_byte_range().end;
-        start..start + self.left_class_byte_len
-    }
-
-    pub fn right_class_byte_range(&self) -> Range<usize> {
-        let start = self.left_class_byte_range().end;
-        start..start + self.right_class_byte_len
-    }
-
-    pub fn kern_index_byte_range(&self) -> Range<usize> {
-        let start = self.right_class_byte_range().end;
-        start..start + self.kern_index_byte_len
-    }
-}
-
-impl MinByteRange for Subtable3Marker {
+impl<'a> MinByteRange for Subtable3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.kern_index_byte_range().end
     }
@@ -688,12 +654,7 @@ impl<'a> FontRead<'a> for Subtable3<'a> {
                 .checked_mul(u8::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(kern_index_byte_len);
-        cursor.finish(Subtable3Marker {
-            kern_value_byte_len,
-            left_class_byte_len,
-            right_class_byte_len,
-            kern_index_byte_len,
-        })
+        cursor.finish(Subtable3Marker {})
     }
 }
 
@@ -702,57 +663,127 @@ pub type Subtable3<'a> = TableRef<'a, Subtable3Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable3<'a> {
+    fn kern_value_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.kern_value_count()) as usize)
+            .checked_mul(i16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn left_class_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn right_class_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn kern_index_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::add_multiply(self.left_class_count(), 0_usize, self.right_class_count()))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn kern_value_count_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn left_class_count_byte_range(&self) -> Range<usize> {
+        let start = self.kern_value_count_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn right_class_count_byte_range(&self) -> Range<usize> {
+        let start = self.left_class_count_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
+        let start = self.right_class_count_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn kern_value_byte_range(&self) -> Range<usize> {
+        let start = self.flags_byte_range().end;
+        start..start + self.kern_value_byte_len(start)
+    }
+
+    pub fn left_class_byte_range(&self) -> Range<usize> {
+        let start = self.kern_value_byte_range().end;
+        start..start + self.left_class_byte_len(start)
+    }
+
+    pub fn right_class_byte_range(&self) -> Range<usize> {
+        let start = self.left_class_byte_range().end;
+        start..start + self.right_class_byte_len(start)
+    }
+
+    pub fn kern_index_byte_range(&self) -> Range<usize> {
+        let start = self.right_class_byte_range().end;
+        start..start + self.kern_index_byte_len(start)
+    }
+
     /// The number of glyphs in this font.
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of kerning values.
     pub fn kern_value_count(&self) -> u8 {
-        let range = self.shape.kern_value_count_byte_range();
+        let range = self.kern_value_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of left-hand classes.
     pub fn left_class_count(&self) -> u8 {
-        let range = self.shape.left_class_count_byte_range();
+        let range = self.left_class_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of right-hand classes.
     pub fn right_class_count(&self) -> u8 {
-        let range = self.shape.right_class_count_byte_range();
+        let range = self.right_class_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Set to zero (reserved for future use).
     pub fn flags(&self) -> u8 {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The kerning values.
     pub fn kern_value(&self) -> &'a [BigEndian<i16>] {
-        let range = self.shape.kern_value_byte_range();
+        let range = self.kern_value_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// The left-hand classes.
     pub fn left_class(&self) -> &'a [u8] {
-        let range = self.shape.left_class_byte_range();
+        let range = self.left_class_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// The right-hand classes.
     pub fn right_class(&self) -> &'a [u8] {
-        let range = self.shape.right_class_byte_range();
+        let range = self.right_class_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// The indices into the kernValue array.
     pub fn kern_index(&self) -> &'a [u8] {
-        let range = self.shape.kern_index_byte_range();
+        let range = self.kern_index_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -67,18 +67,18 @@ impl<'a> Kerx<'a> {
     /// The version number of the extended kerning table (currently 2, 3, or 4)
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of subtables included in the extended kerning table.
     pub fn n_tables(&self) -> u32 {
         let range = self.n_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn subtables(&self) -> VarLenArray<'a, Subtable<'a>> {
         let range = self.subtables_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 }
 
@@ -165,25 +165,25 @@ impl<'a> Subtable<'a> {
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u32 {
         let range = self.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The tuple count. This value is only used with variation fonts and should be 0 for all other fonts. The subtable's tupleCount will be ignored if the 'kerx' table version is less than 4.
     pub fn tuple_count(&self) -> u32 {
         let range = self.tuple_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -272,31 +272,31 @@ impl<'a> Subtable0<'a> {
     /// The number of kerning pairs in this subtable.
     pub fn n_pairs(&self) -> u32 {
         let range = self.n_pairs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The largest power of two less than or equal to the value of nPairs, multiplied by the size in bytes of an entry in the subtable.
     pub fn search_range(&self) -> u32 {
         let range = self.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is calculated as log2 of the largest power of two less than or equal to the value of nPairs. This value indicates how many iterations of the search loop have to be made. For example, in a list of eight items, there would be three iterations of the loop.
     pub fn entry_selector(&self) -> u32 {
         let range = self.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The value of nPairs minus the largest power of two less than or equal to nPairs. This is multiplied by the size in bytes of an entry in the table.
     pub fn range_shift(&self) -> u32 {
         let range = self.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Kerning records.
     pub fn pairs(&self) -> &'a [Subtable0Pair] {
         let range = self.pairs_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [kerx (Extended Kerning)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct KerxMarker {}
+pub struct KerxMarker;
 
 impl<'a> MinByteRange for Kerx<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,21 +23,16 @@ impl TopLevelTable for Kerx<'_> {
 
 impl<'a> FontRead<'a> for Kerx<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let n_tables: u32 = cursor.read()?;
-        let subtables_byte_len = {
-            let data = cursor.remaining().ok_or(ReadError::OutOfBounds)?;
-            <Subtable as VarSize>::total_len_for_count(data, n_tables as usize)?
-        };
-        cursor.advance_by(subtables_byte_len);
-        cursor.finish(KerxMarker {})
+        Ok(TableRef {
+            shape: KerxMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [kerx (Extended Kerning)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html) table.
-pub type Kerx<'a> = TableRef<'a, KerxMarker>;
+pub type Kerx<'a> = TableRef<'a, KerxMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Kerx<'a> {
@@ -116,7 +111,7 @@ impl<'a> std::fmt::Debug for Kerx<'a> {
 /// A subtable in a `kerx` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SubtableMarker {}
+pub struct SubtableMarker;
 
 impl<'a> MinByteRange for Subtable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -126,18 +121,16 @@ impl<'a> MinByteRange for Subtable<'a> {
 
 impl<'a> FontRead<'a> for Subtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(SubtableMarker {})
+        Ok(TableRef {
+            shape: SubtableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// A subtable in a `kerx` table.
-pub type Subtable<'a> = TableRef<'a, SubtableMarker>;
+pub type Subtable<'a> = TableRef<'a, SubtableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable<'a> {
@@ -221,7 +214,7 @@ impl<'a> std::fmt::Debug for Subtable<'a> {
 /// The type 0 `kerx` subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable0Marker {}
+pub struct Subtable0Marker;
 
 impl<'a> MinByteRange for Subtable0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -231,21 +224,16 @@ impl<'a> MinByteRange for Subtable0<'a> {
 
 impl<'a> FontRead<'a> for Subtable0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let n_pairs: u32 = cursor.read()?;
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let pairs_byte_len = (n_pairs as usize)
-            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pairs_byte_len);
-        cursor.finish(Subtable0Marker {})
+        Ok(TableRef {
+            shape: Subtable0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The type 0 `kerx` subtable.
-pub type Subtable0<'a> = TableRef<'a, Subtable0Marker>;
+pub type Subtable0<'a> = TableRef<'a, Subtable0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable0<'a> {

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -8,33 +8,9 @@ use crate::codegen_prelude::*;
 /// The [kerx (Extended Kerning)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct KerxMarker {
-    subtables_byte_len: usize,
-}
+pub struct KerxMarker {}
 
-impl KerxMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn padding_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn n_tables_byte_range(&self) -> Range<usize> {
-        let start = self.padding_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn subtables_byte_range(&self) -> Range<usize> {
-        let start = self.n_tables_byte_range().end;
-        start..start + self.subtables_byte_len
-    }
-}
-
-impl MinByteRange for KerxMarker {
+impl<'a> MinByteRange for Kerx<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.subtables_byte_range().end
     }
@@ -56,7 +32,7 @@ impl<'a> FontRead<'a> for Kerx<'a> {
             <Subtable as VarSize>::total_len_for_count(data, n_tables as usize)?
         };
         cursor.advance_by(subtables_byte_len);
-        cursor.finish(KerxMarker { subtables_byte_len })
+        cursor.finish(KerxMarker {})
     }
 }
 
@@ -65,20 +41,48 @@ pub type Kerx<'a> = TableRef<'a, KerxMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Kerx<'a> {
+    fn subtables_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let data = self.data.split_off(start).unwrap();
+            <Subtable as VarSize>::total_len_for_count(data, (self.n_tables()) as usize).unwrap()
+        }
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn padding_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn n_tables_byte_range(&self) -> Range<usize> {
+        let start = self.padding_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn subtables_byte_range(&self) -> Range<usize> {
+        let start = self.n_tables_byte_range().end;
+        start..start + self.subtables_byte_len(start)
+    }
+
     /// The version number of the extended kerning table (currently 2, 3, or 4)
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of subtables included in the extended kerning table.
     pub fn n_tables(&self) -> u32 {
-        let range = self.shape.n_tables_byte_range();
+        let range = self.n_tables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn subtables(&self) -> VarLenArray<'a, Subtable<'a>> {
-        let range = self.shape.subtables_byte_range();
+        let range = self.subtables_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
     }
 }
@@ -112,11 +116,39 @@ impl<'a> std::fmt::Debug for Kerx<'a> {
 /// A subtable in a `kerx` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SubtableMarker {
-    data_byte_len: usize,
+pub struct SubtableMarker {}
+
+impl<'a> MinByteRange for Subtable<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.data_byte_range().end
+    }
 }
 
-impl SubtableMarker {
+impl<'a> FontRead<'a> for Subtable<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(data_byte_len);
+        cursor.finish(SubtableMarker {})
+    }
+}
+
+/// A subtable in a `kerx` table.
+pub type Subtable<'a> = TableRef<'a, SubtableMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Subtable<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
@@ -134,54 +166,30 @@ impl SubtableMarker {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_count_byte_range().end;
-        start..start + self.data_byte_len
+        start..start + self.data_byte_len(start)
     }
-}
 
-impl MinByteRange for SubtableMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Subtable<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(SubtableMarker { data_byte_len })
-    }
-}
-
-/// A subtable in a `kerx` table.
-pub type Subtable<'a> = TableRef<'a, SubtableMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Subtable<'a> {
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u32 {
-        let range = self.shape.coverage_byte_range();
+        let range = self.coverage_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The tuple count. This value is only used with variation fonts and should be 0 for all other fonts. The subtable's tupleCount will be ignored if the 'kerx' table version is less than 4.
     pub fn tuple_count(&self) -> u32 {
-        let range = self.shape.tuple_count_byte_range();
+        let range = self.tuple_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -213,11 +221,41 @@ impl<'a> std::fmt::Debug for Subtable<'a> {
 /// The type 0 `kerx` subtable.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Subtable0Marker {
-    pairs_byte_len: usize,
+pub struct Subtable0Marker {}
+
+impl<'a> MinByteRange for Subtable0<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.pairs_byte_range().end
+    }
 }
 
-impl Subtable0Marker {
+impl<'a> FontRead<'a> for Subtable0<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let n_pairs: u32 = cursor.read()?;
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let pairs_byte_len = (n_pairs as usize)
+            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(pairs_byte_len);
+        cursor.finish(Subtable0Marker {})
+    }
+}
+
+/// The type 0 `kerx` subtable.
+pub type Subtable0<'a> = TableRef<'a, Subtable0Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Subtable0<'a> {
+    fn pairs_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_pairs()) as usize)
+            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn n_pairs_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
@@ -240,63 +278,36 @@ impl Subtable0Marker {
 
     pub fn pairs_byte_range(&self) -> Range<usize> {
         let start = self.range_shift_byte_range().end;
-        start..start + self.pairs_byte_len
+        start..start + self.pairs_byte_len(start)
     }
-}
 
-impl MinByteRange for Subtable0Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.pairs_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Subtable0<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let n_pairs: u32 = cursor.read()?;
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let pairs_byte_len = (n_pairs as usize)
-            .checked_mul(Subtable0Pair::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(pairs_byte_len);
-        cursor.finish(Subtable0Marker { pairs_byte_len })
-    }
-}
-
-/// The type 0 `kerx` subtable.
-pub type Subtable0<'a> = TableRef<'a, Subtable0Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Subtable0<'a> {
     /// The number of kerning pairs in this subtable.
     pub fn n_pairs(&self) -> u32 {
-        let range = self.shape.n_pairs_byte_range();
+        let range = self.n_pairs_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The largest power of two less than or equal to the value of nPairs, multiplied by the size in bytes of an entry in the subtable.
     pub fn search_range(&self) -> u32 {
-        let range = self.shape.search_range_byte_range();
+        let range = self.search_range_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// This is calculated as log2 of the largest power of two less than or equal to the value of nPairs. This value indicates how many iterations of the search loop have to be made. For example, in a list of eight items, there would be three iterations of the loop.
     pub fn entry_selector(&self) -> u32 {
-        let range = self.shape.entry_selector_byte_range();
+        let range = self.entry_selector_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The value of nPairs minus the largest power of two less than or equal to nPairs. This is multiplied by the size in bytes of an entry in the table.
     pub fn range_shift(&self) -> u32 {
-        let range = self.shape.range_shift_byte_range();
+        let range = self.range_shift_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Kerning records.
     pub fn pairs(&self) -> &'a [Subtable0Pair] {
-        let range = self.shape.pairs_byte_range();
+        let range = self.pairs_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Kerx<'_> {
 impl<'a> FontRead<'a> for Kerx<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: KerxMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -122,9 +122,9 @@ impl<'a> MinByteRange for Subtable<'a> {
 impl<'a> FontRead<'a> for Subtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SubtableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -225,9 +225,9 @@ impl<'a> MinByteRange for Subtable0<'a> {
 impl<'a> FontRead<'a> for Subtable0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Subtable0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -51,13 +51,13 @@ impl<'a> ScriptList<'a> {
     /// Number of ScriptRecords
     pub fn script_count(&self) -> u16 {
         let range = self.script_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of ScriptRecords, listed alphabetically by script tag
     pub fn script_records(&self) -> &'a [ScriptRecord] {
         let range = self.script_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -195,7 +195,7 @@ impl<'a> Script<'a> {
     /// — may be NULL
     pub fn default_lang_sys_offset(&self) -> Nullable<Offset16> {
         let range = self.default_lang_sys_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`default_lang_sys_offset`][Self::default_lang_sys_offset].
@@ -208,13 +208,13 @@ impl<'a> Script<'a> {
     /// default LangSys
     pub fn lang_sys_count(&self) -> u16 {
         let range = self.lang_sys_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of LangSysRecords, listed alphabetically by LangSys tag
     pub fn lang_sys_records(&self) -> &'a [LangSysRecord] {
         let range = self.lang_sys_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -360,20 +360,20 @@ impl<'a> LangSys<'a> {
     /// required features = 0xFFFF
     pub fn required_feature_index(&self) -> u16 {
         let range = self.required_feature_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of feature index values for this language system —
     /// excludes the required feature
     pub fn feature_index_count(&self) -> u16 {
         let range = self.feature_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of indices into the FeatureList, in arbitrary order
     pub fn feature_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.feature_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -452,14 +452,14 @@ impl<'a> FeatureList<'a> {
     /// Number of FeatureRecords in this table
     pub fn feature_count(&self) -> u16 {
         let range = self.feature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
     pub fn feature_records(&self) -> &'a [FeatureRecord] {
         let range = self.feature_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -613,7 +613,7 @@ impl<'a> Feature<'a> {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     pub fn feature_params_offset(&self) -> Nullable<Offset16> {
         let range = self.feature_params_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`feature_params_offset`][Self::feature_params_offset].
@@ -626,14 +626,14 @@ impl<'a> Feature<'a> {
     /// Number of LookupList indices for this feature
     pub fn lookup_index_count(&self) -> u16 {
         let range = self.lookup_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of indices into the LookupList — zero-based (first
     /// lookup is LookupListIndex = 0)
     pub fn lookup_list_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.lookup_list_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn feature_tag(&self) -> Tag {
@@ -742,14 +742,14 @@ impl<'a, T> LookupList<'a, T> {
     /// Number of lookups in this table
     pub fn lookup_count(&self) -> u16 {
         let range = self.lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
     pub fn lookup_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.lookup_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`lookup_offsets`][Self::lookup_offsets].
@@ -891,26 +891,26 @@ impl<'a, T> Lookup<'a, T> {
     /// Different enumerations for GSUB and GPOS
     pub fn lookup_type(&self) -> u16 {
         let range = self.lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Lookup qualifiers
     pub fn lookup_flag(&self) -> LookupFlag {
         let range = self.lookup_flag_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of subtables for this lookup
     pub fn sub_table_count(&self) -> u16 {
         let range = self.sub_table_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to lookup subtables, from beginning of Lookup
     /// table
     pub fn subtable_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.subtable_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`subtable_offsets`][Self::subtable_offsets].
@@ -928,7 +928,7 @@ impl<'a, T> Lookup<'a, T> {
     /// set.
     pub fn mark_filtering_set(&self) -> Option<u16> {
         let range = self.mark_filtering_set_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 
@@ -1029,19 +1029,19 @@ impl<'a> CoverageFormat1<'a> {
     /// Format identifier — format = 1
     pub fn coverage_format(&self) -> u16 {
         let range = self.coverage_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of glyphs in the glyph array
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of glyph IDs — in numerical order
     pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.glyph_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1123,19 +1123,19 @@ impl<'a> CoverageFormat2<'a> {
     /// Format identifier — format = 2
     pub fn coverage_format(&self) -> u16 {
         let range = self.coverage_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of RangeRecords
     pub fn range_count(&self) -> u16 {
         let range = self.range_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of glyph ranges — ordered by startGlyphID.
     pub fn range_records(&self) -> &'a [RangeRecord] {
         let range = self.range_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1355,25 +1355,25 @@ impl<'a> ClassDefFormat1<'a> {
     /// Format identifier — format = 1
     pub fn class_format(&self) -> u16 {
         let range = self.class_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// First glyph ID of the classValueArray
     pub fn start_glyph_id(&self) -> GlyphId16 {
         let range = self.start_glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Size of the classValueArray
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of Class Values — one per glyph ID
     pub fn class_value_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.class_value_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1456,19 +1456,19 @@ impl<'a> ClassDefFormat2<'a> {
     /// Format identifier — format = 2
     pub fn class_format(&self) -> u16 {
         let range = self.class_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of ClassRangeRecords
     pub fn class_range_count(&self) -> u16 {
         let range = self.class_range_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of ClassRangeRecords — ordered by startGlyphID
     pub fn class_range_records(&self) -> &'a [ClassRangeRecord] {
         let range = self.class_range_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1727,14 +1727,14 @@ impl<'a> SequenceContextFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1746,14 +1746,14 @@ impl<'a> SequenceContextFormat1<'a> {
     /// Number of SequenceRuleSet tables
     pub fn seq_rule_set_count(&self) -> u16 {
         let range = self.seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to SequenceRuleSet tables, from beginning of
     /// SequenceContextFormat1 table (offsets may be NULL)
     pub fn seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
@@ -1850,14 +1850,14 @@ impl<'a> SequenceRuleSet<'a> {
     /// Number of SequenceRule tables
     pub fn seq_rule_count(&self) -> u16 {
         let range = self.seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
     pub fn seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_offsets`][Self::seq_rule_offsets].
@@ -1965,25 +1965,25 @@ impl<'a> SequenceRule<'a> {
     /// Number of glyphs in the input glyph sequence
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of input glyph IDs—starting with the second glyph
     pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Array of Sequence lookup records
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2083,14 +2083,14 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2103,7 +2103,7 @@ impl<'a> SequenceContextFormat2<'a> {
     /// SequenceContextFormat2 table
     pub fn class_def_offset(&self) -> Offset16 {
         let range = self.class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`class_def_offset`][Self::class_def_offset].
@@ -2115,14 +2115,14 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Number of ClassSequenceRuleSet tables
     pub fn class_seq_rule_set_count(&self) -> u16 {
         let range = self.class_seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to ClassSequenceRuleSet tables, from beginning
     /// of SequenceContextFormat2 table (may be NULL)
     pub fn class_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.class_seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
@@ -2228,14 +2228,14 @@ impl<'a> ClassSequenceRuleSet<'a> {
     /// Number of ClassSequenceRule tables
     pub fn class_seq_rule_count(&self) -> u16 {
         let range = self.class_seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
     pub fn class_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.class_seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
@@ -2346,26 +2346,26 @@ impl<'a> ClassSequenceRule<'a> {
     /// Number of glyphs to be matched
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
     pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2471,26 +2471,26 @@ impl<'a> SequenceContextFormat3<'a> {
     /// Format identifier: format = 3
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of glyphs in the input sequence
     pub fn glyph_count(&self) -> u16 {
         let range = self.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
     pub fn coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
@@ -2503,7 +2503,7 @@ impl<'a> SequenceContextFormat3<'a> {
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -2689,14 +2689,14 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2708,14 +2708,14 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// Number of ChainedSequenceRuleSet tables
     pub fn chained_seq_rule_set_count(&self) -> u16 {
         let range = self.chained_seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to ChainedSeqRuleSet tables, from beginning of
     /// ChainedSequenceContextFormat1 table (may be NULL)
     pub fn chained_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.chained_seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
@@ -2817,14 +2817,14 @@ impl<'a> ChainedSequenceRuleSet<'a> {
     /// Number of ChainedSequenceRule tables
     pub fn chained_seq_rule_count(&self) -> u16 {
         let range = self.chained_seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
     pub fn chained_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.chained_seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
@@ -2967,49 +2967,49 @@ impl<'a> ChainedSequenceRule<'a> {
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of backtrack glyph IDs
     pub fn backtrack_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.backtrack_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
         let range = self.input_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of input glyph IDs—start with second glyph
     pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of lookahead glyph IDs
     pub fn lookahead_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.lookahead_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -3129,14 +3129,14 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -3149,7 +3149,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn backtrack_class_def_offset(&self) -> Offset16 {
         let range = self.backtrack_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`backtrack_class_def_offset`][Self::backtrack_class_def_offset].
@@ -3162,7 +3162,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn input_class_def_offset(&self) -> Offset16 {
         let range = self.input_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`input_class_def_offset`][Self::input_class_def_offset].
@@ -3175,7 +3175,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn lookahead_class_def_offset(&self) -> Offset16 {
         let range = self.lookahead_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`lookahead_class_def_offset`][Self::lookahead_class_def_offset].
@@ -3187,14 +3187,14 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Number of ChainedClassSequenceRuleSet tables
     pub fn chained_class_seq_rule_set_count(&self) -> u16 {
         let range = self.chained_class_seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to ChainedClassSequenceRuleSet tables, from
     /// beginning of ChainedSequenceContextFormat2 table (may be NULL)
     pub fn chained_class_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.chained_class_seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
@@ -3314,14 +3314,14 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     /// Number of ChainedClassSequenceRule tables
     pub fn chained_class_seq_rule_count(&self) -> u16 {
         let range = self.chained_class_seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
     pub fn chained_class_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.chained_class_seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
@@ -3466,50 +3466,50 @@ impl<'a> ChainedClassSequenceRule<'a> {
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of backtrack-sequence classes
     pub fn backtrack_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.backtrack_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Total number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
         let range = self.input_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of input sequence classes, beginning with the second
     /// glyph position
     pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of lookahead-sequence classes
     pub fn lookahead_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.lookahead_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -3657,19 +3657,19 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Format identifier: format = 3
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to coverage tables for the backtrack sequence
     pub fn backtrack_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.backtrack_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
@@ -3682,13 +3682,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
         let range = self.input_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to coverage tables for the input sequence
     pub fn input_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.input_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`input_coverage_offsets`][Self::input_coverage_offsets].
@@ -3701,13 +3701,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to coverage tables for the lookahead sequence
     pub fn lookahead_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.lookahead_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
@@ -3720,13 +3720,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -3998,25 +3998,25 @@ impl<'a> Device<'a> {
     /// Smallest size to correct, in ppem
     pub fn start_size(&self) -> u16 {
         let range = self.start_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Largest size to correct, in ppem
     pub fn end_size(&self) -> u16 {
         let range = self.end_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of deltaValue array data: 0x0001, 0x0002, or 0x0003
     pub fn delta_format(&self) -> DeltaFormat {
         let range = self.delta_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of compressed data
     pub fn delta_value(&self) -> &'a [BigEndian<u16>] {
         let range = self.delta_value_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -4089,20 +4089,20 @@ impl<'a> VariationIndex<'a> {
     /// data subtable within the item variation store.
     pub fn delta_set_outer_index(&self) -> u16 {
         let range = self.delta_set_outer_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A delta-set inner index — used to select a delta-set row
     /// within an item variation data subtable.
     pub fn delta_set_inner_index(&self) -> u16 {
         let range = self.delta_set_inner_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format, = 0x8000
     pub fn delta_format(&self) -> DeltaFormat {
         let range = self.delta_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4255,19 +4255,19 @@ impl<'a> FeatureVariations<'a> {
 
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of feature variation records.
     pub fn feature_variation_record_count(&self) -> u32 {
         let range = self.feature_variation_record_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of feature variation records.
     pub fn feature_variation_records(&self) -> &'a [FeatureVariationRecord] {
         let range = self.feature_variation_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -4429,14 +4429,14 @@ impl<'a> ConditionSet<'a> {
     /// Number of conditions for this condition set.
     pub fn condition_count(&self) -> u16 {
         let range = self.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
@@ -4628,28 +4628,28 @@ impl<'a> ConditionFormat1<'a> {
     /// Format, = 1
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
     pub fn axis_index(&self) -> u16 {
         let range = self.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum value of the font variation instances that satisfy this
     /// condition.
     pub fn filter_range_min_value(&self) -> F2Dot14 {
         let range = self.filter_range_min_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum value of the font variation instances that satisfy this
     /// condition.
     pub fn filter_range_max_value(&self) -> F2Dot14 {
         let range = self.filter_range_max_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4731,19 +4731,19 @@ impl<'a> ConditionFormat2<'a> {
     /// Format, = 2
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Value at default instance.
     pub fn default_value(&self) -> i16 {
         let range = self.default_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Variation index to vary the value based on current designspace location.
     pub fn var_index(&self) -> u32 {
         let range = self.var_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -4825,19 +4825,19 @@ impl<'a> ConditionFormat3<'a> {
     /// Format, = 3
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of conditions.
     pub fn condition_count(&self) -> u8 {
         let range = self.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of condition tables for this conjunction (AND) expression.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset24>] {
         let range = self.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
@@ -4939,19 +4939,19 @@ impl<'a> ConditionFormat4<'a> {
     /// Format, = 4
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of conditions.
     pub fn condition_count(&self) -> u8 {
         let range = self.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of condition tables for this disjunction (OR) expression.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset24>] {
         let range = self.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
@@ -5041,13 +5041,13 @@ impl<'a> ConditionFormat5<'a> {
     /// Format, = 5
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Condition to negate.
     pub fn condition_offset(&self) -> Offset24 {
         let range = self.condition_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`condition_offset`][Self::condition_offset].
@@ -5133,19 +5133,19 @@ impl<'a> FeatureTableSubstitution<'a> {
     /// Major & minor version of the table: (1, 0)
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of feature table substitution records.
     pub fn substitution_count(&self) -> u16 {
         let range = self.substitution_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of feature table substitution records.
     pub fn substitutions(&self) -> &'a [FeatureTableSubstitutionRecord] {
         let range = self.substitutions_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -5284,7 +5284,7 @@ impl<'a> SizeParams<'a> {
     /// no recommended size range, the rest of the array will consist of zeros.
     pub fn design_size(&self) -> u16 {
         let range = self.design_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The second value has no independent meaning, but serves as an identifier that associates fonts in a subfamily.
@@ -5295,7 +5295,7 @@ impl<'a> SizeParams<'a> {
     /// If this value is zero, the remaining fields in the array will be ignored.
     pub fn identifier(&self) -> u16 {
         let range = self.identifier_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The third value enables applications to use a single name for the subfamily identified by the second value.
@@ -5310,7 +5310,7 @@ impl<'a> SizeParams<'a> {
     /// appropriate version based on their selection criteria.
     pub fn name_entry(&self) -> u16 {
         let range = self.name_entry_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The fourth and fifth values represent the small end of the recommended
@@ -5320,12 +5320,12 @@ impl<'a> SizeParams<'a> {
     /// Ranges must not overlap, and should generally be contiguous.
     pub fn range_start(&self) -> u16 {
         let range = self.range_start_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn range_end(&self) -> u16 {
         let range = self.range_end_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5390,7 +5390,7 @@ impl<'a> StylisticSetParams<'a> {
 
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The 'name' table name ID that specifies a string (or strings, for
@@ -5404,7 +5404,7 @@ impl<'a> StylisticSetParams<'a> {
     /// comfortably with different application interfaces.
     pub fn ui_name_id(&self) -> NameId {
         let range = self.ui_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -5510,7 +5510,7 @@ impl<'a> CharacterVariantParams<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The 'name' table name ID that specifies a string (or strings,
@@ -5518,7 +5518,7 @@ impl<'a> CharacterVariantParams<'a> {
     /// feature. (May be NULL.)
     pub fn feat_ui_label_name_id(&self) -> NameId {
         let range = self.feat_ui_label_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The 'name' table name ID that specifies a string (or strings,
@@ -5526,20 +5526,20 @@ impl<'a> CharacterVariantParams<'a> {
     /// text for this feature. (May be NULL.)
     pub fn feat_ui_tooltip_text_name_id(&self) -> NameId {
         let range = self.feat_ui_tooltip_text_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The 'name' table name ID that specifies sample text that
     /// illustrates the effect of this feature. (May be NULL.)
     pub fn sample_text_name_id(&self) -> NameId {
         let range = self.sample_text_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of named parameters. (May be zero.)
     pub fn num_named_parameters(&self) -> u16 {
         let range = self.num_named_parameters_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The first 'name' table name ID used to specify strings for
@@ -5547,21 +5547,21 @@ impl<'a> CharacterVariantParams<'a> {
     /// if numParameters is zero.)
     pub fn first_param_ui_label_name_id(&self) -> NameId {
         let range = self.first_param_ui_label_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The count of characters for which this feature provides glyph
     /// variants. (May be zero.)
     pub fn char_count(&self) -> u16 {
         let range = self.char_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The Unicode Scalar Value of the characters for which this
     /// feature provides glyph variants.
     pub fn character(&self) -> &'a [BigEndian<Uint24>] {
         let range = self.character_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ScriptListMarker {}
+pub struct ScriptListMarker;
 
 impl<'a> MinByteRange for ScriptList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -18,18 +18,16 @@ impl<'a> MinByteRange for ScriptList<'a> {
 
 impl<'a> FontRead<'a> for ScriptList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let script_count: u16 = cursor.read()?;
-        let script_records_byte_len = (script_count as usize)
-            .checked_mul(ScriptRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(script_records_byte_len);
-        cursor.finish(ScriptListMarker {})
+        Ok(TableRef {
+            shape: ScriptListMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
-pub type ScriptList<'a> = TableRef<'a, ScriptListMarker>;
+pub type ScriptList<'a> = TableRef<'a, ScriptListMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ScriptList<'a> {
@@ -148,7 +146,7 @@ impl<'a> SomeRecord<'a> for ScriptRecord {
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ScriptMarker {}
+pub struct ScriptMarker;
 
 impl<'a> MinByteRange for Script<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -158,19 +156,16 @@ impl<'a> MinByteRange for Script<'a> {
 
 impl<'a> FontRead<'a> for Script<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Offset16>();
-        let lang_sys_count: u16 = cursor.read()?;
-        let lang_sys_records_byte_len = (lang_sys_count as usize)
-            .checked_mul(LangSysRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lang_sys_records_byte_len);
-        cursor.finish(ScriptMarker {})
+        Ok(TableRef {
+            shape: ScriptMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
-pub type Script<'a> = TableRef<'a, ScriptMarker>;
+pub type Script<'a> = TableRef<'a, ScriptMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Script<'a> {
@@ -311,7 +306,7 @@ impl<'a> SomeRecord<'a> for LangSysRecord {
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LangSysMarker {}
+pub struct LangSysMarker;
 
 impl<'a> MinByteRange for LangSys<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -321,20 +316,16 @@ impl<'a> MinByteRange for LangSys<'a> {
 
 impl<'a> FontRead<'a> for LangSys<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let feature_index_count: u16 = cursor.read()?;
-        let feature_indices_byte_len = (feature_index_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(feature_indices_byte_len);
-        cursor.finish(LangSysMarker {})
+        Ok(TableRef {
+            shape: LangSysMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
-pub type LangSys<'a> = TableRef<'a, LangSysMarker>;
+pub type LangSys<'a> = TableRef<'a, LangSysMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> LangSys<'a> {
@@ -418,7 +409,7 @@ impl<'a> std::fmt::Debug for LangSys<'a> {
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureListMarker {}
+pub struct FeatureListMarker;
 
 impl<'a> MinByteRange for FeatureList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -428,18 +419,16 @@ impl<'a> MinByteRange for FeatureList<'a> {
 
 impl<'a> FontRead<'a> for FeatureList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let feature_count: u16 = cursor.read()?;
-        let feature_records_byte_len = (feature_count as usize)
-            .checked_mul(FeatureRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(feature_records_byte_len);
-        cursor.finish(FeatureListMarker {})
+        Ok(TableRef {
+            shape: FeatureListMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
-pub type FeatureList<'a> = TableRef<'a, FeatureListMarker>;
+pub type FeatureList<'a> = TableRef<'a, FeatureListMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FeatureList<'a> {
@@ -560,9 +549,7 @@ impl<'a> SomeRecord<'a> for FeatureRecord {
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureMarker {
-    feature_tag: Tag,
-}
+pub struct FeatureMarker;
 
 impl<'a> MinByteRange for Feature<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -576,15 +563,12 @@ impl ReadArgs for Feature<'_> {
 
 impl<'a> FontReadWithArgs<'a> for Feature<'a> {
     fn read_with_args(data: FontData<'a>, args: &Tag) -> Result<Self, ReadError> {
-        let feature_tag = *args;
-        let mut cursor = data.cursor();
-        cursor.advance::<Offset16>();
-        let lookup_index_count: u16 = cursor.read()?;
-        let lookup_list_indices_byte_len = (lookup_index_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lookup_list_indices_byte_len);
-        cursor.finish(FeatureMarker { feature_tag })
+        let args = *args;
+        Ok(TableRef {
+            shape: FeatureMarker,
+            args,
+            data,
+        })
     }
 }
 
@@ -600,7 +584,7 @@ impl<'a> Feature<'a> {
 }
 
 /// [Feature Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-table)
-pub type Feature<'a> = TableRef<'a, FeatureMarker>;
+pub type Feature<'a> = TableRef<'a, FeatureMarker, Tag>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Feature<'a> {
@@ -653,7 +637,7 @@ impl<'a> Feature<'a> {
     }
 
     pub(crate) fn feature_tag(&self) -> Tag {
-        self.shape.feature_tag
+        self.args
     }
 }
 
@@ -687,11 +671,9 @@ impl<'a> std::fmt::Debug for Feature<'a> {
 }
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LookupListMarker<T = ()> {
-    offset_type: std::marker::PhantomData<*const T>,
-}
+pub struct LookupListMarker;
 
 impl<'a, T> MinByteRange for LookupList<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -699,24 +681,12 @@ impl<'a, T> MinByteRange for LookupList<'a, T> {
     }
 }
 
-impl<T> Clone for LookupListMarker<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T> Copy for LookupListMarker<T> {}
-
 impl<'a, T> FontRead<'a> for LookupList<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let lookup_count: u16 = cursor.read()?;
-        let lookup_offsets_byte_len = (lookup_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lookup_offsets_byte_len);
-        cursor.finish(LookupListMarker {
-            offset_type: std::marker::PhantomData,
+        Ok(TableRef {
+            shape: LookupListMarker,
+            args: std::marker::PhantomData,
+            data,
         })
     }
 }
@@ -726,9 +696,8 @@ impl<'a> LookupList<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> LookupList<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupListMarker {
-                offset_type: std::marker::PhantomData,
-            },
+            shape: LookupListMarker,
+            args: std::marker::PhantomData,
             data,
         }
     }
@@ -740,16 +709,16 @@ impl<'a, T> LookupList<'a, T> {
     pub(crate) fn of_unit_type(&self) -> LookupList<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupListMarker {
-                offset_type: std::marker::PhantomData,
-            },
+            shape: LookupListMarker,
+            args: std::marker::PhantomData,
             data: *data,
         }
     }
 }
 
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
-pub type LookupList<'a, T> = TableRef<'a, LookupListMarker<T>>;
+pub type LookupList<'a, T = ()> =
+    TableRef<'a, LookupListMarker, std::marker::PhantomData<*const T>>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> LookupList<'a, T> {
@@ -830,12 +799,9 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for LookupList<'a
 }
 
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LookupMarker<T = ()> {
-    mark_filtering_set_byte_start: Option<usize>,
-    offset_type: std::marker::PhantomData<*const T>,
-}
+pub struct LookupMarker;
 
 impl<'a, T> MinByteRange for Lookup<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -843,34 +809,12 @@ impl<'a, T> MinByteRange for Lookup<'a, T> {
     }
 }
 
-impl<T> Clone for LookupMarker<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T> Copy for LookupMarker<T> {}
-
 impl<'a, T> FontRead<'a> for Lookup<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let lookup_flag: LookupFlag = cursor.read()?;
-        let sub_table_count: u16 = cursor.read()?;
-        let subtable_offsets_byte_len = (sub_table_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(subtable_offsets_byte_len);
-        let mark_filtering_set_byte_start = lookup_flag
-            .contains(LookupFlag::USE_MARK_FILTERING_SET)
-            .then(|| cursor.position())
-            .transpose()?;
-        lookup_flag
-            .contains(LookupFlag::USE_MARK_FILTERING_SET)
-            .then(|| cursor.advance::<u16>());
-        cursor.finish(LookupMarker {
-            mark_filtering_set_byte_start,
-            offset_type: std::marker::PhantomData,
+        Ok(TableRef {
+            shape: LookupMarker,
+            args: std::marker::PhantomData,
+            data,
         })
     }
 }
@@ -878,12 +822,10 @@ impl<'a, T> FontRead<'a> for Lookup<'a, T> {
 impl<'a> Lookup<'a, ()> {
     #[allow(dead_code)]
     pub(crate) fn into_concrete<T>(self) -> Lookup<'a, T> {
-        let TableRef { data, shape } = self;
+        let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupMarker {
-                mark_filtering_set_byte_start: shape.mark_filtering_set_byte_start,
-                offset_type: std::marker::PhantomData,
-            },
+            shape: LookupMarker,
+            args: std::marker::PhantomData,
             data,
         }
     }
@@ -893,19 +835,17 @@ impl<'a, T> Lookup<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`
     pub(crate) fn of_unit_type(&self) -> Lookup<'a, ()> {
-        let TableRef { data, shape } = self;
+        let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupMarker {
-                mark_filtering_set_byte_start: shape.mark_filtering_set_byte_start,
-                offset_type: std::marker::PhantomData,
-            },
+            shape: LookupMarker,
+            args: std::marker::PhantomData,
             data: *data,
         }
     }
 }
 
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
-pub type Lookup<'a, T> = TableRef<'a, LookupMarker<T>>;
+pub type Lookup<'a, T = ()> = TableRef<'a, LookupMarker, std::marker::PhantomData<*const T>>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> Lookup<'a, T> {
@@ -937,8 +877,15 @@ impl<'a, T> Lookup<'a, T> {
     }
 
     pub fn mark_filtering_set_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.mark_filtering_set_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self
+            .lookup_flag()
+            .contains(LookupFlag::USE_MARK_FILTERING_SET)
+        {
+            let start = self.subtable_offsets_byte_range().end;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     /// Different enumerations for GSUB and GPOS
@@ -1034,7 +981,7 @@ impl Format<u16> for CoverageFormat1Marker {
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CoverageFormat1Marker {}
+pub struct CoverageFormat1Marker;
 
 impl<'a> MinByteRange for CoverageFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1044,19 +991,16 @@ impl<'a> MinByteRange for CoverageFormat1<'a> {
 
 impl<'a> FontRead<'a> for CoverageFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let glyph_count: u16 = cursor.read()?;
-        let glyph_array_byte_len = (glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(glyph_array_byte_len);
-        cursor.finish(CoverageFormat1Marker {})
+        Ok(TableRef {
+            shape: CoverageFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
-pub type CoverageFormat1<'a> = TableRef<'a, CoverageFormat1Marker>;
+pub type CoverageFormat1<'a> = TableRef<'a, CoverageFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CoverageFormat1<'a> {
@@ -1131,7 +1075,7 @@ impl Format<u16> for CoverageFormat2Marker {
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CoverageFormat2Marker {}
+pub struct CoverageFormat2Marker;
 
 impl<'a> MinByteRange for CoverageFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1141,19 +1085,16 @@ impl<'a> MinByteRange for CoverageFormat2<'a> {
 
 impl<'a> FontRead<'a> for CoverageFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let range_count: u16 = cursor.read()?;
-        let range_records_byte_len = (range_count as usize)
-            .checked_mul(RangeRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(range_records_byte_len);
-        cursor.finish(CoverageFormat2Marker {})
+        Ok(TableRef {
+            shape: CoverageFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
-pub type CoverageFormat2<'a> = TableRef<'a, CoverageFormat2Marker>;
+pub type CoverageFormat2<'a> = TableRef<'a, CoverageFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CoverageFormat2<'a> {
@@ -1361,7 +1302,7 @@ impl Format<u16> for ClassDefFormat1Marker {
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassDefFormat1Marker {}
+pub struct ClassDefFormat1Marker;
 
 impl<'a> MinByteRange for ClassDefFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1371,20 +1312,16 @@ impl<'a> MinByteRange for ClassDefFormat1<'a> {
 
 impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<GlyphId16>();
-        let glyph_count: u16 = cursor.read()?;
-        let class_value_array_byte_len = (glyph_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_value_array_byte_len);
-        cursor.finish(ClassDefFormat1Marker {})
+        Ok(TableRef {
+            shape: ClassDefFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
-pub type ClassDefFormat1<'a> = TableRef<'a, ClassDefFormat1Marker>;
+pub type ClassDefFormat1<'a> = TableRef<'a, ClassDefFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassDefFormat1<'a> {
@@ -1471,7 +1408,7 @@ impl Format<u16> for ClassDefFormat2Marker {
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassDefFormat2Marker {}
+pub struct ClassDefFormat2Marker;
 
 impl<'a> MinByteRange for ClassDefFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1481,19 +1418,16 @@ impl<'a> MinByteRange for ClassDefFormat2<'a> {
 
 impl<'a> FontRead<'a> for ClassDefFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let class_range_count: u16 = cursor.read()?;
-        let class_range_records_byte_len = (class_range_count as usize)
-            .checked_mul(ClassRangeRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_range_records_byte_len);
-        cursor.finish(ClassDefFormat2Marker {})
+        Ok(TableRef {
+            shape: ClassDefFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
-pub type ClassDefFormat2<'a> = TableRef<'a, ClassDefFormat2Marker>;
+pub type ClassDefFormat2<'a> = TableRef<'a, ClassDefFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassDefFormat2<'a> {
@@ -1740,7 +1674,7 @@ impl Format<u16> for SequenceContextFormat1Marker {
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceContextFormat1Marker {}
+pub struct SequenceContextFormat1Marker;
 
 impl<'a> MinByteRange for SequenceContextFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1750,20 +1684,16 @@ impl<'a> MinByteRange for SequenceContextFormat1<'a> {
 
 impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let seq_rule_set_count: u16 = cursor.read()?;
-        let seq_rule_set_offsets_byte_len = (seq_rule_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_rule_set_offsets_byte_len);
-        cursor.finish(SequenceContextFormat1Marker {})
+        Ok(TableRef {
+            shape: SequenceContextFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
-pub type SequenceContextFormat1<'a> = TableRef<'a, SequenceContextFormat1Marker>;
+pub type SequenceContextFormat1<'a> = TableRef<'a, SequenceContextFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceContextFormat1<'a> {
@@ -1877,7 +1807,7 @@ impl<'a> std::fmt::Debug for SequenceContextFormat1<'a> {
 /// Part of [SequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceRuleSetMarker {}
+pub struct SequenceRuleSetMarker;
 
 impl<'a> MinByteRange for SequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1887,18 +1817,16 @@ impl<'a> MinByteRange for SequenceRuleSet<'a> {
 
 impl<'a> FontRead<'a> for SequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let seq_rule_count: u16 = cursor.read()?;
-        let seq_rule_offsets_byte_len = (seq_rule_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_rule_offsets_byte_len);
-        cursor.finish(SequenceRuleSetMarker {})
+        Ok(TableRef {
+            shape: SequenceRuleSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [SequenceContextFormat1]
-pub type SequenceRuleSet<'a> = TableRef<'a, SequenceRuleSetMarker>;
+pub type SequenceRuleSet<'a> = TableRef<'a, SequenceRuleSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceRuleSet<'a> {
@@ -1978,7 +1906,7 @@ impl<'a> std::fmt::Debug for SequenceRuleSet<'a> {
 /// Part of [SequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceRuleMarker {}
+pub struct SequenceRuleMarker;
 
 impl<'a> MinByteRange for SequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1988,23 +1916,16 @@ impl<'a> MinByteRange for SequenceRule<'a> {
 
 impl<'a> FontRead<'a> for SequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let glyph_count: u16 = cursor.read()?;
-        let seq_lookup_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = (transforms::subtract(glyph_count, 1_usize))
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(input_sequence_byte_len);
-        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
-            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(SequenceRuleMarker {})
+        Ok(TableRef {
+            shape: SequenceRuleMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [SequenceContextFormat1]
-pub type SequenceRule<'a> = TableRef<'a, SequenceRuleMarker>;
+pub type SequenceRule<'a> = TableRef<'a, SequenceRuleMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceRule<'a> {
@@ -2104,7 +2025,7 @@ impl Format<u16> for SequenceContextFormat2Marker {
 /// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceContextFormat2Marker {}
+pub struct SequenceContextFormat2Marker;
 
 impl<'a> MinByteRange for SequenceContextFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2114,21 +2035,16 @@ impl<'a> MinByteRange for SequenceContextFormat2<'a> {
 
 impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let class_seq_rule_set_count: u16 = cursor.read()?;
-        let class_seq_rule_set_offsets_byte_len = (class_seq_rule_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_seq_rule_set_offsets_byte_len);
-        cursor.finish(SequenceContextFormat2Marker {})
+        Ok(TableRef {
+            shape: SequenceContextFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
-pub type SequenceContextFormat2<'a> = TableRef<'a, SequenceContextFormat2Marker>;
+pub type SequenceContextFormat2<'a> = TableRef<'a, SequenceContextFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceContextFormat2<'a> {
@@ -2269,7 +2185,7 @@ impl<'a> std::fmt::Debug for SequenceContextFormat2<'a> {
 /// Part of [SequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassSequenceRuleSetMarker {}
+pub struct ClassSequenceRuleSetMarker;
 
 impl<'a> MinByteRange for ClassSequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2279,18 +2195,16 @@ impl<'a> MinByteRange for ClassSequenceRuleSet<'a> {
 
 impl<'a> FontRead<'a> for ClassSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let class_seq_rule_count: u16 = cursor.read()?;
-        let class_seq_rule_offsets_byte_len = (class_seq_rule_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_seq_rule_offsets_byte_len);
-        cursor.finish(ClassSequenceRuleSetMarker {})
+        Ok(TableRef {
+            shape: ClassSequenceRuleSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [SequenceContextFormat2]
-pub type ClassSequenceRuleSet<'a> = TableRef<'a, ClassSequenceRuleSetMarker>;
+pub type ClassSequenceRuleSet<'a> = TableRef<'a, ClassSequenceRuleSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassSequenceRuleSet<'a> {
@@ -2373,7 +2287,7 @@ impl<'a> std::fmt::Debug for ClassSequenceRuleSet<'a> {
 /// Part of [SequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassSequenceRuleMarker {}
+pub struct ClassSequenceRuleMarker;
 
 impl<'a> MinByteRange for ClassSequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2383,23 +2297,16 @@ impl<'a> MinByteRange for ClassSequenceRule<'a> {
 
 impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let glyph_count: u16 = cursor.read()?;
-        let seq_lookup_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = (transforms::subtract(glyph_count, 1_usize))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(input_sequence_byte_len);
-        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
-            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ClassSequenceRuleMarker {})
+        Ok(TableRef {
+            shape: ClassSequenceRuleMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [SequenceContextFormat2]
-pub type ClassSequenceRule<'a> = TableRef<'a, ClassSequenceRuleMarker>;
+pub type ClassSequenceRule<'a> = TableRef<'a, ClassSequenceRuleMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassSequenceRule<'a> {
@@ -2500,7 +2407,7 @@ impl Format<u16> for SequenceContextFormat3Marker {
 /// [Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceContextFormat3Marker {}
+pub struct SequenceContextFormat3Marker;
 
 impl<'a> MinByteRange for SequenceContextFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2510,24 +2417,16 @@ impl<'a> MinByteRange for SequenceContextFormat3<'a> {
 
 impl<'a> FontRead<'a> for SequenceContextFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let glyph_count: u16 = cursor.read()?;
-        let seq_lookup_count: u16 = cursor.read()?;
-        let coverage_offsets_byte_len = (glyph_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(coverage_offsets_byte_len);
-        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
-            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(SequenceContextFormat3Marker {})
+        Ok(TableRef {
+            shape: SequenceContextFormat3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
-pub type SequenceContextFormat3<'a> = TableRef<'a, SequenceContextFormat3Marker>;
+pub type SequenceContextFormat3<'a> = TableRef<'a, SequenceContextFormat3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceContextFormat3<'a> {
@@ -2737,7 +2636,7 @@ impl Format<u16> for ChainedSequenceContextFormat1Marker {
 /// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceContextFormat1Marker {}
+pub struct ChainedSequenceContextFormat1Marker;
 
 impl<'a> MinByteRange for ChainedSequenceContextFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2747,20 +2646,16 @@ impl<'a> MinByteRange for ChainedSequenceContextFormat1<'a> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let chained_seq_rule_set_count: u16 = cursor.read()?;
-        let chained_seq_rule_set_offsets_byte_len = (chained_seq_rule_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(chained_seq_rule_set_offsets_byte_len);
-        cursor.finish(ChainedSequenceContextFormat1Marker {})
+        Ok(TableRef {
+            shape: ChainedSequenceContextFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
-pub type ChainedSequenceContextFormat1<'a> = TableRef<'a, ChainedSequenceContextFormat1Marker>;
+pub type ChainedSequenceContextFormat1<'a> = TableRef<'a, ChainedSequenceContextFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceContextFormat1<'a> {
@@ -2879,7 +2774,7 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat1<'a> {
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceRuleSetMarker {}
+pub struct ChainedSequenceRuleSetMarker;
 
 impl<'a> MinByteRange for ChainedSequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2889,18 +2784,16 @@ impl<'a> MinByteRange for ChainedSequenceRuleSet<'a> {
 
 impl<'a> FontRead<'a> for ChainedSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let chained_seq_rule_count: u16 = cursor.read()?;
-        let chained_seq_rule_offsets_byte_len = (chained_seq_rule_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(chained_seq_rule_offsets_byte_len);
-        cursor.finish(ChainedSequenceRuleSetMarker {})
+        Ok(TableRef {
+            shape: ChainedSequenceRuleSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [ChainedSequenceContextFormat1]
-pub type ChainedSequenceRuleSet<'a> = TableRef<'a, ChainedSequenceRuleSetMarker>;
+pub type ChainedSequenceRuleSet<'a> = TableRef<'a, ChainedSequenceRuleSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceRuleSet<'a> {
@@ -2983,7 +2876,7 @@ impl<'a> std::fmt::Debug for ChainedSequenceRuleSet<'a> {
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceRuleMarker {}
+pub struct ChainedSequenceRuleMarker;
 
 impl<'a> MinByteRange for ChainedSequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -2993,33 +2886,16 @@ impl<'a> MinByteRange for ChainedSequenceRule<'a> {
 
 impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_sequence_byte_len = (backtrack_glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(backtrack_sequence_byte_len);
-        let input_glyph_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = (transforms::subtract(input_glyph_count, 1_usize))
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(input_sequence_byte_len);
-        let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_sequence_byte_len = (lookahead_glyph_count as usize)
-            .checked_mul(GlyphId16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lookahead_sequence_byte_len);
-        let seq_lookup_count: u16 = cursor.read()?;
-        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
-            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ChainedSequenceRuleMarker {})
+        Ok(TableRef {
+            shape: ChainedSequenceRuleMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [ChainedSequenceContextFormat1]
-pub type ChainedSequenceRule<'a> = TableRef<'a, ChainedSequenceRuleMarker>;
+pub type ChainedSequenceRule<'a> = TableRef<'a, ChainedSequenceRuleMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceRule<'a> {
@@ -3185,7 +3061,7 @@ impl Format<u16> for ChainedSequenceContextFormat2Marker {
 /// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceContextFormat2Marker {}
+pub struct ChainedSequenceContextFormat2Marker;
 
 impl<'a> MinByteRange for ChainedSequenceContextFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3195,24 +3071,16 @@ impl<'a> MinByteRange for ChainedSequenceContextFormat2<'a> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let chained_class_seq_rule_set_count: u16 = cursor.read()?;
-        let chained_class_seq_rule_set_offsets_byte_len = (chained_class_seq_rule_set_count
-            as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(chained_class_seq_rule_set_offsets_byte_len);
-        cursor.finish(ChainedSequenceContextFormat2Marker {})
+        Ok(TableRef {
+            shape: ChainedSequenceContextFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
-pub type ChainedSequenceContextFormat2<'a> = TableRef<'a, ChainedSequenceContextFormat2Marker>;
+pub type ChainedSequenceContextFormat2<'a> = TableRef<'a, ChainedSequenceContextFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceContextFormat2<'a> {
@@ -3403,7 +3271,7 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat2<'a> {
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedClassSequenceRuleSetMarker {}
+pub struct ChainedClassSequenceRuleSetMarker;
 
 impl<'a> MinByteRange for ChainedClassSequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3413,18 +3281,16 @@ impl<'a> MinByteRange for ChainedClassSequenceRuleSet<'a> {
 
 impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let chained_class_seq_rule_count: u16 = cursor.read()?;
-        let chained_class_seq_rule_offsets_byte_len = (chained_class_seq_rule_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(chained_class_seq_rule_offsets_byte_len);
-        cursor.finish(ChainedClassSequenceRuleSetMarker {})
+        Ok(TableRef {
+            shape: ChainedClassSequenceRuleSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [ChainedSequenceContextFormat2]
-pub type ChainedClassSequenceRuleSet<'a> = TableRef<'a, ChainedClassSequenceRuleSetMarker>;
+pub type ChainedClassSequenceRuleSet<'a> = TableRef<'a, ChainedClassSequenceRuleSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedClassSequenceRuleSet<'a> {
@@ -3509,7 +3375,7 @@ impl<'a> std::fmt::Debug for ChainedClassSequenceRuleSet<'a> {
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedClassSequenceRuleMarker {}
+pub struct ChainedClassSequenceRuleMarker;
 
 impl<'a> MinByteRange for ChainedClassSequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3519,33 +3385,16 @@ impl<'a> MinByteRange for ChainedClassSequenceRule<'a> {
 
 impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_sequence_byte_len = (backtrack_glyph_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(backtrack_sequence_byte_len);
-        let input_glyph_count: u16 = cursor.read()?;
-        let input_sequence_byte_len = (transforms::subtract(input_glyph_count, 1_usize))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(input_sequence_byte_len);
-        let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_sequence_byte_len = (lookahead_glyph_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lookahead_sequence_byte_len);
-        let seq_lookup_count: u16 = cursor.read()?;
-        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
-            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ChainedClassSequenceRuleMarker {})
+        Ok(TableRef {
+            shape: ChainedClassSequenceRuleMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Part of [ChainedSequenceContextFormat2]
-pub type ChainedClassSequenceRule<'a> = TableRef<'a, ChainedClassSequenceRuleMarker>;
+pub type ChainedClassSequenceRule<'a> = TableRef<'a, ChainedClassSequenceRuleMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedClassSequenceRule<'a> {
@@ -3712,7 +3561,7 @@ impl Format<u16> for ChainedSequenceContextFormat3Marker {
 /// [Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceContextFormat3Marker {}
+pub struct ChainedSequenceContextFormat3Marker;
 
 impl<'a> MinByteRange for ChainedSequenceContextFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -3722,34 +3571,16 @@ impl<'a> MinByteRange for ChainedSequenceContextFormat3<'a> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let backtrack_glyph_count: u16 = cursor.read()?;
-        let backtrack_coverage_offsets_byte_len = (backtrack_glyph_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(backtrack_coverage_offsets_byte_len);
-        let input_glyph_count: u16 = cursor.read()?;
-        let input_coverage_offsets_byte_len = (input_glyph_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(input_coverage_offsets_byte_len);
-        let lookahead_glyph_count: u16 = cursor.read()?;
-        let lookahead_coverage_offsets_byte_len = (lookahead_glyph_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(lookahead_coverage_offsets_byte_len);
-        let seq_lookup_count: u16 = cursor.read()?;
-        let seq_lookup_records_byte_len = (seq_lookup_count as usize)
-            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ChainedSequenceContextFormat3Marker {})
+        Ok(TableRef {
+            shape: ChainedSequenceContextFormat3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
-pub type ChainedSequenceContextFormat3<'a> = TableRef<'a, ChainedSequenceContextFormat3Marker>;
+pub type ChainedSequenceContextFormat3<'a> = TableRef<'a, ChainedSequenceContextFormat3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceContextFormat3<'a> {
@@ -4114,7 +3945,7 @@ impl<'a> From<DeltaFormat> for FieldType<'a> {
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DeviceMarker {}
+pub struct DeviceMarker;
 
 impl<'a> MinByteRange for Device<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4124,20 +3955,16 @@ impl<'a> MinByteRange for Device<'a> {
 
 impl<'a> FontRead<'a> for Device<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let start_size: u16 = cursor.read()?;
-        let end_size: u16 = cursor.read()?;
-        let delta_format: DeltaFormat = cursor.read()?;
-        let delta_value_byte_len = (DeltaFormat::value_count(delta_format, start_size, end_size))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(delta_value_byte_len);
-        cursor.finish(DeviceMarker {})
+        Ok(TableRef {
+            shape: DeviceMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
-pub type Device<'a> = TableRef<'a, DeviceMarker>;
+pub type Device<'a> = TableRef<'a, DeviceMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Device<'a> {
@@ -4220,7 +4047,7 @@ impl<'a> std::fmt::Debug for Device<'a> {
 /// Variation index table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VariationIndexMarker {}
+pub struct VariationIndexMarker;
 
 impl<'a> MinByteRange for VariationIndex<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4230,16 +4057,16 @@ impl<'a> MinByteRange for VariationIndex<'a> {
 
 impl<'a> FontRead<'a> for VariationIndex<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<DeltaFormat>();
-        cursor.finish(VariationIndexMarker {})
+        Ok(TableRef {
+            shape: VariationIndexMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Variation index table
-pub type VariationIndex<'a> = TableRef<'a, VariationIndexMarker>;
+pub type VariationIndex<'a> = TableRef<'a, VariationIndexMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VariationIndex<'a> {
@@ -4381,7 +4208,7 @@ impl<'a> SomeTable<'a> for DeviceOrVariationIndex<'a> {
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureVariationsMarker {}
+pub struct FeatureVariationsMarker;
 
 impl<'a> MinByteRange for FeatureVariations<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4391,19 +4218,16 @@ impl<'a> MinByteRange for FeatureVariations<'a> {
 
 impl<'a> FontRead<'a> for FeatureVariations<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        let feature_variation_record_count: u32 = cursor.read()?;
-        let feature_variation_records_byte_len = (feature_variation_record_count as usize)
-            .checked_mul(FeatureVariationRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(feature_variation_records_byte_len);
-        cursor.finish(FeatureVariationsMarker {})
+        Ok(TableRef {
+            shape: FeatureVariationsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
-pub type FeatureVariations<'a> = TableRef<'a, FeatureVariationsMarker>;
+pub type FeatureVariations<'a> = TableRef<'a, FeatureVariationsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FeatureVariations<'a> {
@@ -4562,7 +4386,7 @@ impl<'a> SomeRecord<'a> for FeatureVariationRecord {
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionSetMarker {}
+pub struct ConditionSetMarker;
 
 impl<'a> MinByteRange for ConditionSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4572,18 +4396,16 @@ impl<'a> MinByteRange for ConditionSet<'a> {
 
 impl<'a> FontRead<'a> for ConditionSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let condition_count: u16 = cursor.read()?;
-        let condition_offsets_byte_len = (condition_count as usize)
-            .checked_mul(Offset32::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionSetMarker {})
+        Ok(TableRef {
+            shape: ConditionSetMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
-pub type ConditionSet<'a> = TableRef<'a, ConditionSetMarker>;
+pub type ConditionSet<'a> = TableRef<'a, ConditionSetMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionSet<'a> {
@@ -4760,7 +4582,7 @@ impl Format<u16> for ConditionFormat1Marker {
 /// [Condition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range): Font Variation Axis Range
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat1Marker {}
+pub struct ConditionFormat1Marker;
 
 impl<'a> MinByteRange for ConditionFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4770,17 +4592,16 @@ impl<'a> MinByteRange for ConditionFormat1<'a> {
 
 impl<'a> FontRead<'a> for ConditionFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<F2Dot14>();
-        cursor.advance::<F2Dot14>();
-        cursor.finish(ConditionFormat1Marker {})
+        Ok(TableRef {
+            shape: ConditionFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Condition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range): Font Variation Axis Range
-pub type ConditionFormat1<'a> = TableRef<'a, ConditionFormat1Marker>;
+pub type ConditionFormat1<'a> = TableRef<'a, ConditionFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat1<'a> {
@@ -4869,7 +4690,7 @@ impl Format<u16> for ConditionFormat2Marker {
 /// [Condition Table Format 2](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3237-L3255): Variation index
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat2Marker {}
+pub struct ConditionFormat2Marker;
 
 impl<'a> MinByteRange for ConditionFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4879,16 +4700,16 @@ impl<'a> MinByteRange for ConditionFormat2<'a> {
 
 impl<'a> FontRead<'a> for ConditionFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u32>();
-        cursor.finish(ConditionFormat2Marker {})
+        Ok(TableRef {
+            shape: ConditionFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Condition Table Format 2](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3237-L3255): Variation index
-pub type ConditionFormat2<'a> = TableRef<'a, ConditionFormat2Marker>;
+pub type ConditionFormat2<'a> = TableRef<'a, ConditionFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat2<'a> {
@@ -4956,7 +4777,7 @@ impl Format<u16> for ConditionFormat3Marker {
 /// [Condition Table Format 3](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3257-L3275): AND
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat3Marker {}
+pub struct ConditionFormat3Marker;
 
 impl<'a> MinByteRange for ConditionFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -4966,19 +4787,16 @@ impl<'a> MinByteRange for ConditionFormat3<'a> {
 
 impl<'a> FontRead<'a> for ConditionFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let condition_count: u8 = cursor.read()?;
-        let condition_offsets_byte_len = (condition_count as usize)
-            .checked_mul(Offset24::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionFormat3Marker {})
+        Ok(TableRef {
+            shape: ConditionFormat3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Condition Table Format 3](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3257-L3275): AND
-pub type ConditionFormat3<'a> = TableRef<'a, ConditionFormat3Marker>;
+pub type ConditionFormat3<'a> = TableRef<'a, ConditionFormat3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat3<'a> {
@@ -5073,7 +4891,7 @@ impl Format<u16> for ConditionFormat4Marker {
 /// [Condition Table Format 4](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3276-L3295): OR
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat4Marker {}
+pub struct ConditionFormat4Marker;
 
 impl<'a> MinByteRange for ConditionFormat4<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -5083,19 +4901,16 @@ impl<'a> MinByteRange for ConditionFormat4<'a> {
 
 impl<'a> FontRead<'a> for ConditionFormat4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let condition_count: u8 = cursor.read()?;
-        let condition_offsets_byte_len = (condition_count as usize)
-            .checked_mul(Offset24::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionFormat4Marker {})
+        Ok(TableRef {
+            shape: ConditionFormat4Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Condition Table Format 4](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3276-L3295): OR
-pub type ConditionFormat4<'a> = TableRef<'a, ConditionFormat4Marker>;
+pub type ConditionFormat4<'a> = TableRef<'a, ConditionFormat4Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat4<'a> {
@@ -5190,7 +5005,7 @@ impl Format<u16> for ConditionFormat5Marker {
 /// [Condition Table Format 5](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3296-L3308): NOT
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat5Marker {}
+pub struct ConditionFormat5Marker;
 
 impl<'a> MinByteRange for ConditionFormat5<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -5200,15 +5015,16 @@ impl<'a> MinByteRange for ConditionFormat5<'a> {
 
 impl<'a> FontRead<'a> for ConditionFormat5<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset24>();
-        cursor.finish(ConditionFormat5Marker {})
+        Ok(TableRef {
+            shape: ConditionFormat5Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [Condition Table Format 5](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3296-L3308): NOT
-pub type ConditionFormat5<'a> = TableRef<'a, ConditionFormat5Marker>;
+pub type ConditionFormat5<'a> = TableRef<'a, ConditionFormat5Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat5<'a> {
@@ -5269,7 +5085,7 @@ impl<'a> std::fmt::Debug for ConditionFormat5<'a> {
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureTableSubstitutionMarker {}
+pub struct FeatureTableSubstitutionMarker;
 
 impl<'a> MinByteRange for FeatureTableSubstitution<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -5279,19 +5095,16 @@ impl<'a> MinByteRange for FeatureTableSubstitution<'a> {
 
 impl<'a> FontRead<'a> for FeatureTableSubstitution<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        let substitution_count: u16 = cursor.read()?;
-        let substitutions_byte_len = (substitution_count as usize)
-            .checked_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(substitutions_byte_len);
-        cursor.finish(FeatureTableSubstitutionMarker {})
+        Ok(TableRef {
+            shape: FeatureTableSubstitutionMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
-pub type FeatureTableSubstitution<'a> = TableRef<'a, FeatureTableSubstitutionMarker>;
+pub type FeatureTableSubstitution<'a> = TableRef<'a, FeatureTableSubstitutionMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FeatureTableSubstitution<'a> {
@@ -5418,7 +5231,7 @@ impl<'a> SomeRecord<'a> for FeatureTableSubstitutionRecord {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SizeParamsMarker {}
+pub struct SizeParamsMarker;
 
 impl<'a> MinByteRange for SizeParams<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -5428,17 +5241,15 @@ impl<'a> MinByteRange for SizeParams<'a> {
 
 impl<'a> FontRead<'a> for SizeParams<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.finish(SizeParamsMarker {})
+        Ok(TableRef {
+            shape: SizeParamsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type SizeParams<'a> = TableRef<'a, SizeParamsMarker>;
+pub type SizeParams<'a> = TableRef<'a, SizeParamsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SizeParams<'a> {
@@ -5545,7 +5356,7 @@ impl<'a> std::fmt::Debug for SizeParams<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct StylisticSetParamsMarker {}
+pub struct StylisticSetParamsMarker;
 
 impl<'a> MinByteRange for StylisticSetParams<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -5555,14 +5366,15 @@ impl<'a> MinByteRange for StylisticSetParams<'a> {
 
 impl<'a> FontRead<'a> for StylisticSetParams<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<NameId>();
-        cursor.finish(StylisticSetParamsMarker {})
+        Ok(TableRef {
+            shape: StylisticSetParamsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type StylisticSetParams<'a> = TableRef<'a, StylisticSetParamsMarker>;
+pub type StylisticSetParams<'a> = TableRef<'a, StylisticSetParamsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> StylisticSetParams<'a> {
@@ -5625,7 +5437,7 @@ impl Format<u16> for CharacterVariantParamsMarker {
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CharacterVariantParamsMarker {}
+pub struct CharacterVariantParamsMarker;
 
 impl<'a> MinByteRange for CharacterVariantParams<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -5635,24 +5447,16 @@ impl<'a> MinByteRange for CharacterVariantParams<'a> {
 
 impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<NameId>();
-        cursor.advance::<NameId>();
-        cursor.advance::<NameId>();
-        cursor.advance::<u16>();
-        cursor.advance::<NameId>();
-        let char_count: u16 = cursor.read()?;
-        let character_byte_len = (char_count as usize)
-            .checked_mul(Uint24::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(character_byte_len);
-        cursor.finish(CharacterVariantParamsMarker {})
+        Ok(TableRef {
+            shape: CharacterVariantParamsMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
-pub type CharacterVariantParams<'a> = TableRef<'a, CharacterVariantParamsMarker>;
+pub type CharacterVariantParams<'a> = TableRef<'a, CharacterVariantParamsMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharacterVariantParams<'a> {

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -8,23 +8,9 @@ use crate::codegen_prelude::*;
 /// [Script List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-list-table-and-script-record)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ScriptListMarker {
-    script_records_byte_len: usize,
-}
+pub struct ScriptListMarker {}
 
-impl ScriptListMarker {
-    pub fn script_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn script_records_byte_range(&self) -> Range<usize> {
-        let start = self.script_count_byte_range().end;
-        start..start + self.script_records_byte_len
-    }
-}
-
-impl MinByteRange for ScriptListMarker {
+impl<'a> MinByteRange for ScriptList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.script_records_byte_range().end
     }
@@ -38,9 +24,7 @@ impl<'a> FontRead<'a> for ScriptList<'a> {
             .checked_mul(ScriptRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(script_records_byte_len);
-        cursor.finish(ScriptListMarker {
-            script_records_byte_len,
-        })
+        cursor.finish(ScriptListMarker {})
     }
 }
 
@@ -49,15 +33,32 @@ pub type ScriptList<'a> = TableRef<'a, ScriptListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ScriptList<'a> {
+    fn script_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.script_count()) as usize)
+            .checked_mul(ScriptRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn script_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn script_records_byte_range(&self) -> Range<usize> {
+        let start = self.script_count_byte_range().end;
+        start..start + self.script_records_byte_len(start)
+    }
+
     /// Number of ScriptRecords
     pub fn script_count(&self) -> u16 {
-        let range = self.shape.script_count_byte_range();
+        let range = self.script_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of ScriptRecords, listed alphabetically by script tag
     pub fn script_records(&self) -> &'a [ScriptRecord] {
-        let range = self.shape.script_records_byte_range();
+        let range = self.script_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -147,28 +148,9 @@ impl<'a> SomeRecord<'a> for ScriptRecord {
 /// [Script Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#script-table-and-language-system-record)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ScriptMarker {
-    lang_sys_records_byte_len: usize,
-}
+pub struct ScriptMarker {}
 
-impl ScriptMarker {
-    pub fn default_lang_sys_offset_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn lang_sys_count_byte_range(&self) -> Range<usize> {
-        let start = self.default_lang_sys_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lang_sys_records_byte_range(&self) -> Range<usize> {
-        let start = self.lang_sys_count_byte_range().end;
-        start..start + self.lang_sys_records_byte_len
-    }
-}
-
-impl MinByteRange for ScriptMarker {
+impl<'a> MinByteRange for Script<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.lang_sys_records_byte_range().end
     }
@@ -183,9 +165,7 @@ impl<'a> FontRead<'a> for Script<'a> {
             .checked_mul(LangSysRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lang_sys_records_byte_len);
-        cursor.finish(ScriptMarker {
-            lang_sys_records_byte_len,
-        })
+        cursor.finish(ScriptMarker {})
     }
 }
 
@@ -194,10 +174,32 @@ pub type Script<'a> = TableRef<'a, ScriptMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Script<'a> {
+    fn lang_sys_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lang_sys_count()) as usize)
+            .checked_mul(LangSysRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn default_lang_sys_offset_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn lang_sys_count_byte_range(&self) -> Range<usize> {
+        let start = self.default_lang_sys_offset_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lang_sys_records_byte_range(&self) -> Range<usize> {
+        let start = self.lang_sys_count_byte_range().end;
+        start..start + self.lang_sys_records_byte_len(start)
+    }
+
     /// Offset to default LangSys table, from beginning of Script table
     /// — may be NULL
     pub fn default_lang_sys_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.default_lang_sys_offset_byte_range();
+        let range = self.default_lang_sys_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -210,13 +212,13 @@ impl<'a> Script<'a> {
     /// Number of LangSysRecords for this script — excluding the
     /// default LangSys
     pub fn lang_sys_count(&self) -> u16 {
-        let range = self.shape.lang_sys_count_byte_range();
+        let range = self.lang_sys_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of LangSysRecords, listed alphabetically by LangSys tag
     pub fn lang_sys_records(&self) -> &'a [LangSysRecord] {
-        let range = self.shape.lang_sys_records_byte_range();
+        let range = self.lang_sys_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -309,11 +311,40 @@ impl<'a> SomeRecord<'a> for LangSysRecord {
 /// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LangSysMarker {
-    feature_indices_byte_len: usize,
+pub struct LangSysMarker {}
+
+impl<'a> MinByteRange for LangSys<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.feature_indices_byte_range().end
+    }
 }
 
-impl LangSysMarker {
+impl<'a> FontRead<'a> for LangSys<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let feature_index_count: u16 = cursor.read()?;
+        let feature_indices_byte_len = (feature_index_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(feature_indices_byte_len);
+        cursor.finish(LangSysMarker {})
+    }
+}
+
+/// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
+pub type LangSys<'a> = TableRef<'a, LangSysMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> LangSys<'a> {
+    fn feature_indices_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.feature_index_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn lookup_order_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -331,54 +362,26 @@ impl LangSysMarker {
 
     pub fn feature_indices_byte_range(&self) -> Range<usize> {
         let start = self.feature_index_count_byte_range().end;
-        start..start + self.feature_indices_byte_len
+        start..start + self.feature_indices_byte_len(start)
     }
-}
 
-impl MinByteRange for LangSysMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.feature_indices_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for LangSys<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let feature_index_count: u16 = cursor.read()?;
-        let feature_indices_byte_len = (feature_index_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(feature_indices_byte_len);
-        cursor.finish(LangSysMarker {
-            feature_indices_byte_len,
-        })
-    }
-}
-
-/// [Language System Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#language-system-table)
-pub type LangSys<'a> = TableRef<'a, LangSysMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> LangSys<'a> {
     /// Index of a feature required for this language system; if no
     /// required features = 0xFFFF
     pub fn required_feature_index(&self) -> u16 {
-        let range = self.shape.required_feature_index_byte_range();
+        let range = self.required_feature_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of feature index values for this language system —
     /// excludes the required feature
     pub fn feature_index_count(&self) -> u16 {
-        let range = self.shape.feature_index_count_byte_range();
+        let range = self.feature_index_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of indices into the FeatureList, in arbitrary order
     pub fn feature_indices(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.feature_indices_byte_range();
+        let range = self.feature_indices_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -415,23 +418,9 @@ impl<'a> std::fmt::Debug for LangSys<'a> {
 /// [Feature List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#feature-list-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureListMarker {
-    feature_records_byte_len: usize,
-}
+pub struct FeatureListMarker {}
 
-impl FeatureListMarker {
-    pub fn feature_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn feature_records_byte_range(&self) -> Range<usize> {
-        let start = self.feature_count_byte_range().end;
-        start..start + self.feature_records_byte_len
-    }
-}
-
-impl MinByteRange for FeatureListMarker {
+impl<'a> MinByteRange for FeatureList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.feature_records_byte_range().end
     }
@@ -445,9 +434,7 @@ impl<'a> FontRead<'a> for FeatureList<'a> {
             .checked_mul(FeatureRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(feature_records_byte_len);
-        cursor.finish(FeatureListMarker {
-            feature_records_byte_len,
-        })
+        cursor.finish(FeatureListMarker {})
     }
 }
 
@@ -456,16 +443,33 @@ pub type FeatureList<'a> = TableRef<'a, FeatureListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FeatureList<'a> {
+    fn feature_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.feature_count()) as usize)
+            .checked_mul(FeatureRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn feature_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn feature_records_byte_range(&self) -> Range<usize> {
+        let start = self.feature_count_byte_range().end;
+        start..start + self.feature_records_byte_len(start)
+    }
+
     /// Number of FeatureRecords in this table
     pub fn feature_count(&self) -> u16 {
-        let range = self.shape.feature_count_byte_range();
+        let range = self.feature_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
     pub fn feature_records(&self) -> &'a [FeatureRecord] {
-        let range = self.shape.feature_records_byte_range();
+        let range = self.feature_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -558,27 +562,9 @@ impl<'a> SomeRecord<'a> for FeatureRecord {
 #[doc(hidden)]
 pub struct FeatureMarker {
     feature_tag: Tag,
-    lookup_list_indices_byte_len: usize,
 }
 
-impl FeatureMarker {
-    pub fn feature_params_offset_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn lookup_index_count_byte_range(&self) -> Range<usize> {
-        let start = self.feature_params_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookup_list_indices_byte_range(&self) -> Range<usize> {
-        let start = self.lookup_index_count_byte_range().end;
-        start..start + self.lookup_list_indices_byte_len
-    }
-}
-
-impl MinByteRange for FeatureMarker {
+impl<'a> MinByteRange for Feature<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.lookup_list_indices_byte_range().end
     }
@@ -598,10 +584,7 @@ impl<'a> FontReadWithArgs<'a> for Feature<'a> {
             .checked_mul(u16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookup_list_indices_byte_len);
-        cursor.finish(FeatureMarker {
-            feature_tag,
-            lookup_list_indices_byte_len,
-        })
+        cursor.finish(FeatureMarker { feature_tag })
     }
 }
 
@@ -621,9 +604,31 @@ pub type Feature<'a> = TableRef<'a, FeatureMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Feature<'a> {
+    fn lookup_list_indices_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lookup_index_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn feature_params_offset_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn lookup_index_count_byte_range(&self) -> Range<usize> {
+        let start = self.feature_params_offset_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookup_list_indices_byte_range(&self) -> Range<usize> {
+        let start = self.lookup_index_count_byte_range().end;
+        start..start + self.lookup_list_indices_byte_len(start)
+    }
+
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     pub fn feature_params_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.feature_params_offset_byte_range();
+        let range = self.feature_params_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -636,14 +641,14 @@ impl<'a> Feature<'a> {
 
     /// Number of LookupList indices for this feature
     pub fn lookup_index_count(&self) -> u16 {
-        let range = self.shape.lookup_index_count_byte_range();
+        let range = self.lookup_index_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of indices into the LookupList — zero-based (first
     /// lookup is LookupListIndex = 0)
     pub fn lookup_list_indices(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.lookup_list_indices_byte_range();
+        let range = self.lookup_list_indices_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -685,23 +690,10 @@ impl<'a> std::fmt::Debug for Feature<'a> {
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct LookupListMarker<T = ()> {
-    lookup_offsets_byte_len: usize,
     offset_type: std::marker::PhantomData<*const T>,
 }
 
-impl<T> LookupListMarker<T> {
-    pub fn lookup_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookup_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.lookup_count_byte_range().end;
-        start..start + self.lookup_offsets_byte_len
-    }
-}
-
-impl MinByteRange for LookupListMarker {
+impl<'a, T> MinByteRange for LookupList<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.lookup_offsets_byte_range().end
     }
@@ -724,7 +716,6 @@ impl<'a, T> FontRead<'a> for LookupList<'a, T> {
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(lookup_offsets_byte_len);
         cursor.finish(LookupListMarker {
-            lookup_offsets_byte_len,
             offset_type: std::marker::PhantomData,
         })
     }
@@ -733,10 +724,9 @@ impl<'a, T> FontRead<'a> for LookupList<'a, T> {
 impl<'a> LookupList<'a, ()> {
     #[allow(dead_code)]
     pub(crate) fn into_concrete<T>(self) -> LookupList<'a, T> {
-        let TableRef { data, shape } = self;
+        let TableRef { data, .. } = self;
         TableRef {
             shape: LookupListMarker {
-                lookup_offsets_byte_len: shape.lookup_offsets_byte_len,
                 offset_type: std::marker::PhantomData,
             },
             data,
@@ -748,10 +738,9 @@ impl<'a, T> LookupList<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`
     pub(crate) fn of_unit_type(&self) -> LookupList<'a, ()> {
-        let TableRef { data, shape } = self;
+        let TableRef { data, .. } = self;
         TableRef {
             shape: LookupListMarker {
-                lookup_offsets_byte_len: shape.lookup_offsets_byte_len,
                 offset_type: std::marker::PhantomData,
             },
             data: *data,
@@ -764,16 +753,33 @@ pub type LookupList<'a, T> = TableRef<'a, LookupListMarker<T>>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> LookupList<'a, T> {
+    fn lookup_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lookup_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn lookup_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookup_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.lookup_count_byte_range().end;
+        start..start + self.lookup_offsets_byte_len(start)
+    }
+
     /// Number of lookups in this table
     pub fn lookup_count(&self) -> u16 {
-        let range = self.shape.lookup_count_byte_range();
+        let range = self.lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
     pub fn lookup_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.lookup_offsets_byte_range();
+        let range = self.lookup_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -827,39 +833,11 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for LookupList<'a
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct LookupMarker<T = ()> {
-    subtable_offsets_byte_len: usize,
     mark_filtering_set_byte_start: Option<usize>,
     offset_type: std::marker::PhantomData<*const T>,
 }
 
-impl<T> LookupMarker<T> {
-    pub fn lookup_type_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookup_flag_byte_range(&self) -> Range<usize> {
-        let start = self.lookup_type_byte_range().end;
-        start..start + LookupFlag::RAW_BYTE_LEN
-    }
-
-    pub fn sub_table_count_byte_range(&self) -> Range<usize> {
-        let start = self.lookup_flag_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.sub_table_count_byte_range().end;
-        start..start + self.subtable_offsets_byte_len
-    }
-
-    pub fn mark_filtering_set_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.mark_filtering_set_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for LookupMarker {
+impl<'a, T> MinByteRange for Lookup<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.subtable_offsets_byte_range().end
     }
@@ -891,7 +869,6 @@ impl<'a, T> FontRead<'a> for Lookup<'a, T> {
             .contains(LookupFlag::USE_MARK_FILTERING_SET)
             .then(|| cursor.advance::<u16>());
         cursor.finish(LookupMarker {
-            subtable_offsets_byte_len,
             mark_filtering_set_byte_start,
             offset_type: std::marker::PhantomData,
         })
@@ -904,7 +881,6 @@ impl<'a> Lookup<'a, ()> {
         let TableRef { data, shape } = self;
         TableRef {
             shape: LookupMarker {
-                subtable_offsets_byte_len: shape.subtable_offsets_byte_len,
                 mark_filtering_set_byte_start: shape.mark_filtering_set_byte_start,
                 offset_type: std::marker::PhantomData,
             },
@@ -920,7 +896,6 @@ impl<'a, T> Lookup<'a, T> {
         let TableRef { data, shape } = self;
         TableRef {
             shape: LookupMarker {
-                subtable_offsets_byte_len: shape.subtable_offsets_byte_len,
                 mark_filtering_set_byte_start: shape.mark_filtering_set_byte_start,
                 offset_type: std::marker::PhantomData,
             },
@@ -934,28 +909,60 @@ pub type Lookup<'a, T> = TableRef<'a, LookupMarker<T>>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T> Lookup<'a, T> {
+    fn subtable_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.sub_table_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn lookup_type_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookup_flag_byte_range(&self) -> Range<usize> {
+        let start = self.lookup_type_byte_range().end;
+        start..start + LookupFlag::RAW_BYTE_LEN
+    }
+
+    pub fn sub_table_count_byte_range(&self) -> Range<usize> {
+        let start = self.lookup_flag_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.sub_table_count_byte_range().end;
+        start..start + self.subtable_offsets_byte_len(start)
+    }
+
+    pub fn mark_filtering_set_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.mark_filtering_set_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
     /// Different enumerations for GSUB and GPOS
     pub fn lookup_type(&self) -> u16 {
-        let range = self.shape.lookup_type_byte_range();
+        let range = self.lookup_type_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Lookup qualifiers
     pub fn lookup_flag(&self) -> LookupFlag {
-        let range = self.shape.lookup_flag_byte_range();
+        let range = self.lookup_flag_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of subtables for this lookup
     pub fn sub_table_count(&self) -> u16 {
-        let range = self.shape.sub_table_count_byte_range();
+        let range = self.sub_table_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to lookup subtables, from beginning of Lookup
     /// table
     pub fn subtable_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.subtable_offsets_byte_range();
+        let range = self.subtable_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -973,7 +980,7 @@ impl<'a, T> Lookup<'a, T> {
     /// is only present if the USE_MARK_FILTERING_SET lookup flag is
     /// set.
     pub fn mark_filtering_set(&self) -> Option<u16> {
-        let range = self.shape.mark_filtering_set_byte_range()?;
+        let range = self.mark_filtering_set_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 }
@@ -1027,28 +1034,9 @@ impl Format<u16> for CoverageFormat1Marker {
 /// [Coverage Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CoverageFormat1Marker {
-    glyph_array_byte_len: usize,
-}
+pub struct CoverageFormat1Marker {}
 
-impl CoverageFormat1Marker {
-    pub fn coverage_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.coverage_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn glyph_array_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + self.glyph_array_byte_len
-    }
-}
-
-impl MinByteRange for CoverageFormat1Marker {
+impl<'a> MinByteRange for CoverageFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.glyph_array_byte_range().end
     }
@@ -1063,9 +1051,7 @@ impl<'a> FontRead<'a> for CoverageFormat1<'a> {
             .checked_mul(GlyphId16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_array_byte_len);
-        cursor.finish(CoverageFormat1Marker {
-            glyph_array_byte_len,
-        })
+        cursor.finish(CoverageFormat1Marker {})
     }
 }
 
@@ -1074,21 +1060,43 @@ pub type CoverageFormat1<'a> = TableRef<'a, CoverageFormat1Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CoverageFormat1<'a> {
+    fn glyph_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn coverage_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_array_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + self.glyph_array_byte_len(start)
+    }
+
     /// Format identifier — format = 1
     pub fn coverage_format(&self) -> u16 {
-        let range = self.shape.coverage_format_byte_range();
+        let range = self.coverage_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of glyphs in the glyph array
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of glyph IDs — in numerical order
     pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.glyph_array_byte_range();
+        let range = self.glyph_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1123,28 +1131,9 @@ impl Format<u16> for CoverageFormat2Marker {
 /// [Coverage Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CoverageFormat2Marker {
-    range_records_byte_len: usize,
-}
+pub struct CoverageFormat2Marker {}
 
-impl CoverageFormat2Marker {
-    pub fn coverage_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn range_count_byte_range(&self) -> Range<usize> {
-        let start = self.coverage_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn range_records_byte_range(&self) -> Range<usize> {
-        let start = self.range_count_byte_range().end;
-        start..start + self.range_records_byte_len
-    }
-}
-
-impl MinByteRange for CoverageFormat2Marker {
+impl<'a> MinByteRange for CoverageFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.range_records_byte_range().end
     }
@@ -1159,9 +1148,7 @@ impl<'a> FontRead<'a> for CoverageFormat2<'a> {
             .checked_mul(RangeRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(range_records_byte_len);
-        cursor.finish(CoverageFormat2Marker {
-            range_records_byte_len,
-        })
+        cursor.finish(CoverageFormat2Marker {})
     }
 }
 
@@ -1170,21 +1157,43 @@ pub type CoverageFormat2<'a> = TableRef<'a, CoverageFormat2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CoverageFormat2<'a> {
+    fn range_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.range_count()) as usize)
+            .checked_mul(RangeRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn coverage_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn range_count_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn range_records_byte_range(&self) -> Range<usize> {
+        let start = self.range_count_byte_range().end;
+        start..start + self.range_records_byte_len(start)
+    }
+
     /// Format identifier — format = 2
     pub fn coverage_format(&self) -> u16 {
-        let range = self.shape.coverage_format_byte_range();
+        let range = self.coverage_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of RangeRecords
     pub fn range_count(&self) -> u16 {
-        let range = self.shape.range_count_byte_range();
+        let range = self.range_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of glyph ranges — ordered by startGlyphID.
     pub fn range_records(&self) -> &'a [RangeRecord] {
-        let range = self.shape.range_records_byte_range();
+        let range = self.range_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1352,11 +1361,40 @@ impl Format<u16> for ClassDefFormat1Marker {
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassDefFormat1Marker {
-    class_value_array_byte_len: usize,
+pub struct ClassDefFormat1Marker {}
+
+impl<'a> MinByteRange for ClassDefFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.class_value_array_byte_range().end
+    }
 }
 
-impl ClassDefFormat1Marker {
+impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<GlyphId16>();
+        let glyph_count: u16 = cursor.read()?;
+        let class_value_array_byte_len = (glyph_count as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(class_value_array_byte_len);
+        cursor.finish(ClassDefFormat1Marker {})
+    }
+}
+
+/// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
+pub type ClassDefFormat1<'a> = TableRef<'a, ClassDefFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ClassDefFormat1<'a> {
+    fn class_value_array_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn class_format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1374,58 +1412,30 @@ impl ClassDefFormat1Marker {
 
     pub fn class_value_array_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + self.class_value_array_byte_len
+        start..start + self.class_value_array_byte_len(start)
     }
-}
 
-impl MinByteRange for ClassDefFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.class_value_array_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<GlyphId16>();
-        let glyph_count: u16 = cursor.read()?;
-        let class_value_array_byte_len = (glyph_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_value_array_byte_len);
-        cursor.finish(ClassDefFormat1Marker {
-            class_value_array_byte_len,
-        })
-    }
-}
-
-/// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
-pub type ClassDefFormat1<'a> = TableRef<'a, ClassDefFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> ClassDefFormat1<'a> {
     /// Format identifier — format = 1
     pub fn class_format(&self) -> u16 {
-        let range = self.shape.class_format_byte_range();
+        let range = self.class_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// First glyph ID of the classValueArray
     pub fn start_glyph_id(&self) -> GlyphId16 {
-        let range = self.shape.start_glyph_id_byte_range();
+        let range = self.start_glyph_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Size of the classValueArray
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of Class Values — one per glyph ID
     pub fn class_value_array(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.class_value_array_byte_range();
+        let range = self.class_value_array_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1461,28 +1471,9 @@ impl Format<u16> for ClassDefFormat2Marker {
 /// [Class Definition Table Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-2)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassDefFormat2Marker {
-    class_range_records_byte_len: usize,
-}
+pub struct ClassDefFormat2Marker {}
 
-impl ClassDefFormat2Marker {
-    pub fn class_format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn class_range_count_byte_range(&self) -> Range<usize> {
-        let start = self.class_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn class_range_records_byte_range(&self) -> Range<usize> {
-        let start = self.class_range_count_byte_range().end;
-        start..start + self.class_range_records_byte_len
-    }
-}
-
-impl MinByteRange for ClassDefFormat2Marker {
+impl<'a> MinByteRange for ClassDefFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.class_range_records_byte_range().end
     }
@@ -1497,9 +1488,7 @@ impl<'a> FontRead<'a> for ClassDefFormat2<'a> {
             .checked_mul(ClassRangeRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_range_records_byte_len);
-        cursor.finish(ClassDefFormat2Marker {
-            class_range_records_byte_len,
-        })
+        cursor.finish(ClassDefFormat2Marker {})
     }
 }
 
@@ -1508,21 +1497,43 @@ pub type ClassDefFormat2<'a> = TableRef<'a, ClassDefFormat2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassDefFormat2<'a> {
+    fn class_range_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.class_range_count()) as usize)
+            .checked_mul(ClassRangeRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn class_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn class_range_count_byte_range(&self) -> Range<usize> {
+        let start = self.class_format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn class_range_records_byte_range(&self) -> Range<usize> {
+        let start = self.class_range_count_byte_range().end;
+        start..start + self.class_range_records_byte_len(start)
+    }
+
     /// Format identifier — format = 2
     pub fn class_format(&self) -> u16 {
-        let range = self.shape.class_format_byte_range();
+        let range = self.class_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of ClassRangeRecords
     pub fn class_range_count(&self) -> u16 {
-        let range = self.shape.class_range_count_byte_range();
+        let range = self.class_range_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of ClassRangeRecords — ordered by startGlyphID
     pub fn class_range_records(&self) -> &'a [ClassRangeRecord] {
-        let range = self.shape.class_range_records_byte_range();
+        let range = self.class_range_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -1729,11 +1740,40 @@ impl Format<u16> for SequenceContextFormat1Marker {
 /// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceContextFormat1Marker {
-    seq_rule_set_offsets_byte_len: usize,
+pub struct SequenceContextFormat1Marker {}
+
+impl<'a> MinByteRange for SequenceContextFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.seq_rule_set_offsets_byte_range().end
+    }
 }
 
-impl SequenceContextFormat1Marker {
+impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let seq_rule_set_count: u16 = cursor.read()?;
+        let seq_rule_set_offsets_byte_len = (seq_rule_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(seq_rule_set_offsets_byte_len);
+        cursor.finish(SequenceContextFormat1Marker {})
+    }
+}
+
+/// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
+pub type SequenceContextFormat1<'a> = TableRef<'a, SequenceContextFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SequenceContextFormat1<'a> {
+    fn seq_rule_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_rule_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1751,47 +1791,19 @@ impl SequenceContextFormat1Marker {
 
     pub fn seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.seq_rule_set_count_byte_range().end;
-        start..start + self.seq_rule_set_offsets_byte_len
+        start..start + self.seq_rule_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for SequenceContextFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.seq_rule_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let seq_rule_set_count: u16 = cursor.read()?;
-        let seq_rule_set_offsets_byte_len = (seq_rule_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(seq_rule_set_offsets_byte_len);
-        cursor.finish(SequenceContextFormat1Marker {
-            seq_rule_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-1-simple-glyph-contexts)
-pub type SequenceContextFormat1<'a> = TableRef<'a, SequenceContextFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SequenceContextFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1803,14 +1815,14 @@ impl<'a> SequenceContextFormat1<'a> {
 
     /// Number of SequenceRuleSet tables
     pub fn seq_rule_set_count(&self) -> u16 {
-        let range = self.shape.seq_rule_set_count_byte_range();
+        let range = self.seq_rule_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to SequenceRuleSet tables, from beginning of
     /// SequenceContextFormat1 table (offsets may be NULL)
     pub fn seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
-        let range = self.shape.seq_rule_set_offsets_byte_range();
+        let range = self.seq_rule_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1865,23 +1877,9 @@ impl<'a> std::fmt::Debug for SequenceContextFormat1<'a> {
 /// Part of [SequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceRuleSetMarker {
-    seq_rule_offsets_byte_len: usize,
-}
+pub struct SequenceRuleSetMarker {}
 
-impl SequenceRuleSetMarker {
-    pub fn seq_rule_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_rule_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.seq_rule_count_byte_range().end;
-        start..start + self.seq_rule_offsets_byte_len
-    }
-}
-
-impl MinByteRange for SequenceRuleSetMarker {
+impl<'a> MinByteRange for SequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_rule_offsets_byte_range().end
     }
@@ -1895,9 +1893,7 @@ impl<'a> FontRead<'a> for SequenceRuleSet<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_rule_offsets_byte_len);
-        cursor.finish(SequenceRuleSetMarker {
-            seq_rule_offsets_byte_len,
-        })
+        cursor.finish(SequenceRuleSetMarker {})
     }
 }
 
@@ -1906,16 +1902,33 @@ pub type SequenceRuleSet<'a> = TableRef<'a, SequenceRuleSetMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceRuleSet<'a> {
+    fn seq_rule_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_rule_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn seq_rule_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_rule_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.seq_rule_count_byte_range().end;
+        start..start + self.seq_rule_offsets_byte_len(start)
+    }
+
     /// Number of SequenceRule tables
     pub fn seq_rule_count(&self) -> u16 {
-        let range = self.shape.seq_rule_count_byte_range();
+        let range = self.seq_rule_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
     pub fn seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.seq_rule_offsets_byte_range();
+        let range = self.seq_rule_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1965,34 +1978,9 @@ impl<'a> std::fmt::Debug for SequenceRuleSet<'a> {
 /// Part of [SequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceRuleMarker {
-    input_sequence_byte_len: usize,
-    seq_lookup_records_byte_len: usize,
-}
+pub struct SequenceRuleMarker {}
 
-impl SequenceRuleMarker {
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn input_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.seq_lookup_count_byte_range().end;
-        start..start + self.input_sequence_byte_len
-    }
-
-    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
-        let start = self.input_sequence_byte_range().end;
-        start..start + self.seq_lookup_records_byte_len
-    }
-}
-
-impl MinByteRange for SequenceRuleMarker {
+impl<'a> MinByteRange for SequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_lookup_records_byte_range().end
     }
@@ -2011,10 +1999,7 @@ impl<'a> FontRead<'a> for SequenceRule<'a> {
             .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(SequenceRuleMarker {
-            input_sequence_byte_len,
-            seq_lookup_records_byte_len,
-        })
+        cursor.finish(SequenceRuleMarker {})
     }
 }
 
@@ -2023,27 +2008,60 @@ pub type SequenceRule<'a> = TableRef<'a, SequenceRuleMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceRule<'a> {
+    fn input_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.glyph_count(), 1_usize))
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn seq_lookup_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_lookup_count()) as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.seq_lookup_count_byte_range().end;
+        start..start + self.input_sequence_byte_len(start)
+    }
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+        let start = self.input_sequence_byte_range().end;
+        start..start + self.seq_lookup_records_byte_len(start)
+    }
+
     /// Number of glyphs in the input glyph sequence
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
-        let range = self.shape.seq_lookup_count_byte_range();
+        let range = self.seq_lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of input glyph IDs—starting with the second glyph
     pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.input_sequence_byte_range();
+        let range = self.input_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Array of Sequence lookup records
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
-        let range = self.shape.seq_lookup_records_byte_range();
+        let range = self.seq_lookup_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -2086,11 +2104,41 @@ impl Format<u16> for SequenceContextFormat2Marker {
 /// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceContextFormat2Marker {
-    class_seq_rule_set_offsets_byte_len: usize,
+pub struct SequenceContextFormat2Marker {}
+
+impl<'a> MinByteRange for SequenceContextFormat2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.class_seq_rule_set_offsets_byte_range().end
+    }
 }
 
-impl SequenceContextFormat2Marker {
+impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        let class_seq_rule_set_count: u16 = cursor.read()?;
+        let class_seq_rule_set_offsets_byte_len = (class_seq_rule_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(class_seq_rule_set_offsets_byte_len);
+        cursor.finish(SequenceContextFormat2Marker {})
+    }
+}
+
+/// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
+pub type SequenceContextFormat2<'a> = TableRef<'a, SequenceContextFormat2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SequenceContextFormat2<'a> {
+    fn class_seq_rule_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.class_seq_rule_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -2113,48 +2161,19 @@ impl SequenceContextFormat2Marker {
 
     pub fn class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.class_seq_rule_set_count_byte_range().end;
-        start..start + self.class_seq_rule_set_offsets_byte_len
+        start..start + self.class_seq_rule_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for SequenceContextFormat2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.class_seq_rule_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let class_seq_rule_set_count: u16 = cursor.read()?;
-        let class_seq_rule_set_offsets_byte_len = (class_seq_rule_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(class_seq_rule_set_offsets_byte_len);
-        cursor.finish(SequenceContextFormat2Marker {
-            class_seq_rule_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-2-class-based-glyph-contexts)
-pub type SequenceContextFormat2<'a> = TableRef<'a, SequenceContextFormat2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SequenceContextFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2167,7 +2186,7 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Offset to ClassDef table, from beginning of
     /// SequenceContextFormat2 table
     pub fn class_def_offset(&self) -> Offset16 {
-        let range = self.shape.class_def_offset_byte_range();
+        let range = self.class_def_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2179,14 +2198,14 @@ impl<'a> SequenceContextFormat2<'a> {
 
     /// Number of ClassSequenceRuleSet tables
     pub fn class_seq_rule_set_count(&self) -> u16 {
-        let range = self.shape.class_seq_rule_set_count_byte_range();
+        let range = self.class_seq_rule_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to ClassSequenceRuleSet tables, from beginning
     /// of SequenceContextFormat2 table (may be NULL)
     pub fn class_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
-        let range = self.shape.class_seq_rule_set_offsets_byte_range();
+        let range = self.class_seq_rule_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -2250,23 +2269,9 @@ impl<'a> std::fmt::Debug for SequenceContextFormat2<'a> {
 /// Part of [SequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassSequenceRuleSetMarker {
-    class_seq_rule_offsets_byte_len: usize,
-}
+pub struct ClassSequenceRuleSetMarker {}
 
-impl ClassSequenceRuleSetMarker {
-    pub fn class_seq_rule_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.class_seq_rule_count_byte_range().end;
-        start..start + self.class_seq_rule_offsets_byte_len
-    }
-}
-
-impl MinByteRange for ClassSequenceRuleSetMarker {
+impl<'a> MinByteRange for ClassSequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.class_seq_rule_offsets_byte_range().end
     }
@@ -2280,9 +2285,7 @@ impl<'a> FontRead<'a> for ClassSequenceRuleSet<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(class_seq_rule_offsets_byte_len);
-        cursor.finish(ClassSequenceRuleSetMarker {
-            class_seq_rule_offsets_byte_len,
-        })
+        cursor.finish(ClassSequenceRuleSetMarker {})
     }
 }
 
@@ -2291,16 +2294,33 @@ pub type ClassSequenceRuleSet<'a> = TableRef<'a, ClassSequenceRuleSetMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassSequenceRuleSet<'a> {
+    fn class_seq_rule_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.class_seq_rule_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn class_seq_rule_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.class_seq_rule_count_byte_range().end;
+        start..start + self.class_seq_rule_offsets_byte_len(start)
+    }
+
     /// Number of ClassSequenceRule tables
     pub fn class_seq_rule_count(&self) -> u16 {
-        let range = self.shape.class_seq_rule_count_byte_range();
+        let range = self.class_seq_rule_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
     pub fn class_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.class_seq_rule_offsets_byte_range();
+        let range = self.class_seq_rule_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -2353,34 +2373,9 @@ impl<'a> std::fmt::Debug for ClassSequenceRuleSet<'a> {
 /// Part of [SequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ClassSequenceRuleMarker {
-    input_sequence_byte_len: usize,
-    seq_lookup_records_byte_len: usize,
-}
+pub struct ClassSequenceRuleMarker {}
 
-impl ClassSequenceRuleMarker {
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn input_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.seq_lookup_count_byte_range().end;
-        start..start + self.input_sequence_byte_len
-    }
-
-    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
-        let start = self.input_sequence_byte_range().end;
-        start..start + self.seq_lookup_records_byte_len
-    }
-}
-
-impl MinByteRange for ClassSequenceRuleMarker {
+impl<'a> MinByteRange for ClassSequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_lookup_records_byte_range().end
     }
@@ -2399,10 +2394,7 @@ impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
             .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ClassSequenceRuleMarker {
-            input_sequence_byte_len,
-            seq_lookup_records_byte_len,
-        })
+        cursor.finish(ClassSequenceRuleMarker {})
     }
 }
 
@@ -2411,28 +2403,61 @@ pub type ClassSequenceRule<'a> = TableRef<'a, ClassSequenceRuleMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ClassSequenceRule<'a> {
+    fn input_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.glyph_count(), 1_usize))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn seq_lookup_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_lookup_count()) as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.seq_lookup_count_byte_range().end;
+        start..start + self.input_sequence_byte_len(start)
+    }
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+        let start = self.input_sequence_byte_range().end;
+        start..start + self.seq_lookup_records_byte_len(start)
+    }
+
     /// Number of glyphs to be matched
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
-        let range = self.shape.seq_lookup_count_byte_range();
+        let range = self.seq_lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
     pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.input_sequence_byte_range();
+        let range = self.input_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
-        let range = self.shape.seq_lookup_records_byte_range();
+        let range = self.seq_lookup_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -2475,39 +2500,9 @@ impl Format<u16> for SequenceContextFormat3Marker {
 /// [Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-context-format-3-coverage-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SequenceContextFormat3Marker {
-    coverage_offsets_byte_len: usize,
-    seq_lookup_records_byte_len: usize,
-}
+pub struct SequenceContextFormat3Marker {}
 
-impl SequenceContextFormat3Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
-        let start = self.glyph_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.seq_lookup_count_byte_range().end;
-        start..start + self.coverage_offsets_byte_len
-    }
-
-    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
-        let start = self.coverage_offsets_byte_range().end;
-        start..start + self.seq_lookup_records_byte_len
-    }
-}
-
-impl MinByteRange for SequenceContextFormat3Marker {
+impl<'a> MinByteRange for SequenceContextFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_lookup_records_byte_range().end
     }
@@ -2527,10 +2522,7 @@ impl<'a> FontRead<'a> for SequenceContextFormat3<'a> {
             .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(SequenceContextFormat3Marker {
-            coverage_offsets_byte_len,
-            seq_lookup_records_byte_len,
-        })
+        cursor.finish(SequenceContextFormat3Marker {})
     }
 }
 
@@ -2539,28 +2531,66 @@ pub type SequenceContextFormat3<'a> = TableRef<'a, SequenceContextFormat3Marker>
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SequenceContextFormat3<'a> {
+    fn coverage_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.glyph_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn seq_lookup_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_lookup_count()) as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+        let start = self.glyph_count_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.seq_lookup_count_byte_range().end;
+        start..start + self.coverage_offsets_byte_len(start)
+    }
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_offsets_byte_range().end;
+        start..start + self.seq_lookup_records_byte_len(start)
+    }
+
     /// Format identifier: format = 3
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of glyphs in the input sequence
     pub fn glyph_count(&self) -> u16 {
-        let range = self.shape.glyph_count_byte_range();
+        let range = self.glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
-        let range = self.shape.seq_lookup_count_byte_range();
+        let range = self.seq_lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
     pub fn coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.coverage_offsets_byte_range();
+        let range = self.coverage_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -2573,7 +2603,7 @@ impl<'a> SequenceContextFormat3<'a> {
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
-        let range = self.shape.seq_lookup_records_byte_range();
+        let range = self.seq_lookup_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -2707,11 +2737,40 @@ impl Format<u16> for ChainedSequenceContextFormat1Marker {
 /// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceContextFormat1Marker {
-    chained_seq_rule_set_offsets_byte_len: usize,
+pub struct ChainedSequenceContextFormat1Marker {}
+
+impl<'a> MinByteRange for ChainedSequenceContextFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.chained_seq_rule_set_offsets_byte_range().end
+    }
 }
 
-impl ChainedSequenceContextFormat1Marker {
+impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        let chained_seq_rule_set_count: u16 = cursor.read()?;
+        let chained_seq_rule_set_offsets_byte_len = (chained_seq_rule_set_count as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(chained_seq_rule_set_offsets_byte_len);
+        cursor.finish(ChainedSequenceContextFormat1Marker {})
+    }
+}
+
+/// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
+pub type ChainedSequenceContextFormat1<'a> = TableRef<'a, ChainedSequenceContextFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ChainedSequenceContextFormat1<'a> {
+    fn chained_seq_rule_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.chained_seq_rule_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -2729,47 +2788,19 @@ impl ChainedSequenceContextFormat1Marker {
 
     pub fn chained_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.chained_seq_rule_set_count_byte_range().end;
-        start..start + self.chained_seq_rule_set_offsets_byte_len
+        start..start + self.chained_seq_rule_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for ChainedSequenceContextFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.chained_seq_rule_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        let chained_seq_rule_set_count: u16 = cursor.read()?;
-        let chained_seq_rule_set_offsets_byte_len = (chained_seq_rule_set_count as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(chained_seq_rule_set_offsets_byte_len);
-        cursor.finish(ChainedSequenceContextFormat1Marker {
-            chained_seq_rule_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Chained Sequence Context Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-1-simple-glyph-contexts)
-pub type ChainedSequenceContextFormat1<'a> = TableRef<'a, ChainedSequenceContextFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> ChainedSequenceContextFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -2781,14 +2812,14 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
 
     /// Number of ChainedSequenceRuleSet tables
     pub fn chained_seq_rule_set_count(&self) -> u16 {
-        let range = self.shape.chained_seq_rule_set_count_byte_range();
+        let range = self.chained_seq_rule_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to ChainedSeqRuleSet tables, from beginning of
     /// ChainedSequenceContextFormat1 table (may be NULL)
     pub fn chained_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
-        let range = self.shape.chained_seq_rule_set_offsets_byte_range();
+        let range = self.chained_seq_rule_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -2848,23 +2879,9 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat1<'a> {
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceRuleSetMarker {
-    chained_seq_rule_offsets_byte_len: usize,
-}
+pub struct ChainedSequenceRuleSetMarker {}
 
-impl ChainedSequenceRuleSetMarker {
-    pub fn chained_seq_rule_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn chained_seq_rule_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.chained_seq_rule_count_byte_range().end;
-        start..start + self.chained_seq_rule_offsets_byte_len
-    }
-}
-
-impl MinByteRange for ChainedSequenceRuleSetMarker {
+impl<'a> MinByteRange for ChainedSequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.chained_seq_rule_offsets_byte_range().end
     }
@@ -2878,9 +2895,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRuleSet<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(chained_seq_rule_offsets_byte_len);
-        cursor.finish(ChainedSequenceRuleSetMarker {
-            chained_seq_rule_offsets_byte_len,
-        })
+        cursor.finish(ChainedSequenceRuleSetMarker {})
     }
 }
 
@@ -2889,16 +2904,33 @@ pub type ChainedSequenceRuleSet<'a> = TableRef<'a, ChainedSequenceRuleSetMarker>
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceRuleSet<'a> {
+    fn chained_seq_rule_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.chained_seq_rule_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn chained_seq_rule_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn chained_seq_rule_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.chained_seq_rule_count_byte_range().end;
+        start..start + self.chained_seq_rule_offsets_byte_len(start)
+    }
+
     /// Number of ChainedSequenceRule tables
     pub fn chained_seq_rule_count(&self) -> u16 {
-        let range = self.shape.chained_seq_rule_count_byte_range();
+        let range = self.chained_seq_rule_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
     pub fn chained_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.chained_seq_rule_offsets_byte_range();
+        let range = self.chained_seq_rule_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -2951,56 +2983,9 @@ impl<'a> std::fmt::Debug for ChainedSequenceRuleSet<'a> {
 /// Part of [ChainedSequenceContextFormat1]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceRuleMarker {
-    backtrack_sequence_byte_len: usize,
-    input_sequence_byte_len: usize,
-    lookahead_sequence_byte_len: usize,
-    seq_lookup_records_byte_len: usize,
-}
+pub struct ChainedSequenceRuleMarker {}
 
-impl ChainedSequenceRuleMarker {
-    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + self.backtrack_sequence_byte_len
-    }
-
-    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn input_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.input_glyph_count_byte_range().end;
-        start..start + self.input_sequence_byte_len
-    }
-
-    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.input_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + self.lookahead_sequence_byte_len
-    }
-
-    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
-        let start = self.seq_lookup_count_byte_range().end;
-        start..start + self.seq_lookup_records_byte_len
-    }
-}
-
-impl MinByteRange for ChainedSequenceRuleMarker {
+impl<'a> MinByteRange for ChainedSequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_lookup_records_byte_range().end
     }
@@ -3029,12 +3014,7 @@ impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
             .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ChainedSequenceRuleMarker {
-            backtrack_sequence_byte_len,
-            input_sequence_byte_len,
-            lookahead_sequence_byte_len,
-            seq_lookup_records_byte_len,
-        })
+        cursor.finish(ChainedSequenceRuleMarker {})
     }
 }
 
@@ -3043,51 +3023,116 @@ pub type ChainedSequenceRule<'a> = TableRef<'a, ChainedSequenceRuleMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceRule<'a> {
+    fn backtrack_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.backtrack_glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn input_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.input_glyph_count(), 1_usize))
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn lookahead_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lookahead_glyph_count()) as usize)
+            .checked_mul(GlyphId16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn seq_lookup_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_lookup_count()) as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_glyph_count_byte_range().end;
+        start..start + self.backtrack_sequence_byte_len(start)
+    }
+
+    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_sequence_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.input_glyph_count_byte_range().end;
+        start..start + self.input_sequence_byte_len(start)
+    }
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.input_sequence_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_glyph_count_byte_range().end;
+        start..start + self.lookahead_sequence_byte_len(start)
+    }
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_sequence_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+        let start = self.seq_lookup_count_byte_range().end;
+        start..start + self.seq_lookup_records_byte_len(start)
+    }
+
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
-        let range = self.shape.backtrack_glyph_count_byte_range();
+        let range = self.backtrack_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of backtrack glyph IDs
     pub fn backtrack_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.backtrack_sequence_byte_range();
+        let range = self.backtrack_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
-        let range = self.shape.input_glyph_count_byte_range();
+        let range = self.input_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of input glyph IDs—start with second glyph
     pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.input_sequence_byte_range();
+        let range = self.input_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
-        let range = self.shape.lookahead_glyph_count_byte_range();
+        let range = self.lookahead_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of lookahead glyph IDs
     pub fn lookahead_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
-        let range = self.shape.lookahead_sequence_byte_range();
+        let range = self.lookahead_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
-        let range = self.shape.seq_lookup_count_byte_range();
+        let range = self.seq_lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
-        let range = self.shape.seq_lookup_records_byte_range();
+        let range = self.seq_lookup_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -3140,11 +3185,44 @@ impl Format<u16> for ChainedSequenceContextFormat2Marker {
 /// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceContextFormat2Marker {
-    chained_class_seq_rule_set_offsets_byte_len: usize,
+pub struct ChainedSequenceContextFormat2Marker {}
+
+impl<'a> MinByteRange for ChainedSequenceContextFormat2<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.chained_class_seq_rule_set_offsets_byte_range().end
+    }
 }
 
-impl ChainedSequenceContextFormat2Marker {
+impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        cursor.advance::<Offset16>();
+        let chained_class_seq_rule_set_count: u16 = cursor.read()?;
+        let chained_class_seq_rule_set_offsets_byte_len = (chained_class_seq_rule_set_count
+            as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(chained_class_seq_rule_set_offsets_byte_len);
+        cursor.finish(ChainedSequenceContextFormat2Marker {})
+    }
+}
+
+/// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
+pub type ChainedSequenceContextFormat2<'a> = TableRef<'a, ChainedSequenceContextFormat2Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ChainedSequenceContextFormat2<'a> {
+    fn chained_class_seq_rule_set_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.chained_class_seq_rule_set_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -3177,51 +3255,19 @@ impl ChainedSequenceContextFormat2Marker {
 
     pub fn chained_class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let start = self.chained_class_seq_rule_set_count_byte_range().end;
-        start..start + self.chained_class_seq_rule_set_offsets_byte_len
+        start..start + self.chained_class_seq_rule_set_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for ChainedSequenceContextFormat2Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.chained_class_seq_rule_set_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        let chained_class_seq_rule_set_count: u16 = cursor.read()?;
-        let chained_class_seq_rule_set_offsets_byte_len = (chained_class_seq_rule_set_count
-            as usize)
-            .checked_mul(Offset16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(chained_class_seq_rule_set_offsets_byte_len);
-        cursor.finish(ChainedSequenceContextFormat2Marker {
-            chained_class_seq_rule_set_offsets_byte_len,
-        })
-    }
-}
-
-/// [Chained Sequence Context Format 2](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-2-class-based-glyph-contexts)
-pub type ChainedSequenceContextFormat2<'a> = TableRef<'a, ChainedSequenceContextFormat2Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
     pub fn coverage_offset(&self) -> Offset16 {
-        let range = self.shape.coverage_offset_byte_range();
+        let range = self.coverage_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3234,7 +3280,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Offset to ClassDef table containing backtrack sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn backtrack_class_def_offset(&self) -> Offset16 {
-        let range = self.shape.backtrack_class_def_offset_byte_range();
+        let range = self.backtrack_class_def_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3247,7 +3293,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Offset to ClassDef table containing input sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn input_class_def_offset(&self) -> Offset16 {
-        let range = self.shape.input_class_def_offset_byte_range();
+        let range = self.input_class_def_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3260,7 +3306,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Offset to ClassDef table containing lookahead sequence context,
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn lookahead_class_def_offset(&self) -> Offset16 {
-        let range = self.shape.lookahead_class_def_offset_byte_range();
+        let range = self.lookahead_class_def_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -3272,14 +3318,14 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
 
     /// Number of ChainedClassSequenceRuleSet tables
     pub fn chained_class_seq_rule_set_count(&self) -> u16 {
-        let range = self.shape.chained_class_seq_rule_set_count_byte_range();
+        let range = self.chained_class_seq_rule_set_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to ChainedClassSequenceRuleSet tables, from
     /// beginning of ChainedSequenceContextFormat2 table (may be NULL)
     pub fn chained_class_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
-        let range = self.shape.chained_class_seq_rule_set_offsets_byte_range();
+        let range = self.chained_class_seq_rule_set_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -3357,23 +3403,9 @@ impl<'a> std::fmt::Debug for ChainedSequenceContextFormat2<'a> {
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedClassSequenceRuleSetMarker {
-    chained_class_seq_rule_offsets_byte_len: usize,
-}
+pub struct ChainedClassSequenceRuleSetMarker {}
 
-impl ChainedClassSequenceRuleSetMarker {
-    pub fn chained_class_seq_rule_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn chained_class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.chained_class_seq_rule_count_byte_range().end;
-        start..start + self.chained_class_seq_rule_offsets_byte_len
-    }
-}
-
-impl MinByteRange for ChainedClassSequenceRuleSetMarker {
+impl<'a> MinByteRange for ChainedClassSequenceRuleSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.chained_class_seq_rule_offsets_byte_range().end
     }
@@ -3387,9 +3419,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet<'a> {
             .checked_mul(Offset16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(chained_class_seq_rule_offsets_byte_len);
-        cursor.finish(ChainedClassSequenceRuleSetMarker {
-            chained_class_seq_rule_offsets_byte_len,
-        })
+        cursor.finish(ChainedClassSequenceRuleSetMarker {})
     }
 }
 
@@ -3398,16 +3428,33 @@ pub type ChainedClassSequenceRuleSet<'a> = TableRef<'a, ChainedClassSequenceRule
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedClassSequenceRuleSet<'a> {
+    fn chained_class_seq_rule_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.chained_class_seq_rule_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn chained_class_seq_rule_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn chained_class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.chained_class_seq_rule_count_byte_range().end;
+        start..start + self.chained_class_seq_rule_offsets_byte_len(start)
+    }
+
     /// Number of ChainedClassSequenceRule tables
     pub fn chained_class_seq_rule_count(&self) -> u16 {
-        let range = self.shape.chained_class_seq_rule_count_byte_range();
+        let range = self.chained_class_seq_rule_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
     pub fn chained_class_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.chained_class_seq_rule_offsets_byte_range();
+        let range = self.chained_class_seq_rule_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -3462,56 +3509,9 @@ impl<'a> std::fmt::Debug for ChainedClassSequenceRuleSet<'a> {
 /// Part of [ChainedSequenceContextFormat2]
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedClassSequenceRuleMarker {
-    backtrack_sequence_byte_len: usize,
-    input_sequence_byte_len: usize,
-    lookahead_sequence_byte_len: usize,
-    seq_lookup_records_byte_len: usize,
-}
+pub struct ChainedClassSequenceRuleMarker {}
 
-impl ChainedClassSequenceRuleMarker {
-    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + self.backtrack_sequence_byte_len
-    }
-
-    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn input_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.input_glyph_count_byte_range().end;
-        start..start + self.input_sequence_byte_len
-    }
-
-    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.input_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + self.lookahead_sequence_byte_len
-    }
-
-    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
-        let start = self.seq_lookup_count_byte_range().end;
-        start..start + self.seq_lookup_records_byte_len
-    }
-}
-
-impl MinByteRange for ChainedClassSequenceRuleMarker {
+impl<'a> MinByteRange for ChainedClassSequenceRule<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_lookup_records_byte_range().end
     }
@@ -3540,12 +3540,7 @@ impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
             .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ChainedClassSequenceRuleMarker {
-            backtrack_sequence_byte_len,
-            input_sequence_byte_len,
-            lookahead_sequence_byte_len,
-            seq_lookup_records_byte_len,
-        })
+        cursor.finish(ChainedClassSequenceRuleMarker {})
     }
 }
 
@@ -3554,52 +3549,117 @@ pub type ChainedClassSequenceRule<'a> = TableRef<'a, ChainedClassSequenceRuleMar
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedClassSequenceRule<'a> {
+    fn backtrack_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.backtrack_glyph_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn input_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::subtract(self.input_glyph_count(), 1_usize))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn lookahead_sequence_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lookahead_glyph_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn seq_lookup_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_lookup_count()) as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_glyph_count_byte_range().end;
+        start..start + self.backtrack_sequence_byte_len(start)
+    }
+
+    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_sequence_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn input_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.input_glyph_count_byte_range().end;
+        start..start + self.input_sequence_byte_len(start)
+    }
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.input_sequence_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_glyph_count_byte_range().end;
+        start..start + self.lookahead_sequence_byte_len(start)
+    }
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_sequence_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+        let start = self.seq_lookup_count_byte_range().end;
+        start..start + self.seq_lookup_records_byte_len(start)
+    }
+
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
-        let range = self.shape.backtrack_glyph_count_byte_range();
+        let range = self.backtrack_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of backtrack-sequence classes
     pub fn backtrack_sequence(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.backtrack_sequence_byte_range();
+        let range = self.backtrack_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Total number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
-        let range = self.shape.input_glyph_count_byte_range();
+        let range = self.input_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of input sequence classes, beginning with the second
     /// glyph position
     pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.input_sequence_byte_range();
+        let range = self.input_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
-        let range = self.shape.lookahead_glyph_count_byte_range();
+        let range = self.lookahead_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of lookahead-sequence classes
     pub fn lookahead_sequence(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.lookahead_sequence_byte_range();
+        let range = self.lookahead_sequence_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
-        let range = self.shape.seq_lookup_count_byte_range();
+        let range = self.seq_lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
-        let range = self.shape.seq_lookup_records_byte_range();
+        let range = self.seq_lookup_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -3652,61 +3712,9 @@ impl Format<u16> for ChainedSequenceContextFormat3Marker {
 /// [Chained Sequence Context Format 3](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#chained-sequence-context-format-3-coverage-based-glyph-contexts)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainedSequenceContextFormat3Marker {
-    backtrack_coverage_offsets_byte_len: usize,
-    input_coverage_offsets_byte_len: usize,
-    lookahead_coverage_offsets_byte_len: usize,
-    seq_lookup_records_byte_len: usize,
-}
+pub struct ChainedSequenceContextFormat3Marker {}
 
-impl ChainedSequenceContextFormat3Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + self.backtrack_coverage_offsets_byte_len
-    }
-
-    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.backtrack_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn input_coverage_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.input_glyph_count_byte_range().end;
-        start..start + self.input_coverage_offsets_byte_len
-    }
-
-    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
-        let start = self.input_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + self.lookahead_coverage_offsets_byte_len
-    }
-
-    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
-        let start = self.lookahead_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
-        let start = self.seq_lookup_count_byte_range().end;
-        start..start + self.seq_lookup_records_byte_len
-    }
-}
-
-impl MinByteRange for ChainedSequenceContextFormat3Marker {
+impl<'a> MinByteRange for ChainedSequenceContextFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.seq_lookup_records_byte_range().end
     }
@@ -3736,12 +3744,7 @@ impl<'a> FontRead<'a> for ChainedSequenceContextFormat3<'a> {
             .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(seq_lookup_records_byte_len);
-        cursor.finish(ChainedSequenceContextFormat3Marker {
-            backtrack_coverage_offsets_byte_len,
-            input_coverage_offsets_byte_len,
-            lookahead_coverage_offsets_byte_len,
-            seq_lookup_records_byte_len,
-        })
+        cursor.finish(ChainedSequenceContextFormat3Marker {})
     }
 }
 
@@ -3750,21 +3753,91 @@ pub type ChainedSequenceContextFormat3<'a> = TableRef<'a, ChainedSequenceContext
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ChainedSequenceContextFormat3<'a> {
+    fn backtrack_coverage_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.backtrack_glyph_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn input_coverage_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.input_glyph_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn lookahead_coverage_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.lookahead_glyph_count()) as usize)
+            .checked_mul(Offset16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn seq_lookup_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.seq_lookup_count()) as usize)
+            .checked_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_glyph_count_byte_range().end;
+        start..start + self.backtrack_coverage_offsets_byte_len(start)
+    }
+
+    pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.backtrack_coverage_offsets_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn input_coverage_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.input_glyph_count_byte_range().end;
+        start..start + self.input_coverage_offsets_byte_len(start)
+    }
+
+    pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.input_coverage_offsets_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_glyph_count_byte_range().end;
+        start..start + self.lookahead_coverage_offsets_byte_len(start)
+    }
+
+    pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
+        let start = self.lookahead_coverage_offsets_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
+        let start = self.seq_lookup_count_byte_range().end;
+        start..start + self.seq_lookup_records_byte_len(start)
+    }
+
     /// Format identifier: format = 3
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
-        let range = self.shape.backtrack_glyph_count_byte_range();
+        let range = self.backtrack_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to coverage tables for the backtrack sequence
     pub fn backtrack_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.backtrack_coverage_offsets_byte_range();
+        let range = self.backtrack_coverage_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -3777,13 +3850,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
 
     /// Number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
-        let range = self.shape.input_glyph_count_byte_range();
+        let range = self.input_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to coverage tables for the input sequence
     pub fn input_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.input_coverage_offsets_byte_range();
+        let range = self.input_coverage_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -3796,13 +3869,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
-        let range = self.shape.lookahead_glyph_count_byte_range();
+        let range = self.lookahead_glyph_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to coverage tables for the lookahead sequence
     pub fn lookahead_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
-        let range = self.shape.lookahead_coverage_offsets_byte_range();
+        let range = self.lookahead_coverage_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -3815,13 +3888,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
-        let range = self.shape.seq_lookup_count_byte_range();
+        let range = self.seq_lookup_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
-        let range = self.shape.seq_lookup_records_byte_range();
+        let range = self.seq_lookup_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -4041,11 +4114,40 @@ impl<'a> From<DeltaFormat> for FieldType<'a> {
 /// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DeviceMarker {
-    delta_value_byte_len: usize,
+pub struct DeviceMarker {}
+
+impl<'a> MinByteRange for Device<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.delta_value_byte_range().end
+    }
 }
 
-impl DeviceMarker {
+impl<'a> FontRead<'a> for Device<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let start_size: u16 = cursor.read()?;
+        let end_size: u16 = cursor.read()?;
+        let delta_format: DeltaFormat = cursor.read()?;
+        let delta_value_byte_len = (DeltaFormat::value_count(delta_format, start_size, end_size))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(delta_value_byte_len);
+        cursor.finish(DeviceMarker {})
+    }
+}
+
+/// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
+pub type Device<'a> = TableRef<'a, DeviceMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Device<'a> {
+    fn delta_value_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (DeltaFormat::value_count(self.delta_format(), self.start_size(), self.end_size()))
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn start_size_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -4063,58 +4165,30 @@ impl DeviceMarker {
 
     pub fn delta_value_byte_range(&self) -> Range<usize> {
         let start = self.delta_format_byte_range().end;
-        start..start + self.delta_value_byte_len
+        start..start + self.delta_value_byte_len(start)
     }
-}
 
-impl MinByteRange for DeviceMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.delta_value_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Device<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let start_size: u16 = cursor.read()?;
-        let end_size: u16 = cursor.read()?;
-        let delta_format: DeltaFormat = cursor.read()?;
-        let delta_value_byte_len = (DeltaFormat::value_count(delta_format, start_size, end_size))
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(delta_value_byte_len);
-        cursor.finish(DeviceMarker {
-            delta_value_byte_len,
-        })
-    }
-}
-
-/// [Device Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#device-and-variationindex-tables)
-pub type Device<'a> = TableRef<'a, DeviceMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Device<'a> {
     /// Smallest size to correct, in ppem
     pub fn start_size(&self) -> u16 {
-        let range = self.shape.start_size_byte_range();
+        let range = self.start_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Largest size to correct, in ppem
     pub fn end_size(&self) -> u16 {
-        let range = self.shape.end_size_byte_range();
+        let range = self.end_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Format of deltaValue array data: 0x0001, 0x0002, or 0x0003
     pub fn delta_format(&self) -> DeltaFormat {
-        let range = self.shape.delta_format_byte_range();
+        let range = self.delta_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of compressed data
     pub fn delta_value(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.delta_value_byte_range();
+        let range = self.delta_value_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -4148,24 +4222,7 @@ impl<'a> std::fmt::Debug for Device<'a> {
 #[doc(hidden)]
 pub struct VariationIndexMarker {}
 
-impl VariationIndexMarker {
-    pub fn delta_set_outer_index_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn delta_set_inner_index_byte_range(&self) -> Range<usize> {
-        let start = self.delta_set_outer_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn delta_format_byte_range(&self) -> Range<usize> {
-        let start = self.delta_set_inner_index_byte_range().end;
-        start..start + DeltaFormat::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for VariationIndexMarker {
+impl<'a> MinByteRange for VariationIndex<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.delta_format_byte_range().end
     }
@@ -4186,23 +4243,38 @@ pub type VariationIndex<'a> = TableRef<'a, VariationIndexMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VariationIndex<'a> {
+    pub fn delta_set_outer_index_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn delta_set_inner_index_byte_range(&self) -> Range<usize> {
+        let start = self.delta_set_outer_index_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn delta_format_byte_range(&self) -> Range<usize> {
+        let start = self.delta_set_inner_index_byte_range().end;
+        start..start + DeltaFormat::RAW_BYTE_LEN
+    }
+
     /// A delta-set outer index — used to select an item variation
     /// data subtable within the item variation store.
     pub fn delta_set_outer_index(&self) -> u16 {
-        let range = self.shape.delta_set_outer_index_byte_range();
+        let range = self.delta_set_outer_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A delta-set inner index — used to select a delta-set row
     /// within an item variation data subtable.
     pub fn delta_set_inner_index(&self) -> u16 {
-        let range = self.shape.delta_set_inner_index_byte_range();
+        let range = self.delta_set_inner_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Format, = 0x8000
     pub fn delta_format(&self) -> DeltaFormat {
-        let range = self.shape.delta_format_byte_range();
+        let range = self.delta_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4309,28 +4381,9 @@ impl<'a> SomeTable<'a> for DeviceOrVariationIndex<'a> {
 /// [FeatureVariations Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featurevariations-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureVariationsMarker {
-    feature_variation_records_byte_len: usize,
-}
+pub struct FeatureVariationsMarker {}
 
-impl FeatureVariationsMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn feature_variation_record_count_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn feature_variation_records_byte_range(&self) -> Range<usize> {
-        let start = self.feature_variation_record_count_byte_range().end;
-        start..start + self.feature_variation_records_byte_len
-    }
-}
-
-impl MinByteRange for FeatureVariationsMarker {
+impl<'a> MinByteRange for FeatureVariations<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.feature_variation_records_byte_range().end
     }
@@ -4345,9 +4398,7 @@ impl<'a> FontRead<'a> for FeatureVariations<'a> {
             .checked_mul(FeatureVariationRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(feature_variation_records_byte_len);
-        cursor.finish(FeatureVariationsMarker {
-            feature_variation_records_byte_len,
-        })
+        cursor.finish(FeatureVariationsMarker {})
     }
 }
 
@@ -4356,20 +4407,42 @@ pub type FeatureVariations<'a> = TableRef<'a, FeatureVariationsMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FeatureVariations<'a> {
+    fn feature_variation_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.feature_variation_record_count()) as usize)
+            .checked_mul(FeatureVariationRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn feature_variation_record_count_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn feature_variation_records_byte_range(&self) -> Range<usize> {
+        let start = self.feature_variation_record_count_byte_range().end;
+        start..start + self.feature_variation_records_byte_len(start)
+    }
+
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of feature variation records.
     pub fn feature_variation_record_count(&self) -> u32 {
-        let range = self.shape.feature_variation_record_count_byte_range();
+        let range = self.feature_variation_record_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of feature variation records.
     pub fn feature_variation_records(&self) -> &'a [FeatureVariationRecord] {
-        let range = self.shape.feature_variation_records_byte_range();
+        let range = self.feature_variation_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -4489,23 +4562,9 @@ impl<'a> SomeRecord<'a> for FeatureVariationRecord {
 /// [ConditionSet Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#conditionset-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionSetMarker {
-    condition_offsets_byte_len: usize,
-}
+pub struct ConditionSetMarker {}
 
-impl ConditionSetMarker {
-    pub fn condition_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.condition_count_byte_range().end;
-        start..start + self.condition_offsets_byte_len
-    }
-}
-
-impl MinByteRange for ConditionSetMarker {
+impl<'a> MinByteRange for ConditionSet<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.condition_offsets_byte_range().end
     }
@@ -4519,9 +4578,7 @@ impl<'a> FontRead<'a> for ConditionSet<'a> {
             .checked_mul(Offset32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionSetMarker {
-            condition_offsets_byte_len,
-        })
+        cursor.finish(ConditionSetMarker {})
     }
 }
 
@@ -4530,16 +4587,33 @@ pub type ConditionSet<'a> = TableRef<'a, ConditionSetMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionSet<'a> {
+    fn condition_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.condition_count()) as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.condition_count_byte_range().end;
+        start..start + self.condition_offsets_byte_len(start)
+    }
+
     /// Number of conditions for this condition set.
     pub fn condition_count(&self) -> u16 {
-        let range = self.shape.condition_count_byte_range();
+        let range = self.condition_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset32>] {
-        let range = self.shape.condition_offsets_byte_range();
+        let range = self.condition_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -4688,29 +4762,7 @@ impl Format<u16> for ConditionFormat1Marker {
 #[doc(hidden)]
 pub struct ConditionFormat1Marker {}
 
-impl ConditionFormat1Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn axis_index_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn filter_range_min_value_byte_range(&self) -> Range<usize> {
-        let start = self.axis_index_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-
-    pub fn filter_range_max_value_byte_range(&self) -> Range<usize> {
-        let start = self.filter_range_min_value_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for ConditionFormat1Marker {
+impl<'a> MinByteRange for ConditionFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.filter_range_max_value_byte_range().end
     }
@@ -4732,30 +4784,50 @@ pub type ConditionFormat1<'a> = TableRef<'a, ConditionFormat1Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat1<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn axis_index_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn filter_range_min_value_byte_range(&self) -> Range<usize> {
+        let start = self.axis_index_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
+    pub fn filter_range_max_value_byte_range(&self) -> Range<usize> {
+        let start = self.filter_range_min_value_byte_range().end;
+        start..start + F2Dot14::RAW_BYTE_LEN
+    }
+
     /// Format, = 1
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
     pub fn axis_index(&self) -> u16 {
-        let range = self.shape.axis_index_byte_range();
+        let range = self.axis_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum value of the font variation instances that satisfy this
     /// condition.
     pub fn filter_range_min_value(&self) -> F2Dot14 {
-        let range = self.shape.filter_range_min_value_byte_range();
+        let range = self.filter_range_min_value_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum value of the font variation instances that satisfy this
     /// condition.
     pub fn filter_range_max_value(&self) -> F2Dot14 {
-        let range = self.shape.filter_range_max_value_byte_range();
+        let range = self.filter_range_max_value_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4799,24 +4871,7 @@ impl Format<u16> for ConditionFormat2Marker {
 #[doc(hidden)]
 pub struct ConditionFormat2Marker {}
 
-impl ConditionFormat2Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn default_value_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn var_index_byte_range(&self) -> Range<usize> {
-        let start = self.default_value_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for ConditionFormat2Marker {
+impl<'a> MinByteRange for ConditionFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.var_index_byte_range().end
     }
@@ -4837,21 +4892,36 @@ pub type ConditionFormat2<'a> = TableRef<'a, ConditionFormat2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat2<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn default_value_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn var_index_byte_range(&self) -> Range<usize> {
+        let start = self.default_value_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
     /// Format, = 2
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Value at default instance.
     pub fn default_value(&self) -> i16 {
-        let range = self.shape.default_value_byte_range();
+        let range = self.default_value_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Variation index to vary the value based on current designspace location.
     pub fn var_index(&self) -> u32 {
-        let range = self.shape.var_index_byte_range();
+        let range = self.var_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -4886,28 +4956,9 @@ impl Format<u16> for ConditionFormat3Marker {
 /// [Condition Table Format 3](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3257-L3275): AND
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat3Marker {
-    condition_offsets_byte_len: usize,
-}
+pub struct ConditionFormat3Marker {}
 
-impl ConditionFormat3Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn condition_count_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.condition_count_byte_range().end;
-        start..start + self.condition_offsets_byte_len
-    }
-}
-
-impl MinByteRange for ConditionFormat3Marker {
+impl<'a> MinByteRange for ConditionFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.condition_offsets_byte_range().end
     }
@@ -4922,9 +4973,7 @@ impl<'a> FontRead<'a> for ConditionFormat3<'a> {
             .checked_mul(Offset24::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionFormat3Marker {
-            condition_offsets_byte_len,
-        })
+        cursor.finish(ConditionFormat3Marker {})
     }
 }
 
@@ -4933,21 +4982,43 @@ pub type ConditionFormat3<'a> = TableRef<'a, ConditionFormat3Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat3<'a> {
+    fn condition_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.condition_count()) as usize)
+            .checked_mul(Offset24::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.condition_count_byte_range().end;
+        start..start + self.condition_offsets_byte_len(start)
+    }
+
     /// Format, = 3
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of conditions.
     pub fn condition_count(&self) -> u8 {
-        let range = self.shape.condition_count_byte_range();
+        let range = self.condition_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of condition tables for this conjunction (AND) expression.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset24>] {
-        let range = self.shape.condition_offsets_byte_range();
+        let range = self.condition_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -5002,28 +5073,9 @@ impl Format<u16> for ConditionFormat4Marker {
 /// [Condition Table Format 4](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3276-L3295): OR
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionFormat4Marker {
-    condition_offsets_byte_len: usize,
-}
+pub struct ConditionFormat4Marker {}
 
-impl ConditionFormat4Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn condition_count_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
-    }
-
-    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.condition_count_byte_range().end;
-        start..start + self.condition_offsets_byte_len
-    }
-}
-
-impl MinByteRange for ConditionFormat4Marker {
+impl<'a> MinByteRange for ConditionFormat4<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.condition_offsets_byte_range().end
     }
@@ -5038,9 +5090,7 @@ impl<'a> FontRead<'a> for ConditionFormat4<'a> {
             .checked_mul(Offset24::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionFormat4Marker {
-            condition_offsets_byte_len,
-        })
+        cursor.finish(ConditionFormat4Marker {})
     }
 }
 
@@ -5049,21 +5099,43 @@ pub type ConditionFormat4<'a> = TableRef<'a, ConditionFormat4Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat4<'a> {
+    fn condition_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.condition_count()) as usize)
+            .checked_mul(Offset24::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn condition_count_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u8::RAW_BYTE_LEN
+    }
+
+    pub fn condition_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.condition_count_byte_range().end;
+        start..start + self.condition_offsets_byte_len(start)
+    }
+
     /// Format, = 4
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of conditions.
     pub fn condition_count(&self) -> u8 {
-        let range = self.shape.condition_count_byte_range();
+        let range = self.condition_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of condition tables for this disjunction (OR) expression.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset24>] {
-        let range = self.shape.condition_offsets_byte_range();
+        let range = self.condition_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -5120,19 +5192,7 @@ impl Format<u16> for ConditionFormat5Marker {
 #[doc(hidden)]
 pub struct ConditionFormat5Marker {}
 
-impl ConditionFormat5Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn condition_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for ConditionFormat5Marker {
+impl<'a> MinByteRange for ConditionFormat5<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.condition_offset_byte_range().end
     }
@@ -5152,15 +5212,25 @@ pub type ConditionFormat5<'a> = TableRef<'a, ConditionFormat5Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionFormat5<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn condition_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset24::RAW_BYTE_LEN
+    }
+
     /// Format, = 5
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Condition to negate.
     pub fn condition_offset(&self) -> Offset24 {
-        let range = self.shape.condition_offset_byte_range();
+        let range = self.condition_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5199,28 +5269,9 @@ impl<'a> std::fmt::Debug for ConditionFormat5<'a> {
 /// [FeatureTableSubstitution Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#featuretablesubstitution-table)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FeatureTableSubstitutionMarker {
-    substitutions_byte_len: usize,
-}
+pub struct FeatureTableSubstitutionMarker {}
 
-impl FeatureTableSubstitutionMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn substitution_count_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn substitutions_byte_range(&self) -> Range<usize> {
-        let start = self.substitution_count_byte_range().end;
-        start..start + self.substitutions_byte_len
-    }
-}
-
-impl MinByteRange for FeatureTableSubstitutionMarker {
+impl<'a> MinByteRange for FeatureTableSubstitution<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.substitutions_byte_range().end
     }
@@ -5235,9 +5286,7 @@ impl<'a> FontRead<'a> for FeatureTableSubstitution<'a> {
             .checked_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(substitutions_byte_len);
-        cursor.finish(FeatureTableSubstitutionMarker {
-            substitutions_byte_len,
-        })
+        cursor.finish(FeatureTableSubstitutionMarker {})
     }
 }
 
@@ -5246,21 +5295,43 @@ pub type FeatureTableSubstitution<'a> = TableRef<'a, FeatureTableSubstitutionMar
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FeatureTableSubstitution<'a> {
+    fn substitutions_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.substitution_count()) as usize)
+            .checked_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn substitution_count_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn substitutions_byte_range(&self) -> Range<usize> {
+        let start = self.substitution_count_byte_range().end;
+        start..start + self.substitutions_byte_len(start)
+    }
+
     /// Major & minor version of the table: (1, 0)
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of feature table substitution records.
     pub fn substitution_count(&self) -> u16 {
-        let range = self.shape.substitution_count_byte_range();
+        let range = self.substitution_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of feature table substitution records.
     pub fn substitutions(&self) -> &'a [FeatureTableSubstitutionRecord] {
-        let range = self.shape.substitutions_byte_range();
+        let range = self.substitutions_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -5349,7 +5420,28 @@ impl<'a> SomeRecord<'a> for FeatureTableSubstitutionRecord {
 #[doc(hidden)]
 pub struct SizeParamsMarker {}
 
-impl SizeParamsMarker {
+impl<'a> MinByteRange for SizeParams<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.range_end_byte_range().end
+    }
+}
+
+impl<'a> FontRead<'a> for SizeParams<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        cursor.finish(SizeParamsMarker {})
+    }
+}
+
+pub type SizeParams<'a> = TableRef<'a, SizeParamsMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> SizeParams<'a> {
     pub fn design_size_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -5374,36 +5466,13 @@ impl SizeParamsMarker {
         let start = self.range_start_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for SizeParamsMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.range_end_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for SizeParams<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.finish(SizeParamsMarker {})
-    }
-}
-
-pub type SizeParams<'a> = TableRef<'a, SizeParamsMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> SizeParams<'a> {
     /// The first value represents the design size in 720/inch units (decipoints).
     ///
     /// The design size entry must be non-zero. When there is a design size but
     /// no recommended size range, the rest of the array will consist of zeros.
     pub fn design_size(&self) -> u16 {
-        let range = self.shape.design_size_byte_range();
+        let range = self.design_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5414,7 +5483,7 @@ impl<'a> SizeParams<'a> {
     /// which differ in weight or style shall have the same subfamily value.
     /// If this value is zero, the remaining fields in the array will be ignored.
     pub fn identifier(&self) -> u16 {
-        let range = self.shape.identifier_byte_range();
+        let range = self.identifier_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5429,7 +5498,7 @@ impl<'a> SizeParams<'a> {
     /// represent the subfamily in a menu. Applications will choose the
     /// appropriate version based on their selection criteria.
     pub fn name_entry(&self) -> u16 {
-        let range = self.shape.name_entry_byte_range();
+        let range = self.name_entry_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5439,12 +5508,12 @@ impl<'a> SizeParams<'a> {
     ///
     /// Ranges must not overlap, and should generally be contiguous.
     pub fn range_start(&self) -> u16 {
-        let range = self.shape.range_start_byte_range();
+        let range = self.range_start_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn range_end(&self) -> u16 {
-        let range = self.shape.range_end_byte_range();
+        let range = self.range_end_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5478,19 +5547,7 @@ impl<'a> std::fmt::Debug for SizeParams<'a> {
 #[doc(hidden)]
 pub struct StylisticSetParamsMarker {}
 
-impl StylisticSetParamsMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn ui_name_id_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for StylisticSetParamsMarker {
+impl<'a> MinByteRange for StylisticSetParams<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.ui_name_id_byte_range().end
     }
@@ -5509,8 +5566,18 @@ pub type StylisticSetParams<'a> = TableRef<'a, StylisticSetParamsMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> StylisticSetParams<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn ui_name_id_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + NameId::RAW_BYTE_LEN
+    }
+
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5524,7 +5591,7 @@ impl<'a> StylisticSetParams<'a> {
     /// as a fallback. The string should be kept to a minimal length to fit
     /// comfortably with different application interfaces.
     pub fn ui_name_id(&self) -> NameId {
-        let range = self.shape.ui_name_id_byte_range();
+        let range = self.ui_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -5558,11 +5625,44 @@ impl Format<u16> for CharacterVariantParamsMarker {
 /// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CharacterVariantParamsMarker {
-    character_byte_len: usize,
+pub struct CharacterVariantParamsMarker {}
+
+impl<'a> MinByteRange for CharacterVariantParams<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.character_byte_range().end
+    }
 }
 
-impl CharacterVariantParamsMarker {
+impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<NameId>();
+        cursor.advance::<NameId>();
+        cursor.advance::<NameId>();
+        cursor.advance::<u16>();
+        cursor.advance::<NameId>();
+        let char_count: u16 = cursor.read()?;
+        let character_byte_len = (char_count as usize)
+            .checked_mul(Uint24::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(character_byte_len);
+        cursor.finish(CharacterVariantParamsMarker {})
+    }
+}
+
+/// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
+pub type CharacterVariantParams<'a> = TableRef<'a, CharacterVariantParamsMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> CharacterVariantParams<'a> {
+    fn character_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.char_count()) as usize)
+            .checked_mul(Uint24::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -5600,42 +5700,12 @@ impl CharacterVariantParamsMarker {
 
     pub fn character_byte_range(&self) -> Range<usize> {
         let start = self.char_count_byte_range().end;
-        start..start + self.character_byte_len
+        start..start + self.character_byte_len(start)
     }
-}
 
-impl MinByteRange for CharacterVariantParamsMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.character_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<NameId>();
-        cursor.advance::<NameId>();
-        cursor.advance::<NameId>();
-        cursor.advance::<u16>();
-        cursor.advance::<NameId>();
-        let char_count: u16 = cursor.read()?;
-        let character_byte_len = (char_count as usize)
-            .checked_mul(Uint24::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(character_byte_len);
-        cursor.finish(CharacterVariantParamsMarker { character_byte_len })
-    }
-}
-
-/// featureParams for ['cv01'-'cv99'](https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99)
-pub type CharacterVariantParams<'a> = TableRef<'a, CharacterVariantParamsMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> CharacterVariantParams<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5643,7 +5713,7 @@ impl<'a> CharacterVariantParams<'a> {
     /// for multiple languages) for a user-interface label for this
     /// feature. (May be NULL.)
     pub fn feat_ui_label_name_id(&self) -> NameId {
-        let range = self.shape.feat_ui_label_name_id_byte_range();
+        let range = self.feat_ui_label_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5651,20 +5721,20 @@ impl<'a> CharacterVariantParams<'a> {
     /// for multiple languages) that an application can use for tooltip
     /// text for this feature. (May be NULL.)
     pub fn feat_ui_tooltip_text_name_id(&self) -> NameId {
-        let range = self.shape.feat_ui_tooltip_text_name_id_byte_range();
+        let range = self.feat_ui_tooltip_text_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The 'name' table name ID that specifies sample text that
     /// illustrates the effect of this feature. (May be NULL.)
     pub fn sample_text_name_id(&self) -> NameId {
-        let range = self.shape.sample_text_name_id_byte_range();
+        let range = self.sample_text_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of named parameters. (May be zero.)
     pub fn num_named_parameters(&self) -> u16 {
-        let range = self.shape.num_named_parameters_byte_range();
+        let range = self.num_named_parameters_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -5672,21 +5742,21 @@ impl<'a> CharacterVariantParams<'a> {
     /// user-interface labels for the feature parameters. (Must be zero
     /// if numParameters is zero.)
     pub fn first_param_ui_label_name_id(&self) -> NameId {
-        let range = self.shape.first_param_ui_label_name_id_byte_range();
+        let range = self.first_param_ui_label_name_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The count of characters for which this feature provides glyph
     /// variants. (May be zero.)
     pub fn char_count(&self) -> u16 {
-        let range = self.shape.char_count_byte_range();
+        let range = self.char_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The Unicode Scalar Value of the characters for which this
     /// feature provides glyph variants.
     pub fn character(&self) -> &'a [BigEndian<Uint24>] {
-        let range = self.shape.character_byte_range();
+        let range = self.character_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -19,9 +19,9 @@ impl<'a> MinByteRange for ScriptList<'a> {
 impl<'a> FontRead<'a> for ScriptList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ScriptListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -157,9 +157,9 @@ impl<'a> MinByteRange for Script<'a> {
 impl<'a> FontRead<'a> for Script<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ScriptMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -317,9 +317,9 @@ impl<'a> MinByteRange for LangSys<'a> {
 impl<'a> FontRead<'a> for LangSys<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LangSysMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -420,9 +420,9 @@ impl<'a> MinByteRange for FeatureList<'a> {
 impl<'a> FontRead<'a> for FeatureList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FeatureListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -565,9 +565,9 @@ impl<'a> FontReadWithArgs<'a> for Feature<'a> {
     fn read_with_args(data: FontData<'a>, args: &Tag) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: FeatureMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -684,9 +684,9 @@ impl<'a, T> MinByteRange for LookupList<'a, T> {
 impl<'a, T> FontRead<'a> for LookupList<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LookupListMarker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -696,9 +696,9 @@ impl<'a> LookupList<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> LookupList<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupListMarker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -709,9 +709,9 @@ impl<'a, T> LookupList<'a, T> {
     pub(crate) fn of_unit_type(&self) -> LookupList<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupListMarker,
             args: std::marker::PhantomData,
             data: *data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -812,9 +812,9 @@ impl<'a, T> MinByteRange for Lookup<'a, T> {
 impl<'a, T> FontRead<'a> for Lookup<'a, T> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LookupMarker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -824,9 +824,9 @@ impl<'a> Lookup<'a, ()> {
     pub(crate) fn into_concrete<T>(self) -> Lookup<'a, T> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupMarker,
             args: std::marker::PhantomData,
             data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -837,9 +837,9 @@ impl<'a, T> Lookup<'a, T> {
     pub(crate) fn of_unit_type(&self) -> Lookup<'a, ()> {
         let TableRef { data, .. } = self;
         TableRef {
-            shape: LookupMarker,
             args: std::marker::PhantomData,
             data: *data,
+            _marker: std::marker::PhantomData,
         }
     }
 }
@@ -992,9 +992,9 @@ impl<'a> MinByteRange for CoverageFormat1<'a> {
 impl<'a> FontRead<'a> for CoverageFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CoverageFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1086,9 +1086,9 @@ impl<'a> MinByteRange for CoverageFormat2<'a> {
 impl<'a> FontRead<'a> for CoverageFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CoverageFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1313,9 +1313,9 @@ impl<'a> MinByteRange for ClassDefFormat1<'a> {
 impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClassDefFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1419,9 +1419,9 @@ impl<'a> MinByteRange for ClassDefFormat2<'a> {
 impl<'a> FontRead<'a> for ClassDefFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClassDefFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1685,9 +1685,9 @@ impl<'a> MinByteRange for SequenceContextFormat1<'a> {
 impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SequenceContextFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1818,9 +1818,9 @@ impl<'a> MinByteRange for SequenceRuleSet<'a> {
 impl<'a> FontRead<'a> for SequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SequenceRuleSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1917,9 +1917,9 @@ impl<'a> MinByteRange for SequenceRule<'a> {
 impl<'a> FontRead<'a> for SequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SequenceRuleMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2036,9 +2036,9 @@ impl<'a> MinByteRange for SequenceContextFormat2<'a> {
 impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SequenceContextFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2196,9 +2196,9 @@ impl<'a> MinByteRange for ClassSequenceRuleSet<'a> {
 impl<'a> FontRead<'a> for ClassSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClassSequenceRuleSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2298,9 +2298,9 @@ impl<'a> MinByteRange for ClassSequenceRule<'a> {
 impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ClassSequenceRuleMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2418,9 +2418,9 @@ impl<'a> MinByteRange for SequenceContextFormat3<'a> {
 impl<'a> FontRead<'a> for SequenceContextFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SequenceContextFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2647,9 +2647,9 @@ impl<'a> MinByteRange for ChainedSequenceContextFormat1<'a> {
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedSequenceContextFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2785,9 +2785,9 @@ impl<'a> MinByteRange for ChainedSequenceRuleSet<'a> {
 impl<'a> FontRead<'a> for ChainedSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedSequenceRuleSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -2887,9 +2887,9 @@ impl<'a> MinByteRange for ChainedSequenceRule<'a> {
 impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedSequenceRuleMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3072,9 +3072,9 @@ impl<'a> MinByteRange for ChainedSequenceContextFormat2<'a> {
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedSequenceContextFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3282,9 +3282,9 @@ impl<'a> MinByteRange for ChainedClassSequenceRuleSet<'a> {
 impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedClassSequenceRuleSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3386,9 +3386,9 @@ impl<'a> MinByteRange for ChainedClassSequenceRule<'a> {
 impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedClassSequenceRuleMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3572,9 +3572,9 @@ impl<'a> MinByteRange for ChainedSequenceContextFormat3<'a> {
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainedSequenceContextFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -3956,9 +3956,9 @@ impl<'a> MinByteRange for Device<'a> {
 impl<'a> FontRead<'a> for Device<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: DeviceMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4058,9 +4058,9 @@ impl<'a> MinByteRange for VariationIndex<'a> {
 impl<'a> FontRead<'a> for VariationIndex<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VariationIndexMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4219,9 +4219,9 @@ impl<'a> MinByteRange for FeatureVariations<'a> {
 impl<'a> FontRead<'a> for FeatureVariations<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FeatureVariationsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4397,9 +4397,9 @@ impl<'a> MinByteRange for ConditionSet<'a> {
 impl<'a> FontRead<'a> for ConditionSet<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionSetMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4593,9 +4593,9 @@ impl<'a> MinByteRange for ConditionFormat1<'a> {
 impl<'a> FontRead<'a> for ConditionFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4701,9 +4701,9 @@ impl<'a> MinByteRange for ConditionFormat2<'a> {
 impl<'a> FontRead<'a> for ConditionFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4788,9 +4788,9 @@ impl<'a> MinByteRange for ConditionFormat3<'a> {
 impl<'a> FontRead<'a> for ConditionFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -4902,9 +4902,9 @@ impl<'a> MinByteRange for ConditionFormat4<'a> {
 impl<'a> FontRead<'a> for ConditionFormat4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionFormat4Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5016,9 +5016,9 @@ impl<'a> MinByteRange for ConditionFormat5<'a> {
 impl<'a> FontRead<'a> for ConditionFormat5<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionFormat5Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5096,9 +5096,9 @@ impl<'a> MinByteRange for FeatureTableSubstitution<'a> {
 impl<'a> FontRead<'a> for FeatureTableSubstitution<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FeatureTableSubstitutionMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5242,9 +5242,9 @@ impl<'a> MinByteRange for SizeParams<'a> {
 impl<'a> FontRead<'a> for SizeParams<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SizeParamsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5367,9 +5367,9 @@ impl<'a> MinByteRange for StylisticSetParams<'a> {
 impl<'a> FontRead<'a> for StylisticSetParams<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: StylisticSetParamsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -5448,9 +5448,9 @@ impl<'a> MinByteRange for CharacterVariantParams<'a> {
 impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CharacterVariantParamsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -66,25 +66,25 @@ impl<'a> Ltag<'a> {
     /// Table version; currently 1.
     pub fn version(&self) -> u32 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Table flags; currently none defined.
     pub fn flags(&self) -> u32 {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of language tags which follow.
     pub fn num_tags(&self) -> u32 {
         let range = self.num_tags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Range of each tag's string.
     pub fn tag_ranges(&self) -> &'a [FTStringRange] {
         let range = self.tag_ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [language tag](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ltag.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct LtagMarker {}
+pub struct LtagMarker;
 
 impl<'a> MinByteRange for Ltag<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,20 +23,16 @@ impl TopLevelTable for Ltag<'_> {
 
 impl<'a> FontRead<'a> for Ltag<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let num_tags: u32 = cursor.read()?;
-        let tag_ranges_byte_len = (num_tags as usize)
-            .checked_mul(FTStringRange::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(tag_ranges_byte_len);
-        cursor.finish(LtagMarker {})
+        Ok(TableRef {
+            shape: LtagMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [language tag](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ltag.html) table.
-pub type Ltag<'a> = TableRef<'a, LtagMarker>;
+pub type Ltag<'a> = TableRef<'a, LtagMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Ltag<'a> {

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Ltag<'_> {
 impl<'a> FontRead<'a> for Ltag<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: LtagMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -24,84 +24,7 @@ pub struct MaxpMarker {
     max_component_depth_byte_start: Option<usize>,
 }
 
-impl MaxpMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + Version16Dot16::RAW_BYTE_LEN
-    }
-
-    pub fn num_glyphs_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn max_points_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_points_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_contours_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_contours_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_composite_points_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_composite_points_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_composite_contours_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_composite_contours_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_zones_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_zones_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_twilight_points_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_twilight_points_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_storage_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_storage_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_function_defs_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_function_defs_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_instruction_defs_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_instruction_defs_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_stack_elements_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_stack_elements_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_size_of_instructions_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_size_of_instructions_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_component_elements_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_component_elements_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn max_component_depth_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.max_component_depth_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for MaxpMarker {
+impl<'a> MinByteRange for Maxp<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.num_glyphs_byte_range().end
     }
@@ -231,70 +154,145 @@ pub type Maxp<'a> = TableRef<'a, MaxpMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Maxp<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + Version16Dot16::RAW_BYTE_LEN
+    }
+
+    pub fn num_glyphs_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn max_points_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_points_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_contours_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_contours_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_composite_points_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_composite_points_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_composite_contours_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_composite_contours_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_zones_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_zones_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_twilight_points_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_twilight_points_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_storage_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_storage_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_function_defs_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_function_defs_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_instruction_defs_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_instruction_defs_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_stack_elements_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_stack_elements_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_size_of_instructions_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_size_of_instructions_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_component_elements_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_component_elements_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn max_component_depth_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.max_component_depth_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
     /// The version: 0x00005000 for version 0.5, 0x00010000 for version 1.0.
     pub fn version(&self) -> Version16Dot16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of glyphs in the font.
     pub fn num_glyphs(&self) -> u16 {
-        let range = self.shape.num_glyphs_byte_range();
+        let range = self.num_glyphs_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum points in a non-composite glyph.
     pub fn max_points(&self) -> Option<u16> {
-        let range = self.shape.max_points_byte_range()?;
+        let range = self.max_points_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum contours in a non-composite glyph.
     pub fn max_contours(&self) -> Option<u16> {
-        let range = self.shape.max_contours_byte_range()?;
+        let range = self.max_contours_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum points in a composite glyph.
     pub fn max_composite_points(&self) -> Option<u16> {
-        let range = self.shape.max_composite_points_byte_range()?;
+        let range = self.max_composite_points_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum contours in a composite glyph.
     pub fn max_composite_contours(&self) -> Option<u16> {
-        let range = self.shape.max_composite_contours_byte_range()?;
+        let range = self.max_composite_contours_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// 1 if instructions do not use the twilight zone (Z0), or 2 if
     /// instructions do use Z0; should be set to 2 in most cases.
     pub fn max_zones(&self) -> Option<u16> {
-        let range = self.shape.max_zones_byte_range()?;
+        let range = self.max_zones_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum points used in Z0.
     pub fn max_twilight_points(&self) -> Option<u16> {
-        let range = self.shape.max_twilight_points_byte_range()?;
+        let range = self.max_twilight_points_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Number of Storage Area locations.
     pub fn max_storage(&self) -> Option<u16> {
-        let range = self.shape.max_storage_byte_range()?;
+        let range = self.max_storage_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Number of FDEFs, equal to the highest function number + 1.
     pub fn max_function_defs(&self) -> Option<u16> {
-        let range = self.shape.max_function_defs_byte_range()?;
+        let range = self.max_function_defs_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Number of IDEFs.
     pub fn max_instruction_defs(&self) -> Option<u16> {
-        let range = self.shape.max_instruction_defs_byte_range()?;
+        let range = self.max_instruction_defs_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -302,26 +300,26 @@ impl<'a> Maxp<'a> {
     /// Program ('prep' table) and all glyph instructions (in the
     /// 'glyf' table).
     pub fn max_stack_elements(&self) -> Option<u16> {
-        let range = self.shape.max_stack_elements_byte_range()?;
+        let range = self.max_stack_elements_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum byte count for glyph instructions.
     pub fn max_size_of_instructions(&self) -> Option<u16> {
-        let range = self.shape.max_size_of_instructions_byte_range()?;
+        let range = self.max_size_of_instructions_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum number of components referenced at “top level” for
     /// any composite glyph.
     pub fn max_component_elements(&self) -> Option<u16> {
-        let range = self.shape.max_component_elements_byte_range()?;
+        let range = self.max_component_elements_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Maximum levels of recursion; 1 for simple components.
     pub fn max_component_depth(&self) -> Option<u16> {
-        let range = self.shape.max_component_depth_byte_range()?;
+        let range = self.max_component_depth_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 }

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -8,21 +8,7 @@ use crate::codegen_prelude::*;
 /// [`maxp`](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MaxpMarker {
-    max_points_byte_start: Option<usize>,
-    max_contours_byte_start: Option<usize>,
-    max_composite_points_byte_start: Option<usize>,
-    max_composite_contours_byte_start: Option<usize>,
-    max_zones_byte_start: Option<usize>,
-    max_twilight_points_byte_start: Option<usize>,
-    max_storage_byte_start: Option<usize>,
-    max_function_defs_byte_start: Option<usize>,
-    max_instruction_defs_byte_start: Option<usize>,
-    max_stack_elements_byte_start: Option<usize>,
-    max_size_of_instructions_byte_start: Option<usize>,
-    max_component_elements_byte_start: Option<usize>,
-    max_component_depth_byte_start: Option<usize>,
-}
+pub struct MaxpMarker;
 
 impl<'a> MinByteRange for Maxp<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -37,120 +23,16 @@ impl TopLevelTable for Maxp<'_> {
 
 impl<'a> FontRead<'a> for Maxp<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let version: Version16Dot16 = cursor.read()?;
-        cursor.advance::<u16>();
-        let max_points_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_contours_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_composite_points_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_composite_contours_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_zones_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_twilight_points_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_storage_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_function_defs_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_instruction_defs_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_stack_elements_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_size_of_instructions_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_component_elements_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        let max_component_depth_byte_start = version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.position())
-            .transpose()?;
-        version
-            .compatible((1u16, 0u16))
-            .then(|| cursor.advance::<u16>());
-        cursor.finish(MaxpMarker {
-            max_points_byte_start,
-            max_contours_byte_start,
-            max_composite_points_byte_start,
-            max_composite_contours_byte_start,
-            max_zones_byte_start,
-            max_twilight_points_byte_start,
-            max_storage_byte_start,
-            max_function_defs_byte_start,
-            max_instruction_defs_byte_start,
-            max_stack_elements_byte_start,
-            max_size_of_instructions_byte_start,
-            max_component_elements_byte_start,
-            max_component_depth_byte_start,
+        Ok(TableRef {
+            shape: MaxpMarker,
+            args: (),
+            data,
         })
     }
 }
 
 /// [`maxp`](https://docs.microsoft.com/en-us/typography/opentype/spec/maxp)
-pub type Maxp<'a> = TableRef<'a, MaxpMarker>;
+pub type Maxp<'a> = TableRef<'a, MaxpMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Maxp<'a> {
@@ -165,68 +47,229 @@ impl<'a> Maxp<'a> {
     }
 
     pub fn max_points_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_points_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self.num_glyphs_byte_range().end;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_contours_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_contours_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_points_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| self.num_glyphs_byte_range().end);
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_composite_points_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_composite_points_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_contours_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| {
+                    self.max_points_byte_range()
+                        .map(|range| range.end)
+                        .unwrap_or_else(|| self.num_glyphs_byte_range().end)
+                });
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_composite_contours_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_composite_contours_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_composite_points_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| {
+                    self.max_contours_byte_range()
+                        .map(|range| range.end)
+                        .unwrap_or_else(|| {
+                            self.max_points_byte_range()
+                                .map(|range| range.end)
+                                .unwrap_or_else(|| self.num_glyphs_byte_range().end)
+                        })
+                });
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_zones_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_zones_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_composite_contours_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| {
+                    self.max_composite_points_byte_range()
+                        .map(|range| range.end)
+                        .unwrap_or_else(|| {
+                            self.max_contours_byte_range()
+                                .map(|range| range.end)
+                                .unwrap_or_else(|| {
+                                    self.max_points_byte_range()
+                                        .map(|range| range.end)
+                                        .unwrap_or_else(|| self.num_glyphs_byte_range().end)
+                                })
+                        })
+                });
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_twilight_points_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_twilight_points_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_zones_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| {
+                    self.max_composite_contours_byte_range()
+                        .map(|range| range.end)
+                        .unwrap_or_else(|| {
+                            self.max_composite_points_byte_range()
+                                .map(|range| range.end)
+                                .unwrap_or_else(|| {
+                                    self.max_contours_byte_range()
+                                        .map(|range| range.end)
+                                        .unwrap_or_else(|| {
+                                            self.max_points_byte_range()
+                                                .map(|range| range.end)
+                                                .unwrap_or_else(|| self.num_glyphs_byte_range().end)
+                                        })
+                                })
+                        })
+                });
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_storage_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_storage_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_twilight_points_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| {
+                    self.max_zones_byte_range()
+                        .map(|range| range.end)
+                        .unwrap_or_else(|| {
+                            self.max_composite_contours_byte_range()
+                                .map(|range| range.end)
+                                .unwrap_or_else(|| {
+                                    self.max_composite_points_byte_range()
+                                        .map(|range| range.end)
+                                        .unwrap_or_else(|| {
+                                            self.max_contours_byte_range()
+                                                .map(|range| range.end)
+                                                .unwrap_or_else(|| {
+                                                    self.max_points_byte_range()
+                                                        .map(|range| range.end)
+                                                        .unwrap_or_else(|| {
+                                                            self.num_glyphs_byte_range().end
+                                                        })
+                                                })
+                                        })
+                                })
+                        })
+                });
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_function_defs_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_function_defs_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self
+                .max_storage_byte_range()
+                .map(|range| range.end)
+                .unwrap_or_else(|| {
+                    self.max_twilight_points_byte_range()
+                        .map(|range| range.end)
+                        .unwrap_or_else(|| {
+                            self.max_zones_byte_range()
+                                .map(|range| range.end)
+                                .unwrap_or_else(|| {
+                                    self.max_composite_contours_byte_range()
+                                        .map(|range| range.end)
+                                        .unwrap_or_else(|| {
+                                            self.max_composite_points_byte_range()
+                                                .map(|range| range.end)
+                                                .unwrap_or_else(|| {
+                                                    self.max_contours_byte_range()
+                                                        .map(|range| range.end)
+                                                        .unwrap_or_else(|| {
+                                                            self.max_points_byte_range()
+                                                                .map(|range| range.end)
+                                                                .unwrap_or_else(|| {
+                                                                    self.num_glyphs_byte_range().end
+                                                                })
+                                                        })
+                                                })
+                                        })
+                                })
+                        })
+                });
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_instruction_defs_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_instruction_defs_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self . max_function_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_storage_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_twilight_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_zones_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . num_glyphs_byte_range () . end)))))))) ;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_stack_elements_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_stack_elements_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self . max_instruction_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_function_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_storage_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_twilight_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_zones_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . num_glyphs_byte_range () . end))))))))) ;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_size_of_instructions_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_size_of_instructions_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self . max_stack_elements_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_instruction_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_function_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_storage_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_twilight_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_zones_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . num_glyphs_byte_range () . end)))))))))) ;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_component_elements_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_component_elements_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self . max_size_of_instructions_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_stack_elements_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_instruction_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_function_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_storage_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_twilight_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_zones_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . num_glyphs_byte_range () . end))))))))))) ;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     pub fn max_component_depth_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.shape.max_component_depth_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
+        if self.version().compatible((1u16, 0u16)) {
+            let start = self . max_component_elements_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_size_of_instructions_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_stack_elements_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_instruction_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_function_defs_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_storage_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_twilight_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_zones_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_composite_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_contours_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . max_points_byte_range () . map (| range | range . end) . unwrap_or_else (|| self . num_glyphs_byte_range () . end)))))))))))) ;
+            Some(start..start + u16::RAW_BYTE_LEN)
+        } else {
+            None
+        }
     }
 
     /// The version: 0x00005000 for version 0.5, 0x00010000 for version 1.0.

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -275,68 +275,68 @@ impl<'a> Maxp<'a> {
     /// The version: 0x00005000 for version 0.5, 0x00010000 for version 1.0.
     pub fn version(&self) -> Version16Dot16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of glyphs in the font.
     pub fn num_glyphs(&self) -> u16 {
         let range = self.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum points in a non-composite glyph.
     pub fn max_points(&self) -> Option<u16> {
         let range = self.max_points_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum contours in a non-composite glyph.
     pub fn max_contours(&self) -> Option<u16> {
         let range = self.max_contours_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum points in a composite glyph.
     pub fn max_composite_points(&self) -> Option<u16> {
         let range = self.max_composite_points_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum contours in a composite glyph.
     pub fn max_composite_contours(&self) -> Option<u16> {
         let range = self.max_composite_contours_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// 1 if instructions do not use the twilight zone (Z0), or 2 if
     /// instructions do use Z0; should be set to 2 in most cases.
     pub fn max_zones(&self) -> Option<u16> {
         let range = self.max_zones_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum points used in Z0.
     pub fn max_twilight_points(&self) -> Option<u16> {
         let range = self.max_twilight_points_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Number of Storage Area locations.
     pub fn max_storage(&self) -> Option<u16> {
         let range = self.max_storage_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Number of FDEFs, equal to the highest function number + 1.
     pub fn max_function_defs(&self) -> Option<u16> {
         let range = self.max_function_defs_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Number of IDEFs.
     pub fn max_instruction_defs(&self) -> Option<u16> {
         let range = self.max_instruction_defs_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum stack depth across Font Program ('fpgm' table), CVT
@@ -344,26 +344,26 @@ impl<'a> Maxp<'a> {
     /// 'glyf' table).
     pub fn max_stack_elements(&self) -> Option<u16> {
         let range = self.max_stack_elements_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum byte count for glyph instructions.
     pub fn max_size_of_instructions(&self) -> Option<u16> {
         let range = self.max_size_of_instructions_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum number of components referenced at “top level” for
     /// any composite glyph.
     pub fn max_component_elements(&self) -> Option<u16> {
         let range = self.max_component_elements_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Maximum levels of recursion; 1 for simple components.
     pub fn max_component_depth(&self) -> Option<u16> {
         let range = self.max_component_depth_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Maxp<'_> {
 impl<'a> FontRead<'a> for Maxp<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MaxpMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -71,25 +71,25 @@ impl<'a> Meta<'a> {
     /// Version number of the metadata table — set to 1.
     pub fn version(&self) -> u32 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Flags — currently unused; set to 0.
     pub fn flags(&self) -> u32 {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of data maps in the table.
     pub fn data_maps_count(&self) -> u32 {
         let range = self.data_maps_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of data map records.
     pub fn data_maps(&self) -> &'a [DataMapRecord] {
         let range = self.data_maps_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Meta<'_> {
 impl<'a> FontRead<'a> for Meta<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MetaMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// [`meta`](https://docs.microsoft.com/en-us/typography/opentype/spec/meta)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MetaMarker {}
+pub struct MetaMarker;
 
 impl<'a> MinByteRange for Meta<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,21 +23,16 @@ impl TopLevelTable for Meta<'_> {
 
 impl<'a> FontRead<'a> for Meta<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let data_maps_count: u32 = cursor.read()?;
-        let data_maps_byte_len = (data_maps_count as usize)
-            .checked_mul(DataMapRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(data_maps_byte_len);
-        cursor.finish(MetaMarker {})
+        Ok(TableRef {
+            shape: MetaMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [`meta`](https://docs.microsoft.com/en-us/typography/opentype/spec/meta)
-pub type Meta<'a> = TableRef<'a, MetaMarker>;
+pub type Meta<'a> = TableRef<'a, MetaMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Meta<'a> {

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -8,11 +8,46 @@ use crate::codegen_prelude::*;
 /// [`meta`](https://docs.microsoft.com/en-us/typography/opentype/spec/meta)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MetaMarker {
-    data_maps_byte_len: usize,
+pub struct MetaMarker {}
+
+impl<'a> MinByteRange for Meta<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.data_maps_byte_range().end
+    }
 }
 
-impl MetaMarker {
+impl TopLevelTable for Meta<'_> {
+    /// `meta`
+    const TAG: Tag = Tag::new(b"meta");
+}
+
+impl<'a> FontRead<'a> for Meta<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let data_maps_count: u32 = cursor.read()?;
+        let data_maps_byte_len = (data_maps_count as usize)
+            .checked_mul(DataMapRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(data_maps_byte_len);
+        cursor.finish(MetaMarker {})
+    }
+}
+
+/// [`meta`](https://docs.microsoft.com/en-us/typography/opentype/spec/meta)
+pub type Meta<'a> = TableRef<'a, MetaMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Meta<'a> {
+    fn data_maps_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.data_maps_count()) as usize)
+            .checked_mul(DataMapRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
@@ -35,62 +70,30 @@ impl MetaMarker {
 
     pub fn data_maps_byte_range(&self) -> Range<usize> {
         let start = self.data_maps_count_byte_range().end;
-        start..start + self.data_maps_byte_len
+        start..start + self.data_maps_byte_len(start)
     }
-}
 
-impl MinByteRange for MetaMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.data_maps_byte_range().end
-    }
-}
-
-impl TopLevelTable for Meta<'_> {
-    /// `meta`
-    const TAG: Tag = Tag::new(b"meta");
-}
-
-impl<'a> FontRead<'a> for Meta<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let data_maps_count: u32 = cursor.read()?;
-        let data_maps_byte_len = (data_maps_count as usize)
-            .checked_mul(DataMapRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(data_maps_byte_len);
-        cursor.finish(MetaMarker { data_maps_byte_len })
-    }
-}
-
-/// [`meta`](https://docs.microsoft.com/en-us/typography/opentype/spec/meta)
-pub type Meta<'a> = TableRef<'a, MetaMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Meta<'a> {
     /// Version number of the metadata table — set to 1.
     pub fn version(&self) -> u32 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Flags — currently unused; set to 0.
     pub fn flags(&self) -> u32 {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of data maps in the table.
     pub fn data_maps_count(&self) -> u32 {
-        let range = self.shape.data_maps_count_byte_range();
+        let range = self.data_maps_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of data map records.
     pub fn data_maps(&self) -> &'a [DataMapRecord] {
-        let range = self.shape.data_maps_byte_range();
+        let range = self.data_maps_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -67,18 +67,18 @@ impl<'a> Morx<'a> {
     /// Version number of the extended glyph metamorphosis table (either 2 or 3).
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of metamorphosis chains contained in this table.
     pub fn n_chains(&self) -> u32 {
         let range = self.n_chains_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn chains(&self) -> VarLenArray<'a, Chain<'a>> {
         let range = self.chains_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 }
 
@@ -181,37 +181,37 @@ impl<'a> Chain<'a> {
     /// The default specification for subtables.
     pub fn default_flags(&self) -> u32 {
         let range = self.default_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Total byte count, including this header; must be a multiple of 4.
     pub fn chain_length(&self) -> u32 {
         let range = self.chain_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of feature subtable entries.
     pub fn n_feature_entries(&self) -> u32 {
         let range = self.n_feature_entries_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of subtables in the chain.
     pub fn n_subtables(&self) -> u32 {
         let range = self.n_subtables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Feature entries for this chain.
     pub fn features(&self) -> &'a [Feature] {
         let range = self.features_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Array of chain subtables.
     pub fn subtables(&self) -> VarLenArray<'a, Subtable<'a>> {
         let range = self.subtables_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 }
 
@@ -367,25 +367,25 @@ impl<'a> Subtable<'a> {
     /// Total subtable length, including this header.
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Coverage flags and subtable type.
     pub fn coverage(&self) -> u32 {
         let range = self.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).
     pub fn sub_feature_flags(&self) -> u32 {
         let range = self.sub_feature_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Data for specific subtable.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -8,33 +8,9 @@ use crate::codegen_prelude::*;
 /// The [morx (Extended Glyph Metamorphosis)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MorxMarker {
-    chains_byte_len: usize,
-}
+pub struct MorxMarker {}
 
-impl MorxMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn unused_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn n_chains_byte_range(&self) -> Range<usize> {
-        let start = self.unused_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn chains_byte_range(&self) -> Range<usize> {
-        let start = self.n_chains_byte_range().end;
-        start..start + self.chains_byte_len
-    }
-}
-
-impl MinByteRange for MorxMarker {
+impl<'a> MinByteRange for Morx<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.chains_byte_range().end
     }
@@ -56,7 +32,7 @@ impl<'a> FontRead<'a> for Morx<'a> {
             <Chain as VarSize>::total_len_for_count(data, n_chains as usize)?
         };
         cursor.advance_by(chains_byte_len);
-        cursor.finish(MorxMarker { chains_byte_len })
+        cursor.finish(MorxMarker {})
     }
 }
 
@@ -65,20 +41,48 @@ pub type Morx<'a> = TableRef<'a, MorxMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Morx<'a> {
+    fn chains_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let data = self.data.split_off(start).unwrap();
+            <Chain as VarSize>::total_len_for_count(data, (self.n_chains()) as usize).unwrap()
+        }
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn unused_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn n_chains_byte_range(&self) -> Range<usize> {
+        let start = self.unused_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn chains_byte_range(&self) -> Range<usize> {
+        let start = self.n_chains_byte_range().end;
+        start..start + self.chains_byte_len(start)
+    }
+
     /// Version number of the extended glyph metamorphosis table (either 2 or 3).
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of metamorphosis chains contained in this table.
     pub fn n_chains(&self) -> u32 {
-        let range = self.shape.n_chains_byte_range();
+        let range = self.n_chains_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn chains(&self) -> VarLenArray<'a, Chain<'a>> {
-        let range = self.shape.chains_byte_range();
+        let range = self.chains_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
     }
 }
@@ -112,12 +116,53 @@ impl<'a> std::fmt::Debug for Morx<'a> {
 /// A chain in a `morx` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainMarker {
-    features_byte_len: usize,
-    subtables_byte_len: usize,
+pub struct ChainMarker {}
+
+impl<'a> MinByteRange for Chain<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.subtables_byte_range().end
+    }
 }
 
-impl ChainMarker {
+impl<'a> FontRead<'a> for Chain<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let n_feature_entries: u32 = cursor.read()?;
+        let n_subtables: u32 = cursor.read()?;
+        let features_byte_len = (n_feature_entries as usize)
+            .checked_mul(Feature::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(features_byte_len);
+        let subtables_byte_len = {
+            let data = cursor.remaining().ok_or(ReadError::OutOfBounds)?;
+            <Subtable as VarSize>::total_len_for_count(data, n_subtables as usize)?
+        };
+        cursor.advance_by(subtables_byte_len);
+        cursor.finish(ChainMarker {})
+    }
+}
+
+/// A chain in a `morx` table.
+pub type Chain<'a> = TableRef<'a, ChainMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Chain<'a> {
+    fn features_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_feature_entries()) as usize)
+            .checked_mul(Feature::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn subtables_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let data = self.data.split_off(start).unwrap();
+            <Subtable as VarSize>::total_len_for_count(data, (self.n_subtables()) as usize).unwrap()
+        }
+    }
+
     pub fn default_flags_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
@@ -140,82 +185,47 @@ impl ChainMarker {
 
     pub fn features_byte_range(&self) -> Range<usize> {
         let start = self.n_subtables_byte_range().end;
-        start..start + self.features_byte_len
+        start..start + self.features_byte_len(start)
     }
 
     pub fn subtables_byte_range(&self) -> Range<usize> {
         let start = self.features_byte_range().end;
-        start..start + self.subtables_byte_len
+        start..start + self.subtables_byte_len(start)
     }
-}
 
-impl MinByteRange for ChainMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.subtables_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Chain<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let n_feature_entries: u32 = cursor.read()?;
-        let n_subtables: u32 = cursor.read()?;
-        let features_byte_len = (n_feature_entries as usize)
-            .checked_mul(Feature::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(features_byte_len);
-        let subtables_byte_len = {
-            let data = cursor.remaining().ok_or(ReadError::OutOfBounds)?;
-            <Subtable as VarSize>::total_len_for_count(data, n_subtables as usize)?
-        };
-        cursor.advance_by(subtables_byte_len);
-        cursor.finish(ChainMarker {
-            features_byte_len,
-            subtables_byte_len,
-        })
-    }
-}
-
-/// A chain in a `morx` table.
-pub type Chain<'a> = TableRef<'a, ChainMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Chain<'a> {
     /// The default specification for subtables.
     pub fn default_flags(&self) -> u32 {
-        let range = self.shape.default_flags_byte_range();
+        let range = self.default_flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Total byte count, including this header; must be a multiple of 4.
     pub fn chain_length(&self) -> u32 {
-        let range = self.shape.chain_length_byte_range();
+        let range = self.chain_length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of feature subtable entries.
     pub fn n_feature_entries(&self) -> u32 {
-        let range = self.shape.n_feature_entries_byte_range();
+        let range = self.n_feature_entries_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of subtables in the chain.
     pub fn n_subtables(&self) -> u32 {
-        let range = self.shape.n_subtables_byte_range();
+        let range = self.n_subtables_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Feature entries for this chain.
     pub fn features(&self) -> &'a [Feature] {
-        let range = self.shape.features_byte_range();
+        let range = self.features_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Array of chain subtables.
     pub fn subtables(&self) -> VarLenArray<'a, Subtable<'a>> {
-        let range = self.shape.subtables_byte_range();
+        let range = self.subtables_byte_range();
         VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
     }
 }
@@ -318,11 +328,39 @@ impl<'a> SomeRecord<'a> for Feature {
 /// A subtable in a `morx` chain.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SubtableMarker {
-    data_byte_len: usize,
+pub struct SubtableMarker {}
+
+impl<'a> MinByteRange for Subtable<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.data_byte_range().end
+    }
 }
 
-impl SubtableMarker {
+impl<'a> FontRead<'a> for Subtable<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        cursor.advance::<u32>();
+        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(data_byte_len);
+        cursor.finish(SubtableMarker {})
+    }
+}
+
+/// A subtable in a `morx` chain.
+pub type Subtable<'a> = TableRef<'a, SubtableMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Subtable<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u32::RAW_BYTE_LEN
@@ -340,54 +378,30 @@ impl SubtableMarker {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.sub_feature_flags_byte_range().end;
-        start..start + self.data_byte_len
+        start..start + self.data_byte_len(start)
     }
-}
 
-impl MinByteRange for SubtableMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for Subtable<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(SubtableMarker { data_byte_len })
-    }
-}
-
-/// A subtable in a `morx` chain.
-pub type Subtable<'a> = TableRef<'a, SubtableMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Subtable<'a> {
     /// Total subtable length, including this header.
     pub fn length(&self) -> u32 {
-        let range = self.shape.length_byte_range();
+        let range = self.length_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Coverage flags and subtable type.
     pub fn coverage(&self) -> u32 {
-        let range = self.shape.coverage_byte_range();
+        let range = self.coverage_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).
     pub fn sub_feature_flags(&self) -> u32 {
-        let range = self.shape.sub_feature_flags_byte_range();
+        let range = self.sub_feature_flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Data for specific subtable.
     pub fn data(&self) -> &'a [u8] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Morx<'_> {
 impl<'a> FontRead<'a> for Morx<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MorxMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -122,9 +122,9 @@ impl<'a> MinByteRange for Chain<'a> {
 impl<'a> FontRead<'a> for Chain<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ChainMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -324,9 +324,9 @@ impl<'a> MinByteRange for Subtable<'a> {
 impl<'a> FontRead<'a> for Subtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SubtableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [morx (Extended Glyph Metamorphosis)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MorxMarker {}
+pub struct MorxMarker;
 
 impl<'a> MinByteRange for Morx<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,21 +23,16 @@ impl TopLevelTable for Morx<'_> {
 
 impl<'a> FontRead<'a> for Morx<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let n_chains: u32 = cursor.read()?;
-        let chains_byte_len = {
-            let data = cursor.remaining().ok_or(ReadError::OutOfBounds)?;
-            <Chain as VarSize>::total_len_for_count(data, n_chains as usize)?
-        };
-        cursor.advance_by(chains_byte_len);
-        cursor.finish(MorxMarker {})
+        Ok(TableRef {
+            shape: MorxMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [morx (Extended Glyph Metamorphosis)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html) table.
-pub type Morx<'a> = TableRef<'a, MorxMarker>;
+pub type Morx<'a> = TableRef<'a, MorxMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Morx<'a> {
@@ -116,7 +111,7 @@ impl<'a> std::fmt::Debug for Morx<'a> {
 /// A chain in a `morx` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ChainMarker {}
+pub struct ChainMarker;
 
 impl<'a> MinByteRange for Chain<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -126,26 +121,16 @@ impl<'a> MinByteRange for Chain<'a> {
 
 impl<'a> FontRead<'a> for Chain<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let n_feature_entries: u32 = cursor.read()?;
-        let n_subtables: u32 = cursor.read()?;
-        let features_byte_len = (n_feature_entries as usize)
-            .checked_mul(Feature::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(features_byte_len);
-        let subtables_byte_len = {
-            let data = cursor.remaining().ok_or(ReadError::OutOfBounds)?;
-            <Subtable as VarSize>::total_len_for_count(data, n_subtables as usize)?
-        };
-        cursor.advance_by(subtables_byte_len);
-        cursor.finish(ChainMarker {})
+        Ok(TableRef {
+            shape: ChainMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// A chain in a `morx` table.
-pub type Chain<'a> = TableRef<'a, ChainMarker>;
+pub type Chain<'a> = TableRef<'a, ChainMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Chain<'a> {
@@ -328,7 +313,7 @@ impl<'a> SomeRecord<'a> for Feature {
 /// A subtable in a `morx` chain.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SubtableMarker {}
+pub struct SubtableMarker;
 
 impl<'a> MinByteRange for Subtable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -338,18 +323,16 @@ impl<'a> MinByteRange for Subtable<'a> {
 
 impl<'a> FontRead<'a> for Subtable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        cursor.advance::<u32>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(SubtableMarker {})
+        Ok(TableRef {
+            shape: SubtableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// A subtable in a `morx` chain.
-pub type Subtable<'a> = TableRef<'a, SubtableMarker>;
+pub type Subtable<'a> = TableRef<'a, SubtableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Subtable<'a> {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -8,11 +8,47 @@ use crate::codegen_prelude::*;
 /// The [MVAR (Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MvarMarker {
-    value_records_byte_len: usize,
+pub struct MvarMarker {}
+
+impl<'a> MinByteRange for Mvar<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.value_records_byte_range().end
+    }
 }
 
-impl MvarMarker {
+impl TopLevelTable for Mvar<'_> {
+    /// `MVAR`
+    const TAG: Tag = Tag::new(b"MVAR");
+}
+
+impl<'a> FontRead<'a> for Mvar<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<MajorMinor>();
+        cursor.advance::<u16>();
+        cursor.advance::<u16>();
+        let value_record_count: u16 = cursor.read()?;
+        cursor.advance::<Offset16>();
+        let value_records_byte_len = (value_record_count as usize)
+            .checked_mul(ValueRecord::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(value_records_byte_len);
+        cursor.finish(MvarMarker {})
+    }
+}
+
+/// The [MVAR (Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
+pub type Mvar<'a> = TableRef<'a, MvarMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Mvar<'a> {
+    fn value_records_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.value_record_count()) as usize)
+            .checked_mul(ValueRecord::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + MajorMinor::RAW_BYTE_LEN
@@ -40,66 +76,31 @@ impl MvarMarker {
 
     pub fn value_records_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_store_offset_byte_range().end;
-        start..start + self.value_records_byte_len
+        start..start + self.value_records_byte_len(start)
     }
-}
 
-impl MinByteRange for MvarMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.value_records_byte_range().end
-    }
-}
-
-impl TopLevelTable for Mvar<'_> {
-    /// `MVAR`
-    const TAG: Tag = Tag::new(b"MVAR");
-}
-
-impl<'a> FontRead<'a> for Mvar<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let value_record_count: u16 = cursor.read()?;
-        cursor.advance::<Offset16>();
-        let value_records_byte_len = (value_record_count as usize)
-            .checked_mul(ValueRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(value_records_byte_len);
-        cursor.finish(MvarMarker {
-            value_records_byte_len,
-        })
-    }
-}
-
-/// The [MVAR (Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
-pub type Mvar<'a> = TableRef<'a, MvarMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Mvar<'a> {
     /// Major version number of the horizontal metrics variations table — set to 1.
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The size in bytes of each value record — must be greater than zero.
     pub fn value_record_size(&self) -> u16 {
-        let range = self.shape.value_record_size_byte_range();
+        let range = self.value_record_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of value records — may be zero.
     pub fn value_record_count(&self) -> u16 {
-        let range = self.shape.value_record_count_byte_range();
+        let range = self.value_record_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset in bytes from the start of this table to the item variation store table. If valueRecordCount is zero, set to zero; if valueRecordCount is greater than zero, must be greater than zero.
     pub fn item_variation_store_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.item_variation_store_offset_byte_range();
+        let range = self.item_variation_store_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -111,7 +112,7 @@ impl<'a> Mvar<'a> {
 
     /// Array of value records that identify target items and the associated delta-set index for each. The valueTag records must be in binary order of their valueTag field.
     pub fn value_records(&self) -> &'a [ValueRecord] {
-        let range = self.shape.value_records_byte_range();
+        let range = self.value_records_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -77,25 +77,25 @@ impl<'a> Mvar<'a> {
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The size in bytes of each value record — must be greater than zero.
     pub fn value_record_size(&self) -> u16 {
         let range = self.value_record_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of value records — may be zero.
     pub fn value_record_count(&self) -> u16 {
         let range = self.value_record_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the start of this table to the item variation store table. If valueRecordCount is zero, set to zero; if valueRecordCount is greater than zero, must be greater than zero.
     pub fn item_variation_store_offset(&self) -> Nullable<Offset16> {
         let range = self.item_variation_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -107,7 +107,7 @@ impl<'a> Mvar<'a> {
     /// Array of value records that identify target items and the associated delta-set index for each. The valueTag records must be in binary order of their valueTag field.
     pub fn value_records(&self) -> &'a [ValueRecord] {
         let range = self.value_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [MVAR (Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MvarMarker {}
+pub struct MvarMarker;
 
 impl<'a> MinByteRange for Mvar<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,22 +23,16 @@ impl TopLevelTable for Mvar<'_> {
 
 impl<'a> FontRead<'a> for Mvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        let value_record_count: u16 = cursor.read()?;
-        cursor.advance::<Offset16>();
-        let value_records_byte_len = (value_record_count as usize)
-            .checked_mul(ValueRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(value_records_byte_len);
-        cursor.finish(MvarMarker {})
+        Ok(TableRef {
+            shape: MvarMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [MVAR (Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/mvar) table
-pub type Mvar<'a> = TableRef<'a, MvarMarker>;
+pub type Mvar<'a> = TableRef<'a, MvarMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Mvar<'a> {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Mvar<'_> {
 impl<'a> FontRead<'a> for Mvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -93,37 +93,37 @@ impl<'a> Name<'a> {
     /// Table version number (0 or 1)
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of name records.
     pub fn count(&self) -> u16 {
         let range = self.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to start of string storage (from start of table).
     pub fn storage_offset(&self) -> u16 {
         let range = self.storage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The name records where count is the number of records.
     pub fn name_record(&self) -> &'a [NameRecord] {
         let range = self.name_record_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Number of language-tag records.
     pub fn lang_tag_count(&self) -> Option<u16> {
         let range = self.lang_tag_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// The language-tag records where langTagCount is the number of records.
     pub fn lang_tag_record(&self) -> Option<&'a [LangTagRecord]> {
         let range = self.lang_tag_record_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 }
 

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Name<'_> {
 impl<'a> FontRead<'a> for Name<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: NameMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -377,9 +377,9 @@ impl TopLevelTable for Os2<'_> {
 impl<'a> FontRead<'a> for Os2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Os2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -739,7 +739,7 @@ impl<'a> Os2<'a> {
 
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Average weighted escapement](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#xavgcharwidth).
@@ -748,7 +748,7 @@ impl<'a> Os2<'a> {
     /// of the escapement (width) of all non-zero width glyphs in the font.
     pub fn x_avg_char_width(&self) -> i16 {
         let range = self.x_avg_char_width_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Weight class](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass).
@@ -757,7 +757,7 @@ impl<'a> Os2<'a> {
     /// strokes) of the characters in the font. Values from 1 to 1000 are valid.
     pub fn us_weight_class(&self) -> u16 {
         let range = self.us_weight_class_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Width class](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
@@ -766,7 +766,7 @@ impl<'a> Os2<'a> {
     /// ratio) as specified by a font designer for the glyphs in a font.
     pub fn us_width_class(&self) -> u16 {
         let range = self.us_width_class_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Type flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fstype).
@@ -774,83 +774,83 @@ impl<'a> Os2<'a> {
     /// Indicates font embedding licensing rights for the font.
     pub fn fs_type(&self) -> u16 {
         let range = self.fs_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended horizontal size in font design units for subscripts for
     /// this font.
     pub fn y_subscript_x_size(&self) -> i16 {
         let range = self.y_subscript_x_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended vertical size in font design units for subscripts for
     /// this font.
     pub fn y_subscript_y_size(&self) -> i16 {
         let range = self.y_subscript_y_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended horizontal offset in font design units for subscripts
     /// for this font.
     pub fn y_subscript_x_offset(&self) -> i16 {
         let range = self.y_subscript_x_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended vertical offset in font design units for subscripts
     /// for this font.
     pub fn y_subscript_y_offset(&self) -> i16 {
         let range = self.y_subscript_y_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended horizontal size in font design units for superscripts
     /// for this font.
     pub fn y_superscript_x_size(&self) -> i16 {
         let range = self.y_superscript_x_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended vertical size in font design units for superscripts
     /// for this font.
     pub fn y_superscript_y_size(&self) -> i16 {
         let range = self.y_superscript_y_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended horizontal offset in font design units for superscripts
     /// for this font.
     pub fn y_superscript_x_offset(&self) -> i16 {
         let range = self.y_superscript_x_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The recommended vertical offset in font design units for superscripts
     /// for this font.
     pub fn y_superscript_y_offset(&self) -> i16 {
         let range = self.y_superscript_y_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Thickness of the strikeout stroke in font design units.
     pub fn y_strikeout_size(&self) -> i16 {
         let range = self.y_strikeout_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The position of the top of the strikeout stroke relative to the
     /// baseline in font design units.
     pub fn y_strikeout_position(&self) -> i16 {
         let range = self.y_strikeout_position_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Font-family class and subclass](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#sfamilyclass).
     /// This parameter is a classification of font-family design.
     pub fn s_family_class(&self) -> i16 {
         let range = self.s_family_class_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [PANOSE classification number](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#panose).
@@ -859,7 +859,7 @@ impl<'a> Os2<'a> {
     /// character sets.
     pub fn panose_10(&self) -> &'a [u8] {
         let range = self.panose_10_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// [Unicode Character Range](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#ulunicoderange1-bits-031ulunicoderange2-bits-3263ulunicoderange3-bits-6495ulunicoderange4-bits-96127).
@@ -867,25 +867,25 @@ impl<'a> Os2<'a> {
     /// Unicode Character Range (bits 0-31).
     pub fn ul_unicode_range_1(&self) -> u32 {
         let range = self.ul_unicode_range_1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Unicode Character Range (bits 32-63).
     pub fn ul_unicode_range_2(&self) -> u32 {
         let range = self.ul_unicode_range_2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Unicode Character Range (bits 64-95).
     pub fn ul_unicode_range_3(&self) -> u32 {
         let range = self.ul_unicode_range_3_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Unicode Character Range (bits 96-127).
     pub fn ul_unicode_range_4(&self) -> u32 {
         let range = self.ul_unicode_range_4_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Font Vendor Identification](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#achvendid).
@@ -893,7 +893,7 @@ impl<'a> Os2<'a> {
     /// The four-character identifier for the vendor of the given type face.
     pub fn ach_vend_id(&self) -> Tag {
         let range = self.ach_vend_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// [Font selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection).
@@ -901,37 +901,37 @@ impl<'a> Os2<'a> {
     /// Contains information concerning the nature of the font patterns.
     pub fn fs_selection(&self) -> SelectionFlags {
         let range = self.fs_selection_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The minimum Unicode index (character code) in this font.
     pub fn us_first_char_index(&self) -> u16 {
         let range = self.us_first_char_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The maximum Unicode index (character code) in this font.
     pub fn us_last_char_index(&self) -> u16 {
         let range = self.us_last_char_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The typographic ascender for this font.
     pub fn s_typo_ascender(&self) -> i16 {
         let range = self.s_typo_ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The typographic descender for this font.
     pub fn s_typo_descender(&self) -> i16 {
         let range = self.s_typo_descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The typographic line gap for this font.
     pub fn s_typo_line_gap(&self) -> i16 {
         let range = self.s_typo_line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The “Windows ascender” metric.
@@ -940,7 +940,7 @@ impl<'a> Os2<'a> {
     /// clipping region.
     pub fn us_win_ascent(&self) -> u16 {
         let range = self.us_win_ascent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The “Windows descender” metric.
@@ -949,19 +949,19 @@ impl<'a> Os2<'a> {
     /// for a clipping region.
     pub fn us_win_descent(&self) -> u16 {
         let range = self.us_win_descent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Code page character range bits 0-31.
     pub fn ul_code_page_range_1(&self) -> Option<u32> {
         let range = self.ul_code_page_range_1_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Code page character range bits 32-63.
     pub fn ul_code_page_range_2(&self) -> Option<u32> {
         let range = self.ul_code_page_range_2_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This metric specifies the distance between the baseline and the
@@ -969,46 +969,46 @@ impl<'a> Os2<'a> {
     /// FUnits.
     pub fn sx_height(&self) -> Option<i16> {
         let range = self.sx_height_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This metric specifies the distance between the baseline and the
     /// approximate height of uppercase letters measured in FUnits.
     pub fn s_cap_height(&self) -> Option<i16> {
         let range = self.s_cap_height_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used for a default glyph.
     pub fn us_default_char(&self) -> Option<u16> {
         let range = self.us_default_char_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used as a default break character.
     pub fn us_break_char(&self) -> Option<u16> {
         let range = self.us_break_char_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_max_context(&self) -> Option<u16> {
         let range = self.us_max_context_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_lower_optical_point_size(&self) -> Option<u16> {
         let range = self.us_lower_optical_point_size_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_upper_optical_point_size(&self) -> Option<u16> {
         let range = self.us_upper_optical_point_size_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -362,7 +362,6 @@ impl<'a> From<SelectionFlags> for FieldType<'a> {
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct Os2Marker {
-    panose_10_byte_len: usize,
     ul_code_page_range_1_byte_start: Option<usize>,
     ul_code_page_range_2_byte_start: Option<usize>,
     sx_height_byte_start: Option<usize>,
@@ -374,204 +373,7 @@ pub struct Os2Marker {
     us_upper_optical_point_size_byte_start: Option<usize>,
 }
 
-impl Os2Marker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn x_avg_char_width_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn us_weight_class_byte_range(&self) -> Range<usize> {
-        let start = self.x_avg_char_width_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn us_width_class_byte_range(&self) -> Range<usize> {
-        let start = self.us_weight_class_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn fs_type_byte_range(&self) -> Range<usize> {
-        let start = self.us_width_class_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn y_subscript_x_size_byte_range(&self) -> Range<usize> {
-        let start = self.fs_type_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_subscript_y_size_byte_range(&self) -> Range<usize> {
-        let start = self.y_subscript_x_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_subscript_x_offset_byte_range(&self) -> Range<usize> {
-        let start = self.y_subscript_y_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_subscript_y_offset_byte_range(&self) -> Range<usize> {
-        let start = self.y_subscript_x_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_superscript_x_size_byte_range(&self) -> Range<usize> {
-        let start = self.y_subscript_y_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_superscript_y_size_byte_range(&self) -> Range<usize> {
-        let start = self.y_superscript_x_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_superscript_x_offset_byte_range(&self) -> Range<usize> {
-        let start = self.y_superscript_y_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_superscript_y_offset_byte_range(&self) -> Range<usize> {
-        let start = self.y_superscript_x_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_strikeout_size_byte_range(&self) -> Range<usize> {
-        let start = self.y_superscript_y_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn y_strikeout_position_byte_range(&self) -> Range<usize> {
-        let start = self.y_strikeout_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn s_family_class_byte_range(&self) -> Range<usize> {
-        let start = self.y_strikeout_position_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn panose_10_byte_range(&self) -> Range<usize> {
-        let start = self.s_family_class_byte_range().end;
-        start..start + self.panose_10_byte_len
-    }
-
-    pub fn ul_unicode_range_1_byte_range(&self) -> Range<usize> {
-        let start = self.panose_10_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn ul_unicode_range_2_byte_range(&self) -> Range<usize> {
-        let start = self.ul_unicode_range_1_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn ul_unicode_range_3_byte_range(&self) -> Range<usize> {
-        let start = self.ul_unicode_range_2_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn ul_unicode_range_4_byte_range(&self) -> Range<usize> {
-        let start = self.ul_unicode_range_3_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn ach_vend_id_byte_range(&self) -> Range<usize> {
-        let start = self.ul_unicode_range_4_byte_range().end;
-        start..start + Tag::RAW_BYTE_LEN
-    }
-
-    pub fn fs_selection_byte_range(&self) -> Range<usize> {
-        let start = self.ach_vend_id_byte_range().end;
-        start..start + SelectionFlags::RAW_BYTE_LEN
-    }
-
-    pub fn us_first_char_index_byte_range(&self) -> Range<usize> {
-        let start = self.fs_selection_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn us_last_char_index_byte_range(&self) -> Range<usize> {
-        let start = self.us_first_char_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn s_typo_ascender_byte_range(&self) -> Range<usize> {
-        let start = self.us_last_char_index_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn s_typo_descender_byte_range(&self) -> Range<usize> {
-        let start = self.s_typo_ascender_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn s_typo_line_gap_byte_range(&self) -> Range<usize> {
-        let start = self.s_typo_descender_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
-    }
-
-    pub fn us_win_ascent_byte_range(&self) -> Range<usize> {
-        let start = self.s_typo_line_gap_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn us_win_descent_byte_range(&self) -> Range<usize> {
-        let start = self.us_win_ascent_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn ul_code_page_range_1_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.ul_code_page_range_1_byte_start?;
-        Some(start..start + u32::RAW_BYTE_LEN)
-    }
-
-    pub fn ul_code_page_range_2_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.ul_code_page_range_2_byte_start?;
-        Some(start..start + u32::RAW_BYTE_LEN)
-    }
-
-    pub fn sx_height_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.sx_height_byte_start?;
-        Some(start..start + i16::RAW_BYTE_LEN)
-    }
-
-    pub fn s_cap_height_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.s_cap_height_byte_start?;
-        Some(start..start + i16::RAW_BYTE_LEN)
-    }
-
-    pub fn us_default_char_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.us_default_char_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn us_break_char_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.us_break_char_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn us_max_context_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.us_max_context_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn us_lower_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.us_lower_optical_point_size_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn us_upper_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.us_upper_optical_point_size_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for Os2Marker {
+impl<'a> MinByteRange for Os2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.us_win_descent_byte_range().end
     }
@@ -664,7 +466,6 @@ impl<'a> FontRead<'a> for Os2<'a> {
             .transpose()?;
         version.compatible(5u16).then(|| cursor.advance::<u16>());
         cursor.finish(Os2Marker {
-            panose_10_byte_len,
             ul_code_page_range_1_byte_start,
             ul_code_page_range_2_byte_start,
             sx_height_byte_start,
@@ -683,8 +484,208 @@ pub type Os2<'a> = TableRef<'a, Os2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Os2<'a> {
+    fn panose_10_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (10_usize).checked_mul(u8::RAW_BYTE_LEN).unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn x_avg_char_width_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn us_weight_class_byte_range(&self) -> Range<usize> {
+        let start = self.x_avg_char_width_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn us_width_class_byte_range(&self) -> Range<usize> {
+        let start = self.us_weight_class_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn fs_type_byte_range(&self) -> Range<usize> {
+        let start = self.us_width_class_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn y_subscript_x_size_byte_range(&self) -> Range<usize> {
+        let start = self.fs_type_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_subscript_y_size_byte_range(&self) -> Range<usize> {
+        let start = self.y_subscript_x_size_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_subscript_x_offset_byte_range(&self) -> Range<usize> {
+        let start = self.y_subscript_y_size_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_subscript_y_offset_byte_range(&self) -> Range<usize> {
+        let start = self.y_subscript_x_offset_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_superscript_x_size_byte_range(&self) -> Range<usize> {
+        let start = self.y_subscript_y_offset_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_superscript_y_size_byte_range(&self) -> Range<usize> {
+        let start = self.y_superscript_x_size_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_superscript_x_offset_byte_range(&self) -> Range<usize> {
+        let start = self.y_superscript_y_size_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_superscript_y_offset_byte_range(&self) -> Range<usize> {
+        let start = self.y_superscript_x_offset_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_strikeout_size_byte_range(&self) -> Range<usize> {
+        let start = self.y_superscript_y_offset_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn y_strikeout_position_byte_range(&self) -> Range<usize> {
+        let start = self.y_strikeout_size_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn s_family_class_byte_range(&self) -> Range<usize> {
+        let start = self.y_strikeout_position_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn panose_10_byte_range(&self) -> Range<usize> {
+        let start = self.s_family_class_byte_range().end;
+        start..start + self.panose_10_byte_len(start)
+    }
+
+    pub fn ul_unicode_range_1_byte_range(&self) -> Range<usize> {
+        let start = self.panose_10_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn ul_unicode_range_2_byte_range(&self) -> Range<usize> {
+        let start = self.ul_unicode_range_1_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn ul_unicode_range_3_byte_range(&self) -> Range<usize> {
+        let start = self.ul_unicode_range_2_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn ul_unicode_range_4_byte_range(&self) -> Range<usize> {
+        let start = self.ul_unicode_range_3_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn ach_vend_id_byte_range(&self) -> Range<usize> {
+        let start = self.ul_unicode_range_4_byte_range().end;
+        start..start + Tag::RAW_BYTE_LEN
+    }
+
+    pub fn fs_selection_byte_range(&self) -> Range<usize> {
+        let start = self.ach_vend_id_byte_range().end;
+        start..start + SelectionFlags::RAW_BYTE_LEN
+    }
+
+    pub fn us_first_char_index_byte_range(&self) -> Range<usize> {
+        let start = self.fs_selection_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn us_last_char_index_byte_range(&self) -> Range<usize> {
+        let start = self.us_first_char_index_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn s_typo_ascender_byte_range(&self) -> Range<usize> {
+        let start = self.us_last_char_index_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn s_typo_descender_byte_range(&self) -> Range<usize> {
+        let start = self.s_typo_ascender_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn s_typo_line_gap_byte_range(&self) -> Range<usize> {
+        let start = self.s_typo_descender_byte_range().end;
+        start..start + i16::RAW_BYTE_LEN
+    }
+
+    pub fn us_win_ascent_byte_range(&self) -> Range<usize> {
+        let start = self.s_typo_line_gap_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn us_win_descent_byte_range(&self) -> Range<usize> {
+        let start = self.us_win_ascent_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn ul_code_page_range_1_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.ul_code_page_range_1_byte_start?;
+        Some(start..start + u32::RAW_BYTE_LEN)
+    }
+
+    pub fn ul_code_page_range_2_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.ul_code_page_range_2_byte_start?;
+        Some(start..start + u32::RAW_BYTE_LEN)
+    }
+
+    pub fn sx_height_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.sx_height_byte_start?;
+        Some(start..start + i16::RAW_BYTE_LEN)
+    }
+
+    pub fn s_cap_height_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.s_cap_height_byte_start?;
+        Some(start..start + i16::RAW_BYTE_LEN)
+    }
+
+    pub fn us_default_char_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.us_default_char_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn us_break_char_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.us_break_char_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn us_max_context_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.us_max_context_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn us_lower_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.us_lower_optical_point_size_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn us_upper_optical_point_size_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.us_upper_optical_point_size_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -693,7 +694,7 @@ impl<'a> Os2<'a> {
     /// The Average Character Width parameter specifies the arithmetic average
     /// of the escapement (width) of all non-zero width glyphs in the font.
     pub fn x_avg_char_width(&self) -> i16 {
-        let range = self.shape.x_avg_char_width_byte_range();
+        let range = self.x_avg_char_width_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -702,7 +703,7 @@ impl<'a> Os2<'a> {
     /// Indicates the visual weight (degree of blackness or thickness of
     /// strokes) of the characters in the font. Values from 1 to 1000 are valid.
     pub fn us_weight_class(&self) -> u16 {
-        let range = self.shape.us_weight_class_byte_range();
+        let range = self.us_weight_class_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -711,7 +712,7 @@ impl<'a> Os2<'a> {
     /// Indicates a relative change from the normal aspect ratio (width to height
     /// ratio) as specified by a font designer for the glyphs in a font.
     pub fn us_width_class(&self) -> u16 {
-        let range = self.shape.us_width_class_byte_range();
+        let range = self.us_width_class_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -719,83 +720,83 @@ impl<'a> Os2<'a> {
     ///
     /// Indicates font embedding licensing rights for the font.
     pub fn fs_type(&self) -> u16 {
-        let range = self.shape.fs_type_byte_range();
+        let range = self.fs_type_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended horizontal size in font design units for subscripts for
     /// this font.
     pub fn y_subscript_x_size(&self) -> i16 {
-        let range = self.shape.y_subscript_x_size_byte_range();
+        let range = self.y_subscript_x_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended vertical size in font design units for subscripts for
     /// this font.
     pub fn y_subscript_y_size(&self) -> i16 {
-        let range = self.shape.y_subscript_y_size_byte_range();
+        let range = self.y_subscript_y_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended horizontal offset in font design units for subscripts
     /// for this font.
     pub fn y_subscript_x_offset(&self) -> i16 {
-        let range = self.shape.y_subscript_x_offset_byte_range();
+        let range = self.y_subscript_x_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended vertical offset in font design units for subscripts
     /// for this font.
     pub fn y_subscript_y_offset(&self) -> i16 {
-        let range = self.shape.y_subscript_y_offset_byte_range();
+        let range = self.y_subscript_y_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended horizontal size in font design units for superscripts
     /// for this font.
     pub fn y_superscript_x_size(&self) -> i16 {
-        let range = self.shape.y_superscript_x_size_byte_range();
+        let range = self.y_superscript_x_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended vertical size in font design units for superscripts
     /// for this font.
     pub fn y_superscript_y_size(&self) -> i16 {
-        let range = self.shape.y_superscript_y_size_byte_range();
+        let range = self.y_superscript_y_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended horizontal offset in font design units for superscripts
     /// for this font.
     pub fn y_superscript_x_offset(&self) -> i16 {
-        let range = self.shape.y_superscript_x_offset_byte_range();
+        let range = self.y_superscript_x_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The recommended vertical offset in font design units for superscripts
     /// for this font.
     pub fn y_superscript_y_offset(&self) -> i16 {
-        let range = self.shape.y_superscript_y_offset_byte_range();
+        let range = self.y_superscript_y_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Thickness of the strikeout stroke in font design units.
     pub fn y_strikeout_size(&self) -> i16 {
-        let range = self.shape.y_strikeout_size_byte_range();
+        let range = self.y_strikeout_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The position of the top of the strikeout stroke relative to the
     /// baseline in font design units.
     pub fn y_strikeout_position(&self) -> i16 {
-        let range = self.shape.y_strikeout_position_byte_range();
+        let range = self.y_strikeout_position_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// [Font-family class and subclass](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#sfamilyclass).
     /// This parameter is a classification of font-family design.
     pub fn s_family_class(&self) -> i16 {
-        let range = self.shape.s_family_class_byte_range();
+        let range = self.s_family_class_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -804,7 +805,7 @@ impl<'a> Os2<'a> {
     /// Additional specifications are required for PANOSE to classify non-Latin
     /// character sets.
     pub fn panose_10(&self) -> &'a [u8] {
-        let range = self.shape.panose_10_byte_range();
+        let range = self.panose_10_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -812,25 +813,25 @@ impl<'a> Os2<'a> {
     ///
     /// Unicode Character Range (bits 0-31).
     pub fn ul_unicode_range_1(&self) -> u32 {
-        let range = self.shape.ul_unicode_range_1_byte_range();
+        let range = self.ul_unicode_range_1_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Unicode Character Range (bits 32-63).
     pub fn ul_unicode_range_2(&self) -> u32 {
-        let range = self.shape.ul_unicode_range_2_byte_range();
+        let range = self.ul_unicode_range_2_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Unicode Character Range (bits 64-95).
     pub fn ul_unicode_range_3(&self) -> u32 {
-        let range = self.shape.ul_unicode_range_3_byte_range();
+        let range = self.ul_unicode_range_3_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Unicode Character Range (bits 96-127).
     pub fn ul_unicode_range_4(&self) -> u32 {
-        let range = self.shape.ul_unicode_range_4_byte_range();
+        let range = self.ul_unicode_range_4_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -838,7 +839,7 @@ impl<'a> Os2<'a> {
     ///
     /// The four-character identifier for the vendor of the given type face.
     pub fn ach_vend_id(&self) -> Tag {
-        let range = self.shape.ach_vend_id_byte_range();
+        let range = self.ach_vend_id_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -846,37 +847,37 @@ impl<'a> Os2<'a> {
     ///
     /// Contains information concerning the nature of the font patterns.
     pub fn fs_selection(&self) -> SelectionFlags {
-        let range = self.shape.fs_selection_byte_range();
+        let range = self.fs_selection_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The minimum Unicode index (character code) in this font.
     pub fn us_first_char_index(&self) -> u16 {
-        let range = self.shape.us_first_char_index_byte_range();
+        let range = self.us_first_char_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The maximum Unicode index (character code) in this font.
     pub fn us_last_char_index(&self) -> u16 {
-        let range = self.shape.us_last_char_index_byte_range();
+        let range = self.us_last_char_index_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The typographic ascender for this font.
     pub fn s_typo_ascender(&self) -> i16 {
-        let range = self.shape.s_typo_ascender_byte_range();
+        let range = self.s_typo_ascender_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The typographic descender for this font.
     pub fn s_typo_descender(&self) -> i16 {
-        let range = self.shape.s_typo_descender_byte_range();
+        let range = self.s_typo_descender_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The typographic line gap for this font.
     pub fn s_typo_line_gap(&self) -> i16 {
-        let range = self.shape.s_typo_line_gap_byte_range();
+        let range = self.s_typo_line_gap_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -885,7 +886,7 @@ impl<'a> Os2<'a> {
     /// This should be used to specify the height above the baseline for a
     /// clipping region.
     pub fn us_win_ascent(&self) -> u16 {
-        let range = self.shape.us_win_ascent_byte_range();
+        let range = self.us_win_ascent_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -894,19 +895,19 @@ impl<'a> Os2<'a> {
     /// This should be used to specify the vertical extent below the baseline
     /// for a clipping region.
     pub fn us_win_descent(&self) -> u16 {
-        let range = self.shape.us_win_descent_byte_range();
+        let range = self.us_win_descent_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Code page character range bits 0-31.
     pub fn ul_code_page_range_1(&self) -> Option<u32> {
-        let range = self.shape.ul_code_page_range_1_byte_range()?;
+        let range = self.ul_code_page_range_1_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// Code page character range bits 32-63.
     pub fn ul_code_page_range_2(&self) -> Option<u32> {
-        let range = self.shape.ul_code_page_range_2_byte_range()?;
+        let range = self.ul_code_page_range_2_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
@@ -914,46 +915,46 @@ impl<'a> Os2<'a> {
     /// approximate height of non-ascending lowercase letters measured in
     /// FUnits.
     pub fn sx_height(&self) -> Option<i16> {
-        let range = self.shape.sx_height_byte_range()?;
+        let range = self.sx_height_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// This metric specifies the distance between the baseline and the
     /// approximate height of uppercase letters measured in FUnits.
     pub fn s_cap_height(&self) -> Option<i16> {
-        let range = self.shape.s_cap_height_byte_range()?;
+        let range = self.s_cap_height_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used for a default glyph.
     pub fn us_default_char(&self) -> Option<u16> {
-        let range = self.shape.us_default_char_byte_range()?;
+        let range = self.us_default_char_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used as a default break character.
     pub fn us_break_char(&self) -> Option<u16> {
-        let range = self.shape.us_break_char_byte_range()?;
+        let range = self.us_break_char_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_max_context(&self) -> Option<u16> {
-        let range = self.shape.us_max_context_byte_range()?;
+        let range = self.us_max_context_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_lower_optical_point_size(&self) -> Option<u16> {
-        let range = self.shape.us_lower_optical_point_size_byte_range()?;
+        let range = self.us_lower_optical_point_size_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_upper_optical_point_size(&self) -> Option<u16> {
-        let range = self.shape.us_upper_optical_point_size_byte_range()?;
+        let range = self.us_upper_optical_point_size_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 }

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -134,7 +134,7 @@ impl<'a> Post<'a> {
     /// 3.0
     pub fn version(&self) -> Version16Dot16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Italic angle in counter-clockwise degrees from the vertical.
@@ -142,7 +142,7 @@ impl<'a> Post<'a> {
     /// right (forward).
     pub fn italic_angle(&self) -> Fixed {
         let range = self.italic_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// This is the suggested distance of the top of the underline from
@@ -154,7 +154,7 @@ impl<'a> Post<'a> {
     /// value of this field.
     pub fn underline_position(&self) -> FWord {
         let range = self.underline_position_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Suggested values for the underline thickness. In general, the
@@ -163,59 +163,59 @@ impl<'a> Post<'a> {
     /// the strikeout thickness, which is specified in the OS/2 table.
     pub fn underline_thickness(&self) -> FWord {
         let range = self.underline_thickness_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Set to 0 if the font is proportionally spaced, non-zero if the
     /// font is not proportionally spaced (i.e. monospaced).
     pub fn is_fixed_pitch(&self) -> u32 {
         let range = self.is_fixed_pitch_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum memory usage when an OpenType font is downloaded.
     pub fn min_mem_type42(&self) -> u32 {
         let range = self.min_mem_type42_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum memory usage when an OpenType font is downloaded.
     pub fn max_mem_type42(&self) -> u32 {
         let range = self.max_mem_type42_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
     pub fn min_mem_type1(&self) -> u32 {
         let range = self.min_mem_type1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
     pub fn max_mem_type1(&self) -> u32 {
         let range = self.max_mem_type1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of glyphs (this should be the same as numGlyphs in
     /// 'maxp' table).
     pub fn num_glyphs(&self) -> Option<u16> {
         let range = self.num_glyphs_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Array of indices into the string data. See below for details.
     pub fn glyph_name_index(&self) -> Option<&'a [BigEndian<u16>]> {
         let range = self.glyph_name_index_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     /// Storage for the string data.
     pub fn string_data(&self) -> Option<VarLenArray<'a, PString<'a>>> {
         let range = self.string_data_byte_range()?;
-        Some(VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap())
+        Some(VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap())
     }
 }
 

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Post<'_> {
 impl<'a> FontRead<'a> for Post<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: PostMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -68,25 +68,25 @@ impl<'a> Index1<'a> {
     /// Number of objects stored in INDEX.
     pub fn count(&self) -> u16 {
         let range = self.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Object array element size.
     pub fn off_size(&self) -> u8 {
         let range = self.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Bytes containing `count + 1` offsets each of `off_size`.
     pub fn offsets(&self) -> &'a [u8] {
         let range = self.offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Array containing the object data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -177,25 +177,25 @@ impl<'a> Index2<'a> {
     /// Number of objects stored in INDEX.
     pub fn count(&self) -> u32 {
         let range = self.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Object array element size.
     pub fn off_size(&self) -> u8 {
         let range = self.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Bytes containing `count + 1` offsets each of `off_size`.
     pub fn offsets(&self) -> &'a [u8] {
         let range = self.offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Array containing the object data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -352,13 +352,13 @@ impl<'a> FdSelectFormat0<'a> {
     /// Format = 0.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// FD selector array (one entry for each glyph).
     pub fn fds(&self) -> &'a [u8] {
         let range = self.fds_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -444,25 +444,25 @@ impl<'a> FdSelectFormat3<'a> {
     /// Format = 3.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of ranges.
     pub fn n_ranges(&self) -> u16 {
         let range = self.n_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Range3 array.
     pub fn ranges(&self) -> &'a [FdSelectRange3] {
         let range = self.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Sentinel GID. Set equal to the number of glyphs in the font.
     pub fn sentinel(&self) -> u16 {
         let range = self.sentinel_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -599,25 +599,25 @@ impl<'a> FdSelectFormat4<'a> {
     /// Format = 4.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of ranges.
     pub fn n_ranges(&self) -> u32 {
         let range = self.n_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Range4 array.
     pub fn ranges(&self) -> &'a [FdSelectRange4] {
         let range = self.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Sentinel GID. Set equal to the number of glyphs in the font.
     pub fn sentinel(&self) -> u32 {
         let range = self.sentinel_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -823,13 +823,13 @@ impl<'a> CharsetFormat0<'a> {
     /// Format; =0
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Glyph name array.
     pub fn glyph(&self) -> &'a [BigEndian<u16>] {
         let range = self.glyph_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -906,13 +906,13 @@ impl<'a> CharsetFormat1<'a> {
     /// Format; =1
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Range1 array.
     pub fn ranges(&self) -> &'a [CharsetRange1] {
         let range = self.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -1038,13 +1038,13 @@ impl<'a> CharsetFormat2<'a> {
     /// Format; =2
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Range2 array.
     pub fn ranges(&self) -> &'a [CharsetRange2] {
         let range = self.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -19,9 +19,9 @@ impl<'a> MinByteRange for Index1<'a> {
 impl<'a> FontRead<'a> for Index1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Index1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -128,9 +128,9 @@ impl<'a> MinByteRange for Index2<'a> {
 impl<'a> FontRead<'a> for Index2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Index2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -319,9 +319,9 @@ impl<'a> MinByteRange for FdSelectFormat0<'a> {
 impl<'a> FontRead<'a> for FdSelectFormat0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FdSelectFormat0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -402,9 +402,9 @@ impl<'a> MinByteRange for FdSelectFormat3<'a> {
 impl<'a> FontRead<'a> for FdSelectFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FdSelectFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -557,9 +557,9 @@ impl<'a> MinByteRange for FdSelectFormat4<'a> {
 impl<'a> FontRead<'a> for FdSelectFormat4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FdSelectFormat4Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -790,9 +790,9 @@ impl<'a> MinByteRange for CharsetFormat0<'a> {
 impl<'a> FontRead<'a> for CharsetFormat0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CharsetFormat0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -873,9 +873,9 @@ impl<'a> MinByteRange for CharsetFormat1<'a> {
 impl<'a> FontRead<'a> for CharsetFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CharsetFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1005,9 +1005,9 @@ impl<'a> MinByteRange for CharsetFormat2<'a> {
 impl<'a> FontRead<'a> for CharsetFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CharsetFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// An array of variable-sized objects in a `CFF` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Index1Marker {}
+pub struct Index1Marker;
 
 impl<'a> MinByteRange for Index1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -18,21 +18,16 @@ impl<'a> MinByteRange for Index1<'a> {
 
 impl<'a> FontRead<'a> for Index1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let count: u16 = cursor.read()?;
-        let off_size: u8 = cursor.read()?;
-        let offsets_byte_len = (transforms::add_multiply(count, 1_usize, off_size))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(offsets_byte_len);
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(Index1Marker {})
+        Ok(TableRef {
+            shape: Index1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// An array of variable-sized objects in a `CFF` table.
-pub type Index1<'a> = TableRef<'a, Index1Marker>;
+pub type Index1<'a> = TableRef<'a, Index1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Index1<'a> {
@@ -122,7 +117,7 @@ impl<'a> std::fmt::Debug for Index1<'a> {
 /// An array of variable-sized objects in a `CFF2` table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Index2Marker {}
+pub struct Index2Marker;
 
 impl<'a> MinByteRange for Index2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -132,21 +127,16 @@ impl<'a> MinByteRange for Index2<'a> {
 
 impl<'a> FontRead<'a> for Index2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let count: u32 = cursor.read()?;
-        let off_size: u8 = cursor.read()?;
-        let offsets_byte_len = (transforms::add_multiply(count, 1_usize, off_size))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(offsets_byte_len);
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(Index2Marker {})
+        Ok(TableRef {
+            shape: Index2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// An array of variable-sized objects in a `CFF2` table.
-pub type Index2<'a> = TableRef<'a, Index2Marker>;
+pub type Index2<'a> = TableRef<'a, Index2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Index2<'a> {
@@ -318,7 +308,7 @@ impl Format<u8> for FdSelectFormat0Marker {
 /// FdSelect format 0.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FdSelectFormat0Marker {}
+pub struct FdSelectFormat0Marker;
 
 impl<'a> MinByteRange for FdSelectFormat0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -328,16 +318,16 @@ impl<'a> MinByteRange for FdSelectFormat0<'a> {
 
 impl<'a> FontRead<'a> for FdSelectFormat0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let fds_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(fds_byte_len);
-        cursor.finish(FdSelectFormat0Marker {})
+        Ok(TableRef {
+            shape: FdSelectFormat0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// FdSelect format 0.
-pub type FdSelectFormat0<'a> = TableRef<'a, FdSelectFormat0Marker>;
+pub type FdSelectFormat0<'a> = TableRef<'a, FdSelectFormat0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FdSelectFormat0<'a> {
@@ -401,7 +391,7 @@ impl Format<u8> for FdSelectFormat3Marker {
 /// FdSelect format 3.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FdSelectFormat3Marker {}
+pub struct FdSelectFormat3Marker;
 
 impl<'a> MinByteRange for FdSelectFormat3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -411,20 +401,16 @@ impl<'a> MinByteRange for FdSelectFormat3<'a> {
 
 impl<'a> FontRead<'a> for FdSelectFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let n_ranges: u16 = cursor.read()?;
-        let ranges_byte_len = (n_ranges as usize)
-            .checked_mul(FdSelectRange3::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ranges_byte_len);
-        cursor.advance::<u16>();
-        cursor.finish(FdSelectFormat3Marker {})
+        Ok(TableRef {
+            shape: FdSelectFormat3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// FdSelect format 3.
-pub type FdSelectFormat3<'a> = TableRef<'a, FdSelectFormat3Marker>;
+pub type FdSelectFormat3<'a> = TableRef<'a, FdSelectFormat3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FdSelectFormat3<'a> {
@@ -560,7 +546,7 @@ impl Format<u8> for FdSelectFormat4Marker {
 /// FdSelect format 4.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct FdSelectFormat4Marker {}
+pub struct FdSelectFormat4Marker;
 
 impl<'a> MinByteRange for FdSelectFormat4<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -570,20 +556,16 @@ impl<'a> MinByteRange for FdSelectFormat4<'a> {
 
 impl<'a> FontRead<'a> for FdSelectFormat4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let n_ranges: u32 = cursor.read()?;
-        let ranges_byte_len = (n_ranges as usize)
-            .checked_mul(FdSelectRange4::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(ranges_byte_len);
-        cursor.advance::<u32>();
-        cursor.finish(FdSelectFormat4Marker {})
+        Ok(TableRef {
+            shape: FdSelectFormat4Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// FdSelect format 4.
-pub type FdSelectFormat4<'a> = TableRef<'a, FdSelectFormat4Marker>;
+pub type FdSelectFormat4<'a> = TableRef<'a, FdSelectFormat4Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FdSelectFormat4<'a> {
@@ -797,7 +779,7 @@ impl Format<u8> for CharsetFormat0Marker {
 /// Charset format 0.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CharsetFormat0Marker {}
+pub struct CharsetFormat0Marker;
 
 impl<'a> MinByteRange for CharsetFormat0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -807,16 +789,16 @@ impl<'a> MinByteRange for CharsetFormat0<'a> {
 
 impl<'a> FontRead<'a> for CharsetFormat0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let glyph_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
-        cursor.advance_by(glyph_byte_len);
-        cursor.finish(CharsetFormat0Marker {})
+        Ok(TableRef {
+            shape: CharsetFormat0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Charset format 0.
-pub type CharsetFormat0<'a> = TableRef<'a, CharsetFormat0Marker>;
+pub type CharsetFormat0<'a> = TableRef<'a, CharsetFormat0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharsetFormat0<'a> {
@@ -880,7 +862,7 @@ impl Format<u8> for CharsetFormat1Marker {
 /// Charset format 1.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CharsetFormat1Marker {}
+pub struct CharsetFormat1Marker;
 
 impl<'a> MinByteRange for CharsetFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -890,17 +872,16 @@ impl<'a> MinByteRange for CharsetFormat1<'a> {
 
 impl<'a> FontRead<'a> for CharsetFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let ranges_byte_len =
-            cursor.remaining_bytes() / CharsetRange1::RAW_BYTE_LEN * CharsetRange1::RAW_BYTE_LEN;
-        cursor.advance_by(ranges_byte_len);
-        cursor.finish(CharsetFormat1Marker {})
+        Ok(TableRef {
+            shape: CharsetFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Charset format 1.
-pub type CharsetFormat1<'a> = TableRef<'a, CharsetFormat1Marker>;
+pub type CharsetFormat1<'a> = TableRef<'a, CharsetFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharsetFormat1<'a> {
@@ -1013,7 +994,7 @@ impl Format<u8> for CharsetFormat2Marker {
 /// Charset format 2.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CharsetFormat2Marker {}
+pub struct CharsetFormat2Marker;
 
 impl<'a> MinByteRange for CharsetFormat2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1023,17 +1004,16 @@ impl<'a> MinByteRange for CharsetFormat2<'a> {
 
 impl<'a> FontRead<'a> for CharsetFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let ranges_byte_len =
-            cursor.remaining_bytes() / CharsetRange2::RAW_BYTE_LEN * CharsetRange2::RAW_BYTE_LEN;
-        cursor.advance_by(ranges_byte_len);
-        cursor.finish(CharsetFormat2Marker {})
+        Ok(TableRef {
+            shape: CharsetFormat2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// Charset format 2.
-pub type CharsetFormat2<'a> = TableRef<'a, CharsetFormat2Marker>;
+pub type CharsetFormat2<'a> = TableRef<'a, CharsetFormat2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CharsetFormat2<'a> {

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -337,9 +337,9 @@ impl<'a> FontReadWithArgs<'a> for Sbix<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: SbixMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -483,9 +483,9 @@ impl<'a> FontReadWithArgs<'a> for Strike<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: StrikeMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -588,9 +588,9 @@ impl<'a> MinByteRange for GlyphData<'a> {
 impl<'a> FontRead<'a> for GlyphData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: GlyphDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -318,32 +318,9 @@ impl<'a> From<HeaderFlags> for FieldType<'a> {
 #[doc(hidden)]
 pub struct SbixMarker {
     num_glyphs: u16,
-    strike_offsets_byte_len: usize,
 }
 
-impl SbixMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn flags_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + HeaderFlags::RAW_BYTE_LEN
-    }
-
-    pub fn num_strikes_byte_range(&self) -> Range<usize> {
-        let start = self.flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn strike_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.num_strikes_byte_range().end;
-        start..start + self.strike_offsets_byte_len
-    }
-}
-
-impl MinByteRange for SbixMarker {
+impl<'a> MinByteRange for Sbix<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.strike_offsets_byte_range().end
     }
@@ -369,10 +346,7 @@ impl<'a> FontReadWithArgs<'a> for Sbix<'a> {
             .checked_mul(Offset32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(strike_offsets_byte_len);
-        cursor.finish(SbixMarker {
-            num_glyphs,
-            strike_offsets_byte_len,
-        })
+        cursor.finish(SbixMarker { num_glyphs })
     }
 }
 
@@ -392,9 +366,36 @@ pub type Sbix<'a> = TableRef<'a, SbixMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Sbix<'a> {
+    fn strike_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.num_strikes()) as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + HeaderFlags::RAW_BYTE_LEN
+    }
+
+    pub fn num_strikes_byte_range(&self) -> Range<usize> {
+        let start = self.flags_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn strike_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.num_strikes_byte_range().end;
+        start..start + self.strike_offsets_byte_len(start)
+    }
+
     /// Table version number — set to 1.
     pub fn version(&self) -> u16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -402,19 +403,19 @@ impl<'a> Sbix<'a> {
     /// Bit 1: Draw outlines.
     /// Bits 2 to 15: reserved (set to 0).
     pub fn flags(&self) -> HeaderFlags {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of bitmap strikes.
     pub fn num_strikes(&self) -> u32 {
-        let range = self.shape.num_strikes_byte_range();
+        let range = self.num_strikes_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offsets from the beginning of the 'sbix' table to data for each individual bitmap strike.
     pub fn strike_offsets(&self) -> &'a [BigEndian<Offset32>] {
-        let range = self.shape.strike_offsets_byte_range();
+        let range = self.strike_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -473,27 +474,10 @@ impl<'a> std::fmt::Debug for Sbix<'a> {
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct StrikeMarker {
-    glyph_data_offsets_byte_len: usize,
+    num_glyphs: u16,
 }
 
-impl StrikeMarker {
-    pub fn ppem_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn ppi_byte_range(&self) -> Range<usize> {
-        let start = self.ppem_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
-        let start = self.ppi_byte_range().end;
-        start..start + self.glyph_data_offsets_byte_len
-    }
-}
-
-impl MinByteRange for StrikeMarker {
+impl<'a> MinByteRange for Strike<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.glyph_data_offsets_byte_range().end
     }
@@ -513,9 +497,7 @@ impl<'a> FontReadWithArgs<'a> for Strike<'a> {
             .checked_mul(u32::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(glyph_data_offsets_byte_len);
-        cursor.finish(StrikeMarker {
-            glyph_data_offsets_byte_len,
-        })
+        cursor.finish(StrikeMarker { num_glyphs })
     }
 }
 
@@ -535,22 +517,48 @@ pub type Strike<'a> = TableRef<'a, StrikeMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Strike<'a> {
+    fn glyph_data_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (transforms::add(self.shape.num_glyphs, 1_usize))
+            .checked_mul(u32::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn ppem_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn ppi_byte_range(&self) -> Range<usize> {
+        let start = self.ppem_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
+        let start = self.ppi_byte_range().end;
+        start..start + self.glyph_data_offsets_byte_len(start)
+    }
+
     /// The PPEM size for which this strike was designed.
     pub fn ppem(&self) -> u16 {
-        let range = self.shape.ppem_byte_range();
+        let range = self.ppem_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The device pixel density (in PPI) for which this strike was designed. (E.g., 96 PPI, 192 PPI.)
     pub fn ppi(&self) -> u16 {
-        let range = self.shape.ppi_byte_range();
+        let range = self.ppi_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset from the beginning of the strike data header to bitmap data for an individual glyph ID.
     pub fn glyph_data_offsets(&self) -> &'a [BigEndian<u32>] {
-        let range = self.shape.glyph_data_offsets_byte_range();
+        let range = self.glyph_data_offsets_byte_range();
         self.data.read_array(range).unwrap()
+    }
+
+    pub(crate) fn num_glyphs(&self) -> u16 {
+        self.shape.num_glyphs
     }
 }
 
@@ -580,11 +588,39 @@ impl<'a> std::fmt::Debug for Strike<'a> {
 /// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct GlyphDataMarker {
-    data_byte_len: usize,
+pub struct GlyphDataMarker {}
+
+impl<'a> MinByteRange for GlyphData<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.data_byte_range().end
+    }
 }
 
-impl GlyphDataMarker {
+impl<'a> FontRead<'a> for GlyphData<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<Tag>();
+        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        cursor.advance_by(data_byte_len);
+        cursor.finish(GlyphDataMarker {})
+    }
+}
+
+/// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
+pub type GlyphData<'a> = TableRef<'a, GlyphDataMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> GlyphData<'a> {
+    fn data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        }
+    }
+
     pub fn origin_offset_x_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + i16::RAW_BYTE_LEN
@@ -602,54 +638,30 @@ impl GlyphDataMarker {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.graphic_type_byte_range().end;
-        start..start + self.data_byte_len
+        start..start + self.data_byte_len(start)
     }
-}
 
-impl MinByteRange for GlyphDataMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for GlyphData<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<Tag>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(GlyphDataMarker { data_byte_len })
-    }
-}
-
-/// [Glyph data](https://learn.microsoft.com/en-us/typography/opentype/spec/sbix#glyph-data) table
-pub type GlyphData<'a> = TableRef<'a, GlyphDataMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> GlyphData<'a> {
     /// The horizontal (x-axis) position of the left edge of the bitmap graphic in relation to the glyph design space origin.
     pub fn origin_offset_x(&self) -> i16 {
-        let range = self.shape.origin_offset_x_byte_range();
+        let range = self.origin_offset_x_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The vertical (y-axis) position of the bottom edge of the bitmap graphic in relation to the glyph design space origin.
     pub fn origin_offset_y(&self) -> i16 {
-        let range = self.shape.origin_offset_y_byte_range();
+        let range = self.origin_offset_y_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Indicates the format of the embedded graphic data: one of 'jpg ', 'png ' or 'tiff', or the special format 'dupe'.
     pub fn graphic_type(&self) -> Tag {
-        let range = self.shape.graphic_type_byte_range();
+        let range = self.graphic_type_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The actual embedded graphic data. The total length is inferred from sequential entries in the glyphDataOffsets array and the fixed size (8 bytes) of the preceding fields.
     pub fn data(&self) -> &'a [u8] {
-        let range = self.shape.data_byte_range();
+        let range = self.data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -390,7 +390,7 @@ impl<'a> Sbix<'a> {
     /// Table version number — set to 1.
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Bit 0: Set to 1.
@@ -398,19 +398,19 @@ impl<'a> Sbix<'a> {
     /// Bits 2 to 15: reserved (set to 0).
     pub fn flags(&self) -> HeaderFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of bitmap strikes.
     pub fn num_strikes(&self) -> u32 {
         let range = self.num_strikes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offsets from the beginning of the 'sbix' table to data for each individual bitmap strike.
     pub fn strike_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.strike_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`strike_offsets`][Self::strike_offsets].
@@ -531,19 +531,19 @@ impl<'a> Strike<'a> {
     /// The PPEM size for which this strike was designed.
     pub fn ppem(&self) -> u16 {
         let range = self.ppem_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The device pixel density (in PPI) for which this strike was designed. (E.g., 96 PPI, 192 PPI.)
     pub fn ppi(&self) -> u16 {
         let range = self.ppi_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the beginning of the strike data header to bitmap data for an individual glyph ID.
     pub fn glyph_data_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.glyph_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn num_glyphs(&self) -> u16 {
@@ -631,25 +631,25 @@ impl<'a> GlyphData<'a> {
     /// The horizontal (x-axis) position of the left edge of the bitmap graphic in relation to the glyph design space origin.
     pub fn origin_offset_x(&self) -> i16 {
         let range = self.origin_offset_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The vertical (y-axis) position of the bottom edge of the bitmap graphic in relation to the glyph design space origin.
     pub fn origin_offset_y(&self) -> i16 {
         let range = self.origin_offset_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Indicates the format of the embedded graphic data: one of 'jpg ', 'png ' or 'tiff', or the special format 'dupe'.
     pub fn graphic_type(&self) -> Tag {
         let range = self.graphic_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The actual embedded graphic data. The total length is inferred from sequential entries in the glyphDataOffsets array and the fixed size (8 bytes) of the preceding fields.
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -78,13 +78,13 @@ impl<'a> Stat<'a> {
     /// Major/minor version number. Set to 1.2 for new fonts.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The size in bytes of each axis record.
     pub fn design_axis_size(&self) -> u16 {
         let range = self.design_axis_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of axis records. In a font with an 'fvar' table,
@@ -93,7 +93,7 @@ impl<'a> Stat<'a> {
     /// axisValueCount is greater than zero.
     pub fn design_axis_count(&self) -> u16 {
         let range = self.design_axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the beginning of the STAT table to the
@@ -102,7 +102,7 @@ impl<'a> Stat<'a> {
     /// greater than zero.
     pub fn design_axes_offset(&self) -> Offset32 {
         let range = self.design_axes_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`design_axes_offset`][Self::design_axes_offset].
@@ -115,7 +115,7 @@ impl<'a> Stat<'a> {
     /// The number of axis value tables.
     pub fn axis_value_count(&self) -> u16 {
         let range = self.axis_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the beginning of the STAT table to the
@@ -124,7 +124,7 @@ impl<'a> Stat<'a> {
     /// must be greater than zero.
     pub fn offset_to_axis_value_offsets(&self) -> Nullable<Offset32> {
         let range = self.offset_to_axis_value_offsets_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`offset_to_axis_value_offsets`][Self::offset_to_axis_value_offsets].
@@ -140,7 +140,7 @@ impl<'a> Stat<'a> {
     /// elidable elements.
     pub fn elided_fallback_name_id(&self) -> Option<NameId> {
         let range = self.elided_fallback_name_id_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 
@@ -303,7 +303,7 @@ impl<'a> AxisValueArray<'a> {
     /// of the axis value offsets array.
     pub fn axis_value_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.axis_value_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`axis_value_offsets`][Self::axis_value_offsets].
@@ -515,7 +515,7 @@ impl<'a> AxisValueFormat1<'a> {
     /// Format identifier — set to 1.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Zero-base index into the axis record array identifying the axis
@@ -523,26 +523,26 @@ impl<'a> AxisValueFormat1<'a> {
     /// be less than designAxisCount.
     pub fn axis_index(&self) -> u16 {
         let range = self.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     pub fn value_name_id(&self) -> NameId {
         let range = self.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A numeric value for this attribute value.
     pub fn value(&self) -> Fixed {
         let range = self.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -639,7 +639,7 @@ impl<'a> AxisValueFormat2<'a> {
     /// Format identifier — set to 2.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Zero-base index into the axis record array identifying the axis
@@ -647,40 +647,40 @@ impl<'a> AxisValueFormat2<'a> {
     /// be less than designAxisCount.
     pub fn axis_index(&self) -> u16 {
         let range = self.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     pub fn value_name_id(&self) -> NameId {
         let range = self.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A nominal numeric value for this attribute value.
     pub fn nominal_value(&self) -> Fixed {
         let range = self.nominal_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The minimum value for a range associated with the specified
     /// name ID.
     pub fn range_min_value(&self) -> Fixed {
         let range = self.range_min_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The maximum value for a range associated with the specified
     /// name ID.
     pub fn range_max_value(&self) -> Fixed {
         let range = self.range_max_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -774,7 +774,7 @@ impl<'a> AxisValueFormat3<'a> {
     /// Format identifier — set to 3.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Zero-base index into the axis record array identifying the axis
@@ -782,32 +782,32 @@ impl<'a> AxisValueFormat3<'a> {
     /// be less than designAxisCount.
     pub fn axis_index(&self) -> u16 {
         let range = self.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     pub fn value_name_id(&self) -> NameId {
         let range = self.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A numeric value for this attribute value.
     pub fn value(&self) -> Fixed {
         let range = self.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The numeric value for a style-linked mapping from this value.
     pub fn linked_value(&self) -> Fixed {
         let range = self.linked_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -902,34 +902,34 @@ impl<'a> AxisValueFormat4<'a> {
     /// Format identifier — set to 4.
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The total number of axes contributing to this axis-values
     /// combination.
     pub fn axis_count(&self) -> u16 {
         let range = self.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this combination of axis values.
     pub fn value_name_id(&self) -> NameId {
         let range = self.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of AxisValue records that provide the combination of axis
     /// values, one for each contributing axis.
     pub fn axis_values(&self) -> &'a [AxisValueRecord] {
         let range = self.axis_values_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Stat<'_> {
 impl<'a> FontRead<'a> for Stat<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: StatMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -264,9 +264,9 @@ impl<'a> FontReadWithArgs<'a> for AxisValueArray<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: AxisValueArrayMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -475,9 +475,9 @@ impl<'a> MinByteRange for AxisValueFormat1<'a> {
 impl<'a> FontRead<'a> for AxisValueFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AxisValueFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -589,9 +589,9 @@ impl<'a> MinByteRange for AxisValueFormat2<'a> {
 impl<'a> FontRead<'a> for AxisValueFormat2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AxisValueFormat2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -729,9 +729,9 @@ impl<'a> MinByteRange for AxisValueFormat3<'a> {
 impl<'a> FontRead<'a> for AxisValueFormat3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AxisValueFormat3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -855,9 +855,9 @@ impl<'a> MinByteRange for AxisValueFormat4<'a> {
 impl<'a> FontRead<'a> for AxisValueFormat4<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: AxisValueFormat4Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Svg<'_> {
 impl<'a> FontRead<'a> for Svg<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SvgMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -110,9 +110,9 @@ impl<'a> MinByteRange for SVGDocumentList<'a> {
 impl<'a> FontRead<'a> for SVGDocumentList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SVGDocumentListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -54,14 +54,14 @@ impl<'a> Svg<'a> {
     /// Table version (starting at 0). Set to 0.
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset to the SVGDocumentList, from the start of the SVG table.
     /// Must be non-zero.
     pub fn svg_document_list_offset(&self) -> Offset32 {
         let range = self.svg_document_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`svg_document_list_offset`][Self::svg_document_list_offset].
@@ -142,13 +142,13 @@ impl<'a> SVGDocumentList<'a> {
     /// Number of SVGDocumentRecords. Must be non-zero.
     pub fn num_entries(&self) -> u16 {
         let range = self.num_entries_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of SVGDocumentRecords.
     pub fn document_records(&self) -> &'a [SVGDocumentRecord] {
         let range = self.document_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [SVG](https://learn.microsoft.com/en-us/typography/opentype/spec/svg) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SvgMarker {}
+pub struct SvgMarker;
 
 impl<'a> MinByteRange for Svg<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,16 +23,16 @@ impl TopLevelTable for Svg<'_> {
 
 impl<'a> FontRead<'a> for Svg<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<u16>();
-        cursor.finish(SvgMarker {})
+        Ok(TableRef {
+            shape: SvgMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [SVG](https://learn.microsoft.com/en-us/typography/opentype/spec/svg) table
-pub type Svg<'a> = TableRef<'a, SvgMarker>;
+pub type Svg<'a> = TableRef<'a, SvgMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Svg<'a> {
@@ -99,7 +99,7 @@ impl<'a> std::fmt::Debug for Svg<'a> {
 /// [SVGDocumentList](https://learn.microsoft.com/en-us/typography/opentype/spec/svg)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SVGDocumentListMarker {}
+pub struct SVGDocumentListMarker;
 
 impl<'a> MinByteRange for SVGDocumentList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -109,18 +109,16 @@ impl<'a> MinByteRange for SVGDocumentList<'a> {
 
 impl<'a> FontRead<'a> for SVGDocumentList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let num_entries: u16 = cursor.read()?;
-        let document_records_byte_len = (num_entries as usize)
-            .checked_mul(SVGDocumentRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(document_records_byte_len);
-        cursor.finish(SVGDocumentListMarker {})
+        Ok(TableRef {
+            shape: SVGDocumentListMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [SVGDocumentList](https://learn.microsoft.com/en-us/typography/opentype/spec/svg)
-pub type SVGDocumentList<'a> = TableRef<'a, SVGDocumentListMarker>;
+pub type SVGDocumentList<'a> = TableRef<'a, SVGDocumentListMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SVGDocumentList<'a> {

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -12,29 +12,7 @@ pub struct MajorMinorVersionMarker {
     if_20_byte_start: Option<usize>,
 }
 
-impl MajorMinorVersionMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn always_present_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn if_11_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.if_11_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn if_20_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.if_20_byte_start?;
-        Some(start..start + u32::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for MajorMinorVersionMarker {
+impl<'a> MinByteRange for MajorMinorVersion<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.always_present_byte_range().end
     }
@@ -70,23 +48,43 @@ pub type MajorMinorVersion<'a> = TableRef<'a, MajorMinorVersionMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MajorMinorVersion<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn always_present_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn if_11_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.if_11_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn if_20_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.if_20_byte_start?;
+        Some(start..start + u32::RAW_BYTE_LEN)
+    }
+
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn always_present(&self) -> u16 {
-        let range = self.shape.always_present_byte_range();
+        let range = self.always_present_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn if_11(&self) -> Option<u16> {
-        let range = self.shape.if_11_byte_range()?;
+        let range = self.if_11_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     pub fn if_20(&self) -> Option<u32> {
-        let range = self.shape.if_20_byte_range()?;
+        let range = self.if_20_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 }
@@ -433,34 +431,7 @@ pub struct FlagDayMarker {
     baz_byte_start: Option<usize>,
 }
 
-impl FlagDayMarker {
-    pub fn volume_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn flags_byte_range(&self) -> Range<usize> {
-        let start = self.volume_byte_range().end;
-        start..start + GotFlags::RAW_BYTE_LEN
-    }
-
-    pub fn foo_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.foo_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn bar_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.bar_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn baz_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.baz_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-}
-
-impl MinByteRange for FlagDayMarker {
+impl<'a> MinByteRange for FlagDay<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.flags_byte_range().end
     }
@@ -504,28 +475,53 @@ pub type FlagDay<'a> = TableRef<'a, FlagDayMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FlagDay<'a> {
+    pub fn volume_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn flags_byte_range(&self) -> Range<usize> {
+        let start = self.volume_byte_range().end;
+        start..start + GotFlags::RAW_BYTE_LEN
+    }
+
+    pub fn foo_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.foo_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn bar_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.bar_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn baz_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.baz_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
     pub fn volume(&self) -> u16 {
-        let range = self.shape.volume_byte_range();
+        let range = self.volume_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn flags(&self) -> GotFlags {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn foo(&self) -> Option<u16> {
-        let range = self.shape.foo_byte_range()?;
+        let range = self.foo_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     pub fn bar(&self) -> Option<u16> {
-        let range = self.shape.bar_byte_range()?;
+        let range = self.bar_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     pub fn baz(&self) -> Option<u16> {
-        let range = self.shape.baz_byte_range()?;
+        let range = self.baz_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 }
@@ -566,54 +562,7 @@ pub struct FieldsAfterConditionalsMarker {
     baz_byte_start: Option<usize>,
 }
 
-impl FieldsAfterConditionalsMarker {
-    pub fn flags_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + GotFlags::RAW_BYTE_LEN
-    }
-
-    pub fn foo_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.foo_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn always_here_byte_range(&self) -> Range<usize> {
-        let start = self
-            .foo_byte_range()
-            .map(|range| range.end)
-            .unwrap_or_else(|| self.flags_byte_range().end);
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn bar_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.bar_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn baz_byte_range(&self) -> Option<Range<usize>> {
-        let start = self.baz_byte_start?;
-        Some(start..start + u16::RAW_BYTE_LEN)
-    }
-
-    pub fn also_always_here_byte_range(&self) -> Range<usize> {
-        let start = self
-            .baz_byte_range()
-            .map(|range| range.end)
-            .unwrap_or_else(|| {
-                self.bar_byte_range()
-                    .map(|range| range.end)
-                    .unwrap_or_else(|| self.always_here_byte_range().end)
-            });
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn and_me_too_byte_range(&self) -> Range<usize> {
-        let start = self.also_always_here_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for FieldsAfterConditionalsMarker {
+impl<'a> MinByteRange for FieldsAfterConditionals<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.and_me_too_byte_range().end
     }
@@ -659,38 +608,83 @@ pub type FieldsAfterConditionals<'a> = TableRef<'a, FieldsAfterConditionalsMarke
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> FieldsAfterConditionals<'a> {
+    pub fn flags_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + GotFlags::RAW_BYTE_LEN
+    }
+
+    pub fn foo_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.foo_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn always_here_byte_range(&self) -> Range<usize> {
+        let start = self
+            .foo_byte_range()
+            .map(|range| range.end)
+            .unwrap_or_else(|| self.flags_byte_range().end);
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn bar_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.bar_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn baz_byte_range(&self) -> Option<Range<usize>> {
+        let start = self.shape.baz_byte_start?;
+        Some(start..start + u16::RAW_BYTE_LEN)
+    }
+
+    pub fn also_always_here_byte_range(&self) -> Range<usize> {
+        let start = self
+            .baz_byte_range()
+            .map(|range| range.end)
+            .unwrap_or_else(|| {
+                self.bar_byte_range()
+                    .map(|range| range.end)
+                    .unwrap_or_else(|| self.always_here_byte_range().end)
+            });
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn and_me_too_byte_range(&self) -> Range<usize> {
+        let start = self.also_always_here_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     pub fn flags(&self) -> GotFlags {
-        let range = self.shape.flags_byte_range();
+        let range = self.flags_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn foo(&self) -> Option<u16> {
-        let range = self.shape.foo_byte_range()?;
+        let range = self.foo_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     pub fn always_here(&self) -> u16 {
-        let range = self.shape.always_here_byte_range();
+        let range = self.always_here_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn bar(&self) -> Option<u16> {
-        let range = self.shape.bar_byte_range()?;
+        let range = self.bar_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     pub fn baz(&self) -> Option<u16> {
-        let range = self.shape.baz_byte_range()?;
+        let range = self.baz_byte_range()?;
         Some(self.data.read_at(range.start).unwrap())
     }
 
     pub fn also_always_here(&self) -> u16 {
-        let range = self.shape.also_always_here_byte_range();
+        let range = self.also_always_here_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn and_me_too(&self) -> u16 {
-        let range = self.shape.and_me_too_byte_range();
+        let range = self.and_me_too_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -62,22 +62,22 @@ impl<'a> MajorMinorVersion<'a> {
 
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn always_present(&self) -> u16 {
         let range = self.always_present_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn if_11(&self) -> Option<u16> {
         let range = self.if_11_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn if_20(&self) -> Option<u32> {
         let range = self.if_20_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 
@@ -488,27 +488,27 @@ impl<'a> FlagDay<'a> {
 
     pub fn volume(&self) -> u16 {
         let range = self.volume_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn flags(&self) -> GotFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn foo(&self) -> Option<u16> {
         let range = self.foo_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn bar(&self) -> Option<u16> {
         let range = self.bar_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn baz(&self) -> Option<u16> {
         let range = self.baz_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 }
 
@@ -626,37 +626,37 @@ impl<'a> FieldsAfterConditionals<'a> {
 
     pub fn flags(&self) -> GotFlags {
         let range = self.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn foo(&self) -> Option<u16> {
         let range = self.foo_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn always_here(&self) -> u16 {
         let range = self.always_here_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn bar(&self) -> Option<u16> {
         let range = self.bar_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn baz(&self) -> Option<u16> {
         let range = self.baz_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     pub fn also_always_here(&self) -> u16 {
         let range = self.also_always_here_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn and_me_too(&self) -> u16 {
         let range = self.and_me_too_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -18,9 +18,9 @@ impl<'a> MinByteRange for MajorMinorVersion<'a> {
 impl<'a> FontRead<'a> for MajorMinorVersion<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MajorMinorVersionMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -428,9 +428,9 @@ impl<'a> MinByteRange for FlagDay<'a> {
 impl<'a> FontRead<'a> for FlagDay<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FlagDayMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -553,9 +553,9 @@ impl<'a> MinByteRange for FieldsAfterConditionals<'a> {
 impl<'a> FontRead<'a> for FieldsAfterConditionals<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: FieldsAfterConditionalsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -49,12 +49,12 @@ impl<'a> CountAll16<'a> {
 
     pub fn some_field(&self) -> u16 {
         let range = self.some_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn remainder(&self) -> &'a [BigEndian<u16>] {
         let range = self.remainder_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -124,12 +124,12 @@ impl<'a> CountAll32<'a> {
 
     pub fn some_field(&self) -> u16 {
         let range = self.some_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn remainder(&self) -> &'a [BigEndian<u32>] {
         let range = self.remainder_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -7,23 +7,9 @@ use crate::codegen_prelude::*;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CountAll16Marker {
-    remainder_byte_len: usize,
-}
+pub struct CountAll16Marker {}
 
-impl CountAll16Marker {
-    pub fn some_field_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn remainder_byte_range(&self) -> Range<usize> {
-        let start = self.some_field_byte_range().end;
-        start..start + self.remainder_byte_len
-    }
-}
-
-impl MinByteRange for CountAll16Marker {
+impl<'a> MinByteRange for CountAll16<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.remainder_byte_range().end
     }
@@ -35,7 +21,7 @@ impl<'a> FontRead<'a> for CountAll16<'a> {
         cursor.advance::<u16>();
         let remainder_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
         cursor.advance_by(remainder_byte_len);
-        cursor.finish(CountAll16Marker { remainder_byte_len })
+        cursor.finish(CountAll16Marker {})
     }
 }
 
@@ -43,13 +29,31 @@ pub type CountAll16<'a> = TableRef<'a, CountAll16Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CountAll16<'a> {
+    fn remainder_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn some_field_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn remainder_byte_range(&self) -> Range<usize> {
+        let start = self.some_field_byte_range().end;
+        start..start + self.remainder_byte_len(start)
+    }
+
     pub fn some_field(&self) -> u16 {
-        let range = self.shape.some_field_byte_range();
+        let range = self.some_field_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn remainder(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.remainder_byte_range();
+        let range = self.remainder_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -78,23 +82,9 @@ impl<'a> std::fmt::Debug for CountAll16<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CountAll32Marker {
-    remainder_byte_len: usize,
-}
+pub struct CountAll32Marker {}
 
-impl CountAll32Marker {
-    pub fn some_field_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn remainder_byte_range(&self) -> Range<usize> {
-        let start = self.some_field_byte_range().end;
-        start..start + self.remainder_byte_len
-    }
-}
-
-impl MinByteRange for CountAll32Marker {
+impl<'a> MinByteRange for CountAll32<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.remainder_byte_range().end
     }
@@ -106,7 +96,7 @@ impl<'a> FontRead<'a> for CountAll32<'a> {
         cursor.advance::<u16>();
         let remainder_byte_len = cursor.remaining_bytes() / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN;
         cursor.advance_by(remainder_byte_len);
-        cursor.finish(CountAll32Marker { remainder_byte_len })
+        cursor.finish(CountAll32Marker {})
     }
 }
 
@@ -114,13 +104,31 @@ pub type CountAll32<'a> = TableRef<'a, CountAll32Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CountAll32<'a> {
+    fn remainder_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn some_field_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn remainder_byte_range(&self) -> Range<usize> {
+        let start = self.some_field_byte_range().end;
+        start..start + self.remainder_byte_len(start)
+    }
+
     pub fn some_field(&self) -> u16 {
-        let range = self.shape.some_field_byte_range();
+        let range = self.some_field_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn remainder(&self) -> &'a [BigEndian<u32>] {
-        let range = self.shape.remainder_byte_range();
+        let range = self.remainder_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -7,7 +7,7 @@ use crate::codegen_prelude::*;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CountAll16Marker {}
+pub struct CountAll16Marker;
 
 impl<'a> MinByteRange for CountAll16<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -17,15 +17,15 @@ impl<'a> MinByteRange for CountAll16<'a> {
 
 impl<'a> FontRead<'a> for CountAll16<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let remainder_byte_len = cursor.remaining_bytes() / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
-        cursor.advance_by(remainder_byte_len);
-        cursor.finish(CountAll16Marker {})
+        Ok(TableRef {
+            shape: CountAll16Marker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type CountAll16<'a> = TableRef<'a, CountAll16Marker>;
+pub type CountAll16<'a> = TableRef<'a, CountAll16Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CountAll16<'a> {
@@ -82,7 +82,7 @@ impl<'a> std::fmt::Debug for CountAll16<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct CountAll32Marker {}
+pub struct CountAll32Marker;
 
 impl<'a> MinByteRange for CountAll32<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -92,15 +92,15 @@ impl<'a> MinByteRange for CountAll32<'a> {
 
 impl<'a> FontRead<'a> for CountAll32<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let remainder_byte_len = cursor.remaining_bytes() / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN;
-        cursor.advance_by(remainder_byte_len);
-        cursor.finish(CountAll32Marker {})
+        Ok(TableRef {
+            shape: CountAll32Marker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type CountAll32<'a> = TableRef<'a, CountAll32Marker>;
+pub type CountAll32<'a> = TableRef<'a, CountAll32Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> CountAll32<'a> {

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -18,9 +18,9 @@ impl<'a> MinByteRange for CountAll16<'a> {
 impl<'a> FontRead<'a> for CountAll16<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CountAll16Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -93,9 +93,9 @@ impl<'a> MinByteRange for CountAll32<'a> {
 impl<'a> FontRead<'a> for CountAll32<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: CountAll32Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -13,24 +13,7 @@ impl Format<u16> for Table1Marker {
 #[doc(hidden)]
 pub struct Table1Marker {}
 
-impl Table1Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn heft_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
-    }
-
-    pub fn flex_byte_range(&self) -> Range<usize> {
-        let start = self.heft_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for Table1Marker {
+impl<'a> MinByteRange for Table1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.flex_byte_range().end
     }
@@ -50,18 +33,33 @@ pub type Table1<'a> = TableRef<'a, Table1Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table1<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn heft_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u32::RAW_BYTE_LEN
+    }
+
+    pub fn flex_byte_range(&self) -> Range<usize> {
+        let start = self.heft_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn heft(&self) -> u32 {
-        let range = self.shape.heft_byte_range();
+        let range = self.heft_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn flex(&self) -> u16 {
-        let range = self.shape.flex_byte_range();
+        let range = self.flex_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }
@@ -95,28 +93,9 @@ impl Format<u16> for Table2Marker {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Table2Marker {
-    values_byte_len: usize,
-}
+pub struct Table2Marker {}
 
-impl Table2Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn value_count_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn values_byte_range(&self) -> Range<usize> {
-        let start = self.value_count_byte_range().end;
-        start..start + self.values_byte_len
-    }
-}
-
-impl MinByteRange for Table2Marker {
+impl<'a> MinByteRange for Table2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.values_byte_range().end
     }
@@ -131,7 +110,7 @@ impl<'a> FontRead<'a> for Table2<'a> {
             .checked_mul(u16::RAW_BYTE_LEN)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(values_byte_len);
-        cursor.finish(Table2Marker { values_byte_len })
+        cursor.finish(Table2Marker {})
     }
 }
 
@@ -139,18 +118,40 @@ pub type Table2<'a> = TableRef<'a, Table2Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table2<'a> {
+    fn values_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.value_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn value_count_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn values_byte_range(&self) -> Range<usize> {
+        let start = self.value_count_byte_range().end;
+        start..start + self.values_byte_len(start)
+    }
+
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn value_count(&self) -> u16 {
-        let range = self.shape.value_count_byte_range();
+        let range = self.value_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn values(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.values_byte_range();
+        let range = self.values_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -186,19 +187,7 @@ impl Format<u16> for Table3Marker {
 #[doc(hidden)]
 pub struct Table3Marker {}
 
-impl Table3Marker {
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn something_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for Table3Marker {
+impl<'a> MinByteRange for Table3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.something_byte_range().end
     }
@@ -217,13 +206,23 @@ pub type Table3<'a> = TableRef<'a, Table3Marker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table3<'a> {
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn something_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     pub fn something(&self) -> u16 {
-        let range = self.shape.something_byte_range();
+        let range = self.something_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -22,9 +22,9 @@ impl<'a> MinByteRange for Table1<'a> {
 impl<'a> FontRead<'a> for Table1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Table1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -104,9 +104,9 @@ impl<'a> MinByteRange for Table2<'a> {
 impl<'a> FontRead<'a> for Table2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Table2Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -193,9 +193,9 @@ impl<'a> MinByteRange for Table3<'a> {
 impl<'a> FontRead<'a> for Table3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: Table3Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -50,17 +50,17 @@ impl<'a> Table1<'a> {
 
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn heft(&self) -> u32 {
         let range = self.heft_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn flex(&self) -> u16 {
         let range = self.flex_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -139,17 +139,17 @@ impl<'a> Table2<'a> {
 
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn value_count(&self) -> u16 {
         let range = self.value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn values(&self) -> &'a [BigEndian<u16>] {
         let range = self.values_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -216,12 +216,12 @@ impl<'a> Table3<'a> {
 
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn something(&self) -> u16 {
         let range = self.something_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -11,7 +11,7 @@ impl Format<u16> for Table1Marker {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Table1Marker {}
+pub struct Table1Marker;
 
 impl<'a> MinByteRange for Table1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -21,15 +21,15 @@ impl<'a> MinByteRange for Table1<'a> {
 
 impl<'a> FontRead<'a> for Table1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        cursor.advance::<u16>();
-        cursor.finish(Table1Marker {})
+        Ok(TableRef {
+            shape: Table1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type Table1<'a> = TableRef<'a, Table1Marker>;
+pub type Table1<'a> = TableRef<'a, Table1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table1<'a> {
@@ -93,7 +93,7 @@ impl Format<u16> for Table2Marker {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Table2Marker {}
+pub struct Table2Marker;
 
 impl<'a> MinByteRange for Table2<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -103,18 +103,15 @@ impl<'a> MinByteRange for Table2<'a> {
 
 impl<'a> FontRead<'a> for Table2<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let value_count: u16 = cursor.read()?;
-        let values_byte_len = (value_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(values_byte_len);
-        cursor.finish(Table2Marker {})
+        Ok(TableRef {
+            shape: Table2Marker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type Table2<'a> = TableRef<'a, Table2Marker>;
+pub type Table2<'a> = TableRef<'a, Table2Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table2<'a> {
@@ -185,7 +182,7 @@ impl Format<u16> for Table3Marker {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct Table3Marker {}
+pub struct Table3Marker;
 
 impl<'a> MinByteRange for Table3<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -195,14 +192,15 @@ impl<'a> MinByteRange for Table3<'a> {
 
 impl<'a> FontRead<'a> for Table3<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<u16>();
-        cursor.finish(Table3Marker {})
+        Ok(TableRef {
+            shape: Table3Marker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type Table3<'a> = TableRef<'a, Table3Marker>;
+pub type Table3<'a> = TableRef<'a, Table3Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Table3<'a> {

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -18,9 +18,9 @@ impl<'a> MinByteRange for KindsOfOffsets<'a> {
 impl<'a> FontRead<'a> for KindsOfOffsets<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: KindsOfOffsetsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -277,9 +277,9 @@ impl<'a> MinByteRange for KindsOfArraysOfOffsets<'a> {
 impl<'a> FontRead<'a> for KindsOfArraysOfOffsets<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: KindsOfArraysOfOffsetsMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -511,9 +511,9 @@ impl<'a> MinByteRange for KindsOfArrays<'a> {
 impl<'a> FontRead<'a> for KindsOfArrays<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: KindsOfArraysMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -681,9 +681,9 @@ impl<'a> MinByteRange for VarLenHaver<'a> {
 impl<'a> FontRead<'a> for VarLenHaver<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VarLenHaverMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -767,9 +767,9 @@ impl<'a> MinByteRange for Dummy<'a> {
 impl<'a> FontRead<'a> for Dummy<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: DummyMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -99,13 +99,13 @@ impl<'a> KindsOfOffsets<'a> {
     /// The major/minor version of the GDEF table
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A normal offset
     pub fn nonnullable_offset(&self) -> Offset16 {
         let range = self.nonnullable_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`nonnullable_offset`][Self::nonnullable_offset].
@@ -117,7 +117,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// An offset that is nullable, but always present
     pub fn nullable_offset(&self) -> Nullable<Offset16> {
         let range = self.nullable_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`nullable_offset`][Self::nullable_offset].
@@ -129,13 +129,13 @@ impl<'a> KindsOfOffsets<'a> {
     /// count of the array at array_offset
     pub fn array_offset_count(&self) -> u16 {
         let range = self.array_offset_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// An offset to an array:
     pub fn array_offset(&self) -> Offset16 {
         let range = self.array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`array_offset`][Self::array_offset].
@@ -148,7 +148,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// An offset to an array of records
     pub fn record_array_offset(&self) -> Offset16 {
         let range = self.record_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`record_array_offset`][Self::record_array_offset].
@@ -161,7 +161,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// A nullable, versioned offset to an array of records
     pub fn versioned_nullable_record_array_offset(&self) -> Option<Nullable<Offset16>> {
         let range = self.versioned_nullable_record_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`versioned_nullable_record_array_offset`][Self::versioned_nullable_record_array_offset].
@@ -175,7 +175,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// A normal offset that is versioned
     pub fn versioned_nonnullable_offset(&self) -> Option<Offset16> {
         let range = self.versioned_nonnullable_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`versioned_nonnullable_offset`][Self::versioned_nonnullable_offset].
@@ -187,7 +187,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// An offset that is nullable and versioned
     pub fn versioned_nullable_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.versioned_nullable_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unchecked::read_at(self.data, range.start))
     }
 
     /// Attempt to resolve [`versioned_nullable_offset`][Self::versioned_nullable_offset].
@@ -357,19 +357,19 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// The version
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of items in each array
     pub fn count(&self) -> u16 {
         let range = self.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A normal array offset
     pub fn nonnullable_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.nonnullable_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`nonnullable_offsets`][Self::nonnullable_offsets].
@@ -382,7 +382,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// An offset that is nullable, but always present
     pub fn nullable_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.nullable_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`nullable_offsets`][Self::nullable_offsets].
@@ -395,7 +395,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// A normal offset that is versioned
     pub fn versioned_nonnullable_offsets(&self) -> Option<&'a [BigEndian<Offset16>]> {
         let range = self.versioned_nonnullable_offsets_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     /// A dynamically resolving wrapper for [`versioned_nonnullable_offsets`][Self::versioned_nonnullable_offsets].
@@ -408,7 +408,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// An offset that is nullable and versioned
     pub fn versioned_nullable_offsets(&self) -> Option<&'a [BigEndian<Nullable<Offset16>>]> {
         let range = self.versioned_nullable_offsets_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     /// A dynamically resolving wrapper for [`versioned_nullable_offsets`][Self::versioned_nullable_offsets].
@@ -590,37 +590,37 @@ impl<'a> KindsOfArrays<'a> {
 
     pub fn version(&self) -> u16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// the number of items in each array
     pub fn count(&self) -> u16 {
         let range = self.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// an array of scalars
     pub fn scalars(&self) -> &'a [BigEndian<u16>] {
         let range = self.scalars_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// an array of records
     pub fn records(&self) -> &'a [Shmecord] {
         let range = self.records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// a versioned array of scalars
     pub fn versioned_scalars(&self) -> Option<&'a [BigEndian<u16>]> {
         let range = self.versioned_scalars_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 
     /// a versioned array of scalars
     pub fn versioned_records(&self) -> Option<&'a [Shmecord]> {
         let range = self.versioned_records_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unchecked::read_array(self.data, range))
     }
 }
 
@@ -717,17 +717,17 @@ impl<'a> VarLenHaver<'a> {
 
     pub fn count(&self) -> u16 {
         let range = self.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn var_len(&self) -> VarLenArray<'a, VarSizeDummy> {
         let range = self.var_len_byte_range();
-        VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap()
+        VarLenArray::read(unchecked::split_off(self.data, range.start)).unwrap()
     }
 
     pub fn other_field(&self) -> u32 {
         let range = self.other_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 
@@ -790,7 +790,7 @@ impl<'a> Dummy<'a> {
 
     pub fn value(&self) -> u16 {
         let range = self.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -71,29 +71,27 @@ impl<'a> BasicTable<'a> {
 
     pub fn simple_count(&self) -> u16 {
         let range = self.simple_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn simple_records(&self) -> &'a [SimpleRecord] {
         let range = self.simple_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub fn arrays_inner_count(&self) -> u16 {
         let range = self.arrays_inner_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn array_records_count(&self) -> u32 {
         let range = self.array_records_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn array_records(&self) -> ComputedArray<'a, ContainsArrays<'a>> {
         let range = self.array_records_byte_range();
-        self.data
-            .read_with_args(range, &self.arrays_inner_count())
-            .unwrap()
+        unchecked::read_with_args(self.data, range, &self.arrays_inner_count())
     }
 }
 
@@ -377,12 +375,12 @@ impl<'a> VarLenItem<'a> {
 
     pub fn length(&self) -> u32 {
         let range = self.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn data(&self) -> &'a [u8] {
         let range = self.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -18,9 +18,9 @@ impl<'a> MinByteRange for BasicTable<'a> {
 impl<'a> FontRead<'a> for BasicTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: BasicTableMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -346,9 +346,9 @@ impl<'a> MinByteRange for VarLenItem<'a> {
 impl<'a> FontRead<'a> for VarLenItem<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VarLenItemMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -7,7 +7,7 @@ use crate::codegen_prelude::*;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct BasicTableMarker {}
+pub struct BasicTableMarker;
 
 impl<'a> MinByteRange for BasicTable<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -17,25 +17,15 @@ impl<'a> MinByteRange for BasicTable<'a> {
 
 impl<'a> FontRead<'a> for BasicTable<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let simple_count: u16 = cursor.read()?;
-        let simple_records_byte_len = (simple_count as usize)
-            .checked_mul(SimpleRecord::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(simple_records_byte_len);
-        let arrays_inner_count: u16 = cursor.read()?;
-        let array_records_count: u32 = cursor.read()?;
-        let array_records_byte_len = (array_records_count as usize)
-            .checked_mul(<ContainsArrays as ComputeSize>::compute_size(
-                &arrays_inner_count,
-            )?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(array_records_byte_len);
-        cursor.finish(BasicTableMarker {})
+        Ok(TableRef {
+            shape: BasicTableMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type BasicTable<'a> = TableRef<'a, BasicTableMarker>;
+pub type BasicTable<'a> = TableRef<'a, BasicTableMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> BasicTable<'a> {
@@ -345,7 +335,7 @@ impl<'a> SomeRecord<'a> for ContainsOffsets {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VarLenItemMarker {}
+pub struct VarLenItemMarker;
 
 impl<'a> MinByteRange for VarLenItem<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -355,15 +345,15 @@ impl<'a> MinByteRange for VarLenItem<'a> {
 
 impl<'a> FontRead<'a> for VarLenItem<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u32>();
-        let data_byte_len = cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(data_byte_len);
-        cursor.finish(VarLenItemMarker {})
+        Ok(TableRef {
+            shape: VarLenItemMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type VarLenItem<'a> = TableRef<'a, VarLenItemMarker>;
+pub type VarLenItem<'a> = TableRef<'a, VarLenItemMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VarLenItem<'a> {

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -64,19 +64,19 @@ impl<'a> Trak<'a> {
     /// Version number of the tracking table (0x00010000 for the current version).
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Format of the tracking table (set to 0).
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from start of tracking table to TrackData for horizontal text (or 0 if none).
     pub fn horiz_offset(&self) -> Nullable<Offset16> {
         let range = self.horiz_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`horiz_offset`][Self::horiz_offset].
@@ -88,7 +88,7 @@ impl<'a> Trak<'a> {
     /// Offset from start of tracking table to TrackData for vertical text (or 0 if none).
     pub fn vert_offset(&self) -> Nullable<Offset16> {
         let range = self.vert_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`vert_offset`][Self::vert_offset].
@@ -184,25 +184,25 @@ impl<'a> TrackData<'a> {
     /// Number of separate tracks included in this table.
     pub fn n_tracks(&self) -> u16 {
         let range = self.n_tracks_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of point sizes included in this table.
     pub fn n_sizes(&self) -> u16 {
         let range = self.n_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset from the start of the tracking table to the start of the size subtable.
     pub fn size_table_offset(&self) -> u32 {
         let range = self.size_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of TrackTableEntry records.
     pub fn track_table(&self) -> &'a [TrackTableEntry] {
         let range = self.track_table_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Trak<'_> {
 impl<'a> FontRead<'a> for Trak<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: TrakMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -142,9 +142,9 @@ impl<'a> MinByteRange for TrackData<'a> {
 impl<'a> FontRead<'a> for TrackData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: TrackDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [tracking (trak)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct TrakMarker {}
+pub struct TrakMarker;
 
 impl<'a> MinByteRange for Trak<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,18 +23,16 @@ impl TopLevelTable for Trak<'_> {
 
 impl<'a> FontRead<'a> for Trak<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<Offset16>();
-        cursor.advance::<u16>();
-        cursor.finish(TrakMarker {})
+        Ok(TableRef {
+            shape: TrakMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [tracking (trak)](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html) table.
-pub type Trak<'a> = TableRef<'a, TrakMarker>;
+pub type Trak<'a> = TableRef<'a, TrakMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Trak<'a> {
@@ -133,7 +131,7 @@ impl<'a> std::fmt::Debug for Trak<'a> {
 /// The tracking data table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct TrackDataMarker {}
+pub struct TrackDataMarker;
 
 impl<'a> MinByteRange for TrackData<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -143,20 +141,16 @@ impl<'a> MinByteRange for TrackData<'a> {
 
 impl<'a> FontRead<'a> for TrackData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let n_tracks: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let track_table_byte_len = (n_tracks as usize)
-            .checked_mul(TrackTableEntry::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(track_table_byte_len);
-        cursor.finish(TrackDataMarker {})
+        Ok(TableRef {
+            shape: TrackDataMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The tracking data table.
-pub type TrackData<'a> = TableRef<'a, TrackDataMarker>;
+pub type TrackData<'a> = TableRef<'a, TrackDataMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> TrackData<'a> {

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -10,34 +10,7 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct TrakMarker {}
 
-impl TrakMarker {
-    pub fn version_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
-    }
-
-    pub fn format_byte_range(&self) -> Range<usize> {
-        let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn horiz_offset_byte_range(&self) -> Range<usize> {
-        let start = self.format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn vert_offset_byte_range(&self) -> Range<usize> {
-        let start = self.horiz_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
-    }
-
-    pub fn reserved_byte_range(&self) -> Range<usize> {
-        let start = self.vert_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-}
-
-impl MinByteRange for TrakMarker {
+impl<'a> MinByteRange for Trak<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.reserved_byte_range().end
     }
@@ -65,21 +38,46 @@ pub type Trak<'a> = TableRef<'a, TrakMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Trak<'a> {
+    pub fn version_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + MajorMinor::RAW_BYTE_LEN
+    }
+
+    pub fn format_byte_range(&self) -> Range<usize> {
+        let start = self.version_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn horiz_offset_byte_range(&self) -> Range<usize> {
+        let start = self.format_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn vert_offset_byte_range(&self) -> Range<usize> {
+        let start = self.horiz_offset_byte_range().end;
+        start..start + Offset16::RAW_BYTE_LEN
+    }
+
+    pub fn reserved_byte_range(&self) -> Range<usize> {
+        let start = self.vert_offset_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
     /// Version number of the tracking table (0x00010000 for the current version).
     pub fn version(&self) -> MajorMinor {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Format of the tracking table (set to 0).
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset from start of tracking table to TrackData for horizontal text (or 0 if none).
     pub fn horiz_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.horiz_offset_byte_range();
+        let range = self.horiz_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -91,7 +89,7 @@ impl<'a> Trak<'a> {
 
     /// Offset from start of tracking table to TrackData for vertical text (or 0 if none).
     pub fn vert_offset(&self) -> Nullable<Offset16> {
-        let range = self.shape.vert_offset_byte_range();
+        let range = self.vert_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -135,11 +133,40 @@ impl<'a> std::fmt::Debug for Trak<'a> {
 /// The tracking data table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct TrackDataMarker {
-    track_table_byte_len: usize,
+pub struct TrackDataMarker {}
+
+impl<'a> MinByteRange for TrackData<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.track_table_byte_range().end
+    }
 }
 
-impl TrackDataMarker {
+impl<'a> FontRead<'a> for TrackData<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        let n_tracks: u16 = cursor.read()?;
+        cursor.advance::<u16>();
+        cursor.advance::<u32>();
+        let track_table_byte_len = (n_tracks as usize)
+            .checked_mul(TrackTableEntry::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(track_table_byte_len);
+        cursor.finish(TrackDataMarker {})
+    }
+}
+
+/// The tracking data table.
+pub type TrackData<'a> = TableRef<'a, TrackDataMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> TrackData<'a> {
+    fn track_table_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.n_tracks()) as usize)
+            .checked_mul(TrackTableEntry::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn n_tracks_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -157,58 +184,30 @@ impl TrackDataMarker {
 
     pub fn track_table_byte_range(&self) -> Range<usize> {
         let start = self.size_table_offset_byte_range().end;
-        start..start + self.track_table_byte_len
+        start..start + self.track_table_byte_len(start)
     }
-}
 
-impl MinByteRange for TrackDataMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.track_table_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for TrackData<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let n_tracks: u16 = cursor.read()?;
-        cursor.advance::<u16>();
-        cursor.advance::<u32>();
-        let track_table_byte_len = (n_tracks as usize)
-            .checked_mul(TrackTableEntry::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(track_table_byte_len);
-        cursor.finish(TrackDataMarker {
-            track_table_byte_len,
-        })
-    }
-}
-
-/// The tracking data table.
-pub type TrackData<'a> = TableRef<'a, TrackDataMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> TrackData<'a> {
     /// Number of separate tracks included in this table.
     pub fn n_tracks(&self) -> u16 {
-        let range = self.shape.n_tracks_byte_range();
+        let range = self.n_tracks_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of point sizes included in this table.
     pub fn n_sizes(&self) -> u16 {
-        let range = self.shape.n_sizes_byte_range();
+        let range = self.n_sizes_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset from the start of the tracking table to the start of the size subtable.
     pub fn size_table_offset(&self) -> u32 {
-        let range = self.shape.size_table_offset_byte_range();
+        let range = self.size_table_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of TrackTableEntry records.
     pub fn track_table(&self) -> &'a [TrackTableEntry] {
-        let range = self.shape.track_table_byte_range();
+        let range = self.track_table_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -73,12 +73,12 @@ impl<'a> Varc<'a> {
     /// Major/minor version number. Set to 1.0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn coverage_offset(&self) -> Offset32 {
         let range = self.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -89,7 +89,7 @@ impl<'a> Varc<'a> {
 
     pub fn multi_var_store_offset(&self) -> Nullable<Offset32> {
         let range = self.multi_var_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`multi_var_store_offset`][Self::multi_var_store_offset].
@@ -100,7 +100,7 @@ impl<'a> Varc<'a> {
 
     pub fn condition_list_offset(&self) -> Nullable<Offset32> {
         let range = self.condition_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`condition_list_offset`][Self::condition_list_offset].
@@ -111,7 +111,7 @@ impl<'a> Varc<'a> {
 
     pub fn axis_indices_list_offset(&self) -> Nullable<Offset32> {
         let range = self.axis_indices_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`axis_indices_list_offset`][Self::axis_indices_list_offset].
@@ -122,7 +122,7 @@ impl<'a> Varc<'a> {
 
     pub fn var_composite_glyphs_offset(&self) -> Offset32 {
         let range = self.var_composite_glyphs_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`var_composite_glyphs_offset`][Self::var_composite_glyphs_offset].
@@ -237,12 +237,12 @@ impl<'a> MultiItemVariationStore<'a> {
 
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn region_list_offset(&self) -> Offset32 {
         let range = self.region_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`region_list_offset`][Self::region_list_offset].
@@ -253,12 +253,12 @@ impl<'a> MultiItemVariationStore<'a> {
 
     pub fn variation_data_count(&self) -> u16 {
         let range = self.variation_data_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn variation_data_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.variation_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`variation_data_offsets`][Self::variation_data_offsets].
@@ -355,12 +355,12 @@ impl<'a> SparseVariationRegionList<'a> {
 
     pub fn region_count(&self) -> u16 {
         let range = self.region_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn region_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.region_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`region_offsets`][Self::region_offsets].
@@ -449,12 +449,12 @@ impl<'a> SparseVariationRegion<'a> {
 
     pub fn region_axis_count(&self) -> u16 {
         let range = self.region_axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn region_axis_offsets(&self) -> &'a [SparseRegionAxisCoordinates] {
         let range = self.region_axis_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -601,22 +601,22 @@ impl<'a> MultiItemVariationData<'a> {
 
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn region_index_count(&self) -> u16 {
         let range = self.region_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn region_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.region_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub fn raw_delta_sets(&self) -> &'a [u8] {
         let range = self.raw_delta_sets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -687,12 +687,12 @@ impl<'a> ConditionList<'a> {
 
     pub fn condition_count(&self) -> u32 {
         let range = self.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -26,9 +26,9 @@ impl TopLevelTable for Varc<'_> {
 impl<'a> FontRead<'a> for Varc<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VarcMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -195,9 +195,9 @@ impl<'a> MinByteRange for MultiItemVariationStore<'a> {
 impl<'a> FontRead<'a> for MultiItemVariationStore<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MultiItemVariationStoreMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -325,9 +325,9 @@ impl<'a> MinByteRange for SparseVariationRegionList<'a> {
 impl<'a> FontRead<'a> for SparseVariationRegionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SparseVariationRegionListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -419,9 +419,9 @@ impl<'a> MinByteRange for SparseVariationRegion<'a> {
 impl<'a> FontRead<'a> for SparseVariationRegion<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: SparseVariationRegionMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -554,9 +554,9 @@ impl<'a> MinByteRange for MultiItemVariationData<'a> {
 impl<'a> FontRead<'a> for MultiItemVariationData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: MultiItemVariationDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -657,9 +657,9 @@ impl<'a> MinByteRange for ConditionList<'a> {
 impl<'a> FontRead<'a> for ConditionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ConditionListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -10,7 +10,7 @@ use crate::codegen_prelude::*;
 /// [FontTools VARC](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3459-L3476)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VarcMarker {}
+pub struct VarcMarker;
 
 impl<'a> MinByteRange for Varc<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -25,21 +25,18 @@ impl TopLevelTable for Varc<'_> {
 
 impl<'a> FontRead<'a> for Varc<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.finish(VarcMarker {})
+        Ok(TableRef {
+            shape: VarcMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// [VARC](https://github.com/harfbuzz/boring-expansion-spec/blob/main/VARC.md) (Variable Composites / Components Table)
 ///
 /// [FontTools VARC](https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3459-L3476)
-pub type Varc<'a> = TableRef<'a, VarcMarker>;
+pub type Varc<'a> = TableRef<'a, VarcMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Varc<'a> {
@@ -187,7 +184,7 @@ impl Format<u16> for MultiItemVariationStoreMarker {
 /// * <https://github.com/harfbuzz/harfbuzz/blob/7be12b33e3f07067c159d8f516eb31df58c75876/src/hb-ot-layout-common.hh#L3517-L3520C3>
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MultiItemVariationStoreMarker {}
+pub struct MultiItemVariationStoreMarker;
 
 impl<'a> MinByteRange for MultiItemVariationStore<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -197,21 +194,17 @@ impl<'a> MinByteRange for MultiItemVariationStore<'a> {
 
 impl<'a> FontRead<'a> for MultiItemVariationStore<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        let variation_data_count: u16 = cursor.read()?;
-        let variation_data_offsets_byte_len = (variation_data_count as usize)
-            .checked_mul(Offset32::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(variation_data_offsets_byte_len);
-        cursor.finish(MultiItemVariationStoreMarker {})
+        Ok(TableRef {
+            shape: MultiItemVariationStoreMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// * <https://github.com/fonttools/fonttools/blob/5e6b12d12fa08abafbeb7570f47707fbedf69a45/Lib/fontTools/ttLib/tables/otData.py#L3451-L3457>
 /// * <https://github.com/harfbuzz/harfbuzz/blob/7be12b33e3f07067c159d8f516eb31df58c75876/src/hb-ot-layout-common.hh#L3517-L3520C3>
-pub type MultiItemVariationStore<'a> = TableRef<'a, MultiItemVariationStoreMarker>;
+pub type MultiItemVariationStore<'a> = TableRef<'a, MultiItemVariationStoreMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MultiItemVariationStore<'a> {
@@ -321,7 +314,7 @@ impl<'a> std::fmt::Debug for MultiItemVariationStore<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SparseVariationRegionListMarker {}
+pub struct SparseVariationRegionListMarker;
 
 impl<'a> MinByteRange for SparseVariationRegionList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -331,17 +324,15 @@ impl<'a> MinByteRange for SparseVariationRegionList<'a> {
 
 impl<'a> FontRead<'a> for SparseVariationRegionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let region_count: u16 = cursor.read()?;
-        let region_offsets_byte_len = (region_count as usize)
-            .checked_mul(Offset32::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(region_offsets_byte_len);
-        cursor.finish(SparseVariationRegionListMarker {})
+        Ok(TableRef {
+            shape: SparseVariationRegionListMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type SparseVariationRegionList<'a> = TableRef<'a, SparseVariationRegionListMarker>;
+pub type SparseVariationRegionList<'a> = TableRef<'a, SparseVariationRegionListMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SparseVariationRegionList<'a> {
@@ -417,7 +408,7 @@ impl<'a> std::fmt::Debug for SparseVariationRegionList<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct SparseVariationRegionMarker {}
+pub struct SparseVariationRegionMarker;
 
 impl<'a> MinByteRange for SparseVariationRegion<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -427,17 +418,15 @@ impl<'a> MinByteRange for SparseVariationRegion<'a> {
 
 impl<'a> FontRead<'a> for SparseVariationRegion<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let region_axis_count: u16 = cursor.read()?;
-        let region_axis_offsets_byte_len = (region_axis_count as usize)
-            .checked_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(region_axis_offsets_byte_len);
-        cursor.finish(SparseVariationRegionMarker {})
+        Ok(TableRef {
+            shape: SparseVariationRegionMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type SparseVariationRegion<'a> = TableRef<'a, SparseVariationRegionMarker>;
+pub type SparseVariationRegion<'a> = TableRef<'a, SparseVariationRegionMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SparseVariationRegion<'a> {
@@ -554,7 +543,7 @@ impl Format<u8> for MultiItemVariationDataMarker {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct MultiItemVariationDataMarker {}
+pub struct MultiItemVariationDataMarker;
 
 impl<'a> MinByteRange for MultiItemVariationData<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -564,21 +553,15 @@ impl<'a> MinByteRange for MultiItemVariationData<'a> {
 
 impl<'a> FontRead<'a> for MultiItemVariationData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let region_index_count: u16 = cursor.read()?;
-        let region_indices_byte_len = (region_index_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(region_indices_byte_len);
-        let raw_delta_sets_byte_len =
-            cursor.remaining_bytes() / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
-        cursor.advance_by(raw_delta_sets_byte_len);
-        cursor.finish(MultiItemVariationDataMarker {})
+        Ok(TableRef {
+            shape: MultiItemVariationDataMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type MultiItemVariationData<'a> = TableRef<'a, MultiItemVariationDataMarker>;
+pub type MultiItemVariationData<'a> = TableRef<'a, MultiItemVariationDataMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> MultiItemVariationData<'a> {
@@ -663,7 +646,7 @@ impl<'a> std::fmt::Debug for MultiItemVariationData<'a> {
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ConditionListMarker {}
+pub struct ConditionListMarker;
 
 impl<'a> MinByteRange for ConditionList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -673,17 +656,15 @@ impl<'a> MinByteRange for ConditionList<'a> {
 
 impl<'a> FontRead<'a> for ConditionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let condition_count: u32 = cursor.read()?;
-        let condition_offsets_byte_len = (condition_count as usize)
-            .checked_mul(Offset32::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(condition_offsets_byte_len);
-        cursor.finish(ConditionListMarker {})
+        Ok(TableRef {
+            shape: ConditionListMarker,
+            args: (),
+            data,
+        })
     }
 }
 
-pub type ConditionList<'a> = TableRef<'a, ConditionListMarker>;
+pub type ConditionList<'a> = TableRef<'a, ConditionListMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ConditionList<'a> {

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -95,14 +95,14 @@ impl<'a> TupleVariationHeader<'a> {
     /// variation table.
     pub fn variation_data_size(&self) -> u16 {
         let range = self.variation_data_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A packed field. The high 4 bits are flags (see below). The low
     /// 12 bits are an index into a shared tuple records array.
     pub fn tuple_index(&self) -> TupleIndex {
         let range = self.tuple_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     pub(crate) fn axis_count(&self) -> u16 {
@@ -269,26 +269,26 @@ impl<'a> DeltaSetIndexMapFormat0<'a> {
     /// DeltaSetIndexMap format: set to 0.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
     pub fn entry_format(&self) -> EntryFormat {
         let range = self.entry_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of mapping entries.
     pub fn map_count(&self) -> u16 {
         let range = self.map_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The delta-set index mapping data. See details below.
     pub fn map_data(&self) -> &'a [u8] {
         let range = self.map_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -376,26 +376,26 @@ impl<'a> DeltaSetIndexMapFormat1<'a> {
     /// DeltaSetIndexMap format: set to 1.
     pub fn format(&self) -> u8 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
     pub fn entry_format(&self) -> EntryFormat {
         let range = self.entry_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of mapping entries.
     pub fn map_count(&self) -> u32 {
         let range = self.map_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The delta-set index mapping data. See details below.
     pub fn map_data(&self) -> &'a [u8] {
         let range = self.map_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 
@@ -877,20 +877,20 @@ impl<'a> VariationRegionList<'a> {
     /// same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
         let range = self.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of variation region tables in the variation region
     /// list. Must be less than 32,768.
     pub fn region_count(&self) -> u16 {
         let range = self.region_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of variation regions.
     pub fn variation_regions(&self) -> ComputedArray<'a, VariationRegion<'a>> {
         let range = self.variation_regions_byte_range();
-        self.data.read_with_args(range, &self.axis_count()).unwrap()
+        unchecked::read_with_args(self.data, range, &self.axis_count())
     }
 }
 
@@ -1104,14 +1104,14 @@ impl<'a> ItemVariationStore<'a> {
     /// Format— set to 1
     pub fn format(&self) -> u16 {
         let range = self.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the start of the item variation store to
     /// the variation region list.
     pub fn variation_region_list_offset(&self) -> Offset32 {
         let range = self.variation_region_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`variation_region_list_offset`][Self::variation_region_list_offset].
@@ -1123,14 +1123,14 @@ impl<'a> ItemVariationStore<'a> {
     /// The number of item variation data subtables.
     pub fn item_variation_data_count(&self) -> u16 {
         let range = self.item_variation_data_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offsets in bytes from the start of the item variation store to
     /// each item variation data subtable.
     pub fn item_variation_data_offsets(&self) -> &'a [BigEndian<Nullable<Offset32>>] {
         let range = self.item_variation_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
@@ -1260,32 +1260,32 @@ impl<'a> ItemVariationData<'a> {
     /// The number of delta sets for distinct items.
     pub fn item_count(&self) -> u16 {
         let range = self.item_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// A packed field: the high bit is a flag—see details below.
     pub fn word_delta_count(&self) -> u16 {
         let range = self.word_delta_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The number of variation regions referenced.
     pub fn region_index_count(&self) -> u16 {
         let range = self.region_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of indices into the variation region list for the regions
     /// referenced by this item variation data table.
     pub fn region_indexes(&self) -> &'a [BigEndian<u16>] {
         let range = self.region_indexes_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Delta-set rows.
     pub fn delta_sets(&self) -> &'a [u8] {
         let range = self.delta_sets_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -9,39 +9,10 @@ use crate::codegen_prelude::*;
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct TupleVariationHeaderMarker {
-    peak_tuple_byte_len: usize,
-    intermediate_start_tuple_byte_len: usize,
-    intermediate_end_tuple_byte_len: usize,
+    axis_count: u16,
 }
 
-impl TupleVariationHeaderMarker {
-    pub fn variation_data_size_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn tuple_index_byte_range(&self) -> Range<usize> {
-        let start = self.variation_data_size_byte_range().end;
-        start..start + TupleIndex::RAW_BYTE_LEN
-    }
-
-    pub fn peak_tuple_byte_range(&self) -> Range<usize> {
-        let start = self.tuple_index_byte_range().end;
-        start..start + self.peak_tuple_byte_len
-    }
-
-    pub fn intermediate_start_tuple_byte_range(&self) -> Range<usize> {
-        let start = self.peak_tuple_byte_range().end;
-        start..start + self.intermediate_start_tuple_byte_len
-    }
-
-    pub fn intermediate_end_tuple_byte_range(&self) -> Range<usize> {
-        let start = self.intermediate_start_tuple_byte_range().end;
-        start..start + self.intermediate_end_tuple_byte_len
-    }
-}
-
-impl MinByteRange for TupleVariationHeaderMarker {
+impl<'a> MinByteRange for TupleVariationHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.intermediate_end_tuple_byte_range().end
     }
@@ -71,11 +42,7 @@ impl<'a> FontReadWithArgs<'a> for TupleVariationHeader<'a> {
                 .checked_mul(F2Dot14::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(intermediate_end_tuple_byte_len);
-        cursor.finish(TupleVariationHeaderMarker {
-            peak_tuple_byte_len,
-            intermediate_start_tuple_byte_len,
-            intermediate_end_tuple_byte_len,
-        })
+        cursor.finish(TupleVariationHeaderMarker { axis_count })
     }
 }
 
@@ -95,18 +62,66 @@ pub type TupleVariationHeader<'a> = TableRef<'a, TupleVariationHeaderMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> TupleVariationHeader<'a> {
+    fn peak_tuple_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (TupleIndex::tuple_len(self.tuple_index(), self.shape.axis_count, 0_usize))
+            .checked_mul(F2Dot14::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn intermediate_start_tuple_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (TupleIndex::tuple_len(self.tuple_index(), self.shape.axis_count, 1_usize))
+            .checked_mul(F2Dot14::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn intermediate_end_tuple_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (TupleIndex::tuple_len(self.tuple_index(), self.shape.axis_count, 1_usize))
+            .checked_mul(F2Dot14::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
+    pub fn variation_data_size_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn tuple_index_byte_range(&self) -> Range<usize> {
+        let start = self.variation_data_size_byte_range().end;
+        start..start + TupleIndex::RAW_BYTE_LEN
+    }
+
+    pub fn peak_tuple_byte_range(&self) -> Range<usize> {
+        let start = self.tuple_index_byte_range().end;
+        start..start + self.peak_tuple_byte_len(start)
+    }
+
+    pub fn intermediate_start_tuple_byte_range(&self) -> Range<usize> {
+        let start = self.peak_tuple_byte_range().end;
+        start..start + self.intermediate_start_tuple_byte_len(start)
+    }
+
+    pub fn intermediate_end_tuple_byte_range(&self) -> Range<usize> {
+        let start = self.intermediate_start_tuple_byte_range().end;
+        start..start + self.intermediate_end_tuple_byte_len(start)
+    }
+
     /// The size in bytes of the serialized data for this tuple
     /// variation table.
     pub fn variation_data_size(&self) -> u16 {
-        let range = self.shape.variation_data_size_byte_range();
+        let range = self.variation_data_size_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A packed field. The high 4 bits are flags (see below). The low
     /// 12 bits are an index into a shared tuple records array.
     pub fn tuple_index(&self) -> TupleIndex {
-        let range = self.shape.tuple_index_byte_range();
+        let range = self.tuple_index_byte_range();
         self.data.read_at(range.start).unwrap()
+    }
+
+    pub(crate) fn axis_count(&self) -> u16 {
+        self.shape.axis_count
     }
 }
 
@@ -216,11 +231,40 @@ impl Format<u8> for DeltaSetIndexMapFormat0Marker {
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DeltaSetIndexMapFormat0Marker {
-    map_data_byte_len: usize,
+pub struct DeltaSetIndexMapFormat0Marker {}
+
+impl<'a> MinByteRange for DeltaSetIndexMapFormat0<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.map_data_byte_range().end
+    }
 }
 
-impl DeltaSetIndexMapFormat0Marker {
+impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        let entry_format: EntryFormat = cursor.read()?;
+        let map_count: u16 = cursor.read()?;
+        let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(map_data_byte_len);
+        cursor.finish(DeltaSetIndexMapFormat0Marker {})
+    }
+}
+
+/// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
+pub type DeltaSetIndexMapFormat0<'a> = TableRef<'a, DeltaSetIndexMapFormat0Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> DeltaSetIndexMapFormat0<'a> {
+    fn map_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (EntryFormat::map_size(self.entry_format(), self.map_count()))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -238,57 +282,31 @@ impl DeltaSetIndexMapFormat0Marker {
 
     pub fn map_data_byte_range(&self) -> Range<usize> {
         let start = self.map_count_byte_range().end;
-        start..start + self.map_data_byte_len
+        start..start + self.map_data_byte_len(start)
     }
-}
 
-impl MinByteRange for DeltaSetIndexMapFormat0Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.map_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let entry_format: EntryFormat = cursor.read()?;
-        let map_count: u16 = cursor.read()?;
-        let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(map_data_byte_len);
-        cursor.finish(DeltaSetIndexMapFormat0Marker { map_data_byte_len })
-    }
-}
-
-/// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
-pub type DeltaSetIndexMapFormat0<'a> = TableRef<'a, DeltaSetIndexMapFormat0Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> DeltaSetIndexMapFormat0<'a> {
     /// DeltaSetIndexMap format: set to 0.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
     pub fn entry_format(&self) -> EntryFormat {
-        let range = self.shape.entry_format_byte_range();
+        let range = self.entry_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of mapping entries.
     pub fn map_count(&self) -> u16 {
-        let range = self.shape.map_count_byte_range();
+        let range = self.map_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The delta-set index mapping data. See details below.
     pub fn map_data(&self) -> &'a [u8] {
-        let range = self.shape.map_data_byte_range();
+        let range = self.map_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -324,11 +342,40 @@ impl Format<u8> for DeltaSetIndexMapFormat1Marker {
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DeltaSetIndexMapFormat1Marker {
-    map_data_byte_len: usize,
+pub struct DeltaSetIndexMapFormat1Marker {}
+
+impl<'a> MinByteRange for DeltaSetIndexMapFormat1<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.map_data_byte_range().end
+    }
 }
 
-impl DeltaSetIndexMapFormat1Marker {
+impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u8>();
+        let entry_format: EntryFormat = cursor.read()?;
+        let map_count: u32 = cursor.read()?;
+        let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(map_data_byte_len);
+        cursor.finish(DeltaSetIndexMapFormat1Marker {})
+    }
+}
+
+/// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
+pub type DeltaSetIndexMapFormat1<'a> = TableRef<'a, DeltaSetIndexMapFormat1Marker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> DeltaSetIndexMapFormat1<'a> {
+    fn map_data_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (EntryFormat::map_size(self.entry_format(), self.map_count()))
+            .checked_mul(u8::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u8::RAW_BYTE_LEN
@@ -346,57 +393,31 @@ impl DeltaSetIndexMapFormat1Marker {
 
     pub fn map_data_byte_range(&self) -> Range<usize> {
         let start = self.map_count_byte_range().end;
-        start..start + self.map_data_byte_len
+        start..start + self.map_data_byte_len(start)
     }
-}
 
-impl MinByteRange for DeltaSetIndexMapFormat1Marker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.map_data_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let entry_format: EntryFormat = cursor.read()?;
-        let map_count: u32 = cursor.read()?;
-        let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(map_data_byte_len);
-        cursor.finish(DeltaSetIndexMapFormat1Marker { map_data_byte_len })
-    }
-}
-
-/// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
-pub type DeltaSetIndexMapFormat1<'a> = TableRef<'a, DeltaSetIndexMapFormat1Marker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> DeltaSetIndexMapFormat1<'a> {
     /// DeltaSetIndexMap format: set to 1.
     pub fn format(&self) -> u8 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
     pub fn entry_format(&self) -> EntryFormat {
-        let range = self.shape.entry_format_byte_range();
+        let range = self.entry_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of mapping entries.
     pub fn map_count(&self) -> u32 {
-        let range = self.shape.map_count_byte_range();
+        let range = self.map_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The delta-set index mapping data. See details below.
     pub fn map_data(&self) -> &'a [u8] {
-        let range = self.shape.map_data_byte_range();
+        let range = self.map_data_byte_range();
         self.data.read_array(range).unwrap()
     }
 }
@@ -828,28 +849,9 @@ impl<'a> From<EntryFormat> for FieldType<'a> {
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VariationRegionListMarker {
-    variation_regions_byte_len: usize,
-}
+pub struct VariationRegionListMarker {}
 
-impl VariationRegionListMarker {
-    pub fn axis_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn region_count_byte_range(&self) -> Range<usize> {
-        let start = self.axis_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn variation_regions_byte_range(&self) -> Range<usize> {
-        let start = self.region_count_byte_range().end;
-        start..start + self.variation_regions_byte_len
-    }
-}
-
-impl MinByteRange for VariationRegionListMarker {
+impl<'a> MinByteRange for VariationRegionList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.variation_regions_byte_range().end
     }
@@ -864,9 +866,7 @@ impl<'a> FontRead<'a> for VariationRegionList<'a> {
             .checked_mul(<VariationRegion as ComputeSize>::compute_size(&axis_count)?)
             .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(variation_regions_byte_len);
-        cursor.finish(VariationRegionListMarker {
-            variation_regions_byte_len,
-        })
+        cursor.finish(VariationRegionListMarker {})
     }
 }
 
@@ -875,23 +875,47 @@ pub type VariationRegionList<'a> = TableRef<'a, VariationRegionListMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VariationRegionList<'a> {
+    fn variation_regions_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.region_count()) as usize)
+            .checked_mul(
+                <VariationRegion as ComputeSize>::compute_size(&self.axis_count()).unwrap(),
+            )
+            .unwrap()
+    }
+
+    pub fn axis_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn region_count_byte_range(&self) -> Range<usize> {
+        let start = self.axis_count_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn variation_regions_byte_range(&self) -> Range<usize> {
+        let start = self.region_count_byte_range().end;
+        start..start + self.variation_regions_byte_len(start)
+    }
+
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
-        let range = self.shape.axis_count_byte_range();
+        let range = self.axis_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of variation region tables in the variation region
     /// list. Must be less than 32,768.
     pub fn region_count(&self) -> u16 {
-        let range = self.shape.region_count_byte_range();
+        let range = self.region_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of variation regions.
     pub fn variation_regions(&self) -> ComputedArray<'a, VariationRegion<'a>> {
-        let range = self.shape.variation_regions_byte_range();
+        let range = self.variation_regions_byte_range();
         self.data.read_with_args(range, &self.axis_count()).unwrap()
     }
 }
@@ -1053,11 +1077,40 @@ impl<'a> SomeRecord<'a> for RegionAxisCoordinates {
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ItemVariationStoreMarker {
-    item_variation_data_offsets_byte_len: usize,
+pub struct ItemVariationStoreMarker {}
+
+impl<'a> MinByteRange for ItemVariationStore<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.item_variation_data_offsets_byte_range().end
+    }
 }
 
-impl ItemVariationStoreMarker {
+impl<'a> FontRead<'a> for ItemVariationStore<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<u16>();
+        cursor.advance::<Offset32>();
+        let item_variation_data_count: u16 = cursor.read()?;
+        let item_variation_data_offsets_byte_len = (item_variation_data_count as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .ok_or(ReadError::OutOfBounds)?;
+        cursor.advance_by(item_variation_data_offsets_byte_len);
+        cursor.finish(ItemVariationStoreMarker {})
+    }
+}
+
+/// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
+pub type ItemVariationStore<'a> = TableRef<'a, ItemVariationStoreMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ItemVariationStore<'a> {
+    fn item_variation_data_offsets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.item_variation_data_count()) as usize)
+            .checked_mul(Offset32::RAW_BYTE_LEN)
+            .unwrap()
+    }
+
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + u16::RAW_BYTE_LEN
@@ -1075,47 +1128,19 @@ impl ItemVariationStoreMarker {
 
     pub fn item_variation_data_offsets_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_data_count_byte_range().end;
-        start..start + self.item_variation_data_offsets_byte_len
+        start..start + self.item_variation_data_offsets_byte_len(start)
     }
-}
 
-impl MinByteRange for ItemVariationStoreMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.item_variation_data_offsets_byte_range().end
-    }
-}
-
-impl<'a> FontRead<'a> for ItemVariationStore<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        let item_variation_data_count: u16 = cursor.read()?;
-        let item_variation_data_offsets_byte_len = (item_variation_data_count as usize)
-            .checked_mul(Offset32::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(item_variation_data_offsets_byte_len);
-        cursor.finish(ItemVariationStoreMarker {
-            item_variation_data_offsets_byte_len,
-        })
-    }
-}
-
-/// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
-pub type ItemVariationStore<'a> = TableRef<'a, ItemVariationStoreMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> ItemVariationStore<'a> {
     /// Format— set to 1
     pub fn format(&self) -> u16 {
-        let range = self.shape.format_byte_range();
+        let range = self.format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offset in bytes from the start of the item variation store to
     /// the variation region list.
     pub fn variation_region_list_offset(&self) -> Offset32 {
-        let range = self.shape.variation_region_list_offset_byte_range();
+        let range = self.variation_region_list_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -1127,14 +1152,14 @@ impl<'a> ItemVariationStore<'a> {
 
     /// The number of item variation data subtables.
     pub fn item_variation_data_count(&self) -> u16 {
-        let range = self.shape.item_variation_data_count_byte_range();
+        let range = self.item_variation_data_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Offsets in bytes from the start of the item variation store to
     /// each item variation data subtable.
     pub fn item_variation_data_offsets(&self) -> &'a [BigEndian<Nullable<Offset32>>] {
-        let range = self.shape.item_variation_data_offsets_byte_range();
+        let range = self.item_variation_data_offsets_byte_range();
         self.data.read_array(range).unwrap()
     }
 
@@ -1197,39 +1222,9 @@ impl<'a> std::fmt::Debug for ItemVariationStore<'a> {
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ItemVariationDataMarker {
-    region_indexes_byte_len: usize,
-    delta_sets_byte_len: usize,
-}
+pub struct ItemVariationDataMarker {}
 
-impl ItemVariationDataMarker {
-    pub fn item_count_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn word_delta_count_byte_range(&self) -> Range<usize> {
-        let start = self.item_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn region_index_count_byte_range(&self) -> Range<usize> {
-        let start = self.word_delta_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
-    }
-
-    pub fn region_indexes_byte_range(&self) -> Range<usize> {
-        let start = self.region_index_count_byte_range().end;
-        start..start + self.region_indexes_byte_len
-    }
-
-    pub fn delta_sets_byte_range(&self) -> Range<usize> {
-        let start = self.region_indexes_byte_range().end;
-        start..start + self.delta_sets_byte_len
-    }
-}
-
-impl MinByteRange for ItemVariationDataMarker {
+impl<'a> MinByteRange for ItemVariationData<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.delta_sets_byte_range().end
     }
@@ -1250,10 +1245,7 @@ impl<'a> FontRead<'a> for ItemVariationData<'a> {
                 .checked_mul(u8::RAW_BYTE_LEN)
                 .ok_or(ReadError::OutOfBounds)?;
         cursor.advance_by(delta_sets_byte_len);
-        cursor.finish(ItemVariationDataMarker {
-            region_indexes_byte_len,
-            delta_sets_byte_len,
-        })
+        cursor.finish(ItemVariationDataMarker {})
     }
 }
 
@@ -1262,34 +1254,76 @@ pub type ItemVariationData<'a> = TableRef<'a, ItemVariationDataMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ItemVariationData<'a> {
+    fn region_indexes_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.region_index_count()) as usize)
+            .checked_mul(u16::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn delta_sets_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        (ItemVariationData::delta_sets_len(
+            self.item_count(),
+            self.word_delta_count(),
+            self.region_index_count(),
+        ))
+        .checked_mul(u8::RAW_BYTE_LEN)
+        .unwrap()
+    }
+
+    pub fn item_count_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn word_delta_count_byte_range(&self) -> Range<usize> {
+        let start = self.item_count_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn region_index_count_byte_range(&self) -> Range<usize> {
+        let start = self.word_delta_count_byte_range().end;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn region_indexes_byte_range(&self) -> Range<usize> {
+        let start = self.region_index_count_byte_range().end;
+        start..start + self.region_indexes_byte_len(start)
+    }
+
+    pub fn delta_sets_byte_range(&self) -> Range<usize> {
+        let start = self.region_indexes_byte_range().end;
+        start..start + self.delta_sets_byte_len(start)
+    }
+
     /// The number of delta sets for distinct items.
     pub fn item_count(&self) -> u16 {
-        let range = self.shape.item_count_byte_range();
+        let range = self.item_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// A packed field: the high bit is a flag—see details below.
     pub fn word_delta_count(&self) -> u16 {
-        let range = self.shape.word_delta_count_byte_range();
+        let range = self.word_delta_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// The number of variation regions referenced.
     pub fn region_index_count(&self) -> u16 {
-        let range = self.shape.region_index_count_byte_range();
+        let range = self.region_index_count_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Array of indices into the variation region list for the regions
     /// referenced by this item variation data table.
     pub fn region_indexes(&self) -> &'a [BigEndian<u16>] {
-        let range = self.shape.region_indexes_byte_range();
+        let range = self.region_indexes_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Delta-set rows.
     pub fn delta_sets(&self) -> &'a [u8] {
-        let range = self.shape.delta_sets_byte_range();
+        let range = self.delta_sets_byte_range();
         self.data.read_array(range).unwrap()
     }
 }

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -8,9 +8,7 @@ use crate::codegen_prelude::*;
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct TupleVariationHeaderMarker {
-    axis_count: u16,
-}
+pub struct TupleVariationHeaderMarker;
 
 impl<'a> MinByteRange for TupleVariationHeader<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -24,25 +22,12 @@ impl ReadArgs for TupleVariationHeader<'_> {
 
 impl<'a> FontReadWithArgs<'a> for TupleVariationHeader<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
-        let axis_count = *args;
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        let tuple_index: TupleIndex = cursor.read()?;
-        let peak_tuple_byte_len = (TupleIndex::tuple_len(tuple_index, axis_count, 0_usize))
-            .checked_mul(F2Dot14::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(peak_tuple_byte_len);
-        let intermediate_start_tuple_byte_len =
-            (TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))
-                .checked_mul(F2Dot14::RAW_BYTE_LEN)
-                .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(intermediate_start_tuple_byte_len);
-        let intermediate_end_tuple_byte_len =
-            (TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))
-                .checked_mul(F2Dot14::RAW_BYTE_LEN)
-                .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(intermediate_end_tuple_byte_len);
-        cursor.finish(TupleVariationHeaderMarker { axis_count })
+        let args = *args;
+        Ok(TableRef {
+            shape: TupleVariationHeaderMarker,
+            args,
+            data,
+        })
     }
 }
 
@@ -58,25 +43,25 @@ impl<'a> TupleVariationHeader<'a> {
 }
 
 /// [TupleVariationHeader](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader)
-pub type TupleVariationHeader<'a> = TableRef<'a, TupleVariationHeaderMarker>;
+pub type TupleVariationHeader<'a> = TableRef<'a, TupleVariationHeaderMarker, u16>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> TupleVariationHeader<'a> {
     fn peak_tuple_byte_len(&self, start: usize) -> usize {
         let _ = start;
-        (TupleIndex::tuple_len(self.tuple_index(), self.shape.axis_count, 0_usize))
+        (TupleIndex::tuple_len(self.tuple_index(), self.args, 0_usize))
             .checked_mul(F2Dot14::RAW_BYTE_LEN)
             .unwrap()
     }
     fn intermediate_start_tuple_byte_len(&self, start: usize) -> usize {
         let _ = start;
-        (TupleIndex::tuple_len(self.tuple_index(), self.shape.axis_count, 1_usize))
+        (TupleIndex::tuple_len(self.tuple_index(), self.args, 1_usize))
             .checked_mul(F2Dot14::RAW_BYTE_LEN)
             .unwrap()
     }
     fn intermediate_end_tuple_byte_len(&self, start: usize) -> usize {
         let _ = start;
-        (TupleIndex::tuple_len(self.tuple_index(), self.shape.axis_count, 1_usize))
+        (TupleIndex::tuple_len(self.tuple_index(), self.args, 1_usize))
             .checked_mul(F2Dot14::RAW_BYTE_LEN)
             .unwrap()
     }
@@ -121,7 +106,7 @@ impl<'a> TupleVariationHeader<'a> {
     }
 
     pub(crate) fn axis_count(&self) -> u16 {
-        self.shape.axis_count
+        self.args
     }
 }
 
@@ -231,7 +216,7 @@ impl Format<u8> for DeltaSetIndexMapFormat0Marker {
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DeltaSetIndexMapFormat0Marker {}
+pub struct DeltaSetIndexMapFormat0Marker;
 
 impl<'a> MinByteRange for DeltaSetIndexMapFormat0<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -241,20 +226,16 @@ impl<'a> MinByteRange for DeltaSetIndexMapFormat0<'a> {
 
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let entry_format: EntryFormat = cursor.read()?;
-        let map_count: u16 = cursor.read()?;
-        let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(map_data_byte_len);
-        cursor.finish(DeltaSetIndexMapFormat0Marker {})
+        Ok(TableRef {
+            shape: DeltaSetIndexMapFormat0Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 0
-pub type DeltaSetIndexMapFormat0<'a> = TableRef<'a, DeltaSetIndexMapFormat0Marker>;
+pub type DeltaSetIndexMapFormat0<'a> = TableRef<'a, DeltaSetIndexMapFormat0Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> DeltaSetIndexMapFormat0<'a> {
@@ -342,7 +323,7 @@ impl Format<u8> for DeltaSetIndexMapFormat1Marker {
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct DeltaSetIndexMapFormat1Marker {}
+pub struct DeltaSetIndexMapFormat1Marker;
 
 impl<'a> MinByteRange for DeltaSetIndexMapFormat1<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -352,20 +333,16 @@ impl<'a> MinByteRange for DeltaSetIndexMapFormat1<'a> {
 
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u8>();
-        let entry_format: EntryFormat = cursor.read()?;
-        let map_count: u32 = cursor.read()?;
-        let map_data_byte_len = (EntryFormat::map_size(entry_format, map_count))
-            .checked_mul(u8::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(map_data_byte_len);
-        cursor.finish(DeltaSetIndexMapFormat1Marker {})
+        Ok(TableRef {
+            shape: DeltaSetIndexMapFormat1Marker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [DeltaSetIndexMap](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#associating-target-items-to-variation-data) table format 1
-pub type DeltaSetIndexMapFormat1<'a> = TableRef<'a, DeltaSetIndexMapFormat1Marker>;
+pub type DeltaSetIndexMapFormat1<'a> = TableRef<'a, DeltaSetIndexMapFormat1Marker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> DeltaSetIndexMapFormat1<'a> {
@@ -849,7 +826,7 @@ impl<'a> From<EntryFormat> for FieldType<'a> {
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VariationRegionListMarker {}
+pub struct VariationRegionListMarker;
 
 impl<'a> MinByteRange for VariationRegionList<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -859,19 +836,16 @@ impl<'a> MinByteRange for VariationRegionList<'a> {
 
 impl<'a> FontRead<'a> for VariationRegionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let axis_count: u16 = cursor.read()?;
-        let region_count: u16 = cursor.read()?;
-        let variation_regions_byte_len = (region_count as usize)
-            .checked_mul(<VariationRegion as ComputeSize>::compute_size(&axis_count)?)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(variation_regions_byte_len);
-        cursor.finish(VariationRegionListMarker {})
+        Ok(TableRef {
+            shape: VariationRegionListMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
-pub type VariationRegionList<'a> = TableRef<'a, VariationRegionListMarker>;
+pub type VariationRegionList<'a> = TableRef<'a, VariationRegionListMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> VariationRegionList<'a> {
@@ -1077,7 +1051,7 @@ impl<'a> SomeRecord<'a> for RegionAxisCoordinates {
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ItemVariationStoreMarker {}
+pub struct ItemVariationStoreMarker;
 
 impl<'a> MinByteRange for ItemVariationStore<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1087,20 +1061,16 @@ impl<'a> MinByteRange for ItemVariationStore<'a> {
 
 impl<'a> FontRead<'a> for ItemVariationStore<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<u16>();
-        cursor.advance::<Offset32>();
-        let item_variation_data_count: u16 = cursor.read()?;
-        let item_variation_data_offsets_byte_len = (item_variation_data_count as usize)
-            .checked_mul(Offset32::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(item_variation_data_offsets_byte_len);
-        cursor.finish(ItemVariationStoreMarker {})
+        Ok(TableRef {
+            shape: ItemVariationStoreMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [ItemVariationStore](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) table
-pub type ItemVariationStore<'a> = TableRef<'a, ItemVariationStoreMarker>;
+pub type ItemVariationStore<'a> = TableRef<'a, ItemVariationStoreMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ItemVariationStore<'a> {
@@ -1222,7 +1192,7 @@ impl<'a> std::fmt::Debug for ItemVariationStore<'a> {
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct ItemVariationDataMarker {}
+pub struct ItemVariationDataMarker;
 
 impl<'a> MinByteRange for ItemVariationData<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -1232,25 +1202,16 @@ impl<'a> MinByteRange for ItemVariationData<'a> {
 
 impl<'a> FontRead<'a> for ItemVariationData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        let item_count: u16 = cursor.read()?;
-        let word_delta_count: u16 = cursor.read()?;
-        let region_index_count: u16 = cursor.read()?;
-        let region_indexes_byte_len = (region_index_count as usize)
-            .checked_mul(u16::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(region_indexes_byte_len);
-        let delta_sets_byte_len =
-            (ItemVariationData::delta_sets_len(item_count, word_delta_count, region_index_count))
-                .checked_mul(u8::RAW_BYTE_LEN)
-                .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(delta_sets_byte_len);
-        cursor.finish(ItemVariationDataMarker {})
+        Ok(TableRef {
+            shape: ItemVariationDataMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [ItemVariationData](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#item-variation-store-header-and-item-variation-data-subtables) subtable
-pub type ItemVariationData<'a> = TableRef<'a, ItemVariationDataMarker>;
+pub type ItemVariationData<'a> = TableRef<'a, ItemVariationDataMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> ItemVariationData<'a> {

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -24,9 +24,9 @@ impl<'a> FontReadWithArgs<'a> for TupleVariationHeader<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: TupleVariationHeaderMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -227,9 +227,9 @@ impl<'a> MinByteRange for DeltaSetIndexMapFormat0<'a> {
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: DeltaSetIndexMapFormat0Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -334,9 +334,9 @@ impl<'a> MinByteRange for DeltaSetIndexMapFormat1<'a> {
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: DeltaSetIndexMapFormat1Marker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -837,9 +837,9 @@ impl<'a> MinByteRange for VariationRegionList<'a> {
 impl<'a> FontRead<'a> for VariationRegionList<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VariationRegionListMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1062,9 +1062,9 @@ impl<'a> MinByteRange for ItemVariationStore<'a> {
 impl<'a> FontRead<'a> for ItemVariationStore<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ItemVariationStoreMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }
@@ -1203,9 +1203,9 @@ impl<'a> MinByteRange for ItemVariationData<'a> {
 impl<'a> FontRead<'a> for ItemVariationData<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: ItemVariationDataMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -10,7 +10,46 @@ use crate::codegen_prelude::*;
 #[doc(hidden)]
 pub struct VheaMarker {}
 
-impl VheaMarker {
+impl<'a> MinByteRange for Vhea<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.number_of_long_ver_metrics_byte_range().end
+    }
+}
+
+impl TopLevelTable for Vhea<'_> {
+    /// `vhea`
+    const TAG: Tag = Tag::new(b"vhea");
+}
+
+impl<'a> FontRead<'a> for Vhea<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        let mut cursor = data.cursor();
+        cursor.advance::<Version16Dot16>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<UfWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<FWord>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<i16>();
+        cursor.advance::<u16>();
+        cursor.finish(VheaMarker {})
+    }
+}
+
+/// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
+pub type Vhea<'a> = TableRef<'a, VheaMarker>;
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Vhea<'a> {
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + Version16Dot16::RAW_BYTE_LEN
@@ -95,108 +134,67 @@ impl VheaMarker {
         let start = self.metric_data_format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
     }
-}
 
-impl MinByteRange for VheaMarker {
-    fn min_byte_range(&self) -> Range<usize> {
-        0..self.number_of_long_ver_metrics_byte_range().end
-    }
-}
-
-impl TopLevelTable for Vhea<'_> {
-    /// `vhea`
-    const TAG: Tag = Tag::new(b"vhea");
-}
-
-impl<'a> FontRead<'a> for Vhea<'a> {
-    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Version16Dot16>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(VheaMarker {})
-    }
-}
-
-/// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
-pub type Vhea<'a> = TableRef<'a, VheaMarker>;
-
-#[allow(clippy::needless_lifetimes)]
-impl<'a> Vhea<'a> {
     /// The major/minor version (1, 1)
     pub fn version(&self) -> Version16Dot16 {
-        let range = self.shape.version_byte_range();
+        let range = self.version_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Typographic ascent.
     pub fn ascender(&self) -> FWord {
-        let range = self.shape.ascender_byte_range();
+        let range = self.ascender_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Typographic descent.
     pub fn descender(&self) -> FWord {
-        let range = self.shape.descender_byte_range();
+        let range = self.descender_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
     pub fn line_gap(&self) -> FWord {
-        let range = self.shape.line_gap_byte_range();
+        let range = self.line_gap_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Maximum advance height value in 'vmtx' table.
     pub fn advance_height_max(&self) -> UfWord {
-        let range = self.shape.advance_height_max_byte_range();
+        let range = self.advance_height_max_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum top sidebearing value in 'vmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
     pub fn min_top_side_bearing(&self) -> FWord {
-        let range = self.shape.min_top_side_bearing_byte_range();
+        let range = self.min_top_side_bearing_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Minimum bottom sidebearing value
     pub fn min_bottom_side_bearing(&self) -> FWord {
-        let range = self.shape.min_bottom_side_bearing_byte_range();
+        let range = self.min_bottom_side_bearing_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Defined as max( tsb + (yMax-yMin)).
     pub fn y_max_extent(&self) -> FWord {
-        let range = self.shape.y_max_extent_byte_range();
+        let range = self.y_max_extent_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
     pub fn caret_slope_rise(&self) -> i16 {
-        let range = self.shape.caret_slope_rise_byte_range();
+        let range = self.caret_slope_rise_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for vertical caret, 1 for horizontal.
     pub fn caret_slope_run(&self) -> i16 {
-        let range = self.shape.caret_slope_run_byte_range();
+        let range = self.caret_slope_run_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
@@ -204,19 +202,19 @@ impl<'a> Vhea<'a> {
     /// shifted to produce the best appearance. Set to 0 for
     /// non-slanted fonts
     pub fn caret_offset(&self) -> i16 {
-        let range = self.shape.caret_offset_byte_range();
+        let range = self.caret_offset_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// 0 for current format.
     pub fn metric_data_format(&self) -> i16 {
-        let range = self.shape.metric_data_format_byte_range();
+        let range = self.metric_data_format_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 
     /// Number of advance heights in the vertical metrics (`vmtx`) table.
     pub fn number_of_long_ver_metrics(&self) -> u16 {
-        let range = self.shape.number_of_long_ver_metrics_byte_range();
+        let range = self.number_of_long_ver_metrics_byte_range();
         self.data.read_at(range.start).unwrap()
     }
 }

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VheaMarker {}
+pub struct VheaMarker;
 
 impl<'a> MinByteRange for Vhea<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,30 +23,16 @@ impl TopLevelTable for Vhea<'_> {
 
 impl<'a> FontRead<'a> for Vhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<Version16Dot16>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<UfWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<FWord>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<i16>();
-        cursor.advance::<u16>();
-        cursor.finish(VheaMarker {})
+        Ok(TableRef {
+            shape: VheaMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [vhea](https://docs.microsoft.com/en-us/typography/opentype/spec/vhea) Vertical Header Table
-pub type Vhea<'a> = TableRef<'a, VheaMarker>;
+pub type Vhea<'a> = TableRef<'a, VheaMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Vhea<'a> {

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -124,64 +124,64 @@ impl<'a> Vhea<'a> {
     /// The major/minor version (1, 1)
     pub fn version(&self) -> Version16Dot16 {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Typographic ascent.
     pub fn ascender(&self) -> FWord {
         let range = self.ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Typographic descent.
     pub fn descender(&self) -> FWord {
         let range = self.descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
     pub fn line_gap(&self) -> FWord {
         let range = self.line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Maximum advance height value in 'vmtx' table.
     pub fn advance_height_max(&self) -> UfWord {
         let range = self.advance_height_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum top sidebearing value in 'vmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
     pub fn min_top_side_bearing(&self) -> FWord {
         let range = self.min_top_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Minimum bottom sidebearing value
     pub fn min_bottom_side_bearing(&self) -> FWord {
         let range = self.min_bottom_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Defined as max( tsb + (yMax-yMin)).
     pub fn y_max_extent(&self) -> FWord {
         let range = self.y_max_extent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
     pub fn caret_slope_rise(&self) -> i16 {
         let range = self.caret_slope_rise_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 0 for vertical caret, 1 for horizontal.
     pub fn caret_slope_run(&self) -> i16 {
         let range = self.caret_slope_run_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The amount by which a slanted highlight on a glyph needs to be
@@ -189,19 +189,19 @@ impl<'a> Vhea<'a> {
     /// non-slanted fonts
     pub fn caret_offset(&self) -> i16 {
         let range = self.caret_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// 0 for current format.
     pub fn metric_data_format(&self) -> i16 {
         let range = self.metric_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of advance heights in the vertical metrics (`vmtx`) table.
     pub fn number_of_long_ver_metrics(&self) -> u16 {
         let range = self.number_of_long_ver_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 }
 

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Vhea<'_> {
 impl<'a> FontRead<'a> for Vhea<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VheaMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -80,13 +80,13 @@ impl<'a> Vmtx<'a> {
     /// glyph. Records are indexed by glyph ID.
     pub fn v_metrics(&self) -> &'a [LongMetric] {
         let range = self.v_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     /// Top side bearings for glyph IDs greater than or equal to numberOfLongMetrics.
     pub fn top_side_bearings(&self) -> &'a [BigEndian<i16>] {
         let range = self.top_side_bearings_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 
     pub(crate) fn number_of_long_ver_metrics(&self) -> u16 {

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -29,9 +29,9 @@ impl<'a> FontReadWithArgs<'a> for Vmtx<'a> {
     fn read_with_args(data: FontData<'a>, args: &u16) -> Result<Self, ReadError> {
         let args = *args;
         Ok(TableRef {
-            shape: VmtxMarker,
             args,
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -9,23 +9,10 @@ use crate::codegen_prelude::*;
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
 pub struct VmtxMarker {
-    v_metrics_byte_len: usize,
-    top_side_bearings_byte_len: usize,
+    number_of_long_ver_metrics: u16,
 }
 
-impl VmtxMarker {
-    pub fn v_metrics_byte_range(&self) -> Range<usize> {
-        let start = 0;
-        start..start + self.v_metrics_byte_len
-    }
-
-    pub fn top_side_bearings_byte_range(&self) -> Range<usize> {
-        let start = self.v_metrics_byte_range().end;
-        start..start + self.top_side_bearings_byte_len
-    }
-}
-
-impl MinByteRange for VmtxMarker {
+impl<'a> MinByteRange for Vmtx<'a> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.top_side_bearings_byte_range().end
     }
@@ -52,8 +39,7 @@ impl<'a> FontReadWithArgs<'a> for Vmtx<'a> {
             cursor.remaining_bytes() / i16::RAW_BYTE_LEN * i16::RAW_BYTE_LEN;
         cursor.advance_by(top_side_bearings_byte_len);
         cursor.finish(VmtxMarker {
-            v_metrics_byte_len,
-            top_side_bearings_byte_len,
+            number_of_long_ver_metrics,
         })
     }
 }
@@ -74,17 +60,45 @@ pub type Vmtx<'a> = TableRef<'a, VmtxMarker>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Vmtx<'a> {
+    fn v_metrics_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        ((self.shape.number_of_long_ver_metrics) as usize)
+            .checked_mul(LongMetric::RAW_BYTE_LEN)
+            .unwrap()
+    }
+    fn top_side_bearings_byte_len(&self, start: usize) -> usize {
+        let _ = start;
+        {
+            let remaining = self.data.len().saturating_sub(start);
+            remaining / i16::RAW_BYTE_LEN * i16::RAW_BYTE_LEN
+        }
+    }
+
+    pub fn v_metrics_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + self.v_metrics_byte_len(start)
+    }
+
+    pub fn top_side_bearings_byte_range(&self) -> Range<usize> {
+        let start = self.v_metrics_byte_range().end;
+        start..start + self.top_side_bearings_byte_len(start)
+    }
+
     /// Paired advance height and top side bearing values for each
     /// glyph. Records are indexed by glyph ID.
     pub fn v_metrics(&self) -> &'a [LongMetric] {
-        let range = self.shape.v_metrics_byte_range();
+        let range = self.v_metrics_byte_range();
         self.data.read_array(range).unwrap()
     }
 
     /// Top side bearings for glyph IDs greater than or equal to numberOfLongMetrics.
     pub fn top_side_bearings(&self) -> &'a [BigEndian<i16>] {
-        let range = self.shape.top_side_bearings_byte_range();
+        let range = self.top_side_bearings_byte_range();
         self.data.read_array(range).unwrap()
+    }
+
+    pub(crate) fn number_of_long_ver_metrics(&self) -> u16 {
+        self.shape.number_of_long_ver_metrics
     }
 }
 

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -66,7 +66,7 @@ impl<'a> Vorg<'a> {
     /// Major/minor version number. Set to 1.0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// The y coordinate of a glyph’s vertical origin, in the font’s design
@@ -74,19 +74,19 @@ impl<'a> Vorg<'a> {
     /// in the vertOriginYMetrics array.
     pub fn default_vert_origin_y(&self) -> i16 {
         let range = self.default_vert_origin_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Number of elements in the vertOriginYMetrics array.
     pub fn num_vert_origin_y_metrics(&self) -> u16 {
         let range = self.num_vert_origin_y_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Array of VertOriginYMetrics records, sorted by glyph ID.
     pub fn vert_origin_y_metrics(&self) -> &'a [VertOriginYMetrics] {
         let range = self.vert_origin_y_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unchecked::read_array(self.data, range)
     }
 }
 

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Vorg<'_> {
 impl<'a> FontRead<'a> for Vorg<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VorgMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [VORG (Vertical Origin)](https://docs.microsoft.com/en-us/typography/opentype/spec/vorg) table.
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VorgMarker {}
+pub struct VorgMarker;
 
 impl<'a> MinByteRange for Vorg<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,20 +23,16 @@ impl TopLevelTable for Vorg<'_> {
 
 impl<'a> FontRead<'a> for Vorg<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<i16>();
-        let num_vert_origin_y_metrics: u16 = cursor.read()?;
-        let vert_origin_y_metrics_byte_len = (num_vert_origin_y_metrics as usize)
-            .checked_mul(VertOriginYMetrics::RAW_BYTE_LEN)
-            .ok_or(ReadError::OutOfBounds)?;
-        cursor.advance_by(vert_origin_y_metrics_byte_len);
-        cursor.finish(VorgMarker {})
+        Ok(TableRef {
+            shape: VorgMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [VORG (Vertical Origin)](https://docs.microsoft.com/en-us/typography/opentype/spec/vorg) table.
-pub type Vorg<'a> = TableRef<'a, VorgMarker>;
+pub type Vorg<'a> = TableRef<'a, VorgMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Vorg<'a> {

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -8,7 +8,7 @@ use crate::codegen_prelude::*;
 /// The [VVAR (Vertical Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/vvar) table
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
-pub struct VvarMarker {}
+pub struct VvarMarker;
 
 impl<'a> MinByteRange for Vvar<'a> {
     fn min_byte_range(&self) -> Range<usize> {
@@ -23,19 +23,16 @@ impl TopLevelTable for Vvar<'_> {
 
 impl<'a> FontRead<'a> for Vvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
-        let mut cursor = data.cursor();
-        cursor.advance::<MajorMinor>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.advance::<Offset32>();
-        cursor.finish(VvarMarker {})
+        Ok(TableRef {
+            shape: VvarMarker,
+            args: (),
+            data,
+        })
     }
 }
 
 /// The [VVAR (Vertical Metrics Variations)](https://docs.microsoft.com/en-us/typography/opentype/spec/vvar) table
-pub type Vvar<'a> = TableRef<'a, VvarMarker>;
+pub type Vvar<'a> = TableRef<'a, VvarMarker, ()>;
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> Vvar<'a> {

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -70,13 +70,13 @@ impl<'a> Vvar<'a> {
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Offset in bytes from the start of this table to the item variation store table.
     pub fn item_variation_store_offset(&self) -> Offset32 {
         let range = self.item_variation_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -88,7 +88,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for advance heights (may be NULL).
     pub fn advance_height_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.advance_height_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`advance_height_mapping_offset`][Self::advance_height_mapping_offset].
@@ -100,7 +100,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for top side bearings (may be NULL).
     pub fn tsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.tsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`tsb_mapping_offset`][Self::tsb_mapping_offset].
@@ -112,7 +112,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for bottom side bearings (may be NULL).
     pub fn bsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.bsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`bsb_mapping_offset`][Self::bsb_mapping_offset].
@@ -124,7 +124,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for Y coordinates of vertical origins (may be NULL).
     pub fn v_org_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.v_org_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unchecked::read_at(self.data, range.start)
     }
 
     /// Attempt to resolve [`v_org_mapping_offset`][Self::v_org_mapping_offset].

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -24,9 +24,9 @@ impl TopLevelTable for Vvar<'_> {
 impl<'a> FontRead<'a> for Vvar<'a> {
     fn read(data: FontData<'a>) -> Result<Self, ReadError> {
         Ok(TableRef {
-            shape: VvarMarker,
             args: (),
             data,
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -60,6 +60,19 @@ impl<'a> FontData<'a> {
         self.bytes.get(pos..).map(|bytes| FontData { bytes })
     }
 
+    /// Returns `self[pos..]` without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `pos` must be within `self.bytes`.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub(crate) unsafe fn split_off_unchecked(&self, pos: usize) -> FontData<'a> {
+        let len = self.bytes.len() - pos;
+        let ptr = self.bytes.as_ptr().add(pos);
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        FontData { bytes }
+    }
+
     /// returns self[..pos], and updates self to = self[pos..];
     pub fn take_up_to(&mut self, pos: usize) -> Option<FontData<'a>> {
         if pos > self.len() {
@@ -75,6 +88,19 @@ impl<'a> FontData<'a> {
         self.bytes.get(bounds).map(|bytes| FontData { bytes })
     }
 
+    /// Return a subslice without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `range` must be within `self.bytes`.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub(crate) unsafe fn slice_unchecked(&self, range: Range<usize>) -> FontData<'a> {
+        let len = range.end - range.start;
+        let ptr = self.bytes.as_ptr().add(range.start);
+        let bytes = std::slice::from_raw_parts(ptr, len);
+        FontData { bytes }
+    }
+
     /// Read a scalar at the provided location in the data.
     pub fn read_at<T: Scalar>(&self, offset: usize) -> Result<T, ReadError> {
         let end = offset
@@ -84,6 +110,17 @@ impl<'a> FontData<'a> {
             .get(offset..end)
             .and_then(T::read)
             .ok_or(ReadError::OutOfBounds)
+    }
+
+    /// Read a scalar at the provided location in the data, without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `offset..offset + T::RAW_BYTE_LEN` must be within `self.bytes`.
+    pub(crate) unsafe fn read_at_unchecked<T: Scalar>(&self, offset: usize) -> T {
+        let ptr = self.bytes.as_ptr().add(offset) as *const T::Raw;
+        let raw = ptr.read_unaligned();
+        T::from_raw(raw)
     }
 
     /// Read a big-endian value at the provided location in the data.
@@ -97,6 +134,17 @@ impl<'a> FontData<'a> {
             .ok_or(ReadError::OutOfBounds)
     }
 
+    /// Read a big-endian value at the provided location in the data, without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `offset..offset + T::RAW_BYTE_LEN` must be within `self.bytes`.
+    pub(crate) unsafe fn read_be_at_unchecked<T: Scalar>(&self, offset: usize) -> BigEndian<T> {
+        let ptr = self.bytes.as_ptr().add(offset) as *const T::Raw;
+        let raw = ptr.read_unaligned();
+        BigEndian::new(raw)
+    }
+
     pub fn read_with_args<T>(&self, range: Range<usize>, args: &T::Args) -> Result<T, ReadError>
     where
         T: FontReadWithArgs<'a>,
@@ -104,6 +152,23 @@ impl<'a> FontData<'a> {
         self.slice(range)
             .ok_or(ReadError::OutOfBounds)
             .and_then(|data| T::read_with_args(data, args))
+    }
+
+    /// Read a value with args at the provided range, without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `range` must be within `self.bytes`.
+    pub(crate) unsafe fn read_with_args_unchecked<T>(
+        &self,
+        range: Range<usize>,
+        args: &T::Args,
+    ) -> Result<T, ReadError>
+    where
+        T: FontReadWithArgs<'a>,
+    {
+        let data = self.slice_unchecked(range);
+        T::read_with_args(data, args)
     }
 
     fn check_in_bounds(&self, offset: usize) -> Result<(), ReadError> {
@@ -139,6 +204,20 @@ impl<'a> FontData<'a> {
             .map(bytemuck::from_bytes)
     }
 
+    /// Interpret the bytes at the provided offset as a reference to `T`, without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `offset..offset + T::RAW_BYTE_LEN` must be within `self.bytes`, and the
+    /// type must have alignment 1 and no padding.
+    pub(crate) unsafe fn read_ref_unchecked<T: AnyBitPattern + FixedSize>(
+        &self,
+        offset: usize,
+    ) -> &'a T {
+        let ptr = self.bytes.as_ptr().add(offset) as *const T;
+        &*ptr
+    }
+
     /// Interpret the bytes at the provided offset as a slice of `T`.
     ///
     /// Returns an error if `range` is out of bounds for the underlying data,
@@ -170,6 +249,24 @@ impl<'a> FontData<'a> {
             return Err(ReadError::InvalidArrayLen);
         };
         Ok(bytemuck::cast_slice(bytes))
+    }
+
+    /// Interpret the bytes at the provided range as a slice of `T`, without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `range` must be within `self.bytes`, must be a multiple of `T::RAW_BYTE_LEN`,
+    /// and the type must have alignment 1 and no padding.
+    #[allow(clippy::arithmetic_side_effects)]
+    pub(crate) unsafe fn read_array_unchecked<T: AnyBitPattern + FixedSize>(
+        &self,
+        range: Range<usize>,
+    ) -> &'a [T] {
+        let len = range.end - range.start;
+        debug_assert!(len % T::RAW_BYTE_LEN == 0);
+        let count = len / T::RAW_BYTE_LEN;
+        let ptr = self.bytes.as_ptr().add(range.start) as *const T;
+        std::slice::from_raw_parts(ptr, count)
     }
 
     pub(crate) fn cursor(&self) -> Cursor<'a> {
@@ -317,6 +414,70 @@ impl AsRef<[u8]> for FontData<'_> {
 impl<'a> From<&'a [u8]> for FontData<'a> {
     fn from(src: &'a [u8]) -> FontData<'a> {
         FontData::new(src)
+    }
+}
+
+pub(crate) mod unchecked {
+    use super::FontData;
+    use bytemuck::AnyBitPattern;
+    use std::ops::Range;
+    use types::{BigEndian, FixedSize, Scalar};
+
+    use crate::read::FontReadWithArgs;
+
+    #[inline]
+    pub(crate) fn split_off<'a>(data: FontData<'a>, pos: usize) -> FontData<'a> {
+        // SAFETY: callers ensure the range is within bounds.
+        unsafe { data.split_off_unchecked(pos) }
+    }
+
+    #[inline]
+    pub(crate) fn slice<'a>(data: FontData<'a>, range: Range<usize>) -> FontData<'a> {
+        // SAFETY: callers ensure the range is within bounds.
+        unsafe { data.slice_unchecked(range) }
+    }
+
+    #[inline]
+    pub(crate) fn read_at<'a, T: Scalar>(data: FontData<'a>, offset: usize) -> T {
+        // SAFETY: callers ensure the range is within bounds.
+        unsafe { data.read_at_unchecked(offset) }
+    }
+
+    #[inline]
+    pub(crate) fn read_be_at<'a, T: Scalar>(data: FontData<'a>, offset: usize) -> BigEndian<T> {
+        // SAFETY: callers ensure the range is within bounds.
+        unsafe { data.read_be_at_unchecked(offset) }
+    }
+
+    #[inline]
+    pub(crate) fn read_with_args<'a, T>(
+        data: FontData<'a>,
+        range: Range<usize>,
+        args: &T::Args,
+    ) -> T
+    where
+        T: FontReadWithArgs<'a>,
+    {
+        // SAFETY: callers ensure the range is within bounds.
+        unsafe { data.read_with_args_unchecked(range, args).unwrap() }
+    }
+
+    #[inline]
+    pub(crate) fn read_ref<'a, T: AnyBitPattern + FixedSize>(
+        data: FontData<'a>,
+        offset: usize,
+    ) -> &'a T {
+        // SAFETY: callers ensure the range is within bounds and type invariants hold.
+        unsafe { data.read_ref_unchecked(offset) }
+    }
+
+    #[inline]
+    pub(crate) fn read_array<'a, T: AnyBitPattern + FixedSize>(
+        data: FontData<'a>,
+        range: Range<usize>,
+    ) -> &'a [T] {
+        // SAFETY: callers ensure the range is within bounds and aligned to item size.
+        unsafe { data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -292,7 +292,11 @@ impl<'a> Cursor<'a> {
     pub(crate) fn finish<T>(self, shape: T) -> Result<TableRef<'a, T>, ReadError> {
         let data = self.data;
         data.check_in_bounds(self.pos)?;
-        Ok(TableRef { data, shape })
+        Ok(TableRef {
+            data,
+            shape,
+            args: (),
+        })
     }
 }
 

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -292,10 +292,11 @@ impl<'a> Cursor<'a> {
     pub(crate) fn finish<T>(self, shape: T) -> Result<TableRef<'a, T>, ReadError> {
         let data = self.data;
         data.check_in_bounds(self.pos)?;
+        let _ = shape;
         Ok(TableRef {
             data,
-            shape,
             args: (),
+            _marker: std::marker::PhantomData,
         })
     }
 }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -57,7 +57,7 @@
 //! [table-directory]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -99,6 +99,7 @@ pub extern crate font_types as types;
 #[doc(hidden)]
 pub(crate) mod codegen_prelude {
     pub use crate::array::{ComputedArray, VarLenArray};
+    pub(crate) use crate::font_data::unchecked;
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -48,17 +48,20 @@ impl<U, T: Format<U>> Format<U> for TableRef<'_, T> {
     const FORMAT: U = T::FORMAT;
 }
 
-impl<'a, T: MinByteRange> TableRef<'a, T> {
+impl<'a, T> TableRef<'a, T>
+where
+    TableRef<'a, T>: MinByteRange,
+{
     /// Return the minimum byte range of this table
     pub fn min_byte_range(&self) -> Range<usize> {
-        self.shape.min_byte_range()
+        MinByteRange::min_byte_range(self)
     }
 
     /// Return the minimum bytes of this table
     pub fn min_table_bytes(&self) -> &'a [u8] {
         self.offset_data()
             .as_bytes()
-            .get(self.shape.min_byte_range())
+            .get(self.min_byte_range())
             .unwrap_or_default()
     }
 }

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -5,6 +5,7 @@ use crate::{
     font_data::FontData,
     offset::{Offset, ResolveOffset},
 };
+use std::marker::PhantomData;
 use std::ops::Range;
 /// Return the minimum range of the table bytes
 ///
@@ -16,9 +17,9 @@ pub trait MinByteRange {
 #[derive(Clone)]
 /// Typed access to raw table data.
 pub struct TableRef<'a, T, A = ()> {
-    pub(crate) shape: T,
     pub(crate) args: A,
     pub(crate) data: FontData<'a>,
+    pub(crate) _marker: PhantomData<T>,
 }
 
 impl<'a, T, A> TableRef<'a, T, A> {
@@ -34,14 +35,6 @@ impl<'a, T, A> TableRef<'a, T, A> {
         self.data
     }
 
-    /// Return a reference to the table's 'Shape' struct.
-    ///
-    /// This is a low level implementation detail, but it can be useful in
-    /// some cases where you want to know things about a table's layout, such
-    /// as the byte offsets of specific fields.
-    pub fn shape(&self) -> &T {
-        &self.shape
-    }
 }
 
 // a blanket impl so that the format is available through a TableRef

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -34,7 +34,6 @@ impl<'a, T, A> TableRef<'a, T, A> {
     pub fn offset_data(&self) -> FontData<'a> {
         self.data
     }
-
 }
 
 // a blanket impl so that the format is available through a TableRef

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -15,12 +15,13 @@ pub trait MinByteRange {
 
 #[derive(Clone)]
 /// Typed access to raw table data.
-pub struct TableRef<'a, T> {
+pub struct TableRef<'a, T, A = ()> {
     pub(crate) shape: T,
+    pub(crate) args: A,
     pub(crate) data: FontData<'a>,
 }
 
-impl<'a, T> TableRef<'a, T> {
+impl<'a, T, A> TableRef<'a, T, A> {
     /// Resolve the provided offset from the start of this table.
     pub fn resolve_offset<O: Offset, R: FontRead<'a>>(&self, offset: O) -> Result<R, ReadError> {
         offset.resolve(self.data)
@@ -44,13 +45,13 @@ impl<'a, T> TableRef<'a, T> {
 }
 
 // a blanket impl so that the format is available through a TableRef
-impl<U, T: Format<U>> Format<U> for TableRef<'_, T> {
+impl<U, T: Format<U>, A> Format<U> for TableRef<'_, T, A> {
     const FORMAT: U = T::FORMAT;
 }
 
-impl<'a, T> TableRef<'a, T>
+impl<'a, T, A> TableRef<'a, T, A>
 where
-    TableRef<'a, T>: MinByteRange,
+    TableRef<'a, T, A>: MinByteRange,
 {
     /// Return the minimum byte range of this table
     pub fn min_byte_range(&self) -> Range<usize> {

--- a/read-fonts/src/tables/cvar.rs
+++ b/read-fonts/src/tables/cvar.rs
@@ -66,7 +66,7 @@ impl<'a> Cvar<'a> {
     }
 
     fn raw_tuple_header_data(&self) -> FontData<'a> {
-        let range = self.shape.tuple_variation_headers_byte_range();
+        let range = self.tuple_variation_headers_byte_range();
         self.data.split_off(range.start).unwrap()
     }
 }

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -164,7 +164,7 @@ impl PairPosFormat2<'_> {
         // Compute an offset into the 2D array of positioning records
         let record_offset = (class1 as usize * record_size * self.class2_count() as usize)
             + (class2 as usize * record_size)
-            + self.shape().class1_records_byte_range().start;
+            + self.class1_records_byte_range().start;
         Ok([
             Value::read(data, record_offset, format1, context)?,
             Value::read(data, record_offset + format1_len, format2, context)?,

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -51,7 +51,7 @@ impl U16Or32 {
 
 impl<'a> GlyphVariationDataHeader<'a> {
     fn raw_tuple_header_data(&self) -> FontData<'a> {
-        let range = self.shape.tuple_variation_headers_byte_range();
+        let range = self.tuple_variation_headers_byte_range();
         self.data.split_off(range.start).unwrap()
     }
 }

--- a/read-fonts/src/tables/variations.rs
+++ b/read-fonts/src/tables/variations.rs
@@ -165,7 +165,7 @@ impl<'a> TupleVariationHeader<'a> {
     #[inline(always)]
     pub fn peak_tuple(&self) -> Option<Tuple<'a>> {
         self.tuple_index().embedded_peak_tuple().then(|| {
-            let range = self.shape.peak_tuple_byte_range();
+            let range = self.peak_tuple_byte_range();
             Tuple {
                 values: self.data.read_array(range).unwrap(),
             }
@@ -177,7 +177,7 @@ impl<'a> TupleVariationHeader<'a> {
     #[inline(always)]
     pub fn intermediate_start_tuple(&self) -> Option<Tuple<'a>> {
         self.tuple_index().intermediate_region().then(|| {
-            let range = self.shape.intermediate_start_tuple_byte_range();
+            let range = self.intermediate_start_tuple_byte_range();
             Tuple {
                 values: self.data.read_array(range).unwrap(),
             }
@@ -189,7 +189,7 @@ impl<'a> TupleVariationHeader<'a> {
     #[inline(always)]
     pub fn intermediate_end_tuple(&self) -> Option<Tuple<'a>> {
         self.tuple_index().intermediate_region().then(|| {
-            let range = self.shape.intermediate_end_tuple_byte_range();
+            let range = self.intermediate_end_tuple_byte_range();
             Tuple {
                 values: self.data.read_array(range).unwrap(),
             }
@@ -201,8 +201,8 @@ impl<'a> TupleVariationHeader<'a> {
     #[inline(always)]
     pub fn intermediate_tuples(&self) -> Option<(Tuple<'a>, Tuple<'a>)> {
         self.tuple_index().intermediate_region().then(|| {
-            let start_range = self.shape.intermediate_start_tuple_byte_range();
-            let end_range = self.shape.intermediate_end_tuple_byte_range();
+            let start_range = self.intermediate_start_tuple_byte_range();
+            let end_range = self.intermediate_end_tuple_byte_range();
             (
                 Tuple {
                     values: self.data.read_array(start_range).unwrap(),


### PR DESCRIPTION
This is the result of a few days vibe-coding with codex. This moves access checks from table construction time, to each individual fields's getter method.

If there's out of bounds access, this code crashes. We can see if we can codegen `sanitize` methods ala HB to address that and reject at font table level bad data.

Accompanying HR PR: https://github.com/harfbuzz/harfrust/pull/314

Experiment details:
https://docs.google.com/document/d/1LjYFjZj8Kw8zyhqsfZg0_VgzHf2zhYUsksPCkZL7GJI/edit