### PR TITLE
Bump minor for all for MSRV update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,12 @@ core_maths = "0.1"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.10.1", path = "font-types" }
-read-fonts = { version = "0.36.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.11.0", path = "font-types" }
+read-fonts = { version = "0.37.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.39.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.44.1", path = "write-fonts" }
+skrifa = { version = "0.40.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.45.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 klippa = { version = "0.1.0", path = "klippa" }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.10.1"
+version = "0.11.0"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.36.0"
+version = "0.37.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.39.0"
+version = "0.40.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.44.1"
+version = "0.45.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
And to fix docs.rs build failures.

     Changes for font-types from font-types-v0.10.1 to 0.11.0
             38e7270 Fix documentation build (#1697)
     Changes for read-fonts from read-fonts-v0.36.0 to 0.37.0
             34dcd73 Fix fuzzer found addition overflow.
             7bb2b35 fix clippy needless-lifetimes
             38e7270 Fix documentation build (#1697)
     Changes for write-fonts from write-fonts-v0.44.1 to 0.45.0
             38e7270 Fix documentation build (#1697)
     Changes for skrifa from skrifa-v0.39.0 to 0.40.0
             3ca75c9 Implement Clone for Brush
             179267f fix clippy nonmiminal-bool
             7bb2b35 fix clippy needless-lifetimes
             38e7270 Fix documentation build (#1697)