### PR TITLE
[read-fonts] add new Transform type for PS fonts

### DIFF
--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -189,13 +189,13 @@ impl SkrifaType1Instance<'_> {
     ) -> Result<Option<f32>, DrawError> {
         let mut pen = PenCommandSink(pen);
         let mut nop_filter = NopFilterSink::new(&mut pen);
-        let scale = self.ppem.map(|ppem| self.font.scale_for_ppem(ppem));
-        let mut transformer = TransformSink::new(&mut nop_filter, self.font.matrix(), scale);
+        let transform = self.font.transform(self.ppem);
+        let mut transformer = TransformSink::new(&mut nop_filter, transform);
         let width = self
             .font
             .evaluate_charstring(glyph_id, &mut transformer)
             .map_err(DrawError::PostScript)?;
-        let width = width.map(|w| self.font.transform_h_metric(scale, w));
+        let width = width.map(|w| transform.transform_h_metric(w));
         Ok(width.map(|w| w.to_f32().max(0.0)))
     }
 }

--- a/read-fonts/src/tables/postscript.rs
+++ b/read-fonts/src/tables/postscript.rs
@@ -9,6 +9,7 @@ mod fd_select;
 mod index;
 mod stack;
 mod string;
+mod transform;
 
 pub mod charstring;
 pub mod dict;
@@ -22,6 +23,7 @@ pub use encoding::PredefinedEncoding;
 pub use index::Index;
 pub use stack::{Number, Stack};
 pub use string::{Latin1String, StringId, STANDARD_STRINGS};
+pub use transform::Transform;
 
 /// Errors that are specific to PostScript processing.
 #[derive(Clone, Debug)]

--- a/read-fonts/src/tables/postscript/charstring.rs
+++ b/read-fonts/src/tables/postscript/charstring.rs
@@ -1,6 +1,6 @@
 //! Parsing for PostScript charstrings.
 
-use super::{dict::FontMatrix, BlendState, Error, Index, Stack};
+use super::{dict::FontMatrix, BlendState, Error, Index, Stack, Transform};
 use crate::{
     tables::{cff::Cff, postscript::StringId},
     types::{Fixed, Point},
@@ -1117,8 +1117,13 @@ pub struct TransformSink<'a, S> {
 }
 
 impl<'a, S> TransformSink<'a, S> {
+    /// Creates a new sink for the given transform.
+    pub fn new(sink: &'a mut S, transform: Transform) -> Self {
+        Self::from_matrix_scale(sink, transform.matrix, transform.scale)
+    }
+
     /// Creates a new sink for the given matrix and optional scale.
-    pub fn new(sink: &'a mut S, matrix: FontMatrix, scale: Option<Fixed>) -> Self {
+    pub fn from_matrix_scale(sink: &'a mut S, matrix: FontMatrix, scale: Option<Fixed>) -> Self {
         Self {
             inner: sink,
             matrix: (matrix != FontMatrix::IDENTITY).then_some(matrix),
@@ -2018,7 +2023,8 @@ mod tests {
         let expected = [(404, 118i32), (453, 20), (550, -33), (678, -33)]
             .map(|(x, y)| (Fixed::from_bits(x << 10), Fixed::from_bits(y << 10)));
         let mut dummy = ();
-        let sink = TransformSink::new(&mut dummy, TRANSFORM, Some(Fixed::from_bits(167772)));
+        let sink =
+            TransformSink::from_matrix_scale(&mut dummy, TRANSFORM, Some(Fixed::from_bits(167772)));
         let transformed = input.map(|(x, y)| sink.transform(x, y));
         assert_eq!(transformed, expected);
     }
@@ -2032,7 +2038,7 @@ mod tests {
         let expected = [(158, 46i32), (177, 8), (215, -13), (265, -13)]
             .map(|(x, y)| (Fixed::from_bits(x << 16), Fixed::from_bits(y << 16)));
         let mut dummy = ();
-        let sink = TransformSink::new(&mut dummy, TRANSFORM, None);
+        let sink = TransformSink::from_matrix_scale(&mut dummy, TRANSFORM, None);
         let transformed = input.map(|(x, y)| sink.transform(x, y));
         assert_eq!(transformed, expected);
     }
@@ -2050,7 +2056,7 @@ mod tests {
     #[test]
     fn unscaled_transform_sink_produces_integers() {
         let nothing = &mut ();
-        let sink = TransformSink::new(nothing, FontMatrix::IDENTITY, None);
+        let sink = TransformSink::new(nothing, Transform::default());
         for coord in [50.0, 50.1, 50.125, 50.5, 50.9] {
             assert_eq!(
                 sink.transform(Fixed::from_f64(coord), Fixed::ZERO)
@@ -2068,7 +2074,7 @@ mod tests {
         // match FreeType scaling with intermediate conversion to 26.6
         let scale = Fixed::from_bits((ppem * 64.) as i32) / Fixed::from_bits(upem as i32);
         let nothing = &mut ();
-        let sink = TransformSink::new(nothing, FontMatrix::IDENTITY, Some(scale));
+        let sink = TransformSink::from_matrix_scale(nothing, FontMatrix::IDENTITY, Some(scale));
         let inputs = [
             // input coord, expected scaled output
             (0.0, 0.0),

--- a/read-fonts/src/tables/postscript/dict.rs
+++ b/read-fonts/src/tables/postscript/dict.rs
@@ -562,6 +562,12 @@ impl FontMatrix {
     }
 }
 
+impl Default for FontMatrix {
+    fn default() -> Self {
+        Self::IDENTITY
+    }
+}
+
 /// An affine matrix with a scaling factor.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct ScaledFontMatrix {

--- a/read-fonts/src/tables/postscript/font/type1.rs
+++ b/read-fonts/src/tables/postscript/font/type1.rs
@@ -3,7 +3,7 @@
 use super::super::{
     charstring::{self, CharstringContext, CharstringKind, CommandSink},
     dict::{FontMatrix, ScaledFontMatrix},
-    Error, PredefinedEncoding,
+    Error, PredefinedEncoding, Transform,
 };
 use crate::{
     types::{Fixed, GlyphId},
@@ -115,30 +115,12 @@ impl Type1Font {
         self.matrix.scale
     }
 
-    /// Returns the fixed point scale factor for the given font size in
-    /// pixels per em.
-    pub fn scale_for_ppem(&self, ppem: f32) -> Fixed {
-        Fixed::from_bits((ppem * 64.) as i32) / Fixed::from_bits(self.upem().max(1))
-    }
-
-    /// Applies font matrix and scale to a horizontal metric (such as advance
-    /// width).
-    pub fn transform_h_metric(&self, scale: Option<Fixed>, mut metric: Fixed) -> Fixed {
-        metric = Fixed::from_bits(metric.to_i32());
-        let matrix = &self.matrix.matrix.0;
-        if matrix[0] != Fixed::ONE {
-            // x scale
-            metric *= matrix[0];
-        }
-        // x translation
-        metric += matrix[4];
-        if let Some(scale) = scale {
-            // Multiplying by scale converts to 26.6 but we want to keep the
-            // result in 16.16
-            Fixed::from_bits((metric * scale).to_bits() << 10)
-        } else {
-            // Metric is currently in font units. Convert back to 16.16
-            Fixed::from_bits(metric.to_bits() << 16)
+    /// Returns the appropriate transform for adjusting points and metrics.
+    pub fn transform(&self, ppem: Option<f32>) -> Transform {
+        let scale = ppem.map(|ppem| Transform::compute_scale(ppem, self.upem()));
+        Transform {
+            matrix: self.matrix(),
+            scale,
         }
     }
 
@@ -164,6 +146,9 @@ impl Type1Font {
 
     /// Evaluates the charstring for the requested glyph and sends the results
     /// to the given sink.
+    ///
+    /// Returns the advance with of the glyph in font units if the charstring
+    /// provides one.
     pub fn evaluate_charstring(
         &self,
         gid: GlyphId,

--- a/read-fonts/src/tables/postscript/transform.rs
+++ b/read-fonts/src/tables/postscript/transform.rs
@@ -1,0 +1,159 @@
+//! PostScript specific transform.
+
+use super::dict::FontMatrix;
+use types::Fixed;
+
+/// Combination of a matrix and optional scale.
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+pub struct Transform {
+    /// Affine font matrix.
+    pub matrix: FontMatrix,
+    /// Fixed point scale factor.
+    ///
+    /// This is assumed to convert from font units to 26.6 values.
+    pub scale: Option<Fixed>,
+}
+
+impl Transform {
+    /// The transform that doesn't modify coordinates or metrics.
+    pub const IDENTITY: Self = Self {
+        matrix: FontMatrix::IDENTITY,
+        scale: None,
+    };
+
+    /// Computes a scale factor for the given ppem and upem values.
+    pub fn compute_scale(ppem: f32, upem: i32) -> Fixed {
+        Fixed::from_bits((ppem * 64.0) as i32) / Fixed::from_bits(upem.max(1))
+    }
+
+    /// Applies the transform to a horizontal metric such as an advance
+    /// width.
+    pub fn transform_h_metric(&self, metric: Fixed) -> Fixed {
+        let mut metric = Fixed::from_bits(metric.to_i32());
+        let matrix = &self.matrix.0;
+        if matrix[0] != Fixed::ONE {
+            // x scale
+            metric *= matrix[0];
+        }
+        // x translation
+        metric += matrix[4];
+        if let Some(scale) = self.scale {
+            // Multiplying by scale converts to 26.6 but we want to keep the
+            // result in 16.16
+            Fixed::from_bits((metric * scale).to_bits() << 10)
+        } else {
+            // Metric is currently in font units. Convert back to 16.16
+            Fixed::from_bits(metric.to_bits() << 16)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_scale() {
+        assert_eq!(Transform::compute_scale(1000.0, 1000).to_bits(), 64 << 16);
+        assert_eq!(Transform::compute_scale(500.0, 1000).to_bits(), 32 << 16);
+        assert_eq!(Transform::compute_scale(2000.0, 1000).to_bits(), 128 << 16);
+        assert_eq!(Transform::compute_scale(16.0, 1000).to_bits(), 67109);
+    }
+
+    #[test]
+    fn h_metric_identity_integral() {
+        for metric in [Fixed::ZERO, Fixed::ONE, Fixed::NEG_ONE, Fixed::from_i32(42)] {
+            assert_eq!(Transform::IDENTITY.transform_h_metric(metric), metric);
+        }
+    }
+
+    #[test]
+    fn h_metric_identity_fractional() {
+        // Like FT, metrics are rounded to font units before applying matrix
+        // and scale
+        for metric in [
+            Fixed::from_f64(42.5),
+            Fixed::from_f64(-20.1),
+            Fixed::from_f64(18.8),
+        ] {
+            assert_eq!(
+                Transform::IDENTITY.transform_h_metric(metric),
+                metric.round()
+            );
+        }
+    }
+
+    #[test]
+    fn h_metric_matrix_scale() {
+        let transform = Transform {
+            matrix: FontMatrix([2.0, 0.0, 0.0, 1.0, 0.0, 0.0].map(Fixed::from_f64)),
+            scale: None,
+        };
+        // metric.round() * 2
+        let pairs = [(42.5, 86.0), (-20.1, -40.0), (18.8, 38.0)];
+        for (metric, transformed_metric) in pairs {
+            assert_eq!(
+                transform
+                    .transform_h_metric(Fixed::from_f64(metric))
+                    .to_f64(),
+                transformed_metric
+            );
+        }
+    }
+
+    #[test]
+    fn h_metric_matrix_scale_offset() {
+        let transform = Transform {
+            matrix: FontMatrix([2.0, 0.0, 0.0, 1.0, 10.0 / 65536.0, 0.0].map(Fixed::from_f64)),
+            scale: None,
+        };
+        // metric.round() * 2 + 10
+        let pairs = [(42.5, 96.0), (-20.1, -30.0), (18.8, 48.0)];
+        for (metric, transformed_metric) in pairs {
+            assert_eq!(
+                transform
+                    .transform_h_metric(Fixed::from_f64(metric))
+                    .to_f64(),
+                transformed_metric
+            );
+        }
+    }
+
+    #[test]
+    fn h_metric_scale() {
+        let transform = Transform {
+            matrix: FontMatrix::IDENTITY,
+            // Scale by 0.5
+            scale: Some(Fixed::from_i32(32)),
+        };
+        // metric.round() / 2
+        let pairs = [(42.5, 21.5), (-20.1, -10.0), (18.8, 9.5)];
+        for (metric, transformed_metric) in pairs {
+            assert_eq!(
+                transform
+                    .transform_h_metric(Fixed::from_f64(metric))
+                    .to_f64(),
+                transformed_metric
+            );
+        }
+    }
+
+    #[test]
+    fn h_metric_scale_matrix_scale_offset() {
+        let transform = Transform {
+            matrix: FontMatrix([4.0, 0.0, 0.0, 1.0, 10.0 / 65536.0, 0.0].map(Fixed::from_f64)),
+            // Scale by 0.5
+            scale: Some(Fixed::from_i32(32)),
+        };
+        // (metric.round() * 4 + 10) / 2
+        let pairs = [(42.5, 91.0), (-20.1, -35.0), (18.8, 43.0)];
+        for (metric, transformed_metric) in pairs {
+            assert_eq!(
+                transform
+                    .transform_h_metric(Fixed::from_f64(metric))
+                    .to_f64(),
+                transformed_metric
+            );
+        }
+    }
+}

--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -276,8 +276,11 @@ impl<'a> Outlines<'a> {
                     HintingSink::new(&subfont.hint_state, &mut transform_sink);
                 cs_eval.evaluate(&mut hinting_adapter)?;
             } else {
-                let mut transform_sink =
-                    TransformSink::new(&mut simplifying_adapter, matrix, subfont.scale);
+                let mut transform_sink = TransformSink::from_matrix_scale(
+                    &mut simplifying_adapter,
+                    matrix,
+                    subfont.scale,
+                );
                 cs_eval.evaluate(&mut transform_sink)?;
             }
         } else if apply_hinting {
@@ -285,7 +288,7 @@ impl<'a> Outlines<'a> {
                 HintingSink::new(&subfont.hint_state, &mut simplifying_adapter);
             cs_eval.evaluate(&mut hinting_adapter)?;
         } else {
-            let mut scaling_adapter = TransformSink::new(
+            let mut scaling_adapter = TransformSink::from_matrix_scale(
                 &mut simplifying_adapter,
                 FontMatrix::IDENTITY,
                 subfont.scale,


### PR DESCRIPTION
PostScript scaling separates font matrix and scale factor by necessity so add a new `Transform` type to represent the combination of these values so that users don't have to manage them independently.