### PR TITLE
[read-fonts] return actual number of fonts in ttc

### DIFF
--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -268,7 +268,7 @@ impl<'a> CollectionRef<'a> {
 
     /// Returns the number of fonts in the collection.
     pub fn len(&self) -> u32 {
-        self.header.num_fonts()
+        self.header.table_directory_offsets().len() as u32
     }
 
     /// Returns true if the collection is empty.


### PR DESCRIPTION
After we removed some validation, we now successfully parse bad TTC headers with crazy large values in the `num_fonts` field. Change the `CollectionRef::len` method to return the length of `table_directory_offsets` instead so users get an accurate count (namely, 0).

JMM