### PR TITLE
Implement Error for error types

### DIFF
--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -153,8 +153,7 @@ impl std::fmt::Display for ReadError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ReadError {}
+impl core::error::Error for ReadError {}
 
 #[cfg(test)]
 mod tests {

--- a/read-fonts/src/tables/postscript.rs
+++ b/read-fonts/src/tables/postscript.rs
@@ -1,6 +1,6 @@
 //! PostScript (CFF and CFF2) common tables.
 
-use std::fmt;
+use core::fmt;
 
 mod blend;
 mod charset;
@@ -123,6 +123,15 @@ impl fmt::Display for Error {
                 write!(f, "seac code {code} is not valid")
             }
             Self::Read(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Read(err) => Some(err),
+            _ => None,
         }
     }
 }

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -100,8 +100,8 @@ impl std::fmt::Display for PaintError {
     }
 }
 
-impl std::error::Error for PaintError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for PaintError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             PaintError::ParseError(read_error) => Some(read_error),
             _ => None,

--- a/skrifa/src/outline/glyf/hint/error.rs
+++ b/skrifa/src/outline/glyf/hint/error.rs
@@ -118,3 +118,5 @@ impl core::fmt::Display for HintError {
         write!(f, "@{}:{opcode}{colon} {}", self.pc, self.kind)
     }
 }
+
+impl core::error::Error for HintError {}

--- a/skrifa/src/outline/path.rs
+++ b/skrifa/src/outline/path.rs
@@ -46,6 +46,8 @@ impl fmt::Display for ToPathError {
     }
 }
 
+impl core::error::Error for ToPathError {}
+
 /// Converts a `glyf` outline described by points, flags and contour end points
 /// to a sequence of path elements and invokes the appropriate callback on the
 /// given pen for each.


### PR DESCRIPTION
- Makes it so you can use `from` for `thiserror` based derives.
  - https://github.com/googlefonts/sleipnir/blob/16b2597fe6688676f5e253acca5b5f293a026344/src/text2png.rs#L40