### PR TITLE
[klippa] keep empty HVAR/VVAR tables

### DIFF
--- a/klippa/src/base.rs
+++ b/klippa/src/base.rs
@@ -68,15 +68,16 @@ impl Subset for Base<'_> {
                     .embed(0_u32)
                     .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
 
-                Offset32::serialize_subset(
+                match Offset32::serialize_subset(
                     &var_store,
                     s,
                     plan,
-                    &plan.base_varstore_inner_maps,
+                    (&plan.base_varstore_inner_maps, false),
                     varstore_offset_pos,
-                )
-                .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
-                Ok(())
+                ) {
+                    Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => Ok(()),
+                    Err(_) => Err(SubsetError::SubsetTableError(Base::TAG)),
+                }
             }
             None => {
                 if self.version().minor > 0 {

--- a/klippa/src/colr.rs
+++ b/klippa/src/colr.rs
@@ -65,8 +65,16 @@ impl Subset for Colr<'_> {
             .transpose()
             .map_err(|_| SubsetError::SubsetTableError(Colr::TAG))?
         {
-            Offset32::serialize_subset(&var_store, s, plan, &plan.colr_varstore_inner_maps, 30)
-                .map_err(|_| SubsetError::SubsetTableError(Colr::TAG))?;
+            match Offset32::serialize_subset(
+                &var_store,
+                s,
+                plan,
+                (&plan.colr_varstore_inner_maps, false),
+                30,
+            ) {
+                Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(_) => return Err(SubsetError::SubsetTableError(Colr::TAG)),
+            }
         }
 
         // BaseGlyphList offset pos = 14

--- a/klippa/src/gdef.rs
+++ b/klippa/src/gdef.rs
@@ -91,7 +91,7 @@ fn subset_gdef(
                 &var_store,
                 s,
                 plan,
-                &plan.gdef_varstore_inner_maps,
+                (&plan.gdef_varstore_inner_maps, false),
                 var_store_offset_pos,
             ) {
                 Ok(()) => true,

--- a/klippa/src/hvar.rs
+++ b/klippa/src/hvar.rs
@@ -52,7 +52,7 @@ impl Subset for Hvar<'_> {
             &var_store,
             s,
             plan,
-            hvar_subset_plan.inner_maps(),
+            (hvar_subset_plan.inner_maps(), true),
             var_store_offset_pos,
         )
         .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;

--- a/klippa/src/vvar.rs
+++ b/klippa/src/vvar.rs
@@ -47,7 +47,7 @@ impl Subset for Vvar<'_> {
             &var_store,
             s,
             plan,
-            vvar_subset_plan.inner_maps(),
+            (vvar_subset_plan.inner_maps(), true),
             var_store_offset_pos,
         )
         .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;


### PR DESCRIPTION
From Behdad: an empty HVAR/VVAR table still has semantic value, if we drop the table, the shaper would have to process the slower gvar table. ref: https://github.com/harfbuzz/harfbuzz/issues/5511#issuecomment-3234820072