### PR TITLE
[read-fonts] add context for charstring eval

### DIFF
--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -333,15 +333,9 @@ struct CharstringEvaluator<'a> {
 
 impl CharstringEvaluator<'_> {
     fn evaluate(self, sink: &mut impl CommandSink) -> Result<(), Error> {
-        charstring::evaluate(
-            self.cff_data,
-            self.charstrings,
-            self.global_subrs,
-            self.subrs,
-            self.blend_state,
-            self.charstring_data,
-            sink,
-        )
+        let subrs = self.subrs.unwrap_or_default();
+        let ctx = (self.cff_data, &self.charstrings, &self.global_subrs, &subrs);
+        charstring::evaluate(&ctx, self.blend_state, self.charstring_data, sink)
     }
 }
 


### PR DESCRIPTION
CFF/Type1 have slightly different logic around seac components and subroutines. This introduces a new `CharstringContext` trait abstract those differences.