### PR TITLE
[read] Add unsafe read for scalars and arrays

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -818,9 +818,9 @@ impl Field {
         } else if is_var_array {
             quote!(VarLenArray::read(self.data.split_off(range.start).unwrap()).unwrap())
         } else if is_array {
-            quote!(self.data.read_array(range).unwrap())
+            quote!(unsafe { self.data.read_array_unchecked(range) })
         } else {
-            quote!(self.data.read_at(range.start).unwrap())
+            quote!(unsafe { self.data.read_at_unchecked(range.start) })
         };
         if is_versioned {
             read_stmt = quote!(Some(#read_stmt));

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -76,34 +76,34 @@ impl<'a> TableDirectory<'a> {
     /// 0x00010000 or 0x4F54544F
     pub fn sfnt_version(&self) -> u32 {
         let range = self.shape.sfnt_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of tables.
     pub fn num_tables(&self) -> u16 {
         let range = self.shape.num_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Table records array—one for each top-level table in the font
     pub fn table_records(&self) -> &'a [TableRecord] {
         let range = self.shape.table_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -300,43 +300,43 @@ impl<'a> TTCHeader<'a> {
     /// Font Collection ID string: \"ttcf\"
     pub fn ttc_tag(&self) -> Tag {
         let range = self.shape.ttc_tag_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Major/minor version of the TTC Header
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of fonts in TTC
     pub fn num_fonts(&self) -> u32 {
         let range = self.shape.num_fonts_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to the TableDirectory for each font from the beginning of the file
     pub fn table_directory_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.table_directory_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Tag indicating that a DSIG table exists, 0x44534947 ('DSIG') (null if no signature)
     pub fn dsig_tag(&self) -> Option<u32> {
         let range = self.shape.dsig_tag_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// The length (in bytes) of the DSIG table (null if no signature)
     pub fn dsig_length(&self) -> Option<u32> {
         let range = self.shape.dsig_length_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// The offset (in bytes) of the DSIG table from the beginning of the TTC file (null if no signature)
     pub fn dsig_offset(&self) -> Option<u32> {
         let range = self.shape.dsig_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -153,13 +153,13 @@ impl<'a> Lookup0<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Values, indexed by glyph index.
     pub fn values_data(&self) -> &'a [u8] {
         let range = self.shape.values_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -270,43 +270,43 @@ impl<'a> Lookup2<'a> {
     /// Format number is set to 2.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
         let range = self.shape.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
         let range = self.shape.n_units_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Segments.
     pub fn segments_data(&self) -> &'a [u8] {
         let range = self.shape.segments_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -420,43 +420,43 @@ impl<'a> Lookup4<'a> {
     /// Format number is set to 4.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
         let range = self.shape.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
         let range = self.shape.n_units_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Segments.
     pub fn segments(&self) -> &'a [LookupSegment4] {
         let range = self.shape.segments_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -627,43 +627,43 @@ impl<'a> Lookup6<'a> {
     /// Format number is set to 6.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Size of a lookup unit for this search in bytes.
     pub fn unit_size(&self) -> u16 {
         let range = self.shape.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of units of the preceding size to be searched.
     pub fn n_units(&self) -> u16 {
         let range = self.shape.n_units_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of unitSize times the largest power of 2 that is less than or equal to the value of nUnits.
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The log base 2 of the largest power of 2 less than or equal to the value of nUnits.
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of unitSize times the difference of the value of nUnits minus the largest power of 2 less than or equal to the value of nUnits.
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Values, indexed by glyph index.
     pub fn entries_data(&self) -> &'a [u8] {
         let range = self.shape.entries_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -759,27 +759,27 @@ impl<'a> Lookup8<'a> {
     /// Format number is set to 8.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// First glyph index included in the trimmed array.
     pub fn first_glyph(&self) -> u16 {
         let range = self.shape.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Total number of glyphs (equivalent to the last glyph minus the value
     /// of firstGlyph plus 1).
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The lookup values (indexed by the glyph index minus the value of
     /// firstGlyph). Entries in the value array must be two bytes.
     pub fn value_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.value_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -878,34 +878,34 @@ impl<'a> Lookup10<'a> {
     /// Format number is set to 10.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Size of a lookup unit for this lookup table in bytes. Allowed values
     /// are 1, 2, 4, and 8.
     pub fn unit_size(&self) -> u16 {
         let range = self.shape.unit_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// First glyph index included in the trimmed array.
     pub fn first_glyph(&self) -> u16 {
         let range = self.shape.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Total number of glyphs (equivalent to the last glyph minus the value
     /// of firstGlyph plus 1).
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The lookup values (indexed by the glyph index minus the value of
     /// firstGlyph).
     pub fn values_data(&self) -> &'a [u8] {
         let range = self.shape.values_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -987,13 +987,13 @@ impl<'a> StateHeader<'a> {
     /// field is 16 bits for alignment.
     pub fn state_size(&self) -> u16 {
         let range = self.shape.state_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte offset from the beginning of the state table to the class subtable.
     pub fn class_table_offset(&self) -> Offset16 {
         let range = self.shape.class_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`class_table_offset`][Self::class_table_offset].
@@ -1005,7 +1005,7 @@ impl<'a> StateHeader<'a> {
     /// Byte offset from the beginning of the state table to the state array.
     pub fn state_array_offset(&self) -> Offset16 {
         let range = self.shape.state_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`state_array_offset`][Self::state_array_offset].
@@ -1017,7 +1017,7 @@ impl<'a> StateHeader<'a> {
     /// Byte offset from the beginning of the state table to the entry subtable.
     pub fn entry_table_offset(&self) -> Offset16 {
         let range = self.shape.entry_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`entry_table_offset`][Self::entry_table_offset].
@@ -1113,20 +1113,20 @@ impl<'a> ClassSubtable<'a> {
     /// Glyph index of the first glyph in the class table.
     pub fn first_glyph(&self) -> u16 {
         let range = self.shape.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of glyphs in class table.
     pub fn n_glyphs(&self) -> u16 {
         let range = self.shape.n_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The class codes (indexed by glyph index minus firstGlyph). Class codes
     /// range from 0 to the value of stateSize minus 1.
     pub fn class_array(&self) -> &'a [u8] {
         let range = self.shape.class_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1189,7 +1189,7 @@ pub type RawBytes<'a> = TableRef<'a, RawBytesMarker>;
 impl<'a> RawBytes<'a> {
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1266,13 +1266,13 @@ impl<'a> StxHeader<'a> {
     /// Number of classes, which is the number of 16-bit entry indices in a single line in the state array.
     pub fn n_classes(&self) -> u32 {
         let range = self.shape.n_classes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte offset from the beginning of the state table to the class subtable.
     pub fn class_table_offset(&self) -> Offset32 {
         let range = self.shape.class_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`class_table_offset`][Self::class_table_offset].
@@ -1284,7 +1284,7 @@ impl<'a> StxHeader<'a> {
     /// Byte offset from the beginning of the state table to the state array.
     pub fn state_array_offset(&self) -> Offset32 {
         let range = self.shape.state_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`state_array_offset`][Self::state_array_offset].
@@ -1296,7 +1296,7 @@ impl<'a> StxHeader<'a> {
     /// Byte offset from the beginning of the state table to the entry subtable.
     pub fn entry_table_offset(&self) -> Offset32 {
         let range = self.shape.entry_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`entry_table_offset`][Self::entry_table_offset].
@@ -1375,7 +1375,7 @@ pub type RawWords<'a> = TableRef<'a, RawWordsMarker>;
 impl<'a> RawWords<'a> {
     pub fn data(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -62,13 +62,13 @@ impl<'a> Ankr<'a> {
     /// Version number (set to zero).
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Flags (currently unused; set to zero).
     pub fn flags(&self) -> u16 {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to the table's lookup table; currently this is always `0x0000000C`.
@@ -76,7 +76,7 @@ impl<'a> Ankr<'a> {
     /// Lookup values are two byte offsets into the glyph data table.
     pub fn lookup_table_offset(&self) -> Offset32 {
         let range = self.shape.lookup_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`lookup_table_offset`][Self::lookup_table_offset].
@@ -88,7 +88,7 @@ impl<'a> Ankr<'a> {
     /// Offset to the glyph data table.
     pub fn glyph_data_table_offset(&self) -> u32 {
         let range = self.shape.glyph_data_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -167,13 +167,13 @@ impl<'a> GlyphDataEntry<'a> {
     /// Number of anchor points for this glyph.
     pub fn num_points(&self) -> u32 {
         let range = self.shape.num_points_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Individual anchor points.
     pub fn anchor_points(&self) -> &'a [AnchorPoint] {
         let range = self.shape.anchor_points_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -99,13 +99,13 @@ impl<'a> Avar<'a> {
     /// Minor version number of the axis variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of variation axes for this font. This must be the same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
         let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The segment maps array — one segment map for each axis, in the order of axes specified in the 'fvar' table.
@@ -117,7 +117,7 @@ impl<'a> Avar<'a> {
     /// Offset to DeltaSetIndexMap table (may be NULL).
     pub fn axis_index_map_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.axis_index_map_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`axis_index_map_offset`][Self::axis_index_map_offset].
@@ -129,7 +129,7 @@ impl<'a> Avar<'a> {
     /// Offset to ItemVariationStore (may be NULL).
     pub fn var_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.var_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`var_store_offset`][Self::var_store_offset].

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -72,13 +72,13 @@ impl<'a> Base<'a> {
     /// (major, minor) Version for the BASE table (1,0) or (1,1)
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to horizontal Axis table, from beginning of BASE table (may be NULL)
     pub fn horiz_axis_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.horiz_axis_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`horiz_axis_offset`][Self::horiz_axis_offset].
@@ -90,7 +90,7 @@ impl<'a> Base<'a> {
     /// Offset to vertical Axis table, from beginning of BASE table (may be NULL)
     pub fn vert_axis_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.vert_axis_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`vert_axis_offset`][Self::vert_axis_offset].
@@ -102,7 +102,7 @@ impl<'a> Base<'a> {
     /// Offset to Item Variation Store table, from beginning of BASE table (may be null)
     pub fn item_var_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.item_var_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`item_var_store_offset`][Self::item_var_store_offset].
@@ -187,7 +187,7 @@ impl<'a> Axis<'a> {
     /// be NULL)
     pub fn base_tag_list_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.base_tag_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`base_tag_list_offset`][Self::base_tag_list_offset].
@@ -199,7 +199,7 @@ impl<'a> Axis<'a> {
     /// Offset to BaseScriptList table, from beginning of Axis table
     pub fn base_script_list_offset(&self) -> Offset16 {
         let range = self.shape.base_script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`base_script_list_offset`][Self::base_script_list_offset].
@@ -285,14 +285,14 @@ impl<'a> BaseTagList<'a> {
     /// — may be zero (0)
     pub fn base_tag_count(&self) -> u16 {
         let range = self.shape.base_tag_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of 4-byte baseline identification tags — must be in
     /// alphabetical order
     pub fn baseline_tags(&self) -> &'a [BigEndian<Tag>] {
         let range = self.shape.baseline_tags_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -365,14 +365,14 @@ impl<'a> BaseScriptList<'a> {
     /// Number of BaseScriptRecords defined
     pub fn base_script_count(&self) -> u16 {
         let range = self.shape.base_script_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of BaseScriptRecords, in alphabetical order by
     /// baseScriptTag
     pub fn base_script_records(&self) -> &'a [BaseScriptRecord] {
         let range = self.shape.base_script_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -517,7 +517,7 @@ impl<'a> BaseScript<'a> {
     /// Offset to BaseValues table, from beginning of BaseScript table (may be NULL)
     pub fn base_values_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.base_values_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`base_values_offset`][Self::base_values_offset].
@@ -529,7 +529,7 @@ impl<'a> BaseScript<'a> {
     /// Offset to MinMax table, from beginning of BaseScript table (may be NULL)
     pub fn default_min_max_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.default_min_max_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`default_min_max_offset`][Self::default_min_max_offset].
@@ -541,14 +541,14 @@ impl<'a> BaseScript<'a> {
     /// Number of BaseLangSysRecords defined — may be zero (0)
     pub fn base_lang_sys_count(&self) -> u16 {
         let range = self.shape.base_lang_sys_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of BaseLangSysRecords, in alphabetical order by
     /// BaseLangSysTag
     pub fn base_lang_sys_records(&self) -> &'a [BaseLangSysRecord] {
         let range = self.shape.base_lang_sys_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -700,14 +700,14 @@ impl<'a> BaseValues<'a> {
     /// BaseTagList
     pub fn default_baseline_index(&self) -> u16 {
         let range = self.shape.default_baseline_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of BaseCoord tables defined — should equal
     /// baseTagCount in the BaseTagList
     pub fn base_coord_count(&self) -> u16 {
         let range = self.shape.base_coord_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to BaseCoord tables, from beginning of
@@ -715,7 +715,7 @@ impl<'a> BaseValues<'a> {
     /// BaseTagList
     pub fn base_coord_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.base_coord_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`base_coord_offsets`][Self::base_coord_offsets].
@@ -825,7 +825,7 @@ impl<'a> MinMax<'a> {
     /// value, from the beginning of MinMax table (may be NULL)
     pub fn min_coord_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.min_coord_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`min_coord_offset`][Self::min_coord_offset].
@@ -838,7 +838,7 @@ impl<'a> MinMax<'a> {
     /// from the beginning of MinMax table (may be NULL)
     pub fn max_coord_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.max_coord_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`max_coord_offset`][Self::max_coord_offset].
@@ -850,14 +850,14 @@ impl<'a> MinMax<'a> {
     /// Number of FeatMinMaxRecords — may be zero (0)
     pub fn feat_min_max_count(&self) -> u16 {
         let range = self.shape.feat_min_max_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of FeatMinMaxRecords, in alphabetical order by
     /// featureTableTag
     pub fn feat_min_max_records(&self) -> &'a [FeatMinMaxRecord] {
         let range = self.shape.feat_min_max_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1108,13 +1108,13 @@ impl<'a> BaseCoordFormat1<'a> {
     /// Format identifier — format = 1
     pub fn base_coord_format(&self) -> u16 {
         let range = self.shape.base_coord_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.shape.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -1196,25 +1196,25 @@ impl<'a> BaseCoordFormat2<'a> {
     /// Format identifier — format = 2
     pub fn base_coord_format(&self) -> u16 {
         let range = self.shape.base_coord_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.shape.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Glyph ID of control glyph
     pub fn reference_glyph(&self) -> u16 {
         let range = self.shape.reference_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Index of contour point on the reference glyph
     pub fn base_coord_point(&self) -> u16 {
         let range = self.shape.base_coord_point_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -1292,13 +1292,13 @@ impl<'a> BaseCoordFormat3<'a> {
     /// Format identifier — format = 3
     pub fn base_coord_format(&self) -> u16 {
         let range = self.shape.base_coord_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.shape.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Device table (non-variable font) / Variation Index
@@ -1306,7 +1306,7 @@ impl<'a> BaseCoordFormat3<'a> {
     /// BaseCoord table (may be NULL).
     pub fn device_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -796,7 +796,7 @@ impl<'a> IndexSubtableList<'a> {
     /// Array of IndexSubtableRecords.
     pub fn index_subtable_records(&self) -> &'a [IndexSubtableRecord] {
         let range = self.shape.index_subtable_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -977,24 +977,24 @@ impl<'a> IndexSubtable1<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn sbit_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.sbit_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1089,31 +1089,31 @@ impl<'a> IndexSubtable2<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// All the glyphs are of the same size.
     pub fn image_size(&self) -> u32 {
         let range = self.shape.image_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// All glyphs have the same metrics; glyph data may be compressed, byte-aligned, or bit-aligned.
     pub fn big_metrics(&self) -> &'a [BigGlyphMetrics] {
         let range = self.shape.big_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1236,24 +1236,24 @@ impl<'a> IndexSubtable3<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn sbit_offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.sbit_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1350,31 +1350,31 @@ impl<'a> IndexSubtable4<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array length.
     pub fn num_glyphs(&self) -> u32 {
         let range = self.shape.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// One per glyph.
     pub fn glyph_array(&self) -> &'a [GlyphIdOffsetPair] {
         let range = self.shape.glyph_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1536,43 +1536,43 @@ impl<'a> IndexSubtable5<'a> {
     /// Format of this IndexSubTable.
     pub fn index_format(&self) -> u16 {
         let range = self.shape.index_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of EBDT image data.
     pub fn image_format(&self) -> u16 {
         let range = self.shape.image_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to image data in EBDT table.
     pub fn image_data_offset(&self) -> u32 {
         let range = self.shape.image_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// All glyphs have the same data size.
     pub fn image_size(&self) -> u32 {
         let range = self.shape.image_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// All glyphs have the same metrics.
     pub fn big_metrics(&self) -> &'a [BigGlyphMetrics] {
         let range = self.shape.big_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Array length.
     pub fn num_glyphs(&self) -> u32 {
         let range = self.shape.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// One per glyph, sorted by glyhph ID.
     pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.glyph_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -50,13 +50,13 @@ impl<'a> Cbdt<'a> {
     /// Major version of the CBDT table, = 3.
     pub fn major_version(&self) -> u16 {
         let range = self.shape.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minor version of CBDT table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.shape.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -69,25 +69,25 @@ impl<'a> Cblc<'a> {
     /// Major version of the CBLC table, = 3.
     pub fn major_version(&self) -> u16 {
         let range = self.shape.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minor version of CBLC table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.shape.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of BitmapSize records.
     pub fn num_sizes(&self) -> u32 {
         let range = self.shape.num_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// BitmapSize records array.
     pub fn bitmap_sizes(&self) -> &'a [BitmapSize] {
         let range = self.shape.bitmap_sizes_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -79,37 +79,37 @@ impl<'a> CffHeader<'a> {
     /// Format major version (starting at 1).
     pub fn major(&self) -> u8 {
         let range = self.shape.major_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format minor version (starting at 0).
     pub fn minor(&self) -> u8 {
         let range = self.shape.minor_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Header size (bytes).
     pub fn hdr_size(&self) -> u8 {
         let range = self.shape.hdr_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Absolute offset size.
     pub fn off_size(&self) -> u8 {
         let range = self.shape.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Padding bytes before the start of the Name INDEX.
     pub fn _padding(&self) -> &'a [u8] {
         let range = self.shape._padding_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Remaining table data.
     pub fn trailing_data(&self) -> &'a [u8] {
         let range = self.shape.trailing_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -90,43 +90,43 @@ impl<'a> Cff2Header<'a> {
     /// Format major version (set to 2).
     pub fn major_version(&self) -> u8 {
         let range = self.shape.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format minor version (set to 0).
     pub fn minor_version(&self) -> u8 {
         let range = self.shape.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Header size (bytes).
     pub fn header_size(&self) -> u8 {
         let range = self.shape.header_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Length of Top DICT structure in bytes.
     pub fn top_dict_length(&self) -> u16 {
         let range = self.shape.top_dict_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Padding bytes before the start of the Top DICT.
     pub fn _padding(&self) -> &'a [u8] {
         let range = self.shape._padding_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Data containing the Top DICT.
     pub fn top_dict_data(&self) -> &'a [u8] {
         let range = self.shape.top_dict_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Remaining table data.
     pub fn trailing_data(&self) -> &'a [u8] {
         let range = self.shape.trailing_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -63,18 +63,18 @@ impl<'a> Cmap<'a> {
     /// Table version number (0).
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of encoding tables that follow.
     pub fn num_tables(&self) -> u16 {
         let range = self.shape.num_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn encoding_records(&self) -> &'a [EncodingRecord] {
         let range = self.shape.encoding_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -401,26 +401,26 @@ impl<'a> Cmap0<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// An array that maps character codes to glyph index values.
     pub fn glyph_id_array(&self) -> &'a [u8] {
         let range = self.shape.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -511,27 +511,27 @@ impl<'a> Cmap2<'a> {
     /// Format number is set to 2.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array that maps high bytes to subHeaders: value is subHeader
     /// index × 8.
     pub fn sub_header_keys(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.sub_header_keys_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -754,26 +754,26 @@ impl<'a> Cmap4<'a> {
     /// Format number is set to 4.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 2 × segCount.
     pub fn seg_count_x2(&self) -> u16 {
         let range = self.shape.seg_count_x2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum power of 2 less than or equal to segCount, times 2
@@ -781,51 +781,51 @@ impl<'a> Cmap4<'a> {
     /// exponentiation operator)
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Log2 of the maximum power of 2 less than or equal to numTables
     /// (log2(searchRange/2), which is equal to floor(log2(segCount)))
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// segCount times 2, minus searchRange ((segCount * 2) -
     /// searchRange)
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End characterCode for each segment, last=0xFFFF.
     pub fn end_code(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.end_code_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Start character code for each segment.
     pub fn start_code(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.start_code_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Delta for all character codes in segment.
     pub fn id_delta(&self) -> &'a [BigEndian<i16>] {
         let range = self.shape.id_delta_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Offsets into glyphIdArray or 0
     pub fn id_range_offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.id_range_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Glyph index array (arbitrary length)
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -936,38 +936,38 @@ impl<'a> Cmap6<'a> {
     /// Format number is set to 6.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is the length in bytes of the subtable.
     pub fn length(&self) -> u16 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u16 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// First character code of subrange.
     pub fn first_code(&self) -> u16 {
         let range = self.shape.first_code_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of character codes in subrange.
     pub fn entry_count(&self) -> u16 {
         let range = self.shape.entry_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of glyph index values for character codes in the range.
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1083,20 +1083,20 @@ impl<'a> Cmap8<'a> {
     /// Subtable format; set to 8.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Tightly packed array of bits (8K bytes total) indicating
@@ -1104,19 +1104,19 @@ impl<'a> Cmap8<'a> {
     /// 32-bit character code
     pub fn is32(&self) -> &'a [u8] {
         let range = self.shape.is32_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
         let range = self.shape.num_groups_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of SequentialMapGroup records.
     pub fn groups(&self) -> &'a [SequentialMapGroup] {
         let range = self.shape.groups_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1292,38 +1292,38 @@ impl<'a> Cmap10<'a> {
     /// Subtable format; set to 10.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// First character code covered
     pub fn start_char_code(&self) -> u32 {
         let range = self.shape.start_char_code_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of character codes covered
     pub fn num_chars(&self) -> u32 {
         let range = self.shape.num_chars_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of glyph indices for the character codes covered
     pub fn glyph_id_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.glyph_id_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1426,32 +1426,32 @@ impl<'a> Cmap12<'a> {
     /// Subtable format; set to 12.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
         let range = self.shape.num_groups_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of SequentialMapGroup records.
     pub fn groups(&self) -> &'a [SequentialMapGroup] {
         let range = self.shape.groups_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1560,32 +1560,32 @@ impl<'a> Cmap13<'a> {
     /// Subtable format; set to 13.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte length of this subtable (including the header)
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// For requirements on use of the language field, see “Use of
     /// the language field in 'cmap' subtables” in this document.
     pub fn language(&self) -> u32 {
         let range = self.shape.language_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of groupings which follow
     pub fn num_groups(&self) -> u32 {
         let range = self.shape.num_groups_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of ConstantMapGroup records.
     pub fn groups(&self) -> &'a [ConstantMapGroup] {
         let range = self.shape.groups_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1736,25 +1736,25 @@ impl<'a> Cmap14<'a> {
     /// Subtable format. Set to 14.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Byte length of this subtable (including this header)
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of variation Selector Records
     pub fn num_var_selector_records(&self) -> u32 {
         let range = self.shape.num_var_selector_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of VariationSelector records.
     pub fn var_selector(&self) -> &'a [VariationSelector] {
         let range = self.shape.var_selector_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1919,13 +1919,13 @@ impl<'a> DefaultUvs<'a> {
     /// Number of Unicode character ranges.
     pub fn num_unicode_value_ranges(&self) -> u32 {
         let range = self.shape.num_unicode_value_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of UnicodeRange records.
     pub fn ranges(&self) -> &'a [UnicodeRange] {
         let range = self.shape.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2007,12 +2007,12 @@ pub type NonDefaultUvs<'a> = TableRef<'a, NonDefaultUvsMarker>;
 impl<'a> NonDefaultUvs<'a> {
     pub fn num_uvs_mappings(&self) -> u32 {
         let range = self.shape.num_uvs_mappings_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn uvs_mapping(&self) -> &'a [UvsMapping] {
         let range = self.shape.uvs_mapping_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -140,19 +140,19 @@ impl<'a> Colr<'a> {
     /// Table version number - set to 0 or 1.
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of BaseGlyph records; may be 0 in a version 1 table.
     pub fn num_base_glyph_records(&self) -> u16 {
         let range = self.shape.num_base_glyph_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to baseGlyphRecords array (may be NULL).
     pub fn base_glyph_records_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.base_glyph_records_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`base_glyph_records_offset`][Self::base_glyph_records_offset].
@@ -166,7 +166,7 @@ impl<'a> Colr<'a> {
     /// Offset to layerRecords array (may be NULL).
     pub fn layer_records_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.layer_records_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`layer_records_offset`][Self::layer_records_offset].
@@ -179,13 +179,13 @@ impl<'a> Colr<'a> {
     /// Number of Layer records; may be 0 in a version 1 table.
     pub fn num_layer_records(&self) -> u16 {
         let range = self.shape.num_layer_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to BaseGlyphList table.
     pub fn base_glyph_list_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.base_glyph_list_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`base_glyph_list_offset`][Self::base_glyph_list_offset].
@@ -197,7 +197,7 @@ impl<'a> Colr<'a> {
     /// Offset to LayerList table (may be NULL).
     pub fn layer_list_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.layer_list_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`layer_list_offset`][Self::layer_list_offset].
@@ -209,7 +209,7 @@ impl<'a> Colr<'a> {
     /// Offset to ClipList table (may be NULL).
     pub fn clip_list_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.clip_list_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`clip_list_offset`][Self::clip_list_offset].
@@ -221,7 +221,7 @@ impl<'a> Colr<'a> {
     /// Offset to DeltaSetIndexMap table (may be NULL).
     pub fn var_index_map_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.var_index_map_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`var_index_map_offset`][Self::var_index_map_offset].
@@ -233,7 +233,7 @@ impl<'a> Colr<'a> {
     /// Offset to ItemVariationStore (may be NULL).
     pub fn item_variation_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.item_variation_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -453,12 +453,12 @@ pub type BaseGlyphList<'a> = TableRef<'a, BaseGlyphListMarker>;
 impl<'a> BaseGlyphList<'a> {
     pub fn num_base_glyph_paint_records(&self) -> u32 {
         let range = self.shape.num_base_glyph_paint_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn base_glyph_paint_records(&self) -> &'a [BaseGlyphPaint] {
         let range = self.shape.base_glyph_paint_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -593,13 +593,13 @@ pub type LayerList<'a> = TableRef<'a, LayerListMarker>;
 impl<'a> LayerList<'a> {
     pub fn num_layers(&self) -> u32 {
         let range = self.shape.num_layers_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offsets to Paint tables.
     pub fn paint_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.paint_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`paint_offsets`][Self::paint_offsets].
@@ -696,19 +696,19 @@ impl<'a> ClipList<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of Clip records.
     pub fn num_clips(&self) -> u32 {
         let range = self.shape.num_clips_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Clip records. Sorted by startGlyphID.
     pub fn clips(&self) -> &'a [Clip] {
         let range = self.shape.clips_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -970,31 +970,31 @@ impl<'a> ClipBoxFormat1<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum x of clip box.
     pub fn x_min(&self) -> FWord {
         let range = self.shape.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum y of clip box.
     pub fn y_min(&self) -> FWord {
         let range = self.shape.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum x of clip box.
     pub fn x_max(&self) -> FWord {
         let range = self.shape.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum y of clip box.
     pub fn y_max(&self) -> FWord {
         let range = self.shape.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -1091,37 +1091,37 @@ impl<'a> ClipBoxFormat2<'a> {
     /// Set to 2.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum x of clip box. For variation, use varIndexBase + 0.
     pub fn x_min(&self) -> FWord {
         let range = self.shape.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum y of clip box. For variation, use varIndexBase + 1.
     pub fn y_min(&self) -> FWord {
         let range = self.shape.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum x of clip box. For variation, use varIndexBase + 2.
     pub fn x_max(&self) -> FWord {
         let range = self.shape.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum y of clip box. For variation, use varIndexBase + 3.
     pub fn y_max(&self) -> FWord {
         let range = self.shape.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -1405,18 +1405,18 @@ impl<'a> ColorLine<'a> {
     /// An Extend enum value.
     pub fn extend(&self) -> Extend {
         let range = self.shape.extend_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of ColorStop records.
     pub fn num_stops(&self) -> u16 {
         let range = self.shape.num_stops_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn color_stops(&self) -> &'a [ColorStop] {
         let range = self.shape.color_stops_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1503,19 +1503,19 @@ impl<'a> VarColorLine<'a> {
     /// An Extend enum value.
     pub fn extend(&self) -> Extend {
         let range = self.shape.extend_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of ColorStop records.
     pub fn num_stops(&self) -> u16 {
         let range = self.shape.num_stops_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Allows for variations.
     pub fn color_stops(&self) -> &'a [VarColorStop] {
         let range = self.shape.color_stops_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1920,19 +1920,19 @@ impl<'a> PaintColrLayers<'a> {
     /// Set to 1.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of offsets to paint tables to read from LayerList.
     pub fn num_layers(&self) -> u8 {
         let range = self.shape.num_layers_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Index (base 0) into the LayerList.
     pub fn first_layer_index(&self) -> u32 {
         let range = self.shape.first_layer_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2009,19 +2009,19 @@ impl<'a> PaintSolid<'a> {
     /// Set to 2.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Index for a CPAL palette entry.
     pub fn palette_index(&self) -> u16 {
         let range = self.shape.palette_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Alpha value.
     pub fn alpha(&self) -> F2Dot14 {
         let range = self.shape.alpha_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2104,25 +2104,25 @@ impl<'a> PaintVarSolid<'a> {
     /// Set to 3.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Index for a CPAL palette entry.
     pub fn palette_index(&self) -> u16 {
         let range = self.shape.palette_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Alpha value. For variation, use varIndexBase + 0.
     pub fn alpha(&self) -> F2Dot14 {
         let range = self.shape.alpha_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2230,13 +2230,13 @@ impl<'a> PaintLinearGradient<'a> {
     /// Set to 4.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.shape.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2248,37 +2248,37 @@ impl<'a> PaintLinearGradient<'a> {
     /// Start point (p₀) x coordinate.
     pub fn x0(&self) -> FWord {
         let range = self.shape.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start point (p₀) y coordinate.
     pub fn y0(&self) -> FWord {
         let range = self.shape.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End point (p₁) x coordinate.
     pub fn x1(&self) -> FWord {
         let range = self.shape.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End point (p₁) y coordinate.
     pub fn y1(&self) -> FWord {
         let range = self.shape.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Rotation point (p₂) x coordinate.
     pub fn x2(&self) -> FWord {
         let range = self.shape.x2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Rotation point (p₂) y coordinate.
     pub fn y2(&self) -> FWord {
         let range = self.shape.y2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2399,13 +2399,13 @@ impl<'a> PaintVarLinearGradient<'a> {
     /// Set to 5.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.shape.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2418,48 +2418,48 @@ impl<'a> PaintVarLinearGradient<'a> {
     /// varIndexBase + 0.
     pub fn x0(&self) -> FWord {
         let range = self.shape.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start point (p₀) y coordinate. For variation, use
     /// varIndexBase + 1.
     pub fn y0(&self) -> FWord {
         let range = self.shape.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End point (p₁) x coordinate. For variation, use varIndexBase
     /// + 2.
     pub fn x1(&self) -> FWord {
         let range = self.shape.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End point (p₁) y coordinate. For variation, use varIndexBase
     /// + 3.
     pub fn y1(&self) -> FWord {
         let range = self.shape.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Rotation point (p₂) x coordinate. For variation, use
     /// varIndexBase + 4.
     pub fn x2(&self) -> FWord {
         let range = self.shape.x2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Rotation point (p₂) y coordinate. For variation, use
     /// varIndexBase + 5.
     pub fn y2(&self) -> FWord {
         let range = self.shape.y2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2575,13 +2575,13 @@ impl<'a> PaintRadialGradient<'a> {
     /// Set to 6.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.shape.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2593,37 +2593,37 @@ impl<'a> PaintRadialGradient<'a> {
     /// Start circle center x coordinate.
     pub fn x0(&self) -> FWord {
         let range = self.shape.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start circle center y coordinate.
     pub fn y0(&self) -> FWord {
         let range = self.shape.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start circle radius.
     pub fn radius0(&self) -> UfWord {
         let range = self.shape.radius0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End circle center x coordinate.
     pub fn x1(&self) -> FWord {
         let range = self.shape.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End circle center y coordinate.
     pub fn y1(&self) -> FWord {
         let range = self.shape.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End circle radius.
     pub fn radius1(&self) -> UfWord {
         let range = self.shape.radius1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2744,13 +2744,13 @@ impl<'a> PaintVarRadialGradient<'a> {
     /// Set to 7.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.shape.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2763,46 +2763,46 @@ impl<'a> PaintVarRadialGradient<'a> {
     /// varIndexBase + 0.
     pub fn x0(&self) -> FWord {
         let range = self.shape.x0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start circle center y coordinate. For variation, use
     /// varIndexBase + 1.
     pub fn y0(&self) -> FWord {
         let range = self.shape.y0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start circle radius. For variation, use varIndexBase + 2.
     pub fn radius0(&self) -> UfWord {
         let range = self.shape.radius0_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End circle center x coordinate. For variation, use varIndexBase
     /// + 3.
     pub fn x1(&self) -> FWord {
         let range = self.shape.x1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End circle center y coordinate. For variation, use varIndexBase
     /// + 4.
     pub fn y1(&self) -> FWord {
         let range = self.shape.y1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End circle radius. For variation, use varIndexBase + 5.
     pub fn radius1(&self) -> UfWord {
         let range = self.shape.radius1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -2906,13 +2906,13 @@ impl<'a> PaintSweepGradient<'a> {
     /// Set to 8.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to ColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.shape.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -2924,27 +2924,27 @@ impl<'a> PaintSweepGradient<'a> {
     /// Center x coordinate.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Center y coordinate.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn start_angle(&self) -> F2Dot14 {
         let range = self.shape.start_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End of the angular range of the gradient, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn end_angle(&self) -> F2Dot14 {
         let range = self.shape.end_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3051,13 +3051,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// Set to 9.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to VarColorLine table.
     pub fn color_line_offset(&self) -> Offset24 {
         let range = self.shape.color_line_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_line_offset`][Self::color_line_offset].
@@ -3069,13 +3069,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// Center x coordinate. For variation, use varIndexBase + 0.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Center y coordinate. For variation, use varIndexBase + 1.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Start of the angular range of the gradient, 180° in
@@ -3083,7 +3083,7 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// varIndexBase + 2.
     pub fn start_angle(&self) -> F2Dot14 {
         let range = self.shape.start_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// End of the angular range of the gradient, 180° in
@@ -3091,13 +3091,13 @@ impl<'a> PaintVarSweepGradient<'a> {
     /// varIndexBase + 3.
     pub fn end_angle(&self) -> F2Dot14 {
         let range = self.shape.end_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3181,13 +3181,13 @@ impl<'a> PaintGlyph<'a> {
     /// Set to 10.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint table.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3199,7 +3199,7 @@ impl<'a> PaintGlyph<'a> {
     /// Glyph ID for the source outline.
     pub fn glyph_id(&self) -> GlyphId16 {
         let range = self.shape.glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3273,13 +3273,13 @@ impl<'a> PaintColrGlyph<'a> {
     /// Set to 11.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Glyph ID for a BaseGlyphList base glyph.
     pub fn glyph_id(&self) -> GlyphId16 {
         let range = self.shape.glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3355,13 +3355,13 @@ impl<'a> PaintTransform<'a> {
     /// Set to 12.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3373,7 +3373,7 @@ impl<'a> PaintTransform<'a> {
     /// Offset to an Affine2x3 table.
     pub fn transform_offset(&self) -> Offset24 {
         let range = self.shape.transform_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`transform_offset`][Self::transform_offset].
@@ -3462,13 +3462,13 @@ impl<'a> PaintVarTransform<'a> {
     /// Set to 13.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3480,7 +3480,7 @@ impl<'a> PaintVarTransform<'a> {
     /// Offset to a VarAffine2x3 table.
     pub fn transform_offset(&self) -> Offset24 {
         let range = self.shape.transform_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`transform_offset`][Self::transform_offset].
@@ -3583,37 +3583,37 @@ impl<'a> Affine2x3<'a> {
     /// x-component of transformed x-basis vector.
     pub fn xx(&self) -> Fixed {
         let range = self.shape.xx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y-component of transformed x-basis vector.
     pub fn yx(&self) -> Fixed {
         let range = self.shape.yx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x-component of transformed y-basis vector.
     pub fn xy(&self) -> Fixed {
         let range = self.shape.xy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y-component of transformed y-basis vector.
     pub fn yy(&self) -> Fixed {
         let range = self.shape.yy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Translation in x direction.
     pub fn dx(&self) -> Fixed {
         let range = self.shape.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Translation in y direction.
     pub fn dy(&self) -> Fixed {
         let range = self.shape.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3714,46 +3714,46 @@ impl<'a> VarAffine2x3<'a> {
     /// varIndexBase + 0.
     pub fn xx(&self) -> Fixed {
         let range = self.shape.xx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y-component of transformed x-basis vector. For variation, use
     /// varIndexBase + 1.
     pub fn yx(&self) -> Fixed {
         let range = self.shape.yx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 2.
     pub fn xy(&self) -> Fixed {
         let range = self.shape.xy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y-component of transformed y-basis vector. For variation, use
     /// varIndexBase + 3.
     pub fn yy(&self) -> Fixed {
         let range = self.shape.yy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Translation in x direction. For variation, use varIndexBase + 4.
     pub fn dx(&self) -> Fixed {
         let range = self.shape.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Translation in y direction. For variation, use varIndexBase + 5.
     pub fn dy(&self) -> Fixed {
         let range = self.shape.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3840,13 +3840,13 @@ impl<'a> PaintTranslate<'a> {
     /// Set to 14.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3858,13 +3858,13 @@ impl<'a> PaintTranslate<'a> {
     /// Translation in x direction.
     pub fn dx(&self) -> FWord {
         let range = self.shape.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Translation in y direction.
     pub fn dy(&self) -> FWord {
         let range = self.shape.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -3957,13 +3957,13 @@ impl<'a> PaintVarTranslate<'a> {
     /// Set to 15.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -3975,19 +3975,19 @@ impl<'a> PaintVarTranslate<'a> {
     /// Translation in x direction. For variation, use varIndexBase + 0.
     pub fn dx(&self) -> FWord {
         let range = self.shape.dx_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Translation in y direction. For variation, use varIndexBase + 1.
     pub fn dy(&self) -> FWord {
         let range = self.shape.dy_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4075,13 +4075,13 @@ impl<'a> PaintScale<'a> {
     /// Set to 16.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4093,13 +4093,13 @@ impl<'a> PaintScale<'a> {
     /// Scale factor in x direction.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.shape.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Scale factor in y direction.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.shape.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4192,13 +4192,13 @@ impl<'a> PaintVarScale<'a> {
     /// Set to 17.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4211,20 +4211,20 @@ impl<'a> PaintVarScale<'a> {
     /// 0.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.shape.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.shape.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4324,13 +4324,13 @@ impl<'a> PaintScaleAroundCenter<'a> {
     /// Set to 18.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4342,25 +4342,25 @@ impl<'a> PaintScaleAroundCenter<'a> {
     /// Scale factor in x direction.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.shape.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Scale factor in y direction.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.shape.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of scaling.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of scaling.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4467,13 +4467,13 @@ impl<'a> PaintVarScaleAroundCenter<'a> {
     /// Set to 19.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4486,34 +4486,34 @@ impl<'a> PaintVarScaleAroundCenter<'a> {
     /// 0.
     pub fn scale_x(&self) -> F2Dot14 {
         let range = self.shape.scale_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Scale factor in y direction. For variation, use varIndexBase +
     /// 1.
     pub fn scale_y(&self) -> F2Dot14 {
         let range = self.shape.scale_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 3.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4597,13 +4597,13 @@ impl<'a> PaintScaleUniform<'a> {
     /// Set to 20.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4615,7 +4615,7 @@ impl<'a> PaintScaleUniform<'a> {
     /// Scale factor in x and y directions.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.shape.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4701,13 +4701,13 @@ impl<'a> PaintVarScaleUniform<'a> {
     /// Set to 21.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4720,13 +4720,13 @@ impl<'a> PaintVarScaleUniform<'a> {
     /// varIndexBase + 0.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.shape.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4819,13 +4819,13 @@ impl<'a> PaintScaleUniformAroundCenter<'a> {
     /// Set to 22.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4837,19 +4837,19 @@ impl<'a> PaintScaleUniformAroundCenter<'a> {
     /// Scale factor in x and y directions.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.shape.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of scaling.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of scaling.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4950,13 +4950,13 @@ impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     /// Set to 23.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -4969,27 +4969,27 @@ impl<'a> PaintVarScaleUniformAroundCenter<'a> {
     /// varIndexBase + 0.
     pub fn scale(&self) -> F2Dot14 {
         let range = self.shape.scale_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of scaling. For variation, use
     /// varIndexBase + 1.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of scaling. For variation, use
     /// varIndexBase + 2.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5072,13 +5072,13 @@ impl<'a> PaintRotate<'a> {
     /// Set to 24.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5091,7 +5091,7 @@ impl<'a> PaintRotate<'a> {
     /// value.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.shape.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5177,13 +5177,13 @@ impl<'a> PaintVarRotate<'a> {
     /// Set to 25.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5196,13 +5196,13 @@ impl<'a> PaintVarRotate<'a> {
     /// value. For variation, use varIndexBase + 0.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.shape.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5295,13 +5295,13 @@ impl<'a> PaintRotateAroundCenter<'a> {
     /// Set to 26.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5314,19 +5314,19 @@ impl<'a> PaintRotateAroundCenter<'a> {
     /// value.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.shape.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of rotation.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of rotation.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5426,13 +5426,13 @@ impl<'a> PaintVarRotateAroundCenter<'a> {
     /// Set to 27.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5445,27 +5445,27 @@ impl<'a> PaintVarRotateAroundCenter<'a> {
     /// value. For variation, use varIndexBase + 0.
     pub fn angle(&self) -> F2Dot14 {
         let range = self.shape.angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 1.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5554,13 +5554,13 @@ impl<'a> PaintSkew<'a> {
     /// Set to 28.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5573,14 +5573,14 @@ impl<'a> PaintSkew<'a> {
     /// counter-clockwise degrees per 1.0 of value.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5673,13 +5673,13 @@ impl<'a> PaintVarSkew<'a> {
     /// Set to 29.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5693,7 +5693,7 @@ impl<'a> PaintVarSkew<'a> {
     /// varIndexBase + 0.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
@@ -5701,13 +5701,13 @@ impl<'a> PaintVarSkew<'a> {
     /// varIndexBase + 1.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5807,13 +5807,13 @@ impl<'a> PaintSkewAroundCenter<'a> {
     /// Set to 30.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5826,26 +5826,26 @@ impl<'a> PaintSkewAroundCenter<'a> {
     /// counter-clockwise degrees per 1.0 of value.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
     /// counter-clockwise degrees per 1.0 of value.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of rotation.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of rotation.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5952,13 +5952,13 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// Set to 31.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a Paint subtable.
     pub fn paint_offset(&self) -> Offset24 {
         let range = self.shape.paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`paint_offset`][Self::paint_offset].
@@ -5972,7 +5972,7 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// varIndexBase + 0.
     pub fn x_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.x_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Angle of skew in the direction of the y-axis, 180° in
@@ -5980,27 +5980,27 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
     /// varIndexBase + 1.
     pub fn y_skew_angle(&self) -> F2Dot14 {
         let range = self.shape.y_skew_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// x coordinate for the center of rotation. For variation, use
     /// varIndexBase + 2.
     pub fn center_x(&self) -> FWord {
         let range = self.shape.center_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// y coordinate for the center of rotation. For variation, use
     /// varIndexBase + 3.
     pub fn center_y(&self) -> FWord {
         let range = self.shape.center_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Base index into DeltaSetIndexMap.
     pub fn var_index_base(&self) -> u32 {
         let range = self.shape.var_index_base_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -6090,13 +6090,13 @@ impl<'a> PaintComposite<'a> {
     /// Set to 32.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a source Paint table.
     pub fn source_paint_offset(&self) -> Offset24 {
         let range = self.shape.source_paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`source_paint_offset`][Self::source_paint_offset].
@@ -6108,13 +6108,13 @@ impl<'a> PaintComposite<'a> {
     /// A CompositeMode enumeration value.
     pub fn composite_mode(&self) -> CompositeMode {
         let range = self.shape.composite_mode_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to a backdrop Paint table.
     pub fn backdrop_paint_offset(&self) -> Offset24 {
         let range = self.shape.backdrop_paint_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`backdrop_paint_offset`][Self::backdrop_paint_offset].

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -123,32 +123,32 @@ impl<'a> Cpal<'a> {
     /// Table version number (=0).
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of palette entries in each palette.
     pub fn num_palette_entries(&self) -> u16 {
         let range = self.shape.num_palette_entries_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of palettes in the table.
     pub fn num_palettes(&self) -> u16 {
         let range = self.shape.num_palettes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Total number of color records, combined for all palettes.
     pub fn num_color_records(&self) -> u16 {
         let range = self.shape.num_color_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the beginning of CPAL table to the first
     /// ColorRecord.
     pub fn color_records_array_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.color_records_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`color_records_array_offset`][Self::color_records_array_offset].
@@ -163,7 +163,7 @@ impl<'a> Cpal<'a> {
     /// color record array.
     pub fn color_record_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.color_record_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Offset from the beginning of CPAL table to the [Palette Types Array][].
@@ -173,7 +173,7 @@ impl<'a> Cpal<'a> {
     /// [Palette Types Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-type-array
     pub fn palette_types_array_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.palette_types_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`palette_types_array_offset`][Self::palette_types_array_offset].
@@ -193,7 +193,7 @@ impl<'a> Cpal<'a> {
     /// [Palette Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-labels-array
     pub fn palette_labels_array_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.palette_labels_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`palette_labels_array_offset`][Self::palette_labels_array_offset].
@@ -215,7 +215,7 @@ impl<'a> Cpal<'a> {
     /// [Palette Entry Labels Array]: https://learn.microsoft.com/en-us/typography/opentype/spec/cpal#palette-entry-label-array
     pub fn palette_entry_labels_array_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.palette_entry_labels_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`palette_entry_labels_array_offset`][Self::palette_entry_labels_array_offset].

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -67,7 +67,7 @@ impl<'a> Cvar<'a> {
     /// Major/minor version number of the CVT variations table — set to (1,0).
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A packed field. The high 4 bits are flags, and the low 12 bits
@@ -76,13 +76,13 @@ impl<'a> Cvar<'a> {
     /// and 4095.
     pub fn tuple_variation_count(&self) -> TupleVariationCount {
         let range = self.shape.tuple_variation_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the start of the 'cvar' table to the serialized data.
     pub fn data_offset(&self) -> Offset16 {
         let range = self.shape.data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`data_offset`][Self::data_offset].

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -69,25 +69,25 @@ impl<'a> Dsig<'a> {
     /// Version number of the DSIG table (0x00000001)
     pub fn version(&self) -> u32 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of signatures in the table
     pub fn num_signatures(&self) -> u16 {
         let range = self.shape.num_signatures_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Permission flags
     pub fn flags(&self) -> PermissionFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of signature records
     pub fn signature_records(&self) -> &'a [SignatureRecord] {
         let range = self.shape.signature_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -536,13 +536,13 @@ impl<'a> SignatureBlockFormat1<'a> {
     /// Length (in bytes) of the PKCS#7 packet in the signature field.
     pub fn signature_length(&self) -> u32 {
         let range = self.shape.signature_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// PKCS#7 packet
     pub fn signature(&self) -> &'a [u8] {
         let range = self.shape.signature_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -50,13 +50,13 @@ impl<'a> Ebdt<'a> {
     /// Major version of the EBDT table, = 2.
     pub fn major_version(&self) -> u16 {
         let range = self.shape.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minor version of EBDT table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.shape.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -69,25 +69,25 @@ impl<'a> Eblc<'a> {
     /// Major version of the EBLC table, = 2.
     pub fn major_version(&self) -> u16 {
         let range = self.shape.major_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minor version of EBLC table, = 0.
     pub fn minor_version(&self) -> u16 {
         let range = self.shape.minor_version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of BitmapSize records.
     pub fn num_sizes(&self) -> u32 {
         let range = self.shape.num_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// BitmapSize records array.
     pub fn bitmap_sizes(&self) -> &'a [BitmapSize] {
         let range = self.shape.bitmap_sizes_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -74,19 +74,19 @@ impl<'a> Feat<'a> {
     /// version).
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of entries in the feature name array.
     pub fn feature_name_count(&self) -> u16 {
         let range = self.shape.feature_name_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The feature name array, sorted by feature type.
     pub fn names(&self) -> &'a [FeatureName] {
         let range = self.shape.names_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -261,7 +261,7 @@ impl<'a> SettingNameArray<'a> {
     /// List of setting names for a feature.
     pub fn settings(&self) -> &'a [SettingName] {
         let range = self.shape.settings_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -81,14 +81,14 @@ impl<'a> Fvar<'a> {
     /// Minor version number of the font variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the beginning of the table to the start of the VariationAxisRecord array. The
     /// InstanceRecord array directly follows.
     pub fn axis_instance_arrays_offset(&self) -> Offset16 {
         let range = self.shape.axis_instance_arrays_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`axis_instance_arrays_offset`][Self::axis_instance_arrays_offset].
@@ -106,25 +106,25 @@ impl<'a> Fvar<'a> {
     /// The number of variation axes in the font (the number of records in the axes array).
     pub fn axis_count(&self) -> u16 {
         let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The size in bytes of each VariationAxisRecord — set to 20 (0x0014) for this version.
     pub fn axis_size(&self) -> u16 {
         let range = self.shape.axis_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of named instances defined in the font (the number of records in the instances array).
     pub fn instance_count(&self) -> u16 {
         let range = self.shape.instance_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The size in bytes of each InstanceRecord — set to either axisCount * sizeof(Fixed) + 4, or to axisCount * sizeof(Fixed) + 6.
     pub fn instance_size(&self) -> u16 {
         let range = self.shape.instance_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -240,7 +240,7 @@ impl<'a> AxisInstanceArrays<'a> {
     /// Variation axis record array.
     pub fn axes(&self) -> &'a [VariationAxisRecord] {
         let range = self.shape.axes_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Instance record array.

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -63,19 +63,19 @@ impl<'a> Gasp<'a> {
     /// Version number (set to 1)
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of records to follow
     pub fn num_ranges(&self) -> u16 {
         let range = self.shape.num_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Sorted by ppem
     pub fn gasp_ranges(&self) -> &'a [GaspRange] {
         let range = self.shape.gasp_ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -98,14 +98,14 @@ impl<'a> Gdef<'a> {
     /// The major/minor version of the GDEF table
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to class definition table for glyph type, from beginning
     /// of GDEF header (may be NULL)
     pub fn glyph_class_def_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.glyph_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`glyph_class_def_offset`][Self::glyph_class_def_offset].
@@ -118,7 +118,7 @@ impl<'a> Gdef<'a> {
     /// header (may be NULL)
     pub fn attach_list_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.attach_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`attach_list_offset`][Self::attach_list_offset].
@@ -131,7 +131,7 @@ impl<'a> Gdef<'a> {
     /// header (may be NULL)
     pub fn lig_caret_list_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.lig_caret_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`lig_caret_list_offset`][Self::lig_caret_list_offset].
@@ -144,7 +144,7 @@ impl<'a> Gdef<'a> {
     /// beginning of GDEF header (may be NULL)
     pub fn mark_attach_class_def_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.mark_attach_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark_attach_class_def_offset`][Self::mark_attach_class_def_offset].
@@ -157,7 +157,7 @@ impl<'a> Gdef<'a> {
     /// beginning of GDEF header (may be NULL)
     pub fn mark_glyph_sets_def_offset(&self) -> Option<Nullable<Offset16>> {
         let range = self.shape.mark_glyph_sets_def_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`mark_glyph_sets_def_offset`][Self::mark_glyph_sets_def_offset].
@@ -170,7 +170,7 @@ impl<'a> Gdef<'a> {
     /// GDEF header (may be NULL)
     pub fn item_var_store_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.item_var_store_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`item_var_store_offset`][Self::item_var_store_offset].
@@ -334,7 +334,7 @@ impl<'a> AttachList<'a> {
     /// Offset to Coverage table - from beginning of AttachList table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -346,14 +346,14 @@ impl<'a> AttachList<'a> {
     /// Number of glyphs with attachment points
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to AttachPoint tables-from beginning of
     /// AttachList table-in Coverage Index order
     pub fn attach_point_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.attach_point_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`attach_point_offsets`][Self::attach_point_offsets].
@@ -450,13 +450,13 @@ impl<'a> AttachPoint<'a> {
     /// Number of attachment points on this glyph
     pub fn point_count(&self) -> u16 {
         let range = self.shape.point_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of contour point indices -in increasing numerical order
     pub fn point_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.point_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -535,7 +535,7 @@ impl<'a> LigCaretList<'a> {
     /// Offset to Coverage table - from beginning of LigCaretList table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -547,14 +547,14 @@ impl<'a> LigCaretList<'a> {
     /// Number of ligature glyphs
     pub fn lig_glyph_count(&self) -> u16 {
         let range = self.shape.lig_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to LigGlyph tables, from beginning of
     /// LigCaretList table —in Coverage Index order
     pub fn lig_glyph_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.lig_glyph_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`lig_glyph_offsets`][Self::lig_glyph_offsets].
@@ -651,14 +651,14 @@ impl<'a> LigGlyph<'a> {
     /// Number of CaretValue tables for this ligature (components - 1)
     pub fn caret_count(&self) -> u16 {
         let range = self.shape.caret_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to CaretValue tables, from beginning of
     /// LigGlyph table — in increasing coordinate order
     pub fn caret_value_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.caret_value_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`caret_value_offsets`][Self::caret_value_offsets].
@@ -826,13 +826,13 @@ impl<'a> CaretValueFormat1<'a> {
     /// Format identifier: format = 1
     pub fn caret_value_format(&self) -> u16 {
         let range = self.shape.caret_value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.shape.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -902,13 +902,13 @@ impl<'a> CaretValueFormat2<'a> {
     /// Format identifier: format = 2
     pub fn caret_value_format(&self) -> u16 {
         let range = self.shape.caret_value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Contour point index on glyph
     pub fn caret_value_point_index(&self) -> u16 {
         let range = self.shape.caret_value_point_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -987,13 +987,13 @@ impl<'a> CaretValueFormat3<'a> {
     /// Format identifier-format = 3
     pub fn caret_value_format(&self) -> u16 {
         let range = self.shape.caret_value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// X or Y value, in design units
     pub fn coordinate(&self) -> i16 {
         let range = self.shape.coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Device table (non-variable font) / Variation Index
@@ -1001,7 +1001,7 @@ impl<'a> CaretValueFormat3<'a> {
     /// CaretValue table
     pub fn device_offset(&self) -> Offset16 {
         let range = self.shape.device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`device_offset`][Self::device_offset].
@@ -1094,20 +1094,20 @@ impl<'a> MarkGlyphSets<'a> {
     /// Format identifier == 1
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of mark glyph sets defined
     pub fn mark_glyph_set_count(&self) -> u16 {
         let range = self.shape.mark_glyph_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to mark glyph set coverage tables, from the
     /// start of the MarkGlyphSets table.
     pub fn coverage_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -152,38 +152,38 @@ impl<'a> SimpleGlyph<'a> {
     /// — the value -1 should be used for composite glyphs.
     pub fn number_of_contours(&self) -> i16 {
         let range = self.shape.number_of_contours_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum x for coordinate data.
     pub fn x_min(&self) -> i16 {
         let range = self.shape.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum y for coordinate data.
     pub fn y_min(&self) -> i16 {
         let range = self.shape.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum x for coordinate data.
     pub fn x_max(&self) -> i16 {
         let range = self.shape.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum y for coordinate data.
     pub fn y_max(&self) -> i16 {
         let range = self.shape.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of point indices for the last point of each contour,
     /// in increasing numeric order
     pub fn end_pts_of_contours(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.end_pts_of_contours_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Total number of bytes for instructions. If instructionLength is
@@ -191,19 +191,19 @@ impl<'a> SimpleGlyph<'a> {
     /// field is followed directly by the flags field.
     pub fn instruction_length(&self) -> u16 {
         let range = self.shape.instruction_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of instruction byte code for the glyph.
     pub fn instructions(&self) -> &'a [u8] {
         let range = self.shape.instructions_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// the raw data for flags & x/y coordinates
     pub fn glyph_data(&self) -> &'a [u8] {
         let range = self.shape.glyph_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -709,38 +709,38 @@ impl<'a> CompositeGlyph<'a> {
     /// — the value -1 should be used for composite glyphs.
     pub fn number_of_contours(&self) -> i16 {
         let range = self.shape.number_of_contours_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum x for coordinate data.
     pub fn x_min(&self) -> i16 {
         let range = self.shape.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum y for coordinate data.
     pub fn y_min(&self) -> i16 {
         let range = self.shape.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum x for coordinate data.
     pub fn x_max(&self) -> i16 {
         let range = self.shape.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum y for coordinate data.
     pub fn y_max(&self) -> i16 {
         let range = self.shape.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// component flag
     /// glyph index of component
     pub fn component_data(&self) -> &'a [u8] {
         let range = self.shape.component_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -80,13 +80,13 @@ impl<'a> Gpos<'a> {
     /// The major and minor version of the GPOS table, as a tuple (u16, u16)
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to ScriptList table, from beginning of GPOS table
     pub fn script_list_offset(&self) -> Offset16 {
         let range = self.shape.script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
@@ -98,7 +98,7 @@ impl<'a> Gpos<'a> {
     /// Offset to FeatureList table, from beginning of GPOS table
     pub fn feature_list_offset(&self) -> Offset16 {
         let range = self.shape.feature_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
@@ -110,7 +110,7 @@ impl<'a> Gpos<'a> {
     /// Offset to LookupList table, from beginning of GPOS table
     pub fn lookup_list_offset(&self) -> Offset16 {
         let range = self.shape.lookup_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
@@ -121,7 +121,7 @@ impl<'a> Gpos<'a> {
 
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.feature_variations_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
@@ -747,19 +747,19 @@ impl<'a> AnchorFormat1<'a> {
     /// Format identifier, = 1
     pub fn anchor_format(&self) -> u16 {
         let range = self.shape.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
         let range = self.shape.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
         let range = self.shape.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -842,25 +842,25 @@ impl<'a> AnchorFormat2<'a> {
     /// Format identifier, = 2
     pub fn anchor_format(&self) -> u16 {
         let range = self.shape.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
         let range = self.shape.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
         let range = self.shape.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Index to glyph contour point
     pub fn anchor_point(&self) -> u16 {
         let range = self.shape.anchor_point_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -950,19 +950,19 @@ impl<'a> AnchorFormat3<'a> {
     /// Format identifier, = 3
     pub fn anchor_format(&self) -> u16 {
         let range = self.shape.anchor_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Horizontal value, in design units
     pub fn x_coordinate(&self) -> i16 {
         let range = self.shape.x_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Vertical value, in design units
     pub fn y_coordinate(&self) -> i16 {
         let range = self.shape.y_coordinate_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Device table (non-variable font) / VariationIndex
@@ -970,7 +970,7 @@ impl<'a> AnchorFormat3<'a> {
     /// Anchor table (may be NULL)
     pub fn x_device_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.x_device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`x_device_offset`][Self::x_device_offset].
@@ -984,7 +984,7 @@ impl<'a> AnchorFormat3<'a> {
     /// Anchor table (may be NULL)
     pub fn y_device_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.y_device_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`y_device_offset`][Self::y_device_offset].
@@ -1072,14 +1072,14 @@ impl<'a> MarkArray<'a> {
     /// Number of MarkRecords
     pub fn mark_count(&self) -> u16 {
         let range = self.shape.mark_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of MarkRecords, ordered by corresponding glyphs in the
     /// associated mark Coverage table.
     pub fn mark_records(&self) -> &'a [MarkRecord] {
         let range = self.shape.mark_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1314,13 +1314,13 @@ impl<'a> SinglePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1332,7 +1332,7 @@ impl<'a> SinglePosFormat1<'a> {
     /// Defines the types of data in the ValueRecord.
     pub fn value_format(&self) -> ValueFormat {
         let range = self.shape.value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Defines positioning value(s) — applied to all glyphs in the
@@ -1444,13 +1444,13 @@ impl<'a> SinglePosFormat2<'a> {
     /// Format identifier: format = 2
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of SinglePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1462,14 +1462,14 @@ impl<'a> SinglePosFormat2<'a> {
     /// Defines the types of data in the ValueRecords.
     pub fn value_format(&self) -> ValueFormat {
         let range = self.shape.value_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of ValueRecords — must equal glyphCount in the
     /// Coverage table.
     pub fn value_count(&self) -> u16 {
         let range = self.shape.value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of ValueRecords — positioning values applied to glyphs.
@@ -1689,13 +1689,13 @@ impl<'a> PairPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1708,27 +1708,27 @@ impl<'a> PairPosFormat1<'a> {
     /// glyph in the pair (may be zero).
     pub fn value_format1(&self) -> ValueFormat {
         let range = self.shape.value_format1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Defines the types of data in valueRecord2 — for the second
     /// glyph in the pair (may be zero).
     pub fn value_format2(&self) -> ValueFormat {
         let range = self.shape.value_format2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of PairSet tables
     pub fn pair_set_count(&self) -> u16 {
         let range = self.shape.pair_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to PairSet tables. Offsets are from beginning
     /// of PairPos subtable, ordered by Coverage Index.
     pub fn pair_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.pair_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`pair_set_offsets`][Self::pair_set_offsets].
@@ -1860,7 +1860,7 @@ impl<'a> PairSet<'a> {
     /// Number of PairValueRecords
     pub fn pair_value_count(&self) -> u16 {
         let range = self.shape.pair_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of PairValueRecords, ordered by glyph ID of the second
@@ -2112,13 +2112,13 @@ impl<'a> PairPosFormat2<'a> {
     /// Format identifier: format = 2
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of PairPos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2131,21 +2131,21 @@ impl<'a> PairPosFormat2<'a> {
     /// be zero).
     pub fn value_format1(&self) -> ValueFormat {
         let range = self.shape.value_format1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// ValueRecord definition — for the second glyph of the pair
     /// (may be zero).
     pub fn value_format2(&self) -> ValueFormat {
         let range = self.shape.value_format2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to ClassDef table, from beginning of PairPos subtable
     /// — for the first glyph of the pair.
     pub fn class_def1_offset(&self) -> Offset16 {
         let range = self.shape.class_def1_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`class_def1_offset`][Self::class_def1_offset].
@@ -2158,7 +2158,7 @@ impl<'a> PairPosFormat2<'a> {
     /// — for the second glyph of the pair.
     pub fn class_def2_offset(&self) -> Offset16 {
         let range = self.shape.class_def2_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`class_def2_offset`][Self::class_def2_offset].
@@ -2170,13 +2170,13 @@ impl<'a> PairPosFormat2<'a> {
     /// Number of classes in classDef1 table — includes Class 0.
     pub fn class1_count(&self) -> u16 {
         let range = self.shape.class1_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of classes in classDef2 table — includes Class 0.
     pub fn class2_count(&self) -> u16 {
         let range = self.shape.class2_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of Class1 records, ordered by classes in classDef1.
@@ -2477,13 +2477,13 @@ impl<'a> CursivePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of CursivePos subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2495,13 +2495,13 @@ impl<'a> CursivePosFormat1<'a> {
     /// Number of EntryExit records
     pub fn entry_exit_count(&self) -> u16 {
         let range = self.shape.entry_exit_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of EntryExit records, in Coverage index order.
     pub fn entry_exit_record(&self) -> &'a [EntryExitRecord] {
         let range = self.shape.entry_exit_record_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2683,14 +2683,14 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to markCoverage table, from beginning of MarkBasePos
     /// subtable.
     pub fn mark_coverage_offset(&self) -> Offset16 {
         let range = self.shape.mark_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
@@ -2703,7 +2703,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// subtable.
     pub fn base_coverage_offset(&self) -> Offset16 {
         let range = self.shape.base_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`base_coverage_offset`][Self::base_coverage_offset].
@@ -2715,14 +2715,14 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Number of classes defined for marks
     pub fn mark_class_count(&self) -> u16 {
         let range = self.shape.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to MarkArray table, from beginning of MarkBasePos
     /// subtable.
     pub fn mark_array_offset(&self) -> Offset16 {
         let range = self.shape.mark_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
@@ -2735,7 +2735,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// subtable.
     pub fn base_array_offset(&self) -> Offset16 {
         let range = self.shape.base_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`base_array_offset`][Self::base_array_offset].
@@ -2851,7 +2851,7 @@ impl<'a> BaseArray<'a> {
     /// Number of BaseRecords
     pub fn base_count(&self) -> u16 {
         let range = self.shape.base_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of BaseRecords, in order of baseCoverage Index.
@@ -3058,14 +3058,14 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to markCoverage table, from beginning of MarkLigPos
     /// subtable.
     pub fn mark_coverage_offset(&self) -> Offset16 {
         let range = self.shape.mark_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
@@ -3078,7 +3078,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// subtable.
     pub fn ligature_coverage_offset(&self) -> Offset16 {
         let range = self.shape.ligature_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`ligature_coverage_offset`][Self::ligature_coverage_offset].
@@ -3090,14 +3090,14 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Number of defined mark classes
     pub fn mark_class_count(&self) -> u16 {
         let range = self.shape.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to MarkArray table, from beginning of MarkLigPos
     /// subtable.
     pub fn mark_array_offset(&self) -> Offset16 {
         let range = self.shape.mark_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
@@ -3110,7 +3110,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// subtable.
     pub fn ligature_array_offset(&self) -> Offset16 {
         let range = self.shape.ligature_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`ligature_array_offset`][Self::ligature_array_offset].
@@ -3224,7 +3224,7 @@ impl<'a> LigatureArray<'a> {
     /// Number of LigatureAttach table offsets
     pub fn ligature_count(&self) -> u16 {
         let range = self.shape.ligature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to LigatureAttach tables. Offsets are from
@@ -3232,7 +3232,7 @@ impl<'a> LigatureArray<'a> {
     /// index.
     pub fn ligature_attach_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.ligature_attach_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`ligature_attach_offsets`][Self::ligature_attach_offsets].
@@ -3351,7 +3351,7 @@ impl<'a> LigatureAttach<'a> {
     /// Number of ComponentRecords in this ligature
     pub fn component_count(&self) -> u16 {
         let range = self.shape.component_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of Component records, ordered in writing direction.
@@ -3558,14 +3558,14 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Combining Mark Coverage table, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark1_coverage_offset(&self) -> Offset16 {
         let range = self.shape.mark1_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark1_coverage_offset`][Self::mark1_coverage_offset].
@@ -3578,7 +3578,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// MarkMarkPos subtable.
     pub fn mark2_coverage_offset(&self) -> Offset16 {
         let range = self.shape.mark2_coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark2_coverage_offset`][Self::mark2_coverage_offset].
@@ -3590,14 +3590,14 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Number of Combining Mark classes defined
     pub fn mark_class_count(&self) -> u16 {
         let range = self.shape.mark_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to MarkArray table for mark1, from beginning of
     /// MarkMarkPos subtable.
     pub fn mark1_array_offset(&self) -> Offset16 {
         let range = self.shape.mark1_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark1_array_offset`][Self::mark1_array_offset].
@@ -3610,7 +3610,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// MarkMarkPos subtable.
     pub fn mark2_array_offset(&self) -> Offset16 {
         let range = self.shape.mark2_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`mark2_array_offset`][Self::mark2_array_offset].
@@ -3726,7 +3726,7 @@ impl<'a> Mark2Array<'a> {
     /// Number of Mark2 records
     pub fn mark2_count(&self) -> u16 {
         let range = self.shape.mark2_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of Mark2Records, in Coverage order.
@@ -3954,14 +3954,14 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// Format identifier: format = 1
     pub fn pos_format(&self) -> u16 {
         let range = self.shape.pos_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
     pub fn extension_lookup_type(&self) -> u16 {
         let range = self.shape.extension_lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to the extension subtable, of lookup type
@@ -3969,7 +3969,7 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// ExtensionPosFormat1 subtable.
     pub fn extension_offset(&self) -> Offset32 {
         let range = self.shape.extension_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -78,13 +78,13 @@ impl<'a> Gsub<'a> {
     /// The major and minor version of the GSUB table, as a tuple (u16, u16)
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to ScriptList table, from beginning of GSUB table
     pub fn script_list_offset(&self) -> Offset16 {
         let range = self.shape.script_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
@@ -96,7 +96,7 @@ impl<'a> Gsub<'a> {
     /// Offset to FeatureList table, from beginning of GSUB table
     pub fn feature_list_offset(&self) -> Offset16 {
         let range = self.shape.feature_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
@@ -108,7 +108,7 @@ impl<'a> Gsub<'a> {
     /// Offset to LookupList table, from beginning of GSUB table
     pub fn lookup_list_offset(&self) -> Offset16 {
         let range = self.shape.lookup_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
@@ -121,7 +121,7 @@ impl<'a> Gsub<'a> {
     /// table (may be NULL)
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.feature_variations_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
@@ -384,14 +384,14 @@ impl<'a> SingleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -403,7 +403,7 @@ impl<'a> SingleSubstFormat1<'a> {
     /// Add to original glyph ID to get substitute glyph ID
     pub fn delta_glyph_id(&self) -> i16 {
         let range = self.shape.delta_glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -496,14 +496,14 @@ impl<'a> SingleSubstFormat2<'a> {
     /// Format identifier: format = 2
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -515,13 +515,13 @@ impl<'a> SingleSubstFormat2<'a> {
     /// Number of glyph IDs in the substituteGlyphIDs array
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of substitute glyph IDs — ordered by Coverage index
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.substitute_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -618,14 +618,14 @@ impl<'a> MultipleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -637,14 +637,14 @@ impl<'a> MultipleSubstFormat1<'a> {
     /// Number of Sequence table offsets in the sequenceOffsets array
     pub fn sequence_count(&self) -> u16 {
         let range = self.shape.sequence_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to Sequence tables. Offsets are from beginning
     /// of substitution subtable, ordered by Coverage index
     pub fn sequence_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.sequence_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`sequence_offsets`][Self::sequence_offsets].
@@ -743,13 +743,13 @@ impl<'a> Sequence<'a> {
     /// always be greater than 0.
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// String of glyph IDs to substitute
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.substitute_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -841,14 +841,14 @@ impl<'a> AlternateSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -860,14 +860,14 @@ impl<'a> AlternateSubstFormat1<'a> {
     /// Number of AlternateSet tables
     pub fn alternate_set_count(&self) -> u16 {
         let range = self.shape.alternate_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to AlternateSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     pub fn alternate_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.alternate_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`alternate_set_offsets`][Self::alternate_set_offsets].
@@ -968,13 +968,13 @@ impl<'a> AlternateSet<'a> {
     /// Number of glyph IDs in the alternateGlyphIDs array
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of alternate glyph IDs, in arbitrary order
     pub fn alternate_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.alternate_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1066,14 +1066,14 @@ impl<'a> LigatureSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1085,14 +1085,14 @@ impl<'a> LigatureSubstFormat1<'a> {
     /// Number of LigatureSet tables
     pub fn ligature_set_count(&self) -> u16 {
         let range = self.shape.ligature_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to LigatureSet tables. Offsets are from
     /// beginning of substitution subtable, ordered by Coverage index
     pub fn ligature_set_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.ligature_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`ligature_set_offsets`][Self::ligature_set_offsets].
@@ -1190,14 +1190,14 @@ impl<'a> LigatureSet<'a> {
     /// Number of Ligature tables
     pub fn ligature_count(&self) -> u16 {
         let range = self.shape.ligature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to Ligature tables. Offsets are from beginning
     /// of LigatureSet table, ordered by preference.
     pub fn ligature_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.ligature_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`ligature_offsets`][Self::ligature_offsets].
@@ -1296,20 +1296,20 @@ impl<'a> Ligature<'a> {
     /// glyph ID of ligature to substitute
     pub fn ligature_glyph(&self) -> GlyphId16 {
         let range = self.shape.ligature_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of components in the ligature
     pub fn component_count(&self) -> u16 {
         let range = self.shape.component_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of component glyph IDs — start with the second
     /// component, ordered in writing direction
     pub fn component_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.component_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1428,14 +1428,14 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     /// Format identifier. Set to 1.
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
     pub fn extension_lookup_type(&self) -> u16 {
         let range = self.shape.extension_lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to the extension subtable, of lookup type
@@ -1443,7 +1443,7 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     /// ExtensionSubstFormat1 subtable.
     pub fn extension_offset(&self) -> Offset32 {
         let range = self.shape.extension_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].
@@ -1659,14 +1659,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Format identifier: format = 1
     pub fn subst_format(&self) -> u16 {
         let range = self.shape.subst_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of substitution
     /// subtable.
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1678,14 +1678,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Number of glyphs in the backtrack sequence.
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.shape.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to coverage tables in backtrack sequence, in
     /// glyph sequence order.
     pub fn backtrack_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.backtrack_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
@@ -1698,14 +1698,14 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Number of glyphs in lookahead sequence.
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.shape.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to coverage tables in lookahead sequence, in
     /// glyph sequence order.
     pub fn lookahead_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.lookahead_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
@@ -1718,13 +1718,13 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Number of glyph IDs in the substituteGlyphIDs array.
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of substitute glyph IDs — ordered by Coverage index.
     pub fn substitute_glyph_ids(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.substitute_glyph_ids_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -93,14 +93,14 @@ impl<'a> Gvar<'a> {
     /// Major/minor version number of the glyph variations table — set to (1,0).
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
         let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of shared tuple records. Shared tuple records can be
@@ -109,13 +109,13 @@ impl<'a> Gvar<'a> {
     /// within a glyph variation data table.
     pub fn shared_tuple_count(&self) -> u16 {
         let range = self.shape.shared_tuple_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the start of this table to the shared tuple records.
     pub fn shared_tuples_offset(&self) -> Offset32 {
         let range = self.shape.shared_tuples_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`shared_tuples_offset`][Self::shared_tuples_offset].
@@ -129,7 +129,7 @@ impl<'a> Gvar<'a> {
     /// of glyphs stored elsewhere in the font.
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Bit-field that gives the format of the offset array that
@@ -137,14 +137,14 @@ impl<'a> Gvar<'a> {
     /// set, the offsets are uint32.
     pub fn flags(&self) -> GvarFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the start of this table to the array of
     /// GlyphVariationData tables.
     pub fn glyph_variation_data_array_offset(&self) -> u32 {
         let range = self.shape.glyph_variation_data_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offsets from the start of the GlyphVariationData array to each
@@ -641,14 +641,14 @@ impl<'a> GlyphVariationDataHeader<'a> {
     /// and 4095.
     pub fn tuple_variation_count(&self) -> TupleVariationCount {
         let range = self.shape.tuple_variation_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the start of the GlyphVariationData table to the
     /// serialized data
     pub fn serialized_data_offset(&self) -> Offset16 {
         let range = self.shape.serialized_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`serialized_data_offset`][Self::serialized_data_offset].

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -90,19 +90,19 @@ impl<'a> Hdmx<'a> {
     /// Table version number (set to 0).
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of device records.
     pub fn num_records(&self) -> u16 {
         let range = self.shape.num_records_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Size of device record, 32-bit aligned.
     pub fn size_device_record(&self) -> u32 {
         let range = self.shape.size_device_record_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of device records.

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -829,13 +829,13 @@ impl<'a> Head<'a> {
     /// Version number of the font header table, set to (1, 0)
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Set by font manufacturer.
     pub fn font_revision(&self) -> Fixed {
         let range = self.shape.font_revision_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// To compute: set it to 0, sum the entire font as uint32, then
@@ -845,19 +845,19 @@ impl<'a> Head<'a> {
     /// directory, and must be ignored.
     pub fn checksum_adjustment(&self) -> u32 {
         let range = self.shape.checksum_adjustment_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Set to 0x5F0F3CF5.
     pub fn magic_number(&self) -> u32 {
         let range = self.shape.magic_number_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// See the flags enum.
     pub fn flags(&self) -> Flags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Set to a value from 16 to 16384. Any value in this range is
@@ -866,75 +866,75 @@ impl<'a> Head<'a> {
     /// rasterizers.
     pub fn units_per_em(&self) -> u16 {
         let range = self.shape.units_per_em_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
     pub fn created(&self) -> LongDateTime {
         let range = self.shape.created_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of seconds since 12:00 midnight that started January 1st
     /// 1904 in GMT/UTC time zone.
     pub fn modified(&self) -> LongDateTime {
         let range = self.shape.modified_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum x coordinate across all glyph bounding boxes.
     pub fn x_min(&self) -> i16 {
         let range = self.shape.x_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum y coordinate across all glyph bounding boxes.
     pub fn y_min(&self) -> i16 {
         let range = self.shape.y_min_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum x coordinate across all glyph bounding boxes.
     pub fn x_max(&self) -> i16 {
         let range = self.shape.x_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum y coordinate across all glyph bounding boxes.
     pub fn y_max(&self) -> i16 {
         let range = self.shape.y_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Bits identifying the font's style; see [MacStyle]
     pub fn mac_style(&self) -> MacStyle {
         let range = self.shape.mac_style_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Smallest readable size in pixels.
     pub fn lowest_rec_ppem(&self) -> u16 {
         let range = self.shape.lowest_rec_ppem_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Deprecated (Set to 2).
     pub fn font_direction_hint(&self) -> i16 {
         let range = self.shape.font_direction_hint_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 0 for short offsets (Offset16), 1 for long (Offset32).
     pub fn index_to_loc_format(&self) -> i16 {
         let range = self.shape.index_to_loc_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 0 for current format.
     pub fn glyph_data_format(&self) -> i16 {
         let range = self.shape.glyph_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -140,65 +140,65 @@ impl<'a> Hhea<'a> {
     /// The major/minor version (1, 0)
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Typographic ascent.
     pub fn ascender(&self) -> FWord {
         let range = self.shape.ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Typographic descent.
     pub fn descender(&self) -> FWord {
         let range = self.shape.descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
     pub fn line_gap(&self) -> FWord {
         let range = self.shape.line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum advance width value in 'hmtx' table.
     pub fn advance_width_max(&self) -> UfWord {
         let range = self.shape.advance_width_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum left sidebearing value in 'hmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
     pub fn min_left_side_bearing(&self) -> FWord {
         let range = self.shape.min_left_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum right sidebearing value; calculated as min(aw - (lsb +
     /// xMax - xMin)) for glyphs with contours (empty glyphs should be ignored).
     pub fn min_right_side_bearing(&self) -> FWord {
         let range = self.shape.min_right_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Max(lsb + (xMax-xMin))
     pub fn x_max_extent(&self) -> FWord {
         let range = self.shape.x_max_extent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
     pub fn caret_slope_rise(&self) -> i16 {
         let range = self.shape.caret_slope_rise_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 0 for vertical caret, 1 for horizontal.
     pub fn caret_slope_run(&self) -> i16 {
         let range = self.shape.caret_slope_run_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The amount by which a slanted highlight on a glyph needs to be
@@ -206,19 +206,19 @@ impl<'a> Hhea<'a> {
     /// non-slanted fonts
     pub fn caret_offset(&self) -> i16 {
         let range = self.shape.caret_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 0 for current format.
     pub fn metric_data_format(&self) -> i16 {
         let range = self.shape.metric_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of hMetric entries in 'hmtx' table
     pub fn number_of_h_metrics(&self) -> u16 {
         let range = self.shape.number_of_h_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -78,14 +78,14 @@ impl<'a> Hmtx<'a> {
     /// glyph. Records are indexed by glyph ID.
     pub fn h_metrics(&self) -> &'a [LongMetric] {
         let range = self.shape.h_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Leading (left/top) side bearings for glyph IDs greater than or equal to
     /// numberOfLongMetrics.
     pub fn left_side_bearings(&self) -> &'a [BigEndian<i16>] {
         let range = self.shape.left_side_bearings_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -69,13 +69,13 @@ impl<'a> Hvar<'a> {
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the start of this table to the item variation store table.
     pub fn item_variation_store_offset(&self) -> Offset32 {
         let range = self.shape.item_variation_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -87,7 +87,7 @@ impl<'a> Hvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for advance widths (may be NULL).
     pub fn advance_width_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.advance_width_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`advance_width_mapping_offset`][Self::advance_width_mapping_offset].
@@ -99,7 +99,7 @@ impl<'a> Hvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for left side bearings (may be NULL).
     pub fn lsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.lsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`lsb_mapping_offset`][Self::lsb_mapping_offset].
@@ -111,7 +111,7 @@ impl<'a> Hvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for right side bearings (may be NULL).
     pub fn rsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.rsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`rsb_mapping_offset`][Self::rsb_mapping_offset].

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -586,41 +586,41 @@ impl<'a> PatchMapFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn field_flags(&self) -> PatchMapFieldPresenceFlags {
         let range = self.shape.field_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Unique ID that identifies compatible patches.
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Largest entry index which appears in either the glyph map or feature map.
     pub fn max_entry_index(&self) -> u16 {
         let range = self.shape.max_entry_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Largest entry index which appears in the glyph map.
     pub fn max_glyph_map_entry_index(&self) -> u16 {
         let range = self.shape.max_glyph_map_entry_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn glyph_count(&self) -> Uint24 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Sub table that maps glyph ids to entry indices.
     pub fn glyph_map_offset(&self) -> Offset32 {
         let range = self.shape.glyph_map_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`glyph_map_offset`][Self::glyph_map_offset].
@@ -633,7 +633,7 @@ impl<'a> PatchMapFormat1<'a> {
     /// Sub table that maps feature and glyph ids to entry indices.
     pub fn feature_map_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.feature_map_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`feature_map_offset`][Self::feature_map_offset].
@@ -645,33 +645,33 @@ impl<'a> PatchMapFormat1<'a> {
 
     pub fn applied_entries_bitmap(&self) -> &'a [u8] {
         let range = self.shape.applied_entries_bitmap_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub fn url_template_length(&self) -> u16 {
         let range = self.shape.url_template_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn url_template(&self) -> &'a [u8] {
         let range = self.shape.url_template_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Patch format number for patches referenced by this mapping.
     pub fn patch_format(&self) -> u8 {
         let range = self.shape.patch_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn cff_charstrings_offset(&self) -> Option<u32> {
         let range = self.shape.cff_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn cff2_charstrings_offset(&self) -> Option<u32> {
         let range = self.shape.cff2_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 
@@ -806,7 +806,7 @@ pub type GlyphMap<'a> = TableRef<'a, GlyphMapMarker>;
 impl<'a> GlyphMap<'a> {
     pub fn first_mapped_glyph(&self) -> u16 {
         let range = self.shape.first_mapped_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn entry_index(&self) -> ComputedArray<'a, U8Or16> {
@@ -917,7 +917,7 @@ pub type FeatureMap<'a> = TableRef<'a, FeatureMapMarker>;
 impl<'a> FeatureMap<'a> {
     pub fn feature_count(&self) -> u16 {
         let range = self.shape.feature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn feature_records(&self) -> ComputedArray<'a, FeatureRecord> {
@@ -929,7 +929,7 @@ impl<'a> FeatureMap<'a> {
 
     pub fn entry_map_data(&self) -> &'a [u8] {
         let range = self.shape.entry_map_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub(crate) fn max_entry_index(&self) -> u16 {
@@ -1264,34 +1264,34 @@ impl<'a> PatchMapFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn field_flags(&self) -> PatchMapFieldPresenceFlags {
         let range = self.shape.field_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Unique ID that identifies compatible patches.
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Patch format number for patches referenced by this mapping.
     pub fn default_patch_format(&self) -> u8 {
         let range = self.shape.default_patch_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn entry_count(&self) -> Uint24 {
         let range = self.shape.entry_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn entries_offset(&self) -> Offset32 {
         let range = self.shape.entries_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`entries_offset`][Self::entries_offset].
@@ -1302,7 +1302,7 @@ impl<'a> PatchMapFormat2<'a> {
 
     pub fn entry_id_string_data_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.entry_id_string_data_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`entry_id_string_data_offset`][Self::entry_id_string_data_offset].
@@ -1313,22 +1313,22 @@ impl<'a> PatchMapFormat2<'a> {
 
     pub fn url_template_length(&self) -> u16 {
         let range = self.shape.url_template_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn url_template(&self) -> &'a [u8] {
         let range = self.shape.url_template_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub fn cff_charstrings_offset(&self) -> Option<u32> {
         let range = self.shape.cff_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn cff2_charstrings_offset(&self) -> Option<u32> {
         let range = self.shape.cff2_charstrings_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 
@@ -1430,7 +1430,7 @@ pub type MappingEntries<'a> = TableRef<'a, MappingEntriesMarker>;
 impl<'a> MappingEntries<'a> {
     pub fn entry_data(&self) -> &'a [u8] {
         let range = self.shape.entry_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1639,42 +1639,42 @@ pub type EntryData<'a> = TableRef<'a, EntryDataMarker>;
 impl<'a> EntryData<'a> {
     pub fn format_flags(&self) -> EntryFormatFlags {
         let range = self.shape.format_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn feature_count(&self) -> Option<u8> {
         let range = self.shape.feature_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn feature_tags(&self) -> Option<&'a [BigEndian<Tag>]> {
         let range = self.shape.feature_tags_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     pub fn design_space_count(&self) -> Option<u16> {
         let range = self.shape.design_space_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn design_space_segments(&self) -> Option<&'a [DesignSpaceSegment]> {
         let range = self.shape.design_space_segments_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     pub fn match_mode_and_count(&self) -> Option<MatchModeAndCount> {
         let range = self.shape.match_mode_and_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn child_indices(&self) -> Option<&'a [BigEndian<Uint24>]> {
         let range = self.shape.child_indices_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     pub fn trailing_data(&self) -> &'a [u8] {
         let range = self.shape.trailing_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2134,7 +2134,7 @@ pub type IdStringData<'a> = TableRef<'a, IdStringDataMarker>;
 impl<'a> IdStringData<'a> {
     pub fn id_data(&self) -> &'a [u8] {
         let range = self.shape.id_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2223,23 +2223,23 @@ pub type TableKeyedPatch<'a> = TableRef<'a, TableKeyedPatchMarker>;
 impl<'a> TableKeyedPatch<'a> {
     pub fn format(&self) -> Tag {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Unique ID that identifies compatible patches.
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn patches_count(&self) -> u16 {
         let range = self.shape.patches_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn patch_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.patch_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`patch_offsets`][Self::patch_offsets].
@@ -2346,22 +2346,22 @@ pub type TablePatch<'a> = TableRef<'a, TablePatchMarker>;
 impl<'a> TablePatch<'a> {
     pub fn tag(&self) -> Tag {
         let range = self.shape.tag_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn flags(&self) -> TablePatchFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn max_uncompressed_length(&self) -> u32 {
         let range = self.shape.max_uncompressed_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn brotli_stream(&self) -> &'a [u8] {
         let range = self.shape.brotli_stream_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2765,27 +2765,27 @@ pub type GlyphKeyedPatch<'a> = TableRef<'a, GlyphKeyedPatchMarker>;
 impl<'a> GlyphKeyedPatch<'a> {
     pub fn format(&self) -> Tag {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn flags(&self) -> GlyphKeyedFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn compatibility_id(&self) -> CompatibilityId {
         let range = self.shape.compatibility_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn max_uncompressed_length(&self) -> u32 {
         let range = self.shape.max_uncompressed_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn brotli_stream(&self) -> &'a [u8] {
         let range = self.shape.brotli_stream_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -3218,12 +3218,12 @@ pub type GlyphPatches<'a> = TableRef<'a, GlyphPatchesMarker>;
 impl<'a> GlyphPatches<'a> {
     pub fn glyph_count(&self) -> u32 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn table_count(&self) -> u8 {
         let range = self.shape.table_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn glyph_ids(&self) -> ComputedArray<'a, U16Or24> {
@@ -3233,12 +3233,12 @@ impl<'a> GlyphPatches<'a> {
 
     pub fn tables(&self) -> &'a [BigEndian<Tag>] {
         let range = self.shape.tables_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub fn glyph_data_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.glyph_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`glyph_data_offsets`][Self::glyph_data_offsets].
@@ -3325,7 +3325,7 @@ pub type GlyphData<'a> = TableRef<'a, GlyphDataMarker>;
 impl<'a> GlyphData<'a> {
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -56,19 +56,19 @@ impl<'a> OtKern<'a> {
     /// Table version number—set to 0.
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of subtables in the kerning table.
     pub fn n_tables(&self) -> u16 {
         let range = self.shape.n_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Data for subtables, immediately following the header.
     pub fn subtable_data(&self) -> &'a [u8] {
         let range = self.shape.subtable_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -146,19 +146,19 @@ impl<'a> AatKern<'a> {
     /// The version number of the kerning table (0x00010000 for the current version).
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of subtables included in the kerning table.
     pub fn n_tables(&self) -> u32 {
         let range = self.shape.n_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Data for subtables, immediately following the header.    
     pub fn subtable_data(&self) -> &'a [u8] {
         let range = self.shape.subtable_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -240,25 +240,25 @@ impl<'a> OtSubtable<'a> {
     /// Kern subtable version number-- set to 0.
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u16 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u16 {
         let range = self.shape.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -341,25 +341,25 @@ impl<'a> AatSubtable<'a> {
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u16 {
         let range = self.shape.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The tuple index (used for variations fonts). This value specifies which tuple this subtable covers.
     pub fn tuple_index(&self) -> u16 {
         let range = self.shape.tuple_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -450,31 +450,31 @@ impl<'a> Subtable0<'a> {
     /// The number of kerning pairs in this subtable.
     pub fn n_pairs(&self) -> u16 {
         let range = self.shape.n_pairs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The largest power of two less than or equal to the value of nPairs, multiplied by the size in bytes of an entry in the subtable.
     pub fn search_range(&self) -> u16 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is calculated as log2 of the largest power of two less than or equal to the value of nPairs. This value indicates how many iterations of the search loop have to be made. For example, in a list of eight items, there would be three iterations of the loop.
     pub fn entry_selector(&self) -> u16 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of nPairs minus the largest power of two less than or equal to nPairs. This is multiplied by the size in bytes of an entry in the table.
     pub fn range_shift(&self) -> u16 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Kerning records.
     pub fn pairs(&self) -> &'a [Subtable0Pair] {
         let range = self.shape.pairs_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -561,19 +561,19 @@ impl<'a> Subtable2ClassTable<'a> {
     /// First glyph in class range.
     pub fn first_glyph(&self) -> GlyphId16 {
         let range = self.shape.first_glyph_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of glyph in class range.
     pub fn n_glyphs(&self) -> u16 {
         let range = self.shape.n_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The offsets array for all of the glyphs in the range.
     pub fn offsets(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -705,55 +705,55 @@ impl<'a> Subtable3<'a> {
     /// The number of glyphs in this font.
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of kerning values.
     pub fn kern_value_count(&self) -> u8 {
         let range = self.shape.kern_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of left-hand classes.
     pub fn left_class_count(&self) -> u8 {
         let range = self.shape.left_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of right-hand classes.
     pub fn right_class_count(&self) -> u8 {
         let range = self.shape.right_class_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Set to zero (reserved for future use).
     pub fn flags(&self) -> u8 {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The kerning values.
     pub fn kern_value(&self) -> &'a [BigEndian<i16>] {
         let range = self.shape.kern_value_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// The left-hand classes.
     pub fn left_class(&self) -> &'a [u8] {
         let range = self.shape.left_class_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// The right-hand classes.
     pub fn right_class(&self) -> &'a [u8] {
         let range = self.shape.right_class_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// The indices into the kernValue array.
     pub fn kern_index(&self) -> &'a [u8] {
         let range = self.shape.kern_index_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -68,13 +68,13 @@ impl<'a> Kerx<'a> {
     /// The version number of the extended kerning table (currently 2, 3, or 4)
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of subtables included in the extended kerning table.
     pub fn n_tables(&self) -> u32 {
         let range = self.shape.n_tables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn subtables(&self) -> VarLenArray<'a, Subtable<'a>> {
@@ -164,25 +164,25 @@ impl<'a> Subtable<'a> {
     /// The length of this subtable in bytes, including this header.
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Circumstances under which this table is used.
     pub fn coverage(&self) -> u32 {
         let range = self.shape.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The tuple count. This value is only used with variation fonts and should be 0 for all other fonts. The subtable's tupleCount will be ignored if the 'kerx' table version is less than 4.
     pub fn tuple_count(&self) -> u32 {
         let range = self.shape.tuple_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Subtable specific data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -273,31 +273,31 @@ impl<'a> Subtable0<'a> {
     /// The number of kerning pairs in this subtable.
     pub fn n_pairs(&self) -> u32 {
         let range = self.shape.n_pairs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The largest power of two less than or equal to the value of nPairs, multiplied by the size in bytes of an entry in the subtable.
     pub fn search_range(&self) -> u32 {
         let range = self.shape.search_range_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is calculated as log2 of the largest power of two less than or equal to the value of nPairs. This value indicates how many iterations of the search loop have to be made. For example, in a list of eight items, there would be three iterations of the loop.
     pub fn entry_selector(&self) -> u32 {
         let range = self.shape.entry_selector_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The value of nPairs minus the largest power of two less than or equal to nPairs. This is multiplied by the size in bytes of an entry in the table.
     pub fn range_shift(&self) -> u32 {
         let range = self.shape.range_shift_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Kerning records.
     pub fn pairs(&self) -> &'a [Subtable0Pair] {
         let range = self.shape.pairs_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -52,13 +52,13 @@ impl<'a> ScriptList<'a> {
     /// Number of ScriptRecords
     pub fn script_count(&self) -> u16 {
         let range = self.shape.script_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of ScriptRecords, listed alphabetically by script tag
     pub fn script_records(&self) -> &'a [ScriptRecord] {
         let range = self.shape.script_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -198,7 +198,7 @@ impl<'a> Script<'a> {
     /// — may be NULL
     pub fn default_lang_sys_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.default_lang_sys_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`default_lang_sys_offset`][Self::default_lang_sys_offset].
@@ -211,13 +211,13 @@ impl<'a> Script<'a> {
     /// default LangSys
     pub fn lang_sys_count(&self) -> u16 {
         let range = self.shape.lang_sys_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of LangSysRecords, listed alphabetically by LangSys tag
     pub fn lang_sys_records(&self) -> &'a [LangSysRecord] {
         let range = self.shape.lang_sys_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -366,20 +366,20 @@ impl<'a> LangSys<'a> {
     /// required features = 0xFFFF
     pub fn required_feature_index(&self) -> u16 {
         let range = self.shape.required_feature_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of feature index values for this language system —
     /// excludes the required feature
     pub fn feature_index_count(&self) -> u16 {
         let range = self.shape.feature_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of indices into the FeatureList, in arbitrary order
     pub fn feature_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.feature_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -459,14 +459,14 @@ impl<'a> FeatureList<'a> {
     /// Number of FeatureRecords in this table
     pub fn feature_count(&self) -> u16 {
         let range = self.shape.feature_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of FeatureRecords — zero-based (first feature has
     /// FeatureIndex = 0), listed alphabetically by feature tag
     pub fn feature_records(&self) -> &'a [FeatureRecord] {
         let range = self.shape.feature_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -624,7 +624,7 @@ impl<'a> Feature<'a> {
     /// Offset from start of Feature table to FeatureParams table, if defined for the feature and present, else NULL
     pub fn feature_params_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.feature_params_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`feature_params_offset`][Self::feature_params_offset].
@@ -637,14 +637,14 @@ impl<'a> Feature<'a> {
     /// Number of LookupList indices for this feature
     pub fn lookup_index_count(&self) -> u16 {
         let range = self.shape.lookup_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of indices into the LookupList — zero-based (first
     /// lookup is LookupListIndex = 0)
     pub fn lookup_list_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.lookup_list_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub(crate) fn feature_tag(&self) -> Tag {
@@ -767,14 +767,14 @@ impl<'a, T> LookupList<'a, T> {
     /// Number of lookups in this table
     pub fn lookup_count(&self) -> u16 {
         let range = self.shape.lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to Lookup tables, from beginning of LookupList
     /// — zero based (first lookup is Lookup index = 0)
     pub fn lookup_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.lookup_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`lookup_offsets`][Self::lookup_offsets].
@@ -937,26 +937,26 @@ impl<'a, T> Lookup<'a, T> {
     /// Different enumerations for GSUB and GPOS
     pub fn lookup_type(&self) -> u16 {
         let range = self.shape.lookup_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Lookup qualifiers
     pub fn lookup_flag(&self) -> LookupFlag {
         let range = self.shape.lookup_flag_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of subtables for this lookup
     pub fn sub_table_count(&self) -> u16 {
         let range = self.shape.sub_table_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to lookup subtables, from beginning of Lookup
     /// table
     pub fn subtable_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.subtable_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`subtable_offsets`][Self::subtable_offsets].
@@ -974,7 +974,7 @@ impl<'a, T> Lookup<'a, T> {
     /// set.
     pub fn mark_filtering_set(&self) -> Option<u16> {
         let range = self.shape.mark_filtering_set_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 
@@ -1077,19 +1077,19 @@ impl<'a> CoverageFormat1<'a> {
     /// Format identifier — format = 1
     pub fn coverage_format(&self) -> u16 {
         let range = self.shape.coverage_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of glyphs in the glyph array
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of glyph IDs — in numerical order
     pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.glyph_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1173,19 +1173,19 @@ impl<'a> CoverageFormat2<'a> {
     /// Format identifier — format = 2
     pub fn coverage_format(&self) -> u16 {
         let range = self.shape.coverage_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of RangeRecords
     pub fn range_count(&self) -> u16 {
         let range = self.shape.range_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of glyph ranges — ordered by startGlyphID.
     pub fn range_records(&self) -> &'a [RangeRecord] {
         let range = self.shape.range_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1408,25 +1408,25 @@ impl<'a> ClassDefFormat1<'a> {
     /// Format identifier — format = 1
     pub fn class_format(&self) -> u16 {
         let range = self.shape.class_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// First glyph ID of the classValueArray
     pub fn start_glyph_id(&self) -> GlyphId16 {
         let range = self.shape.start_glyph_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Size of the classValueArray
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of Class Values — one per glyph ID
     pub fn class_value_array(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.class_value_array_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1511,19 +1511,19 @@ impl<'a> ClassDefFormat2<'a> {
     /// Format identifier — format = 2
     pub fn class_format(&self) -> u16 {
         let range = self.shape.class_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of ClassRangeRecords
     pub fn class_range_count(&self) -> u16 {
         let range = self.shape.class_range_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of ClassRangeRecords — ordered by startGlyphID
     pub fn class_range_records(&self) -> &'a [ClassRangeRecord] {
         let range = self.shape.class_range_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1785,14 +1785,14 @@ impl<'a> SequenceContextFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat1 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -1804,14 +1804,14 @@ impl<'a> SequenceContextFormat1<'a> {
     /// Number of SequenceRuleSet tables
     pub fn seq_rule_set_count(&self) -> u16 {
         let range = self.shape.seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to SequenceRuleSet tables, from beginning of
     /// SequenceContextFormat1 table (offsets may be NULL)
     pub fn seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.shape.seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
@@ -1909,14 +1909,14 @@ impl<'a> SequenceRuleSet<'a> {
     /// Number of SequenceRule tables
     pub fn seq_rule_count(&self) -> u16 {
         let range = self.shape.seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to SequenceRule tables, from beginning of the
     /// SequenceRuleSet table
     pub fn seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_offsets`][Self::seq_rule_offsets].
@@ -2026,25 +2026,25 @@ impl<'a> SequenceRule<'a> {
     /// Number of glyphs in the input glyph sequence
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.shape.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of input glyph IDs—starting with the second glyph
     pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Array of Sequence lookup records
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.shape.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2148,14 +2148,14 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of
     /// SequenceContextFormat2 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2168,7 +2168,7 @@ impl<'a> SequenceContextFormat2<'a> {
     /// SequenceContextFormat2 table
     pub fn class_def_offset(&self) -> Offset16 {
         let range = self.shape.class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`class_def_offset`][Self::class_def_offset].
@@ -2180,14 +2180,14 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Number of ClassSequenceRuleSet tables
     pub fn class_seq_rule_set_count(&self) -> u16 {
         let range = self.shape.class_seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to ClassSequenceRuleSet tables, from beginning
     /// of SequenceContextFormat2 table (may be NULL)
     pub fn class_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.shape.class_seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
@@ -2294,14 +2294,14 @@ impl<'a> ClassSequenceRuleSet<'a> {
     /// Number of ClassSequenceRule tables
     pub fn class_seq_rule_count(&self) -> u16 {
         let range = self.shape.class_seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to ClassSequenceRule tables, from beginning of
     /// ClassSequenceRuleSet table
     pub fn class_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.class_seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
@@ -2414,26 +2414,26 @@ impl<'a> ClassSequenceRule<'a> {
     /// Number of glyphs to be matched
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.shape.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Sequence of classes to be matched to the input glyph sequence,
     /// beginning with the second glyph position
     pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.shape.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2542,26 +2542,26 @@ impl<'a> SequenceContextFormat3<'a> {
     /// Format identifier: format = 3
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of glyphs in the input sequence
     pub fn glyph_count(&self) -> u16 {
         let range = self.shape.glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.shape.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to Coverage tables, from beginning of
     /// SequenceContextFormat3 subtable
     pub fn coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
@@ -2574,7 +2574,7 @@ impl<'a> SequenceContextFormat3<'a> {
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.shape.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -2763,14 +2763,14 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// Format identifier: format = 1
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of
     /// ChainSequenceContextFormat1 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -2782,14 +2782,14 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// Number of ChainedSequenceRuleSet tables
     pub fn chained_seq_rule_set_count(&self) -> u16 {
         let range = self.shape.chained_seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to ChainedSeqRuleSet tables, from beginning of
     /// ChainedSequenceContextFormat1 table (may be NULL)
     pub fn chained_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.shape.chained_seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
@@ -2892,14 +2892,14 @@ impl<'a> ChainedSequenceRuleSet<'a> {
     /// Number of ChainedSequenceRule tables
     pub fn chained_seq_rule_count(&self) -> u16 {
         let range = self.shape.chained_seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to ChainedSequenceRule tables, from beginning
     /// of ChainedSequenceRuleSet table
     pub fn chained_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.chained_seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
@@ -3046,49 +3046,49 @@ impl<'a> ChainedSequenceRule<'a> {
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.shape.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of backtrack glyph IDs
     pub fn backtrack_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.backtrack_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
         let range = self.shape.input_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of input glyph IDs—start with second glyph
     pub fn input_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.shape.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of lookahead glyph IDs
     pub fn lookahead_sequence(&self) -> &'a [BigEndian<GlyphId16>] {
         let range = self.shape.lookahead_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.shape.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.shape.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -3215,14 +3215,14 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Format identifier: format = 2
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to Coverage table, from beginning of
     /// ChainedSequenceContextFormat2 table
     pub fn coverage_offset(&self) -> Offset16 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -3235,7 +3235,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn backtrack_class_def_offset(&self) -> Offset16 {
         let range = self.shape.backtrack_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`backtrack_class_def_offset`][Self::backtrack_class_def_offset].
@@ -3248,7 +3248,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn input_class_def_offset(&self) -> Offset16 {
         let range = self.shape.input_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`input_class_def_offset`][Self::input_class_def_offset].
@@ -3261,7 +3261,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// from beginning of ChainedSequenceContextFormat2 table
     pub fn lookahead_class_def_offset(&self) -> Offset16 {
         let range = self.shape.lookahead_class_def_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`lookahead_class_def_offset`][Self::lookahead_class_def_offset].
@@ -3273,14 +3273,14 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Number of ChainedClassSequenceRuleSet tables
     pub fn chained_class_seq_rule_set_count(&self) -> u16 {
         let range = self.shape.chained_class_seq_rule_set_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to ChainedClassSequenceRuleSet tables, from
     /// beginning of ChainedSequenceContextFormat2 table (may be NULL)
     pub fn chained_class_seq_rule_set_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.shape.chained_class_seq_rule_set_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
@@ -3401,14 +3401,14 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     /// Number of ChainedClassSequenceRule tables
     pub fn chained_class_seq_rule_count(&self) -> u16 {
         let range = self.shape.chained_class_seq_rule_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to ChainedClassSequenceRule tables, from
     /// beginning of ChainedClassSequenceRuleSet
     pub fn chained_class_seq_rule_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.chained_class_seq_rule_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
@@ -3557,50 +3557,50 @@ impl<'a> ChainedClassSequenceRule<'a> {
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.shape.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of backtrack-sequence classes
     pub fn backtrack_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.backtrack_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Total number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
         let range = self.shape.input_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of input sequence classes, beginning with the second
     /// glyph position
     pub fn input_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.input_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.shape.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of lookahead-sequence classes
     pub fn lookahead_sequence(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.lookahead_sequence_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.shape.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.shape.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -3753,19 +3753,19 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Format identifier: format = 3
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of glyphs in the backtrack sequence
     pub fn backtrack_glyph_count(&self) -> u16 {
         let range = self.shape.backtrack_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to coverage tables for the backtrack sequence
     pub fn backtrack_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.backtrack_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
@@ -3778,13 +3778,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Number of glyphs in the input sequence
     pub fn input_glyph_count(&self) -> u16 {
         let range = self.shape.input_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to coverage tables for the input sequence
     pub fn input_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.input_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`input_coverage_offsets`][Self::input_coverage_offsets].
@@ -3797,13 +3797,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Number of glyphs in the lookahead sequence
     pub fn lookahead_glyph_count(&self) -> u16 {
         let range = self.shape.lookahead_glyph_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to coverage tables for the lookahead sequence
     pub fn lookahead_coverage_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.lookahead_coverage_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
@@ -3816,13 +3816,13 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     /// Number of SequenceLookupRecords
     pub fn seq_lookup_count(&self) -> u16 {
         let range = self.shape.seq_lookup_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of SequenceLookupRecords
     pub fn seq_lookup_records(&self) -> &'a [SequenceLookupRecord] {
         let range = self.shape.seq_lookup_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -4097,25 +4097,25 @@ impl<'a> Device<'a> {
     /// Smallest size to correct, in ppem
     pub fn start_size(&self) -> u16 {
         let range = self.shape.start_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Largest size to correct, in ppem
     pub fn end_size(&self) -> u16 {
         let range = self.shape.end_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of deltaValue array data: 0x0001, 0x0002, or 0x0003
     pub fn delta_format(&self) -> DeltaFormat {
         let range = self.shape.delta_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of compressed data
     pub fn delta_value(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.delta_value_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -4190,20 +4190,20 @@ impl<'a> VariationIndex<'a> {
     /// data subtable within the item variation store.
     pub fn delta_set_outer_index(&self) -> u16 {
         let range = self.shape.delta_set_outer_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A delta-set inner index — used to select a delta-set row
     /// within an item variation data subtable.
     pub fn delta_set_inner_index(&self) -> u16 {
         let range = self.shape.delta_set_inner_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format, = 0x8000
     pub fn delta_format(&self) -> DeltaFormat {
         let range = self.shape.delta_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4358,19 +4358,19 @@ pub type FeatureVariations<'a> = TableRef<'a, FeatureVariationsMarker>;
 impl<'a> FeatureVariations<'a> {
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of feature variation records.
     pub fn feature_variation_record_count(&self) -> u32 {
         let range = self.shape.feature_variation_record_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of feature variation records.
     pub fn feature_variation_records(&self) -> &'a [FeatureVariationRecord] {
         let range = self.shape.feature_variation_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -4533,14 +4533,14 @@ impl<'a> ConditionSet<'a> {
     /// Number of conditions for this condition set.
     pub fn condition_count(&self) -> u16 {
         let range = self.shape.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of offsets to condition tables, from beginning of the
     /// ConditionSet table.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
@@ -4735,28 +4735,28 @@ impl<'a> ConditionFormat1<'a> {
     /// Format, = 1
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Index (zero-based) for the variation axis within the 'fvar'
     /// table.
     pub fn axis_index(&self) -> u16 {
         let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum value of the font variation instances that satisfy this
     /// condition.
     pub fn filter_range_min_value(&self) -> F2Dot14 {
         let range = self.shape.filter_range_min_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum value of the font variation instances that satisfy this
     /// condition.
     pub fn filter_range_max_value(&self) -> F2Dot14 {
         let range = self.shape.filter_range_max_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4840,19 +4840,19 @@ impl<'a> ConditionFormat2<'a> {
     /// Format, = 2
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Value at default instance.
     pub fn default_value(&self) -> i16 {
         let range = self.shape.default_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Variation index to vary the value based on current designspace location.
     pub fn var_index(&self) -> u32 {
         let range = self.shape.var_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -4936,19 +4936,19 @@ impl<'a> ConditionFormat3<'a> {
     /// Format, = 3
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of conditions.
     pub fn condition_count(&self) -> u8 {
         let range = self.shape.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of condition tables for this conjunction (AND) expression.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset24>] {
         let range = self.shape.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
@@ -5052,19 +5052,19 @@ impl<'a> ConditionFormat4<'a> {
     /// Format, = 4
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of conditions.
     pub fn condition_count(&self) -> u8 {
         let range = self.shape.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of condition tables for this disjunction (OR) expression.
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset24>] {
         let range = self.shape.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
@@ -5155,13 +5155,13 @@ impl<'a> ConditionFormat5<'a> {
     /// Format, = 5
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Condition to negate.
     pub fn condition_offset(&self) -> Offset24 {
         let range = self.shape.condition_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`condition_offset`][Self::condition_offset].
@@ -5249,19 +5249,19 @@ impl<'a> FeatureTableSubstitution<'a> {
     /// Major & minor version of the table: (1, 0)
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of feature table substitution records.
     pub fn substitution_count(&self) -> u16 {
         let range = self.shape.substitution_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of feature table substitution records.
     pub fn substitutions(&self) -> &'a [FeatureTableSubstitutionRecord] {
         let range = self.shape.substitutions_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -5404,7 +5404,7 @@ impl<'a> SizeParams<'a> {
     /// no recommended size range, the rest of the array will consist of zeros.
     pub fn design_size(&self) -> u16 {
         let range = self.shape.design_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The second value has no independent meaning, but serves as an identifier that associates fonts in a subfamily.
@@ -5415,7 +5415,7 @@ impl<'a> SizeParams<'a> {
     /// If this value is zero, the remaining fields in the array will be ignored.
     pub fn identifier(&self) -> u16 {
         let range = self.shape.identifier_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The third value enables applications to use a single name for the subfamily identified by the second value.
@@ -5430,7 +5430,7 @@ impl<'a> SizeParams<'a> {
     /// appropriate version based on their selection criteria.
     pub fn name_entry(&self) -> u16 {
         let range = self.shape.name_entry_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The fourth and fifth values represent the small end of the recommended
@@ -5440,12 +5440,12 @@ impl<'a> SizeParams<'a> {
     /// Ranges must not overlap, and should generally be contiguous.
     pub fn range_start(&self) -> u16 {
         let range = self.shape.range_start_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn range_end(&self) -> u16 {
         let range = self.shape.range_end_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5511,7 +5511,7 @@ pub type StylisticSetParams<'a> = TableRef<'a, StylisticSetParamsMarker>;
 impl<'a> StylisticSetParams<'a> {
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The 'name' table name ID that specifies a string (or strings, for
@@ -5525,7 +5525,7 @@ impl<'a> StylisticSetParams<'a> {
     /// comfortably with different application interfaces.
     pub fn ui_name_id(&self) -> NameId {
         let range = self.shape.ui_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -5636,7 +5636,7 @@ impl<'a> CharacterVariantParams<'a> {
     /// Format number is set to 0.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The 'name' table name ID that specifies a string (or strings,
@@ -5644,7 +5644,7 @@ impl<'a> CharacterVariantParams<'a> {
     /// feature. (May be NULL.)
     pub fn feat_ui_label_name_id(&self) -> NameId {
         let range = self.shape.feat_ui_label_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The 'name' table name ID that specifies a string (or strings,
@@ -5652,20 +5652,20 @@ impl<'a> CharacterVariantParams<'a> {
     /// text for this feature. (May be NULL.)
     pub fn feat_ui_tooltip_text_name_id(&self) -> NameId {
         let range = self.shape.feat_ui_tooltip_text_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The 'name' table name ID that specifies sample text that
     /// illustrates the effect of this feature. (May be NULL.)
     pub fn sample_text_name_id(&self) -> NameId {
         let range = self.shape.sample_text_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of named parameters. (May be zero.)
     pub fn num_named_parameters(&self) -> u16 {
         let range = self.shape.num_named_parameters_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The first 'name' table name ID used to specify strings for
@@ -5673,21 +5673,21 @@ impl<'a> CharacterVariantParams<'a> {
     /// if numParameters is zero.)
     pub fn first_param_ui_label_name_id(&self) -> NameId {
         let range = self.shape.first_param_ui_label_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The count of characters for which this feature provides glyph
     /// variants. (May be zero.)
     pub fn char_count(&self) -> u16 {
         let range = self.shape.char_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The Unicode Scalar Value of the characters for which this
     /// feature provides glyph variants.
     pub fn character(&self) -> &'a [BigEndian<Uint24>] {
         let range = self.shape.character_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -69,25 +69,25 @@ impl<'a> Ltag<'a> {
     /// Table version; currently 1.
     pub fn version(&self) -> u32 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Table flags; currently none defined.
     pub fn flags(&self) -> u32 {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of language tags which follow.
     pub fn num_tags(&self) -> u32 {
         let range = self.shape.num_tags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Range of each tag's string.
     pub fn tag_ranges(&self) -> &'a [FTStringRange] {
         let range = self.shape.tag_ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -234,68 +234,68 @@ impl<'a> Maxp<'a> {
     /// The version: 0x00005000 for version 0.5, 0x00010000 for version 1.0.
     pub fn version(&self) -> Version16Dot16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of glyphs in the font.
     pub fn num_glyphs(&self) -> u16 {
         let range = self.shape.num_glyphs_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum points in a non-composite glyph.
     pub fn max_points(&self) -> Option<u16> {
         let range = self.shape.max_points_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum contours in a non-composite glyph.
     pub fn max_contours(&self) -> Option<u16> {
         let range = self.shape.max_contours_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum points in a composite glyph.
     pub fn max_composite_points(&self) -> Option<u16> {
         let range = self.shape.max_composite_points_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum contours in a composite glyph.
     pub fn max_composite_contours(&self) -> Option<u16> {
         let range = self.shape.max_composite_contours_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// 1 if instructions do not use the twilight zone (Z0), or 2 if
     /// instructions do use Z0; should be set to 2 in most cases.
     pub fn max_zones(&self) -> Option<u16> {
         let range = self.shape.max_zones_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum points used in Z0.
     pub fn max_twilight_points(&self) -> Option<u16> {
         let range = self.shape.max_twilight_points_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Number of Storage Area locations.
     pub fn max_storage(&self) -> Option<u16> {
         let range = self.shape.max_storage_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Number of FDEFs, equal to the highest function number + 1.
     pub fn max_function_defs(&self) -> Option<u16> {
         let range = self.shape.max_function_defs_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Number of IDEFs.
     pub fn max_instruction_defs(&self) -> Option<u16> {
         let range = self.shape.max_instruction_defs_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum stack depth across Font Program ('fpgm' table), CVT
@@ -303,26 +303,26 @@ impl<'a> Maxp<'a> {
     /// 'glyf' table).
     pub fn max_stack_elements(&self) -> Option<u16> {
         let range = self.shape.max_stack_elements_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum byte count for glyph instructions.
     pub fn max_size_of_instructions(&self) -> Option<u16> {
         let range = self.shape.max_size_of_instructions_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum number of components referenced at “top level” for
     /// any composite glyph.
     pub fn max_component_elements(&self) -> Option<u16> {
         let range = self.shape.max_component_elements_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Maximum levels of recursion; 1 for simple components.
     pub fn max_component_depth(&self) -> Option<u16> {
         let range = self.shape.max_component_depth_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -73,25 +73,25 @@ impl<'a> Meta<'a> {
     /// Version number of the metadata table — set to 1.
     pub fn version(&self) -> u32 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Flags — currently unused; set to 0.
     pub fn flags(&self) -> u32 {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of data maps in the table.
     pub fn data_maps_count(&self) -> u32 {
         let range = self.shape.data_maps_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of data map records.
     pub fn data_maps(&self) -> &'a [DataMapRecord] {
         let range = self.shape.data_maps_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -68,13 +68,13 @@ impl<'a> Morx<'a> {
     /// Version number of the extended glyph metamorphosis table (either 2 or 3).
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of metamorphosis chains contained in this table.
     pub fn n_chains(&self) -> u32 {
         let range = self.shape.n_chains_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn chains(&self) -> VarLenArray<'a, Chain<'a>> {
@@ -186,31 +186,31 @@ impl<'a> Chain<'a> {
     /// The default specification for subtables.
     pub fn default_flags(&self) -> u32 {
         let range = self.shape.default_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Total byte count, including this header; must be a multiple of 4.
     pub fn chain_length(&self) -> u32 {
         let range = self.shape.chain_length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of feature subtable entries.
     pub fn n_feature_entries(&self) -> u32 {
         let range = self.shape.n_feature_entries_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of subtables in the chain.
     pub fn n_subtables(&self) -> u32 {
         let range = self.shape.n_subtables_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Feature entries for this chain.
     pub fn features(&self) -> &'a [Feature] {
         let range = self.shape.features_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Array of chain subtables.
@@ -370,25 +370,25 @@ impl<'a> Subtable<'a> {
     /// Total subtable length, including this header.
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Coverage flags and subtable type.
     pub fn coverage(&self) -> u32 {
         let range = self.shape.coverage_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The 32-bit mask identifying which subtable this is (the subtable being executed if the AND of this value and the processed defaultFlags is nonzero).
     pub fn sub_feature_flags(&self) -> u32 {
         let range = self.shape.sub_feature_flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Data for specific subtable.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -82,25 +82,25 @@ impl<'a> Mvar<'a> {
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The size in bytes of each value record — must be greater than zero.
     pub fn value_record_size(&self) -> u16 {
         let range = self.shape.value_record_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of value records — may be zero.
     pub fn value_record_count(&self) -> u16 {
         let range = self.shape.value_record_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the start of this table to the item variation store table. If valueRecordCount is zero, set to zero; if valueRecordCount is greater than zero, must be greater than zero.
     pub fn item_variation_store_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.item_variation_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -112,7 +112,7 @@ impl<'a> Mvar<'a> {
     /// Array of value records that identify target items and the associated delta-set index for each. The valueTag records must be in binary order of their valueTag field.
     pub fn value_records(&self) -> &'a [ValueRecord] {
         let range = self.shape.value_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -106,37 +106,37 @@ impl<'a> Name<'a> {
     /// Table version number (0 or 1)
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of name records.
     pub fn count(&self) -> u16 {
         let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to start of string storage (from start of table).
     pub fn storage_offset(&self) -> u16 {
         let range = self.shape.storage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The name records where count is the number of records.
     pub fn name_record(&self) -> &'a [NameRecord] {
         let range = self.shape.name_record_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Number of language-tag records.
     pub fn lang_tag_count(&self) -> Option<u16> {
         let range = self.shape.lang_tag_count_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// The language-tag records where langTagCount is the number of records.
     pub fn lang_tag_record(&self) -> Option<&'a [LangTagRecord]> {
         let range = self.shape.lang_tag_record_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 }
 

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -685,7 +685,7 @@ pub type Os2<'a> = TableRef<'a, Os2Marker>;
 impl<'a> Os2<'a> {
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Average weighted escapement](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#xavgcharwidth).
@@ -694,7 +694,7 @@ impl<'a> Os2<'a> {
     /// of the escapement (width) of all non-zero width glyphs in the font.
     pub fn x_avg_char_width(&self) -> i16 {
         let range = self.shape.x_avg_char_width_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Weight class](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass).
@@ -703,7 +703,7 @@ impl<'a> Os2<'a> {
     /// strokes) of the characters in the font. Values from 1 to 1000 are valid.
     pub fn us_weight_class(&self) -> u16 {
         let range = self.shape.us_weight_class_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Width class](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
@@ -712,7 +712,7 @@ impl<'a> Os2<'a> {
     /// ratio) as specified by a font designer for the glyphs in a font.
     pub fn us_width_class(&self) -> u16 {
         let range = self.shape.us_width_class_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Type flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fstype).
@@ -720,83 +720,83 @@ impl<'a> Os2<'a> {
     /// Indicates font embedding licensing rights for the font.
     pub fn fs_type(&self) -> u16 {
         let range = self.shape.fs_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended horizontal size in font design units for subscripts for
     /// this font.
     pub fn y_subscript_x_size(&self) -> i16 {
         let range = self.shape.y_subscript_x_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended vertical size in font design units for subscripts for
     /// this font.
     pub fn y_subscript_y_size(&self) -> i16 {
         let range = self.shape.y_subscript_y_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended horizontal offset in font design units for subscripts
     /// for this font.
     pub fn y_subscript_x_offset(&self) -> i16 {
         let range = self.shape.y_subscript_x_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended vertical offset in font design units for subscripts
     /// for this font.
     pub fn y_subscript_y_offset(&self) -> i16 {
         let range = self.shape.y_subscript_y_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended horizontal size in font design units for superscripts
     /// for this font.
     pub fn y_superscript_x_size(&self) -> i16 {
         let range = self.shape.y_superscript_x_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended vertical size in font design units for superscripts
     /// for this font.
     pub fn y_superscript_y_size(&self) -> i16 {
         let range = self.shape.y_superscript_y_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended horizontal offset in font design units for superscripts
     /// for this font.
     pub fn y_superscript_x_offset(&self) -> i16 {
         let range = self.shape.y_superscript_x_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The recommended vertical offset in font design units for superscripts
     /// for this font.
     pub fn y_superscript_y_offset(&self) -> i16 {
         let range = self.shape.y_superscript_y_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Thickness of the strikeout stroke in font design units.
     pub fn y_strikeout_size(&self) -> i16 {
         let range = self.shape.y_strikeout_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The position of the top of the strikeout stroke relative to the
     /// baseline in font design units.
     pub fn y_strikeout_position(&self) -> i16 {
         let range = self.shape.y_strikeout_position_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Font-family class and subclass](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#sfamilyclass).
     /// This parameter is a classification of font-family design.
     pub fn s_family_class(&self) -> i16 {
         let range = self.shape.s_family_class_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [PANOSE classification number](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#panose).
@@ -805,7 +805,7 @@ impl<'a> Os2<'a> {
     /// character sets.
     pub fn panose_10(&self) -> &'a [u8] {
         let range = self.shape.panose_10_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// [Unicode Character Range](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#ulunicoderange1-bits-031ulunicoderange2-bits-3263ulunicoderange3-bits-6495ulunicoderange4-bits-96127).
@@ -813,25 +813,25 @@ impl<'a> Os2<'a> {
     /// Unicode Character Range (bits 0-31).
     pub fn ul_unicode_range_1(&self) -> u32 {
         let range = self.shape.ul_unicode_range_1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Unicode Character Range (bits 32-63).
     pub fn ul_unicode_range_2(&self) -> u32 {
         let range = self.shape.ul_unicode_range_2_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Unicode Character Range (bits 64-95).
     pub fn ul_unicode_range_3(&self) -> u32 {
         let range = self.shape.ul_unicode_range_3_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Unicode Character Range (bits 96-127).
     pub fn ul_unicode_range_4(&self) -> u32 {
         let range = self.shape.ul_unicode_range_4_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Font Vendor Identification](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#achvendid).
@@ -839,7 +839,7 @@ impl<'a> Os2<'a> {
     /// The four-character identifier for the vendor of the given type face.
     pub fn ach_vend_id(&self) -> Tag {
         let range = self.shape.ach_vend_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// [Font selection flags](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection).
@@ -847,37 +847,37 @@ impl<'a> Os2<'a> {
     /// Contains information concerning the nature of the font patterns.
     pub fn fs_selection(&self) -> SelectionFlags {
         let range = self.shape.fs_selection_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The minimum Unicode index (character code) in this font.
     pub fn us_first_char_index(&self) -> u16 {
         let range = self.shape.us_first_char_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The maximum Unicode index (character code) in this font.
     pub fn us_last_char_index(&self) -> u16 {
         let range = self.shape.us_last_char_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The typographic ascender for this font.
     pub fn s_typo_ascender(&self) -> i16 {
         let range = self.shape.s_typo_ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The typographic descender for this font.
     pub fn s_typo_descender(&self) -> i16 {
         let range = self.shape.s_typo_descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The typographic line gap for this font.
     pub fn s_typo_line_gap(&self) -> i16 {
         let range = self.shape.s_typo_line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The “Windows ascender” metric.
@@ -886,7 +886,7 @@ impl<'a> Os2<'a> {
     /// clipping region.
     pub fn us_win_ascent(&self) -> u16 {
         let range = self.shape.us_win_ascent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The “Windows descender” metric.
@@ -895,19 +895,19 @@ impl<'a> Os2<'a> {
     /// for a clipping region.
     pub fn us_win_descent(&self) -> u16 {
         let range = self.shape.us_win_descent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Code page character range bits 0-31.
     pub fn ul_code_page_range_1(&self) -> Option<u32> {
         let range = self.shape.ul_code_page_range_1_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Code page character range bits 32-63.
     pub fn ul_code_page_range_2(&self) -> Option<u32> {
         let range = self.shape.ul_code_page_range_2_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This metric specifies the distance between the baseline and the
@@ -915,46 +915,46 @@ impl<'a> Os2<'a> {
     /// FUnits.
     pub fn sx_height(&self) -> Option<i16> {
         let range = self.shape.sx_height_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This metric specifies the distance between the baseline and the
     /// approximate height of uppercase letters measured in FUnits.
     pub fn s_cap_height(&self) -> Option<i16> {
         let range = self.shape.s_cap_height_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used for a default glyph.
     pub fn us_default_char(&self) -> Option<u16> {
         let range = self.shape.us_default_char_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This is the Unicode codepoint, in UTF-16 encoding, of a character that
     /// can be used as a default break character.
     pub fn us_break_char(&self) -> Option<u16> {
         let range = self.shape.us_break_char_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_max_context(&self) -> Option<u16> {
         let range = self.shape.us_max_context_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_lower_optical_point_size(&self) -> Option<u16> {
         let range = self.shape.us_lower_optical_point_size_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// This field is used for fonts with multiple optical styles.
     pub fn us_upper_optical_point_size(&self) -> Option<u16> {
         let range = self.shape.us_upper_optical_point_size_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -152,7 +152,7 @@ impl<'a> Post<'a> {
     /// 3.0
     pub fn version(&self) -> Version16Dot16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Italic angle in counter-clockwise degrees from the vertical.
@@ -160,7 +160,7 @@ impl<'a> Post<'a> {
     /// right (forward).
     pub fn italic_angle(&self) -> Fixed {
         let range = self.shape.italic_angle_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// This is the suggested distance of the top of the underline from
@@ -172,7 +172,7 @@ impl<'a> Post<'a> {
     /// value of this field.
     pub fn underline_position(&self) -> FWord {
         let range = self.shape.underline_position_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Suggested values for the underline thickness. In general, the
@@ -181,53 +181,53 @@ impl<'a> Post<'a> {
     /// the strikeout thickness, which is specified in the OS/2 table.
     pub fn underline_thickness(&self) -> FWord {
         let range = self.shape.underline_thickness_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Set to 0 if the font is proportionally spaced, non-zero if the
     /// font is not proportionally spaced (i.e. monospaced).
     pub fn is_fixed_pitch(&self) -> u32 {
         let range = self.shape.is_fixed_pitch_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum memory usage when an OpenType font is downloaded.
     pub fn min_mem_type42(&self) -> u32 {
         let range = self.shape.min_mem_type42_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum memory usage when an OpenType font is downloaded.
     pub fn max_mem_type42(&self) -> u32 {
         let range = self.shape.max_mem_type42_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
     pub fn min_mem_type1(&self) -> u32 {
         let range = self.shape.min_mem_type1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum memory usage when an OpenType font is downloaded as a
     /// Type 1 font.
     pub fn max_mem_type1(&self) -> u32 {
         let range = self.shape.max_mem_type1_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of glyphs (this should be the same as numGlyphs in
     /// 'maxp' table).
     pub fn num_glyphs(&self) -> Option<u16> {
         let range = self.shape.num_glyphs_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Array of indices into the string data. See below for details.
     pub fn glyph_name_index(&self) -> Option<&'a [BigEndian<u16>]> {
         let range = self.shape.glyph_name_index_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     /// Storage for the string data.

--- a/read-fonts/generated/generated_postscript.rs
+++ b/read-fonts/generated/generated_postscript.rs
@@ -67,25 +67,25 @@ impl<'a> Index1<'a> {
     /// Number of objects stored in INDEX.
     pub fn count(&self) -> u16 {
         let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Object array element size.
     pub fn off_size(&self) -> u8 {
         let range = self.shape.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Bytes containing `count + 1` offsets each of `off_size`.
     pub fn offsets(&self) -> &'a [u8] {
         let range = self.shape.offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Array containing the object data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -175,25 +175,25 @@ impl<'a> Index2<'a> {
     /// Number of objects stored in INDEX.
     pub fn count(&self) -> u32 {
         let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Object array element size.
     pub fn off_size(&self) -> u8 {
         let range = self.shape.off_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Bytes containing `count + 1` offsets each of `off_size`.
     pub fn offsets(&self) -> &'a [u8] {
         let range = self.shape.offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Array containing the object data.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -346,13 +346,13 @@ impl<'a> FdSelectFormat0<'a> {
     /// Format = 0.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// FD selector array (one entry for each glyph).
     pub fn fds(&self) -> &'a [u8] {
         let range = self.shape.fds_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -439,25 +439,25 @@ impl<'a> FdSelectFormat3<'a> {
     /// Format = 3.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of ranges.
     pub fn n_ranges(&self) -> u16 {
         let range = self.shape.n_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Range3 array.
     pub fn ranges(&self) -> &'a [FdSelectRange3] {
         let range = self.shape.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Sentinel GID. Set equal to the number of glyphs in the font.
     pub fn sentinel(&self) -> u16 {
         let range = self.shape.sentinel_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -595,25 +595,25 @@ impl<'a> FdSelectFormat4<'a> {
     /// Format = 4.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of ranges.
     pub fn n_ranges(&self) -> u32 {
         let range = self.shape.n_ranges_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Range4 array.
     pub fn ranges(&self) -> &'a [FdSelectRange4] {
         let range = self.shape.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Sentinel GID. Set equal to the number of glyphs in the font.
     pub fn sentinel(&self) -> u32 {
         let range = self.shape.sentinel_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -815,13 +815,13 @@ impl<'a> CharsetFormat0<'a> {
     /// Format; =0
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Glyph name array.
     pub fn glyph(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.glyph_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -895,13 +895,13 @@ impl<'a> CharsetFormat1<'a> {
     /// Format; =1
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Range1 array.
     pub fn ranges(&self) -> &'a [CharsetRange1] {
         let range = self.shape.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -1024,13 +1024,13 @@ impl<'a> CharsetFormat2<'a> {
     /// Format; =2
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Range2 array.
     pub fn ranges(&self) -> &'a [CharsetRange2] {
         let range = self.shape.ranges_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -395,7 +395,7 @@ impl<'a> Sbix<'a> {
     /// Table version number — set to 1.
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Bit 0: Set to 1.
@@ -403,19 +403,19 @@ impl<'a> Sbix<'a> {
     /// Bits 2 to 15: reserved (set to 0).
     pub fn flags(&self) -> HeaderFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of bitmap strikes.
     pub fn num_strikes(&self) -> u32 {
         let range = self.shape.num_strikes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offsets from the beginning of the 'sbix' table to data for each individual bitmap strike.
     pub fn strike_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.strike_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`strike_offsets`][Self::strike_offsets].
@@ -538,19 +538,19 @@ impl<'a> Strike<'a> {
     /// The PPEM size for which this strike was designed.
     pub fn ppem(&self) -> u16 {
         let range = self.shape.ppem_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The device pixel density (in PPI) for which this strike was designed. (E.g., 96 PPI, 192 PPI.)
     pub fn ppi(&self) -> u16 {
         let range = self.shape.ppi_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the beginning of the strike data header to bitmap data for an individual glyph ID.
     pub fn glyph_data_offsets(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.glyph_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -632,25 +632,25 @@ impl<'a> GlyphData<'a> {
     /// The horizontal (x-axis) position of the left edge of the bitmap graphic in relation to the glyph design space origin.
     pub fn origin_offset_x(&self) -> i16 {
         let range = self.shape.origin_offset_x_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The vertical (y-axis) position of the bottom edge of the bitmap graphic in relation to the glyph design space origin.
     pub fn origin_offset_y(&self) -> i16 {
         let range = self.shape.origin_offset_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Indicates the format of the embedded graphic data: one of 'jpg ', 'png ' or 'tiff', or the special format 'dupe'.
     pub fn graphic_type(&self) -> Tag {
         let range = self.shape.graphic_type_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The actual embedded graphic data. The total length is inferred from sequential entries in the glyphDataOffsets array and the fixed size (8 bytes) of the preceding fields.
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -90,13 +90,13 @@ impl<'a> Stat<'a> {
     /// Major/minor version number. Set to 1.2 for new fonts.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The size in bytes of each axis record.
     pub fn design_axis_size(&self) -> u16 {
         let range = self.shape.design_axis_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of axis records. In a font with an 'fvar' table,
@@ -105,7 +105,7 @@ impl<'a> Stat<'a> {
     /// axisValueCount is greater than zero.
     pub fn design_axis_count(&self) -> u16 {
         let range = self.shape.design_axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the beginning of the STAT table to the
@@ -114,7 +114,7 @@ impl<'a> Stat<'a> {
     /// greater than zero.
     pub fn design_axes_offset(&self) -> Offset32 {
         let range = self.shape.design_axes_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`design_axes_offset`][Self::design_axes_offset].
@@ -127,7 +127,7 @@ impl<'a> Stat<'a> {
     /// The number of axis value tables.
     pub fn axis_value_count(&self) -> u16 {
         let range = self.shape.axis_value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the beginning of the STAT table to the
@@ -136,7 +136,7 @@ impl<'a> Stat<'a> {
     /// must be greater than zero.
     pub fn offset_to_axis_value_offsets(&self) -> Nullable<Offset32> {
         let range = self.shape.offset_to_axis_value_offsets_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`offset_to_axis_value_offsets`][Self::offset_to_axis_value_offsets].
@@ -152,7 +152,7 @@ impl<'a> Stat<'a> {
     /// elidable elements.
     pub fn elided_fallback_name_id(&self) -> Option<NameId> {
         let range = self.shape.elided_fallback_name_id_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 
@@ -315,7 +315,7 @@ impl<'a> AxisValueArray<'a> {
     /// of the axis value offsets array.
     pub fn axis_value_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.axis_value_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`axis_value_offsets`][Self::axis_value_offsets].
@@ -527,7 +527,7 @@ impl<'a> AxisValueFormat1<'a> {
     /// Format identifier — set to 1.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Zero-base index into the axis record array identifying the axis
@@ -535,26 +535,26 @@ impl<'a> AxisValueFormat1<'a> {
     /// be less than designAxisCount.
     pub fn axis_index(&self) -> u16 {
         let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A numeric value for this attribute value.
     pub fn value(&self) -> Fixed {
         let range = self.shape.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -657,7 +657,7 @@ impl<'a> AxisValueFormat2<'a> {
     /// Format identifier — set to 2.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Zero-base index into the axis record array identifying the axis
@@ -665,40 +665,40 @@ impl<'a> AxisValueFormat2<'a> {
     /// be less than designAxisCount.
     pub fn axis_index(&self) -> u16 {
         let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A nominal numeric value for this attribute value.
     pub fn nominal_value(&self) -> Fixed {
         let range = self.shape.nominal_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The minimum value for a range associated with the specified
     /// name ID.
     pub fn range_min_value(&self) -> Fixed {
         let range = self.shape.range_min_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The maximum value for a range associated with the specified
     /// name ID.
     pub fn range_max_value(&self) -> Fixed {
         let range = self.shape.range_max_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -797,7 +797,7 @@ impl<'a> AxisValueFormat3<'a> {
     /// Format identifier — set to 3.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Zero-base index into the axis record array identifying the axis
@@ -805,32 +805,32 @@ impl<'a> AxisValueFormat3<'a> {
     /// be less than designAxisCount.
     pub fn axis_index(&self) -> u16 {
         let range = self.shape.axis_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this attribute value.
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A numeric value for this attribute value.
     pub fn value(&self) -> Fixed {
         let range = self.shape.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The numeric value for a style-linked mapping from this value.
     pub fn linked_value(&self) -> Fixed {
         let range = self.shape.linked_value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -929,34 +929,34 @@ impl<'a> AxisValueFormat4<'a> {
     /// Format identifier — set to 4.
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The total number of axes contributing to this axis-values
     /// combination.
     pub fn axis_count(&self) -> u16 {
         let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Flags — see below for details.
     pub fn flags(&self) -> AxisValueTableFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The name ID for entries in the 'name' table that provide a
     /// display string for this combination of axis values.
     pub fn value_name_id(&self) -> NameId {
         let range = self.shape.value_name_id_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of AxisValue records that provide the combination of axis
     /// values, one for each contributing axis.
     pub fn axis_values(&self) -> &'a [AxisValueRecord] {
         let range = self.shape.axis_values_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -56,14 +56,14 @@ impl<'a> Svg<'a> {
     /// Table version (starting at 0). Set to 0.
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset to the SVGDocumentList, from the start of the SVG table.
     /// Must be non-zero.
     pub fn svg_document_list_offset(&self) -> Offset32 {
         let range = self.shape.svg_document_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`svg_document_list_offset`][Self::svg_document_list_offset].
@@ -145,13 +145,13 @@ impl<'a> SVGDocumentList<'a> {
     /// Number of SVGDocumentRecords. Must be non-zero.
     pub fn num_entries(&self) -> u16 {
         let range = self.shape.num_entries_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of SVGDocumentRecords.
     pub fn document_records(&self) -> &'a [SVGDocumentRecord] {
         let range = self.shape.document_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -72,22 +72,22 @@ pub type MajorMinorVersion<'a> = TableRef<'a, MajorMinorVersionMarker>;
 impl<'a> MajorMinorVersion<'a> {
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn always_present(&self) -> u16 {
         let range = self.shape.always_present_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn if_11(&self) -> Option<u16> {
         let range = self.shape.if_11_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn if_20(&self) -> Option<u32> {
         let range = self.shape.if_20_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 
@@ -506,27 +506,27 @@ pub type FlagDay<'a> = TableRef<'a, FlagDayMarker>;
 impl<'a> FlagDay<'a> {
     pub fn volume(&self) -> u16 {
         let range = self.shape.volume_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn flags(&self) -> GotFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn foo(&self) -> Option<u16> {
         let range = self.shape.foo_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn bar(&self) -> Option<u16> {
         let range = self.shape.bar_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn baz(&self) -> Option<u16> {
         let range = self.shape.baz_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 }
 
@@ -661,37 +661,37 @@ pub type FieldsAfterConditionals<'a> = TableRef<'a, FieldsAfterConditionalsMarke
 impl<'a> FieldsAfterConditionals<'a> {
     pub fn flags(&self) -> GotFlags {
         let range = self.shape.flags_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn foo(&self) -> Option<u16> {
         let range = self.shape.foo_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn always_here(&self) -> u16 {
         let range = self.shape.always_here_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn bar(&self) -> Option<u16> {
         let range = self.shape.bar_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn baz(&self) -> Option<u16> {
         let range = self.shape.baz_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     pub fn also_always_here(&self) -> u16 {
         let range = self.shape.also_always_here_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn and_me_too(&self) -> u16 {
         let range = self.shape.and_me_too_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -45,12 +45,12 @@ pub type CountAll16<'a> = TableRef<'a, CountAll16Marker>;
 impl<'a> CountAll16<'a> {
     pub fn some_field(&self) -> u16 {
         let range = self.shape.some_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn remainder(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.remainder_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -116,12 +116,12 @@ pub type CountAll32<'a> = TableRef<'a, CountAll32Marker>;
 impl<'a> CountAll32<'a> {
     pub fn some_field(&self) -> u16 {
         let range = self.shape.some_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn remainder(&self) -> &'a [BigEndian<u32>] {
         let range = self.shape.remainder_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -52,17 +52,17 @@ pub type Table1<'a> = TableRef<'a, Table1Marker>;
 impl<'a> Table1<'a> {
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn heft(&self) -> u32 {
         let range = self.shape.heft_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn flex(&self) -> u16 {
         let range = self.shape.flex_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -141,17 +141,17 @@ pub type Table2<'a> = TableRef<'a, Table2Marker>;
 impl<'a> Table2<'a> {
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn value_count(&self) -> u16 {
         let range = self.shape.value_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn values(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.values_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -219,12 +219,12 @@ pub type Table3<'a> = TableRef<'a, Table3Marker>;
 impl<'a> Table3<'a> {
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn something(&self) -> u16 {
         let range = self.shape.something_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -111,13 +111,13 @@ impl<'a> KindsOfOffsets<'a> {
     /// The major/minor version of the GDEF table
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A normal offset
     pub fn nonnullable_offset(&self) -> Offset16 {
         let range = self.shape.nonnullable_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`nonnullable_offset`][Self::nonnullable_offset].
@@ -129,7 +129,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// An offset that is nullable, but always present
     pub fn nullable_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.nullable_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`nullable_offset`][Self::nullable_offset].
@@ -141,13 +141,13 @@ impl<'a> KindsOfOffsets<'a> {
     /// count of the array at array_offset
     pub fn array_offset_count(&self) -> u16 {
         let range = self.shape.array_offset_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// An offset to an array:
     pub fn array_offset(&self) -> Offset16 {
         let range = self.shape.array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`array_offset`][Self::array_offset].
@@ -160,7 +160,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// An offset to an array of records
     pub fn record_array_offset(&self) -> Offset16 {
         let range = self.shape.record_array_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`record_array_offset`][Self::record_array_offset].
@@ -175,7 +175,7 @@ impl<'a> KindsOfOffsets<'a> {
         let range = self
             .shape
             .versioned_nullable_record_array_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`versioned_nullable_record_array_offset`][Self::versioned_nullable_record_array_offset].
@@ -189,7 +189,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// A normal offset that is versioned
     pub fn versioned_nonnullable_offset(&self) -> Option<Offset16> {
         let range = self.shape.versioned_nonnullable_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`versioned_nonnullable_offset`][Self::versioned_nonnullable_offset].
@@ -201,7 +201,7 @@ impl<'a> KindsOfOffsets<'a> {
     /// An offset that is nullable and versioned
     pub fn versioned_nullable_offset(&self) -> Option<Nullable<Offset32>> {
         let range = self.shape.versioned_nullable_offset_byte_range()?;
-        Some(self.data.read_at(range.start).unwrap())
+        Some(unsafe { self.data.read_at_unchecked(range.start) })
     }
 
     /// Attempt to resolve [`versioned_nullable_offset`][Self::versioned_nullable_offset].
@@ -382,19 +382,19 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// The version
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of items in each array
     pub fn count(&self) -> u16 {
         let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A normal array offset
     pub fn nonnullable_offsets(&self) -> &'a [BigEndian<Offset16>] {
         let range = self.shape.nonnullable_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`nonnullable_offsets`][Self::nonnullable_offsets].
@@ -407,7 +407,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// An offset that is nullable, but always present
     pub fn nullable_offsets(&self) -> &'a [BigEndian<Nullable<Offset16>>] {
         let range = self.shape.nullable_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`nullable_offsets`][Self::nullable_offsets].
@@ -420,7 +420,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// A normal offset that is versioned
     pub fn versioned_nonnullable_offsets(&self) -> Option<&'a [BigEndian<Offset16>]> {
         let range = self.shape.versioned_nonnullable_offsets_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     /// A dynamically resolving wrapper for [`versioned_nonnullable_offsets`][Self::versioned_nonnullable_offsets].
@@ -433,7 +433,7 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     /// An offset that is nullable and versioned
     pub fn versioned_nullable_offsets(&self) -> Option<&'a [BigEndian<Nullable<Offset16>>]> {
         let range = self.shape.versioned_nullable_offsets_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     /// A dynamically resolving wrapper for [`versioned_nullable_offsets`][Self::versioned_nullable_offsets].
@@ -626,37 +626,37 @@ pub type KindsOfArrays<'a> = TableRef<'a, KindsOfArraysMarker>;
 impl<'a> KindsOfArrays<'a> {
     pub fn version(&self) -> u16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// the number of items in each array
     pub fn count(&self) -> u16 {
         let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// an array of scalars
     pub fn scalars(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.scalars_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// an array of records
     pub fn records(&self) -> &'a [Shmecord] {
         let range = self.shape.records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// a versioned array of scalars
     pub fn versioned_scalars(&self) -> Option<&'a [BigEndian<u16>]> {
         let range = self.shape.versioned_scalars_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 
     /// a versioned array of scalars
     pub fn versioned_records(&self) -> Option<&'a [Shmecord]> {
         let range = self.shape.versioned_records_byte_range()?;
-        Some(self.data.read_array(range).unwrap())
+        Some(unsafe { self.data.read_array_unchecked(range) })
     }
 }
 
@@ -753,7 +753,7 @@ pub type VarLenHaver<'a> = TableRef<'a, VarLenHaverMarker>;
 impl<'a> VarLenHaver<'a> {
     pub fn count(&self) -> u16 {
         let range = self.shape.count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn var_len(&self) -> VarLenArray<'a, VarSizeDummy> {
@@ -763,7 +763,7 @@ impl<'a> VarLenHaver<'a> {
 
     pub fn other_field(&self) -> u32 {
         let range = self.shape.other_field_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -827,7 +827,7 @@ pub type Dummy<'a> = TableRef<'a, DummyMarker>;
 impl<'a> Dummy<'a> {
     pub fn value(&self) -> u16 {
         let range = self.shape.value_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -74,22 +74,22 @@ pub type BasicTable<'a> = TableRef<'a, BasicTableMarker>;
 impl<'a> BasicTable<'a> {
     pub fn simple_count(&self) -> u16 {
         let range = self.shape.simple_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn simple_records(&self) -> &'a [SimpleRecord] {
         let range = self.shape.simple_records_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub fn arrays_inner_count(&self) -> u16 {
         let range = self.shape.arrays_inner_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn array_records_count(&self) -> u32 {
         let range = self.shape.array_records_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn array_records(&self) -> ComputedArray<'a, ContainsArrays<'a>> {
@@ -376,12 +376,12 @@ pub type VarLenItem<'a> = TableRef<'a, VarLenItemMarker>;
 impl<'a> VarLenItem<'a> {
     pub fn length(&self) -> u32 {
         let range = self.shape.length_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn data(&self) -> &'a [u8] {
         let range = self.shape.data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -68,19 +68,19 @@ impl<'a> Trak<'a> {
     /// Version number of the tracking table (0x00010000 for the current version).
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Format of the tracking table (set to 0).
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from start of tracking table to TrackData for horizontal text (or 0 if none).
     pub fn horiz_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.horiz_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`horiz_offset`][Self::horiz_offset].
@@ -92,7 +92,7 @@ impl<'a> Trak<'a> {
     /// Offset from start of tracking table to TrackData for vertical text (or 0 if none).
     pub fn vert_offset(&self) -> Nullable<Offset16> {
         let range = self.shape.vert_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`vert_offset`][Self::vert_offset].
@@ -191,25 +191,25 @@ impl<'a> TrackData<'a> {
     /// Number of separate tracks included in this table.
     pub fn n_tracks(&self) -> u16 {
         let range = self.shape.n_tracks_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of point sizes included in this table.
     pub fn n_sizes(&self) -> u16 {
         let range = self.shape.n_sizes_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset from the start of the tracking table to the start of the size subtable.
     pub fn size_table_offset(&self) -> u32 {
         let range = self.shape.size_table_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of TrackTableEntry records.
     pub fn track_table(&self) -> &'a [TrackTableEntry] {
         let range = self.shape.track_table_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -78,12 +78,12 @@ impl<'a> Varc<'a> {
     /// Major/minor version number. Set to 1.0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn coverage_offset(&self) -> Offset32 {
         let range = self.shape.coverage_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
@@ -94,7 +94,7 @@ impl<'a> Varc<'a> {
 
     pub fn multi_var_store_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.multi_var_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`multi_var_store_offset`][Self::multi_var_store_offset].
@@ -105,7 +105,7 @@ impl<'a> Varc<'a> {
 
     pub fn condition_list_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.condition_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`condition_list_offset`][Self::condition_list_offset].
@@ -116,7 +116,7 @@ impl<'a> Varc<'a> {
 
     pub fn axis_indices_list_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.axis_indices_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`axis_indices_list_offset`][Self::axis_indices_list_offset].
@@ -127,7 +127,7 @@ impl<'a> Varc<'a> {
 
     pub fn var_composite_glyphs_offset(&self) -> Offset32 {
         let range = self.shape.var_composite_glyphs_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`var_composite_glyphs_offset`][Self::var_composite_glyphs_offset].
@@ -245,12 +245,12 @@ pub type MultiItemVariationStore<'a> = TableRef<'a, MultiItemVariationStoreMarke
 impl<'a> MultiItemVariationStore<'a> {
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn region_list_offset(&self) -> Offset32 {
         let range = self.shape.region_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`region_list_offset`][Self::region_list_offset].
@@ -261,12 +261,12 @@ impl<'a> MultiItemVariationStore<'a> {
 
     pub fn variation_data_count(&self) -> u16 {
         let range = self.shape.variation_data_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn variation_data_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.variation_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`variation_data_offsets`][Self::variation_data_offsets].
@@ -364,12 +364,12 @@ pub type SparseVariationRegionList<'a> = TableRef<'a, SparseVariationRegionListM
 impl<'a> SparseVariationRegionList<'a> {
     pub fn region_count(&self) -> u16 {
         let range = self.shape.region_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn region_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.region_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`region_offsets`][Self::region_offsets].
@@ -459,12 +459,12 @@ pub type SparseVariationRegion<'a> = TableRef<'a, SparseVariationRegionMarker>;
 impl<'a> SparseVariationRegion<'a> {
     pub fn region_axis_count(&self) -> u16 {
         let range = self.shape.region_axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn region_axis_offsets(&self) -> &'a [SparseRegionAxisCoordinates] {
         let range = self.shape.region_axis_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -611,22 +611,22 @@ pub type MultiItemVariationData<'a> = TableRef<'a, MultiItemVariationDataMarker>
 impl<'a> MultiItemVariationData<'a> {
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn region_index_count(&self) -> u16 {
         let range = self.shape.region_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn region_indices(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.region_indices_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     pub fn raw_delta_sets(&self) -> &'a [u8] {
         let range = self.shape.raw_delta_sets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -698,12 +698,12 @@ pub type ConditionList<'a> = TableRef<'a, ConditionListMarker>;
 impl<'a> ConditionList<'a> {
     pub fn condition_count(&self) -> u32 {
         let range = self.shape.condition_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     pub fn condition_offsets(&self) -> &'a [BigEndian<Offset32>] {
         let range = self.shape.condition_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -99,14 +99,14 @@ impl<'a> TupleVariationHeader<'a> {
     /// variation table.
     pub fn variation_data_size(&self) -> u16 {
         let range = self.shape.variation_data_size_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A packed field. The high 4 bits are flags (see below). The low
     /// 12 bits are an index into a shared tuple records array.
     pub fn tuple_index(&self) -> TupleIndex {
         let range = self.shape.tuple_index_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 
@@ -270,26 +270,26 @@ impl<'a> DeltaSetIndexMapFormat0<'a> {
     /// DeltaSetIndexMap format: set to 0.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
     pub fn entry_format(&self) -> EntryFormat {
         let range = self.shape.entry_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of mapping entries.
     pub fn map_count(&self) -> u16 {
         let range = self.shape.map_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The delta-set index mapping data. See details below.
     pub fn map_data(&self) -> &'a [u8] {
         let range = self.shape.map_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -378,26 +378,26 @@ impl<'a> DeltaSetIndexMapFormat1<'a> {
     /// DeltaSetIndexMap format: set to 1.
     pub fn format(&self) -> u8 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A packed field that describes the compressed representation of
     /// delta-set indices. See details below.
     pub fn entry_format(&self) -> EntryFormat {
         let range = self.shape.entry_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of mapping entries.
     pub fn map_count(&self) -> u32 {
         let range = self.shape.map_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The delta-set index mapping data. See details below.
     pub fn map_data(&self) -> &'a [u8] {
         let range = self.shape.map_data_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 
@@ -879,14 +879,14 @@ impl<'a> VariationRegionList<'a> {
     /// same number as axisCount in the 'fvar' table.
     pub fn axis_count(&self) -> u16 {
         let range = self.shape.axis_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of variation region tables in the variation region
     /// list. Must be less than 32,768.
     pub fn region_count(&self) -> u16 {
         let range = self.shape.region_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of variation regions.
@@ -1109,14 +1109,14 @@ impl<'a> ItemVariationStore<'a> {
     /// Format— set to 1
     pub fn format(&self) -> u16 {
         let range = self.shape.format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the start of the item variation store to
     /// the variation region list.
     pub fn variation_region_list_offset(&self) -> Offset32 {
         let range = self.shape.variation_region_list_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`variation_region_list_offset`][Self::variation_region_list_offset].
@@ -1128,14 +1128,14 @@ impl<'a> ItemVariationStore<'a> {
     /// The number of item variation data subtables.
     pub fn item_variation_data_count(&self) -> u16 {
         let range = self.shape.item_variation_data_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offsets in bytes from the start of the item variation store to
     /// each item variation data subtable.
     pub fn item_variation_data_offsets(&self) -> &'a [BigEndian<Nullable<Offset32>>] {
         let range = self.shape.item_variation_data_offsets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
@@ -1265,32 +1265,32 @@ impl<'a> ItemVariationData<'a> {
     /// The number of delta sets for distinct items.
     pub fn item_count(&self) -> u16 {
         let range = self.shape.item_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// A packed field: the high bit is a flag—see details below.
     pub fn word_delta_count(&self) -> u16 {
         let range = self.shape.word_delta_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The number of variation regions referenced.
     pub fn region_index_count(&self) -> u16 {
         let range = self.shape.region_index_count_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of indices into the variation region list for the regions
     /// referenced by this item variation data table.
     pub fn region_indexes(&self) -> &'a [BigEndian<u16>] {
         let range = self.shape.region_indexes_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Delta-set rows.
     pub fn delta_sets(&self) -> &'a [u8] {
         let range = self.shape.delta_sets_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -140,64 +140,64 @@ impl<'a> Vhea<'a> {
     /// The major/minor version (1, 1)
     pub fn version(&self) -> Version16Dot16 {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Typographic ascent.
     pub fn ascender(&self) -> FWord {
         let range = self.shape.ascender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Typographic descent.
     pub fn descender(&self) -> FWord {
         let range = self.shape.descender_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Typographic line gap. Negative LineGap values are treated as
     /// zero in some legacy platform implementations.
     pub fn line_gap(&self) -> FWord {
         let range = self.shape.line_gap_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Maximum advance height value in 'vmtx' table.
     pub fn advance_height_max(&self) -> UfWord {
         let range = self.shape.advance_height_max_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum top sidebearing value in 'vmtx' table for glyphs with
     /// contours (empty glyphs should be ignored).
     pub fn min_top_side_bearing(&self) -> FWord {
         let range = self.shape.min_top_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Minimum bottom sidebearing value
     pub fn min_bottom_side_bearing(&self) -> FWord {
         let range = self.shape.min_bottom_side_bearing_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Defined as max( tsb + (yMax-yMin)).
     pub fn y_max_extent(&self) -> FWord {
         let range = self.shape.y_max_extent_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Used to calculate the slope of the cursor (rise/run); 1 for
     /// vertical caret, 0 for horizontal.
     pub fn caret_slope_rise(&self) -> i16 {
         let range = self.shape.caret_slope_rise_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 0 for vertical caret, 1 for horizontal.
     pub fn caret_slope_run(&self) -> i16 {
         let range = self.shape.caret_slope_run_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The amount by which a slanted highlight on a glyph needs to be
@@ -205,19 +205,19 @@ impl<'a> Vhea<'a> {
     /// non-slanted fonts
     pub fn caret_offset(&self) -> i16 {
         let range = self.shape.caret_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// 0 for current format.
     pub fn metric_data_format(&self) -> i16 {
         let range = self.shape.metric_data_format_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of advance heights in the vertical metrics (`vmtx`) table.
     pub fn number_of_long_ver_metrics(&self) -> u16 {
         let range = self.shape.number_of_long_ver_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 }
 

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -78,13 +78,13 @@ impl<'a> Vmtx<'a> {
     /// glyph. Records are indexed by glyph ID.
     pub fn v_metrics(&self) -> &'a [LongMetric] {
         let range = self.shape.v_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 
     /// Top side bearings for glyph IDs greater than or equal to numberOfLongMetrics.
     pub fn top_side_bearings(&self) -> &'a [BigEndian<i16>] {
         let range = self.shape.top_side_bearings_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -69,7 +69,7 @@ impl<'a> Vorg<'a> {
     /// Major/minor version number. Set to 1.0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// The y coordinate of a glyph’s vertical origin, in the font’s design
@@ -77,19 +77,19 @@ impl<'a> Vorg<'a> {
     /// in the vertOriginYMetrics array.
     pub fn default_vert_origin_y(&self) -> i16 {
         let range = self.shape.default_vert_origin_y_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Number of elements in the vertOriginYMetrics array.
     pub fn num_vert_origin_y_metrics(&self) -> u16 {
         let range = self.shape.num_vert_origin_y_metrics_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Array of VertOriginYMetrics records, sorted by glyph ID.
     pub fn vert_origin_y_metrics(&self) -> &'a [VertOriginYMetrics] {
         let range = self.shape.vert_origin_y_metrics_byte_range();
-        self.data.read_array(range).unwrap()
+        unsafe { self.data.read_array_unchecked(range) }
     }
 }
 

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -75,13 +75,13 @@ impl<'a> Vvar<'a> {
     /// Minor version number of the horizontal metrics variations table — set to 0.
     pub fn version(&self) -> MajorMinor {
         let range = self.shape.version_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Offset in bytes from the start of this table to the item variation store table.
     pub fn item_variation_store_offset(&self) -> Offset32 {
         let range = self.shape.item_variation_store_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`item_variation_store_offset`][Self::item_variation_store_offset].
@@ -93,7 +93,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for advance heights (may be NULL).
     pub fn advance_height_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.advance_height_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`advance_height_mapping_offset`][Self::advance_height_mapping_offset].
@@ -105,7 +105,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for top side bearings (may be NULL).
     pub fn tsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.tsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`tsb_mapping_offset`][Self::tsb_mapping_offset].
@@ -117,7 +117,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for bottom side bearings (may be NULL).
     pub fn bsb_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.bsb_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`bsb_mapping_offset`][Self::bsb_mapping_offset].
@@ -129,7 +129,7 @@ impl<'a> Vvar<'a> {
     /// Offset in bytes from the start of this table to the delta-set index mapping for Y coordinates of vertical origins (may be NULL).
     pub fn v_org_mapping_offset(&self) -> Nullable<Offset32> {
         let range = self.shape.v_org_mapping_offset_byte_range();
-        self.data.read_at(range.start).unwrap()
+        unsafe { self.data.read_at_unchecked(range.start) }
     }
 
     /// Attempt to resolve [`v_org_mapping_offset`][Self::v_org_mapping_offset].

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -57,7 +57,7 @@
 //! [table-directory]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
And use it in codegen. This is intended as a proof of concept to explore performance options for harfrust.


This is similar to the first couple commits of #1709 except this is more narrowly scoped (only focused on the two hot-path methods) and is in theory intended to be mergeable if we decide to go this route.