### PR TITLE
[skrifa] Correct default script capitalization

### DIFF
--- a/skrifa/src/outline/autohint/shape.rs
+++ b/skrifa/src/outline/autohint/shape.rs
@@ -175,7 +175,7 @@ impl<'a> Shaper<'a> {
             *a = Some(*b);
         }
         // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afshaper.c#L153>
-        const DEFAULT_SCRIPT: Tag = Tag::new(b"Dflt");
+        const DEFAULT_SCRIPT: Tag = Tag::new(b"DFLT");
         if coverage_kind == ShaperCoverageKind::Default {
             if script_tags[0].is_none() {
                 script_tags[0] = Some(DEFAULT_SCRIPT);


### PR DESCRIPTION
According to the freetype afshaper comment, this should match HB_OT_TAG_DEFAULT_SCRIPT, which is

```
#define HB_OT_TAG_DEFAULT_SCRIPT     HB_TAG ('D', 'F', 'L', 'T')
```

(Not `HB_OT_TAG_DEFAULT_LANGUAGE`). Getting this wrong causes script assignment to fail for some glyphs not directly referenced in cmap.