### PR TITLE
Enforce MSRV for font-codegen, fuzz

### DIFF
--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "codegen"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "codegen"
@@ -16,6 +17,9 @@ path = "src/main.rs"
 [dependencies]
 font-types = { workspace = true }
 rustfmt-wrapper = "0.2"
+# this is not a direct dependecy of ours, but we specify it because the latest
+# version, 0.5.12, doesn't work under our current MSRV
+home = "=0.5.11"
 regex = "1.5"
 miette = { version =  "5.0", features = ["fancy"] }
 syn =  { version = "2.0", features = ["parsing",  "extra-traits", "full"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/int_set_op_processor.rs
+++ b/fuzz/fuzz_targets/int_set_op_processor.rs
@@ -182,7 +182,7 @@ impl SmallEvenInt {
             "Constructed SmallEvenInt with value > MAX_VALUE."
         );
         assert!(
-            value.is_multiple_of(2),
+            (value % 2) == 0,
             "Constructed SmallEvenInt with an odd value."
         );
         SmallEvenInt(value)
@@ -191,7 +191,7 @@ impl SmallEvenInt {
 
 impl SetMember for SmallEvenInt {
     fn create(val: u32) -> Option<SmallEvenInt> {
-        if val > Self::MAX_VALUE || !val.is_multiple_of(2) {
+        if val > Self::MAX_VALUE || (val % 2) != 0 {
             return None;
         }
         Some(SmallEvenInt::new(val))
@@ -216,7 +216,7 @@ impl Domain for SmallEvenInt {
     }
 
     fn contains(value: u32) -> bool {
-        value.is_multiple_of(2) && value <= Self::MAX_VALUE
+        value % 2 == 0 && value <= Self::MAX_VALUE
     }
 
     fn is_continuous() -> bool {


### PR DESCRIPTION
This was annoying me, because I would need to use a different rust version to run codegen versus when I was building read-fonts.

JMM