### PR TITLE
[klippa]fix lookup type for extension lookups

### DIFF
--- a/klippa/src/gpos.rs
+++ b/klippa/src/gpos.rs
@@ -214,14 +214,25 @@ impl<'a> SubsetTable<'a> for PositionLookup<'_> {
         s: &mut Serializer,
         args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
-        s.embed(self.lookup_type())?;
-        let lookup_flag = self.lookup_flag();
-        let lookup_flag_pos = s.embed(lookup_flag)?;
-        let lookup_count_pos = s.embed(0_u16)?;
-
         let subtables = self
             .subtables()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+
+        let lookup_type: u16 = match subtables {
+            PositionSubtables::Single(_) => 1,
+            PositionSubtables::Pair(_) => 2,
+            PositionSubtables::Cursive(_) => 3,
+            PositionSubtables::MarkToBase(_) => 4,
+            PositionSubtables::MarkToLig(_) => 5,
+            PositionSubtables::MarkToMark(_) => 6,
+            PositionSubtables::Contextual(_) => 7,
+            PositionSubtables::ChainContextual(_) => 8,
+        };
+        s.embed(lookup_type)?;
+
+        let lookup_flag = self.lookup_flag();
+        let lookup_flag_pos = s.embed(lookup_flag)?;
+        let lookup_count_pos = s.embed(0_u16)?;
         let lookup_count = subtables.subset(plan, s, args)?;
         s.copy_assign(lookup_count_pos, lookup_count);
 


### PR DESCRIPTION
use ext subtable type instead of lookup type.
Since there's no enum for extension subtables in GSUB/GPOS, see: https://github.com/googlefonts/fontations/blob/0cf460a37a19117d0fd2a40d7fc168f75d13dec7/read-fonts/src/tables/gsub.rs#L41, we have to demote all extension subtables during subsetting, repacker should be able to do extension promotion when an overflow occurs. Maybe we could do the same demotion in harfbuzz.