### PR TITLE
Move OutlinePen to read-fonts

### DIFF
--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -24,7 +24,6 @@ mod longdatetime;
 mod matrix;
 mod name_id;
 mod offset;
-pub mod pen;
 mod point;
 mod raw;
 mod tag;

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -76,6 +76,7 @@ extern crate alloc;
 pub mod array;
 pub mod collections;
 mod font_data;
+pub mod model;
 mod offset;
 mod offset_array;
 pub mod ps;

--- a/read-fonts/src/model.rs
+++ b/read-fonts/src/model.rs
@@ -1,0 +1,3 @@
+//! Higher level interface for accessing font data.
+
+pub mod pen;

--- a/read-fonts/src/model/pen.rs
+++ b/read-fonts/src/model/pen.rs
@@ -1,6 +1,8 @@
 //! Types for collecting the output when drawing a glyph outline.
 
-use super::BoundingBox;
+use alloc::{string::String, vec::Vec};
+use core::fmt::{self, Write};
+use types::BoundingBox;
 
 /// Interface for accepting a sequence of path commands.
 pub trait OutlinePen {
@@ -46,7 +48,6 @@ pub enum PathElement {
     Close,
 }
 
-#[cfg(feature = "std")]
 impl OutlinePen for Vec<PathElement> {
     fn move_to(&mut self, x: f32, y: f32) {
         self.push(PathElement::MoveTo { x, y })
@@ -87,120 +88,111 @@ impl OutlinePen for NullPen {
     fn close(&mut self) {}
 }
 
-#[cfg(feature = "std")]
-pub use svg::SvgPen;
+/// Pen that generates SVG style path data.
+#[derive(Clone, Default, Debug)]
+pub struct SvgPen(String, Option<usize>);
 
-#[cfg(feature = "std")]
-mod svg {
-    use super::OutlinePen;
-    use core::fmt::{self, Write};
-
-    /// Pen that generates SVG style path data.
-    #[derive(Clone, Default, Debug)]
-    pub struct SvgPen(String, Option<usize>);
-
-    impl SvgPen {
-        /// Creates a new SVG pen that formats floating point values with the
-        /// standard behavior.
-        pub fn new() -> Self {
-            Self::default()
-        }
-
-        /// Creates a new SVG pen with the given precision (the number of digits
-        /// that will be printed after the decimal).
-        pub fn with_precision(precision: usize) -> Self {
-            Self(String::default(), Some(precision))
-        }
-
-        /// Clears the content of the internal string.
-        pub fn clear(&mut self) {
-            self.0.clear();
-        }
-
-        fn maybe_push_space(&mut self) {
-            if !self.0.is_empty() {
-                self.0.push(' ');
-            }
-        }
+impl SvgPen {
+    /// Creates a new SVG pen that formats floating point values with the
+    /// standard behavior.
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    impl core::ops::Deref for SvgPen {
-        type Target = str;
-
-        fn deref(&self) -> &Self::Target {
-            self.0.as_str()
-        }
+    /// Creates a new SVG pen with the given precision (the number of digits
+    /// that will be printed after the decimal).
+    pub fn with_precision(precision: usize) -> Self {
+        Self(String::default(), Some(precision))
     }
 
-    impl OutlinePen for SvgPen {
-        fn move_to(&mut self, x: f32, y: f32) {
-            self.maybe_push_space();
-            let _ = if let Some(prec) = self.1 {
-                write!(self.0, "M{x:.0$},{y:.0$}", prec)
-            } else {
-                write!(self.0, "M{x},{y}")
-            };
-        }
-
-        fn line_to(&mut self, x: f32, y: f32) {
-            self.maybe_push_space();
-            let _ = if let Some(prec) = self.1 {
-                write!(self.0, "L{x:.0$},{y:.0$}", prec)
-            } else {
-                write!(self.0, "L{x},{y}")
-            };
-        }
-
-        fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
-            self.maybe_push_space();
-            let _ = if let Some(prec) = self.1 {
-                write!(self.0, "Q{cx0:.0$},{cy0:.0$} {x:.0$},{y:.0$}", prec)
-            } else {
-                write!(self.0, "Q{cx0},{cy0} {x},{y}")
-            };
-        }
-
-        fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
-            self.maybe_push_space();
-            let _ = if let Some(prec) = self.1 {
-                write!(
-                    self.0,
-                    "C{cx0:.0$},{cy0:.0$} {cx1:.0$},{cy1:.0$} {x:.0$},{y:.0$}",
-                    prec
-                )
-            } else {
-                write!(self.0, "C{cx0},{cy0} {cx1},{cy1} {x},{y}")
-            };
-        }
-
-        fn close(&mut self) {
-            self.maybe_push_space();
-            self.0.push('Z');
-        }
+    /// Clears the content of the internal string.
+    pub fn clear(&mut self) {
+        self.0.clear();
     }
 
-    impl AsRef<str> for SvgPen {
-        fn as_ref(&self) -> &str {
-            self.0.as_ref()
+    fn maybe_push_space(&mut self) {
+        if !self.0.is_empty() {
+            self.0.push(' ');
         }
     }
+}
 
-    impl From<String> for SvgPen {
-        fn from(value: String) -> Self {
-            Self(value, None)
-        }
+impl core::ops::Deref for SvgPen {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+impl OutlinePen for SvgPen {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.maybe_push_space();
+        let _ = if let Some(prec) = self.1 {
+            write!(self.0, "M{x:.0$},{y:.0$}", prec)
+        } else {
+            write!(self.0, "M{x},{y}")
+        };
     }
 
-    impl From<SvgPen> for String {
-        fn from(value: SvgPen) -> Self {
-            value.0
-        }
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.maybe_push_space();
+        let _ = if let Some(prec) = self.1 {
+            write!(self.0, "L{x:.0$},{y:.0$}", prec)
+        } else {
+            write!(self.0, "L{x},{y}")
+        };
     }
 
-    impl fmt::Display for SvgPen {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{}", self.0)
-        }
+    fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+        self.maybe_push_space();
+        let _ = if let Some(prec) = self.1 {
+            write!(self.0, "Q{cx0:.0$},{cy0:.0$} {x:.0$},{y:.0$}", prec)
+        } else {
+            write!(self.0, "Q{cx0},{cy0} {x},{y}")
+        };
+    }
+
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        self.maybe_push_space();
+        let _ = if let Some(prec) = self.1 {
+            write!(
+                self.0,
+                "C{cx0:.0$},{cy0:.0$} {cx1:.0$},{cy1:.0$} {x:.0$},{y:.0$}",
+                prec
+            )
+        } else {
+            write!(self.0, "C{cx0},{cy0} {cx1},{cy1} {x},{y}")
+        };
+    }
+
+    fn close(&mut self) {
+        self.maybe_push_space();
+        self.0.push('Z');
+    }
+}
+
+impl AsRef<str> for SvgPen {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl From<String> for SvgPen {
+    fn from(value: String) -> Self {
+        Self(value, None)
+    }
+}
+
+impl From<SvgPen> for String {
+    fn from(value: SvgPen) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for SvgPen {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -264,7 +256,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(feature = "std")]
     fn svg_pen_precision() {
         let svg_data = [None, Some(1), Some(4)].map(|prec| {
             let mut pen = match prec {

--- a/read-fonts/src/ps/cff/font.rs
+++ b/read-fonts/src/ps/cff/font.rs
@@ -1,6 +1,7 @@
 //! Unified access to CFF/CFF2 fonts.
 
 use crate::{
+    model::pen::OutlinePen,
     ps::{
         cff::{
             blend::BlendState, charset::Charset, dict, encoding::Encoding as RawEncoding,
@@ -16,7 +17,7 @@ use crate::{
     FontData, FontRead, ReadError,
 };
 use core::ops::Range;
-use types::{pen::OutlinePen, F2Dot14, Fixed, GlyphId};
+use types::{F2Dot14, Fixed, GlyphId};
 
 /// A CFF or CFF2 font.
 ///

--- a/read-fonts/src/ps/cs.rs
+++ b/read-fonts/src/ps/cs.rs
@@ -1,6 +1,7 @@
 //! Parsing and evaluation of charstrings.
 
 use crate::{
+    model::pen::OutlinePen,
     ps::{
         cff::{blend::BlendState, charset::Charset, index::Index, stack::Stack},
         error::Error,
@@ -9,7 +10,7 @@ use crate::{
         transform::{FontMatrix, Transform},
     },
     tables::cff::Cff,
-    types::{pen::OutlinePen, Fixed, Point},
+    types::{Fixed, Point},
     Cursor, FontData, FontRead,
 };
 

--- a/read-fonts/src/ps/type1.rs
+++ b/read-fonts/src/ps/type1.rs
@@ -8,7 +8,8 @@ use super::{
     transform::{self, FontMatrix, ScaledFontMatrix, Transform},
 };
 use crate::{
-    types::{pen::OutlinePen, Fixed, GlyphId},
+    model::pen::OutlinePen,
+    types::{Fixed, GlyphId},
     ReadError,
 };
 use alloc::vec::Vec;

--- a/skrifa/src/outline/pen.rs
+++ b/skrifa/src/outline/pen.rs
@@ -1,8 +1,6 @@
 //! Types for collecting the output when drawing a glyph outline.
 
-#[cfg(feature = "std")]
-pub use read_fonts::types::pen::SvgPen;
-pub use read_fonts::types::pen::{ControlBoundsPen, NullPen, OutlinePen, PathElement};
+pub use read_fonts::model::pen::{ControlBoundsPen, NullPen, OutlinePen, PathElement, SvgPen};
 
 /// Style for path conversion.
 ///


### PR DESCRIPTION
- reexports from skrifa to prevent breakage in Skia
- adds some `draw` helper methods to `Type1Font` and `CffFontRef` that output directly to `OutlinePen` which covers the vast majority of use cases
- demonstrates the simplified code in fauntlet