### PR TITLE
[chore] Bump versions to release avar2 fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,15 +42,15 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.11.0", path = "font-types" }
-read-fonts = { version = "0.37.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.11.1", path = "font-types" }
+read-fonts = { version = "0.38.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.40.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.45.0", path = "write-fonts" }
+skrifa = { version = "0.41.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.46.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
-skera = { version = "0.1.0", path = "skera" }
+skera = { version = "0.1.1", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.6.1"
+version = "0.6.2"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.11.0"
+version = "0.11.1"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.38.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.1.0"
+version = "0.1.1"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.40.0"
+version = "0.41.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.45.0"
+version = "0.46.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
VARC changes required a minor bump for skrifa, write-fonts, read-fonts. Remaining changes only require a patch release.

Changes for font-types from font-types-v0.11.0 to 0.11.0
        8fac78b [avar2] Fix clamping
Changes for read-fonts from read-fonts-v0.37.0 to 0.38.0
        aec249a [avar2] Avoid f64::round in no_std path
        9fac388 [avar2] Refactor shared coordinate mapping
        9d7ef1c [avar2] Add Amstelvar clamping regression
        df89865 fmt
        b545df1 [variations] Treat empty DeltaSetIndexMap as identity
        725b5b7 [avar2] Keep 16.16 precision through avar2 mapping
        e8bcd80 [avar] Match HarfBuzz zero tie-break behavior
        8fac78b [avar2] Fix clamping
        1e549f9 [read-fonts] collection of small type1 fixes  (#1765)
        cdc133c [read] Improve docs for NameRecord::string (#1766)
        fceedcb [read-fonts] minimal multimaster support for type1 (#1764)
        fbcd823 [fauntlet] add type1 support (#1762)
        b00c0f6 [read-fonts] charstring eval for type1 fonts (#1761)
        2832fa3 [codegen] fixed-length arrays in minimal validate
        9803c4e [codegen] Minimal validation feedback
        ce7cda9 Fixup a few more tests
        fe8023b [codegen] Gen less code
        2a03d91 [codegen] Fix issue with validating scalar after array
        385836f [codegen] Fix a clippy lint
        b7d0ce3 [codegen] Unbreak klippa
        d066d2e [codegen] Non-conditional fields unwrap_or_default
        31bd444 [codegen] Don't unwrap when accessing unvalidated fields
        7ca157e [codegen] Fix up min size logic
        785eb80 [codegen] Get rid of marker types
        da0de30 [codegen] new style read-fonts compiles
        6d5ddb9 [codegen] Ensure we have test inputs that use read args
        45c7bde Checkpoint minimal validate, working for test inputs
        a496098 [read-fonts] Type1 validation fixes (#1760)
        c230df2 Add IFT benchmarks (#1756)
        577aaf1 [read-fonts] parse Type1 encodings (#1758)
        81a95e2 Move transform and nop filter sinks to read-fonts (#1757)
        274a2c9 read-fonts: replace stale uint32var TODO with spec note
        cdd9351 [read-fonts] add Type1Font struct (#1754)
        388be19 [read-fonts] type1: read charstrings (#1753)
        d22b225 [read-fonts] type1: read subroutines (#1752)
        d677a6b [read-fonts] parse type1 font matrix (#1751)
        b2c831b [read-fonts] type1 tokenization (#1750)
        e054134 [read-fonts] raw type1 dict data (#1746)
        03c5abf [codegen] Remove #[if_cond]
        952dbb2 [VARC] Clippy again
        7bbf923 [VARC] Move a method around
        a209f30 [VARC] Remove handcoded SFNT table loading in tests
        d236cb2 [VARC] Clean up flag checking
        6b4a6a8 [read-fonts] add T1 charstring ops (#1734)
        6b8af09 [VARC] Add a few tests
        1ec41e7 [VARC] Another shot in the dark
        a71619e [VARC] Remove unused method
        863045f [VARC] Clean up axis counting
        213ab6f [variations] Speed up PackedDeltas::consume_all()
        6cf1544 [variations] Remove a fastpath
        3b9ddbd [VARC] Micro-opt
        4b57754 [variations] Micro-opt
        53f1445 [variations] Logic shift
        f3ff328 [variations] Micro-opt
        1f61c0d [VARC] Fix a field name
        694dbf4 [variations] Write next() as a match instead of if blocks
        a94b41b [variations] Micro-optimize decoding loop
        56ce1f5 [VARC] Remove redundant check
        b91cb47 [VARC] Optimize "things"
        43ddf4c [variations] Minor code shuffle
        d5cb925 [VARC] Accumulate deltas as f32, not i32
        9123776 [variations] Speed up DeltaRunIter::end()
        948edf3 [VARC] Remove duplicate comment
        bccfc65 [VARC] Use f32 in transforms instead of f64
        ff248de [VARC] Try micro-optimizing parsing of transforms
        9bce59e [VARC] Minor style
        a500f58 [VARC] Tiny micro-optimize
        4d9167f [VARC] Remove comment
        859d983 [VARC] More micro-optimizations
        12d772b [variations] Add TupleValues::fetcher_t ala HarfBuzz
        5d609b8 [VARC] Remove unused annotation
        61c7ae5 [variations] Micro-optimize skip_fast()
        7e03e4e [read-fonts] Speed up DeltaRunIter
        3d0dc23 Initial stab at VARC table rendering
        e868756 [read-fonts] quick fix for CffFontRef::evaluate_charstring (#1726)
        150026d [read-fonts] add subfont type for new CffFontRef (#1723)
        785da8a [read-fonts] add some ops to PS stack (#1724)
        132506d [read-fonts] add context for charstring eval (#1725)
        4d690b5 Implement Error for error types (#1722)
        fdda800 [read-fonts] Add initial CffFontRef type (#1718)
        dda493f [read-fonts] Add types for CFF font matrices (#1717)
        a255fa8 Add some accessors for reading VARC components
Changes for font-test-data from font-test-data-v0.6.1 to 0.6.1
        649f2fb Address review
        292c1c8 fmt
        9d7ef1c [avar2] Add Amstelvar clamping regression
        e054134 [read-fonts] raw type1 dict data (#1746)
Changes for write-fonts from write-fonts-v0.45.0 to 0.46.0
        ce7cda9 Fixup a few more tests
        d42c414 [codegen] Remove dead code
        7ca157e [codegen] Fix up min size logic
        da0de30 [codegen] new style read-fonts compiles
        6d5ddb9 [codegen] Ensure we have test inputs that use read args
        45c7bde Checkpoint minimal validate, working for test inputs
        ca5db04 write-fonts: fix typo in fvar validation message
        73d1e29 write-fonts: correct vhea doc link and description
        c904b62 write-fonts: fix fvar module doc table name
        03c5abf [codegen] Remove #[if_cond]
        1f61c0d [VARC] Fix a field name
        8f6dd3d Remove debug test code
        e755efd Link to docs
        91a8d58 Appease Colin’s neat-freak
        13d2baa Return an error on invalid input
        3b086fc Update write-fonts/src/tables/variations/mivs_builder.rs
        2d42491 Write a VARC table!
        10ea247 Expose more magic number formats
        4575a6b Abstract out common code
        f689943 Make a start on MIVS builder
        3bb829f We've got to be able to build `Index2`s
        ac20747 Tell codegen to compile VARC, plus basic write-fonts scaffolding
        672c4cf [write] Set CFF SFNT version if CFF table present (#1678)
Changes for skrifa from skrifa-v0.40.0 to 0.41.0
        1e549f9 [read-fonts] collection of small type1 fixes  (#1765)
        b00c0f6 [read-fonts] charstring eval for type1 fonts (#1761)
        81a95e2 Move transform and nop filter sinks to read-fonts (#1757)
        7cd80ad [VARC] Disable bytecode hinting (#1740)
        952dbb2 [VARC] Clippy again
        7bbf923 [VARC] Move a method around
        77681c9 [VARC] Move some shared objects to Outlines
        7ed7d3c [VARC] Only store shared data in the context
        209b118 [VARC] Use a Context object to reduce number of function args
        5b42c18 [VARC] Remove leftover debug prints
        6b8af09 [VARC] Add a few tests
        131b4eb Revert "[VARC] Make delta accumulation closer to HB"
        5124bd9 [VARC] Make delta accumulation closer to HB
        16a8742 Use libm and round()
        910d01a Revert "[VARC] TCenter comes after Skew"
        d43c08c [VARC] TCenter comes after Skew
        a8c3494 [VARC] no-std
        4b06437 [VARC] Another speculation
        7df87c9 [VARC] fmt
        1c583d8 [VARC] More debugging
        dd5ca2e [VARC] Try matching HB exactly
        0c6d263 [VARC] Tweak back
        09cae72 [VARC] Clippy
        94283b8 [VARC] Some adjustments to calculate_scalar
        fa03551 [VARC] Lazy skipping
        1e8d64a [VARC] More axis_indices count cleanup
        863045f [VARC] Clean up axis counting
        f28b79e [VARC] Simplify logic
        1c24527 [VARC] Fix coordinates logic
        3b9ddbd [VARC] Micro-opt
        efaafcb [VARC] Tweak vectors again
        c1d4697 [VARC] Constify
        6167ff2 [VARC] Simplify logic????
        53f1445 [variations] Logic shift
        6d5f359 [VARC] Minor tweaks to calculate_scalar
        1f61c0d [VARC] Fix a field name
        f9b7159 [VARC] ..
        eb3542c [VARC] More caching fix
        1961064 [VARC] Minor cache tweak
        2a5e38b [VARC] Minor
        5a33c00 [VARC] Remove an Option<> layer
        ff03a22 [VARC] Cosmetic
        67c76e7 [VARC] Flesh out optimization
        29c09f1 [VARC] Tweak SmallVec sizes again
        75b9db7 [VARC] Make bots happy
        f9b8d28 [VARC] Use a scratchpad and other micro-opts
        3b10a78 [VARC] More scalar_cache reuse
        b5c7117 [VARC] More micro-opts
        74930ed Fix stupid CI "typo" bug
        6391c99 [VARC] Minor micro-opt
        c5ded1f Add resize_and_fill to SmallVec
        cd1248a [VARC] Remove a division
        1e9859b [VARC] Don't recurse on component tree when processing each component!
        b91cb47 [VARC] Optimize "things"
        bd64f34 [VARC] Micro-optimize compute_sparse_region_scalar()
        874a12f [VARC] Speed up scalar_cache
        1e9d963 [VARC] Inline scalar_cache
        f2f19be [VARC] Make scalar_cache non-Option
        8034523 [VARC] Delay more work
        b023ad2 [VARC] Micro-optimize
        5b13531 [VARC] Tweak stack depth limiting
        f403f65 [VARC] Inline a method
        3244701 Revert "[VARC] Another attempt at transform classification"
        4586fde [VARC] Another attempt at transform classification
        c4a0546 [VARC] Define Affine type
        b8d48e2 Revert "[VARC] Categorize transform matrices and used diff pens"
        b2c2ded [VARC] Categorize transform matrices and used diff pens
        9431a59 [VARC] Name diff SmallVec's
        e96b0e1 [VARC] Render glyphs that are not composites in VARC table
        4587b9e [VARC] Micro-optimize depth
        325bace [VARC] Speed up translation-only transforms
        edc16b4 [VARC] Tweak vector size
        c807db0 [VARC] Enlarge scalar-cache
        a13c013 [VARC] Micro-optimize axis indices / values arrays
        22aec21 [VARC] Micro-optimize conditions
        52b7447 [VARC] Micro-optimize lesser used transform components
        80bb150 [VARC] Micro-optimize transformation field counting
        b55cd19 [VARC] Another zip
        9146618 [VARC] Use a zip
        36f3e64 [VARC] Use one TransformPen, with combined transformation
        d5cb925 [VARC] Accumulate deltas as f32, not i32
        9e8efad [VARC] Remove "fast-path"
        8467e0a [glyf] Remove redundant delta clearing
        adcfc9a [VARC] Remove a redundant check
        bccfc65 [VARC] Use f32 in transforms instead of f64
        c410f2a [VARC] Clippy
        5f71b24 [VARC] Clippy
        859d983 [VARC] More micro-optimizations
        19c59ab [VARC] Remove unnecessary check
        0101d56 [VARC] Reuse a SmallVec
        e9cb895 [VARC] Micro-micro-optimize
        198933f [VARC] Micro-micro-optimize
        7a62684 [VARC] Clippy
        a7a0dbd [VARC] Micro-optimize transform variations
        d75fd65 [VARC] Micro-optimize axis_indices / axis_values
        8660644 [VARC] Micro-optimize axes_indices / axis_values
        2e47b24 [VARC] Micro-optimize component_coords()
        ee8adf0 [VARC] Micro-optimize expand_coords()
        12d772b [variations] Add TupleValues::fetcher_t ala HarfBuzz
        866205d [VARC] Clippy
        510cf23 [VARC] Cosmetic
        deca5c5 [VARC] Micro-optimize compute_sparse_region_scalar()
        32700e8 [VARC] In compute_tuple_deltas() special-case tuples of 1
        06f79b5 [VARC] Add a scalar cache
        3d0dc23 Initial stab at VARC table rendering
        132506d [read-fonts] add context for charstring eval (#1725)
        4d690b5 Implement Error for error types (#1722)
        dda493f [read-fonts] Add types for CFF font matrices (#1717)
Changes for skera from skera-v0.1.0 to 0.1.0
        9803c4e [codegen] Minimal validation feedback
        b7d0ce3 [codegen] Unbreak klippa