### PR TITLE
[skrifa] Allow for recording autohinters

### DIFF
--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -16,7 +16,8 @@ repository.workspace = true
 all-features = true
 
 [features]
-default = ["std", "autohint_shaping"]
+default = ["std", "autohint_shaping", "autohinter"]
+autohinter = []
 std = ["read-fonts/std"]
 traversal = ["std", "read-fonts/experimental_traverse"]
 # Enables extended shaping support for the autohinter. Enabled by default.

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -16,8 +16,7 @@ repository.workspace = true
 all-features = true
 
 [features]
-default = ["std", "autohint_shaping", "autohinter"]
-autohinter = []
+default = ["std", "autohint_shaping"]
 std = ["read-fonts/std"]
 traversal = ["std", "read-fonts/experimental_traverse"]
 # Enables extended shaping support for the autohinter. Enabled by default.

--- a/skrifa/generated/generated_autohint_styles.rs
+++ b/skrifa/generated/generated_autohint_styles.rs
@@ -3,7 +3,7 @@
 // Use ../scripts/gen_autohint_scripts.py to regenerate.
 
 #[rustfmt::skip]
-pub(super) const SCRIPT_CLASSES: &[ScriptClass] = &[
+pub const SCRIPT_CLASSES: &[ScriptClass] = &[
     ScriptClass {
         name: "Adlam",
         group: ScriptGroup::Default,
@@ -828,7 +828,7 @@ pub(super) const SCRIPT_CLASSES: &[ScriptClass] = &[
 }
 
 #[rustfmt::skip]
-pub(super) const STYLE_CLASSES: &[StyleClass] = &[
+pub const STYLE_CLASSES: &[StyleClass] = &[
     StyleClass { name: "Adlam", index: 0, script: &SCRIPT_CLASSES[0], feature: None },
     StyleClass { name: "Arabic", index: 1, script: &SCRIPT_CLASSES[1], feature: None },
     StyleClass { name: "Armenian", index: 2, script: &SCRIPT_CLASSES[2], feature: None },

--- a/skrifa/scripts/gen_autohint_styles.py
+++ b/skrifa/scripts/gen_autohint_styles.py
@@ -1354,7 +1354,7 @@ def generate() -> str:
     char_map = {}
 
     buf += "#[rustfmt::skip]\n"
-    buf += "pub(super) const SCRIPT_CLASSES: &[ScriptClass] = &[\n"
+    buf += "pub const SCRIPT_CLASSES: &[ScriptClass] = &[\n"
     # some scripts generate multiple styles so keep track of the style index
     style_index = 0
     for i, script in enumerate(SCRIPT_CLASSES):
@@ -1426,7 +1426,7 @@ def generate() -> str:
 
     # Now run through scripts again and generate style classes
     buf += "#[rustfmt::skip]\n"
-    buf += "pub(super) const STYLE_CLASSES: &[StyleClass] = &[\n"
+    buf += "pub const STYLE_CLASSES: &[StyleClass] = &[\n"
     style_class_tags = []
     style_index = 0
     for i, script in enumerate(SCRIPT_CLASSES):
@@ -1474,7 +1474,7 @@ def generate() -> str:
 
     # and finally output the ranges
     buf += "#[rustfmt::skip]\n"
-    buf += "pub(super) const STYLE_RANGES: &[StyleRange] = &[\n"
+    buf += "pub const STYLE_RANGES: &[StyleRange] = &[\n"
     for char_range in ranges:
         first = char_range[0]
         last = char_range[1]

--- a/skrifa/src/outline/autohint/hint/edges.rs
+++ b/skrifa/src/outline/autohint/hint/edges.rs
@@ -180,13 +180,22 @@ fn align_stem_edges(
     // Now align all other stem edges
     // This code starts at: <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L3123>
     for edge_ix in 0..axis.edges.len() {
-        let edges = axis.edges.as_mut_slice();
-        let edge = &edges[edge_ix];
-        if edge.flags & Edge::DONE != 0 {
+        // Read the values we need to decide on early-exit paths before taking
+        // any &mut borrow that would conflict with align_linked_edge(&mut axis).
+        let (edge_flags, edge_link_ix, edge_pos, edge2_pos_for_cjk, edge2_has_blue) = {
+            let edges = axis.edges.as_slice();
+            let edge = &edges[edge_ix];
+            let link_ix = edge.link_ix.map(|ix| ix as usize);
+            let (edge2_pos, edge2_has_blue) = link_ix
+                .map(|ix| (edges[ix].pos, edges[ix].blue_edge.is_some()))
+                .unwrap_or((0, false));
+            (edge.flags, link_ix, edge.pos, edge2_pos, edge2_has_blue)
+        };
+        if edge_flags & Edge::DONE != 0 {
             continue;
         }
         // Skip all non-stem edges
-        let Some(edge2_ix) = edge.link_ix.map(|ix| ix as usize) else {
+        let Some(edge2_ix) = edge_link_ix else {
             serif_count += 1;
             continue;
         };
@@ -194,15 +203,14 @@ fn align_stem_edges(
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L1912>
         if group != ScriptGroup::Default {
             if let Some(last_pos) = last_stem_pos {
-                if edge.pos < last_pos + 64 || edges[edge2_ix].pos < last_pos + 64 {
+                if edge_pos < last_pos + 64 || edge2_pos_for_cjk < last_pos + 64 {
                     serif_count += 1;
                     continue;
                 }
             }
         }
-        // This shouldn't happen?
-        if edges[edge2_ix].blue_edge.is_some() {
-            edges[edge2_ix].flags |= Edge::DONE;
+        // This should not happen, but match the C fallback.
+        if edge2_has_blue {
             align_linked_edge(
                 axis,
                 metrics,
@@ -212,8 +220,10 @@ fn align_stem_edges(
                 edge_ix,
                 recorder.as_deref_mut(),
             );
+            axis.edges[edge_ix].flags |= Edge::DONE;
             continue;
         }
+        let edges = axis.edges.as_mut_slice();
         if group == ScriptGroup::Default {
             // Now align the stem
             // Note: the branches here are reversed from the FreeType code
@@ -456,14 +466,17 @@ fn align_remaining_edges(
     if group == ScriptGroup::Default {
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L3418>
         for edge_ix in 0..axis.edges.len() {
-            let edges = &mut axis.edges;
-            let edge = &edges[edge_ix];
-            if edge.flags & Edge::DONE != 0 {
+            let (edge_flags, edge_opos, edge_serif_ix, delta) = {
+                let edges = axis.edges.as_slice();
+                let edge = &edges[edge_ix];
+                let delta = edge
+                    .serif(edges)
+                    .map(|serif| (serif.opos - edge.opos).abs())
+                    .unwrap_or(1000);
+                (edge.flags, edge.opos, edge.serif_ix, delta)
+            };
+            if edge_flags & Edge::DONE != 0 {
                 continue;
-            }
-            let mut delta = 1000;
-            if let Some(serif) = edge.serif(edges) {
-                delta = (serif.opos - edge.opos).abs();
             }
             if delta < 64 + 16 {
                 // delta is only < 1000 if edge.serif_ix is Some(_)

--- a/skrifa/src/outline/autohint/hint/edges.rs
+++ b/skrifa/src/outline/autohint/hint/edges.rs
@@ -6,8 +6,9 @@
 
 use super::super::{
     metrics::{fixed_mul_div, pix_floor, pix_round, Scale, ScaledAxisMetrics, ScaledWidth},
+    recorder::{Action, HintsRecorder},
     style::ScriptGroup,
-    topo::{Axis, Edge},
+    topo::{Axis, Dimension, Edge},
 };
 
 /// Main Latin grid-fitting routine.
@@ -21,12 +22,13 @@ pub(crate) fn hint_edges(
     group: ScriptGroup,
     scale: &Scale,
     mut top_to_bottom_hinting: bool,
+    mut recorder: Option<&mut HintsRecorder>,
 ) {
     if axis.dim != Axis::VERTICAL {
         top_to_bottom_hinting = false;
     }
     // First align horizontal edges to blue zones if needed
-    let anchor_ix = align_edges_to_blues(axis, metrics, group, scale);
+    let anchor_ix = align_edges_to_blues(axis, metrics, group, scale, recorder.as_deref_mut());
     // Now align the stem edges
     let (serif_count, anchor_ix) = align_stem_edges(
         axis,
@@ -35,6 +37,7 @@ pub(crate) fn hint_edges(
         scale,
         top_to_bottom_hinting,
         anchor_ix,
+        recorder.as_deref_mut(),
     );
     let edges = axis.edges.as_mut_slice();
     // Special case for lowercase m
@@ -43,7 +46,14 @@ pub(crate) fn hint_edges(
     }
     // Handle serifs and single segment edges
     if serif_count > 0 || anchor_ix.is_none() {
-        align_remaining_edges(axis, group, top_to_bottom_hinting, serif_count, anchor_ix);
+        align_remaining_edges(
+            axis,
+            group,
+            top_to_bottom_hinting,
+            serif_count,
+            anchor_ix,
+            recorder,
+        );
     }
 }
 
@@ -55,6 +65,7 @@ fn align_edges_to_blues(
     metrics: &ScaledAxisMetrics,
     group: ScriptGroup,
     scale: &Scale,
+    mut recorder: Option<&mut HintsRecorder>,
 ) -> Option<usize> {
     let mut anchor_ix = None;
     // For default script group, only do vertical blues
@@ -62,51 +73,87 @@ fn align_edges_to_blues(
         return anchor_ix;
     }
     for edge_ix in 0..axis.edges.len() {
-        let edges = axis.edges.as_mut_slice();
-        let edge = &edges[edge_ix];
-        if edge.flags & Edge::DONE != 0 {
-            continue;
-        }
-        let edge2_ix = edge.link_ix.map(|x| x as usize);
-        let edge2 = edge2_ix.map(|ix| &edges[ix]);
-        // If we have two neutral zones, skip one of them.
-        if let (true, Some(edge2)) = (edge.blue_edge.is_some(), edge2) {
-            if edge2.blue_edge.is_some() {
-                let skip_ix = if edge2.flags & Edge::NEUTRAL != 0 {
-                    edge2_ix
-                } else if edge.flags & Edge::NEUTRAL != 0 {
-                    Some(edge_ix)
+        let mut linked_edge_to_align = None;
+        {
+            let edges = axis.edges.as_mut_slice();
+            let edge = &edges[edge_ix];
+            if edge.flags & Edge::DONE != 0 {
+                continue;
+            }
+            let edge2_ix = edge.link_ix.map(|x| x as usize);
+            let edge2 = edge2_ix.map(|ix| &edges[ix]);
+            // If we have two neutral zones, skip one of them.
+            if let (true, Some(edge2)) = (edge.blue_edge.is_some(), edge2) {
+                if edge2.blue_edge.is_some() {
+                    let skip_ix = if edge2.flags & Edge::NEUTRAL != 0 {
+                        edge2_ix
+                    } else if edge.flags & Edge::NEUTRAL != 0 {
+                        Some(edge_ix)
+                    } else {
+                        None
+                    };
+                    if let Some(skip_ix) = skip_ix {
+                        let skip_edge = &mut edges[skip_ix];
+                        skip_edge.blue_edge = None;
+                        skip_edge.flags &= !Edge::NEUTRAL;
+                    }
+                }
+            }
+            // Flip edges if the other is aligned to a blue zone
+            let blue = edges[edge_ix].blue_edge;
+            let (blue, edge1_ix, edge2_ix) = if let Some(blue) = blue {
+                (blue, Some(edge_ix), edge2_ix)
+            } else if let Some(edge2_blue) = edge2_ix.and_then(|ix| edges[ix].blue_edge) {
+                (edge2_blue, edge2_ix, Some(edge_ix))
+            } else {
+                (Default::default(), None, None)
+            };
+            let Some(edge1_ix) = edge1_ix else {
+                continue;
+            };
+            // Skip if edge1 was already positioned by a previous iteration
+            // (e.g. edge[i] has no blue but its linked-edge does, and that
+            // linked-edge was already processed when the loop visited it directly).
+            if edges[edge1_ix].flags & Edge::DONE != 0 {
+                continue;
+            }
+            let edge1 = &mut edges[edge1_ix];
+            edge1.pos = blue.fitted;
+            edge1.flags |= Edge::DONE;
+            if let Some(recorder) = recorder.as_mut() {
+                let action = if anchor_ix.is_none() {
+                    Action::BlueAnchor
                 } else {
-                    None
+                    Action::Blue
                 };
-                if let Some(skip_ix) = skip_ix {
-                    let skip_edge = &mut edges[skip_ix];
-                    skip_edge.blue_edge = None;
-                    skip_edge.flags &= !Edge::NEUTRAL;
+                recorder.record_edge(
+                    axis.dim,
+                    action,
+                    edge1_ix,
+                    anchor_ix.is_none().then_some(edge_ix),
+                    None,
+                    None,
+                    None,
+                    edges[edge1_ix].blue_provenance,
+                );
+            }
+            if let Some(edge2_ix) = edge2_ix {
+                if edges[edge2_ix].blue_edge.is_none() {
+                    edges[edge2_ix].flags |= Edge::DONE;
+                    linked_edge_to_align = Some((edge1_ix, edge2_ix));
                 }
             }
         }
-        // Flip edges if the other is aligned to a blue zone
-        let blue = edges[edge_ix].blue_edge;
-        let (blue, edge1_ix, edge2_ix) = if let Some(blue) = blue {
-            (blue, Some(edge_ix), edge2_ix)
-        } else if let Some(edge2_blue) = edge2_ix.and_then(|ix| edges[ix].blue_edge) {
-            (edge2_blue, edge2_ix, Some(edge_ix))
-        } else {
-            (Default::default(), None, None)
-        };
-        let Some(edge1_ix) = edge1_ix else {
-            continue;
-        };
-        let edge1 = &mut edges[edge1_ix];
-        edge1.pos = blue.fitted;
-        edge1.flags |= Edge::DONE;
-        if let Some(edge2_ix) = edge2_ix {
-            let edge2 = &mut edges[edge2_ix];
-            if edge2.blue_edge.is_none() {
-                edge2.flags |= Edge::DONE;
-                align_linked_edge(axis, metrics, group, scale, edge1_ix, edge2_ix);
-            }
+        if let Some((edge1_ix, edge2_ix)) = linked_edge_to_align {
+            align_linked_edge(
+                axis,
+                metrics,
+                group,
+                scale,
+                edge1_ix,
+                edge2_ix,
+                recorder.as_deref_mut(),
+            );
         }
         if anchor_ix.is_none() {
             anchor_ix = Some(edge_ix);
@@ -125,6 +172,7 @@ fn align_stem_edges(
     scale: &Scale,
     top_to_bottom_hinting: bool,
     mut anchor_ix: Option<usize>,
+    mut recorder: Option<&mut HintsRecorder>,
 ) -> (usize, Option<usize>) {
     let mut serif_count = 0;
     let mut last_stem_pos = None;
@@ -155,7 +203,15 @@ fn align_stem_edges(
         // This shouldn't happen?
         if edges[edge2_ix].blue_edge.is_some() {
             edges[edge2_ix].flags |= Edge::DONE;
-            align_linked_edge(axis, metrics, group, scale, edge2_ix, edge_ix);
+            align_linked_edge(
+                axis,
+                metrics,
+                group,
+                scale,
+                edge2_ix,
+                edge_ix,
+                recorder.as_deref_mut(),
+            );
             continue;
         }
         if group == ScriptGroup::Default {
@@ -181,6 +237,18 @@ fn align_stem_edges(
                 if edge2.flags & Edge::DONE != 0 {
                     let new_pos = edge2.pos - cur_len;
                     edges[edge_ix].pos = new_pos;
+                    if let Some(recorder) = recorder.as_mut() {
+                        recorder.record_edge(
+                            axis.dim,
+                            Action::Adjust,
+                            edge_ix,
+                            Some(edge2_ix),
+                            None,
+                            edge_ix.checked_sub(1),
+                            None,
+                            None,
+                        );
+                    }
                 } else if cur_len < 96 {
                     let cur_pos1 = pix_round(original_center);
                     let (u_off, d_off) = if cur_len <= 64 { (32, 32) } else { (38, 26) };
@@ -193,6 +261,18 @@ fn align_stem_edges(
                     };
                     edges[edge_ix].pos = cur_pos1 - cur_len / 2;
                     edges[edge2_ix].pos = cur_pos1 + cur_len / 2;
+                    if let Some(recorder) = recorder.as_mut() {
+                        recorder.record_edge(
+                            axis.dim,
+                            Action::Stem,
+                            edge_ix,
+                            Some(edge2_ix),
+                            None,
+                            edge_ix.checked_sub(1),
+                            None,
+                            None,
+                        );
+                    }
                 } else {
                     let cur_pos1 = pix_round(original_pos);
                     let delta1 = (cur_pos1 + (cur_len >> 1) - original_center).abs();
@@ -202,11 +282,30 @@ fn align_stem_edges(
                     let new_pos2 = new_pos + cur_len;
                     edges[edge_ix].pos = new_pos;
                     edges[edge2_ix].pos = new_pos2;
+                    if let Some(recorder) = recorder.as_mut() {
+                        recorder.record_edge(
+                            axis.dim,
+                            Action::Stem,
+                            edge_ix,
+                            Some(edge2_ix),
+                            None,
+                            edge_ix.checked_sub(1),
+                            None,
+                            None,
+                        );
+                    }
                 }
                 edges[edge_ix].flags |= Edge::DONE;
                 edges[edge2_ix].flags |= Edge::DONE;
                 if edge_ix > 0 {
-                    adjust_link(edges, edge_ix, LinkDir::Prev, top_to_bottom_hinting);
+                    adjust_link(
+                        edges,
+                        axis.dim,
+                        edge_ix,
+                        LinkDir::Prev,
+                        top_to_bottom_hinting,
+                        recorder.as_deref_mut(),
+                    );
                 }
             } else {
                 // No stem has been aligned yet
@@ -247,16 +346,44 @@ fn align_stem_edges(
                     edges[edge_ix].pos = pix_round(edge.opos);
                 }
                 edges[edge_ix].flags |= Edge::DONE;
-                align_linked_edge(axis, metrics, group, scale, edge_ix, edge2_ix);
+                if let Some(recorder) = recorder.as_mut() {
+                    recorder.record_edge(
+                        axis.dim,
+                        Action::Anchor,
+                        edge_ix,
+                        Some(edge2_ix),
+                        None,
+                        None,
+                        None,
+                        None,
+                    );
+                }
+                align_linked_edge(
+                    axis,
+                    metrics,
+                    group,
+                    scale,
+                    edge_ix,
+                    edge2_ix,
+                    recorder.as_deref_mut(),
+                );
                 anchor_ix = Some(edge_ix);
             }
         } else {
             // More CJK divergence
             // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L1937>
             if edge2_ix < edge_ix {
-                last_stem_pos = Some(edge.pos);
+                last_stem_pos = Some(edge_pos);
                 edges[edge_ix].flags |= Edge::DONE;
-                align_linked_edge(axis, metrics, group, scale, edge2_ix, edge_ix);
+                align_linked_edge(
+                    axis,
+                    metrics,
+                    group,
+                    scale,
+                    edge2_ix,
+                    edge_ix,
+                    recorder.as_deref_mut(),
+                );
                 continue;
             }
             if axis.dim != Axis::VERTICAL && anchor_ix.is_none() {
@@ -324,6 +451,7 @@ fn align_remaining_edges(
     top_to_bottom_hinting: bool,
     mut serif_count: usize,
     mut anchor_ix: Option<usize>,
+    mut recorder: Option<&mut HintsRecorder>,
 ) {
     if group == ScriptGroup::Default {
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L3418>
@@ -339,9 +467,24 @@ fn align_remaining_edges(
             }
             if delta < 64 + 16 {
                 // delta is only < 1000 if edge.serif_ix is Some(_)
-                let serif_ix = edge.serif_ix.unwrap() as usize;
-                align_serif_edge(axis, serif_ix, edge_ix)
+                let serif_ix = edge_serif_ix.unwrap() as usize;
+                align_serif_edge(axis, serif_ix, edge_ix);
+                if let Some(recorder) = recorder.as_mut() {
+                    let edges = axis.edges.as_slice();
+                    let [lower_bound_ix, upper_bound_ix] = latin_remaining_bounds(edges, edge_ix);
+                    recorder.record_edge(
+                        axis.dim,
+                        Action::Serif,
+                        edge_ix,
+                        Some(serif_ix),
+                        None,
+                        lower_bound_ix,
+                        upper_bound_ix,
+                        None,
+                    );
+                }
             } else if let Some(anchor_ix) = anchor_ix {
+                let edges = axis.edges.as_mut_slice();
                 let [before_ix, after_ix] = find_bounding_completed_edges(edges, edge_ix);
                 if let Some((before_ix, after_ix)) = before_ix.zip(after_ix) {
                     let before = &edges[before_ix];
@@ -351,26 +494,82 @@ fn align_remaining_edges(
                     } else {
                         before.pos
                             + fixed_mul_div(
-                                edge.opos - before.opos,
+                                edge_opos - before.opos,
                                 after.pos - before.pos,
                                 after.opos - before.opos,
                             )
                     };
                     edges[edge_ix].pos = new_pos;
+                    if let Some(recorder) = recorder.as_mut() {
+                        let [lower_bound_ix, upper_bound_ix] =
+                            latin_remaining_bounds(edges, edge_ix);
+                        recorder.record_edge(
+                            axis.dim,
+                            Action::SerifLink1,
+                            edge_ix,
+                            Some(before_ix),
+                            Some(after_ix),
+                            lower_bound_ix,
+                            upper_bound_ix,
+                            None,
+                        );
+                    }
                 } else {
                     let anchor = &edges[anchor_ix];
-                    let new_pos = anchor.pos + ((edge.opos - anchor.opos + 16) & !31);
+                    let new_pos = anchor.pos + ((edge_opos - anchor.opos + 16) & !31);
                     edges[edge_ix].pos = new_pos;
+                    if let Some(recorder) = recorder.as_mut() {
+                        let [lower_bound_ix, upper_bound_ix] =
+                            latin_remaining_bounds(edges, edge_ix);
+                        recorder.record_edge(
+                            axis.dim,
+                            Action::SerifLink2,
+                            edge_ix,
+                            None,
+                            None,
+                            lower_bound_ix,
+                            upper_bound_ix,
+                            None,
+                        );
+                    }
                 }
             } else {
                 anchor_ix = Some(edge_ix);
-                let new_pos = pix_round(edge.opos);
+                let edges = axis.edges.as_mut_slice();
+                let new_pos = pix_round(edge_opos);
                 edges[edge_ix].pos = new_pos;
+                if let Some(recorder) = recorder.as_mut() {
+                    let [lower_bound_ix, upper_bound_ix] = latin_remaining_bounds(edges, edge_ix);
+                    recorder.record_edge(
+                        axis.dim,
+                        Action::SerifAnchor,
+                        edge_ix,
+                        None,
+                        None,
+                        lower_bound_ix,
+                        upper_bound_ix,
+                        None,
+                    );
+                }
             }
             let edges = &mut axis.edges;
             edges[edge_ix].flags |= Edge::DONE;
-            adjust_link(edges, edge_ix, LinkDir::Prev, top_to_bottom_hinting);
-            adjust_link(edges, edge_ix, LinkDir::Next, top_to_bottom_hinting);
+            adjust_link(
+                edges,
+                axis.dim,
+                edge_ix,
+                LinkDir::Prev,
+                top_to_bottom_hinting,
+                recorder.as_deref_mut(),
+            );
+            adjust_link(
+                edges,
+                axis.dim,
+                edge_ix,
+                LinkDir::Next,
+                top_to_bottom_hinting,
+                recorder.as_deref_mut(),
+            );
         }
     } else {
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L2119>
@@ -433,9 +632,11 @@ enum LinkDir {
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L3499>
 fn adjust_link(
     edges: &mut [Edge],
+    dim: Dimension,
     edge_ix: usize,
     link_dir: LinkDir,
     top_to_bottom_hinting: bool,
+    mut recorder: Option<&mut HintsRecorder>,
 ) -> Option<()> {
     let edge = &edges[edge_ix];
     let (edge2, prev_edge) = if link_dir == LinkDir::Next {
@@ -462,8 +663,18 @@ fn adjust_link(
     if (link.pos - prev_edge.pos).abs() > 16 {
         let new_pos = edge2.pos;
         edges[edge_ix].pos = new_pos;
+        if let Some(recorder) = recorder.as_mut() {
+            recorder.record_edge(dim, Action::Bound, edge_ix, None, None, None, None, None);
+        }
     }
     Some(())
+}
+
+fn latin_remaining_bounds(edges: &[Edge], edge_ix: usize) -> [Option<usize>; 2] {
+    let lower_bound_ix = edge_ix.checked_sub(1);
+    let upper_bound_ix = (edge_ix + 1 < edges.len() && edges[edge_ix + 1].flags & Edge::DONE != 0)
+        .then_some(edge_ix + 1);
+    [lower_bound_ix, upper_bound_ix]
 }
 
 /// Returns the indices of the "completed" edges before and after the given
@@ -665,6 +876,7 @@ fn align_linked_edge(
     scale: &Scale,
     base_edge_ix: usize,
     stem_edge_ix: usize,
+    mut recorder: Option<&mut HintsRecorder>,
 ) {
     let edges = axis.edges.as_mut_slice();
     let base_edge = &edges[base_edge_ix];
@@ -681,6 +893,18 @@ fn align_linked_edge(
         stem_edge.flags,
     );
     edges[stem_edge_ix].pos = base_edge.pos + fitted_width;
+    if let Some(recorder) = recorder.as_mut() {
+        recorder.record_edge(
+            axis.dim,
+            Action::Link,
+            base_edge_ix,
+            Some(stem_edge_ix),
+            None,
+            None,
+            None,
+            None,
+        );
+    }
 }
 
 /// Shift the serif edge by the adjustment made to base edge.
@@ -930,6 +1154,7 @@ mod tests {
                 class.script.group,
                 &scale,
                 class.script.hint_top_to_bottom,
+                None,
             );
         }
         // Only pos and flags fields are modified by edge hinting

--- a/skrifa/src/outline/autohint/hint/edges.rs
+++ b/skrifa/src/outline/autohint/hint/edges.rs
@@ -6,7 +6,7 @@
 
 use super::super::{
     metrics::{fixed_mul_div, pix_floor, pix_round, Scale, ScaledAxisMetrics, ScaledWidth},
-    recorder::{Action, HintsRecorder},
+    recorder::{EdgeAction, HintsRecorder},
     style::ScriptGroup,
     topo::{Axis, Dimension, Edge},
 };
@@ -24,7 +24,7 @@ pub(crate) fn hint_edges(
     mut top_to_bottom_hinting: bool,
     mut recorder: Option<&mut HintsRecorder>,
 ) {
-    if axis.dim != Axis::VERTICAL {
+    if axis.dim != Dimension::Vertical {
         top_to_bottom_hinting = false;
     }
     // First align horizontal edges to blue zones if needed
@@ -41,7 +41,7 @@ pub(crate) fn hint_edges(
     );
     let edges = axis.edges.as_mut_slice();
     // Special case for lowercase m
-    if axis.dim == Axis::HORIZONTAL && (edges.len() == 6 || edges.len() == 12) {
+    if axis.dim == Dimension::Horizontal && (edges.len() == 6 || edges.len() == 12) {
         hint_lowercase_m(edges, group);
     }
     // Handle serifs and single segment edges
@@ -69,7 +69,7 @@ fn align_edges_to_blues(
 ) -> Option<usize> {
     let mut anchor_ix = None;
     // For default script group, only do vertical blues
-    if group == ScriptGroup::Default && axis.dim != Axis::VERTICAL {
+    if group == ScriptGroup::Default && axis.dim != Dimension::Vertical {
         return anchor_ix;
     }
     for edge_ix in 0..axis.edges.len() {
@@ -122,9 +122,9 @@ fn align_edges_to_blues(
             edge1.flags |= Edge::DONE;
             if let Some(recorder) = recorder.as_mut() {
                 let action = if anchor_ix.is_none() {
-                    Action::BlueAnchor
+                    EdgeAction::BlueAnchor
                 } else {
-                    Action::Blue
+                    EdgeAction::Blue
                 };
                 recorder.record_edge(
                     axis.dim,
@@ -250,7 +250,7 @@ fn align_stem_edges(
                     if let Some(recorder) = recorder.as_mut() {
                         recorder.record_edge(
                             axis.dim,
-                            Action::Adjust,
+                            EdgeAction::Adjust,
                             edge_ix,
                             Some(edge2_ix),
                             None,
@@ -274,7 +274,7 @@ fn align_stem_edges(
                     if let Some(recorder) = recorder.as_mut() {
                         recorder.record_edge(
                             axis.dim,
-                            Action::Stem,
+                            EdgeAction::Stem,
                             edge_ix,
                             Some(edge2_ix),
                             None,
@@ -295,7 +295,7 @@ fn align_stem_edges(
                     if let Some(recorder) = recorder.as_mut() {
                         recorder.record_edge(
                             axis.dim,
-                            Action::Stem,
+                            EdgeAction::Stem,
                             edge_ix,
                             Some(edge2_ix),
                             None,
@@ -359,7 +359,7 @@ fn align_stem_edges(
                 if let Some(recorder) = recorder.as_mut() {
                     recorder.record_edge(
                         axis.dim,
-                        Action::Anchor,
+                        EdgeAction::Anchor,
                         edge_ix,
                         Some(edge2_ix),
                         None,
@@ -396,7 +396,7 @@ fn align_stem_edges(
                 );
                 continue;
             }
-            if axis.dim != Axis::VERTICAL && anchor_ix.is_none() {
+            if axis.dim != Dimension::Vertical && anchor_ix.is_none() {
                 delta = hint_normal_stem_cjk(axis, metrics, group, scale, edge_ix, edge2_ix, delta);
             } else {
                 hint_normal_stem_cjk(axis, metrics, group, scale, edge_ix, edge2_ix, delta);
@@ -487,7 +487,7 @@ fn align_remaining_edges(
                     let [lower_bound_ix, upper_bound_ix] = latin_remaining_bounds(edges, edge_ix);
                     recorder.record_edge(
                         axis.dim,
-                        Action::Serif,
+                        EdgeAction::Serif,
                         edge_ix,
                         Some(serif_ix),
                         None,
@@ -518,7 +518,7 @@ fn align_remaining_edges(
                             latin_remaining_bounds(edges, edge_ix);
                         recorder.record_edge(
                             axis.dim,
-                            Action::SerifLink1,
+                            EdgeAction::SerifLink1,
                             edge_ix,
                             Some(before_ix),
                             Some(after_ix),
@@ -536,7 +536,7 @@ fn align_remaining_edges(
                             latin_remaining_bounds(edges, edge_ix);
                         recorder.record_edge(
                             axis.dim,
-                            Action::SerifLink2,
+                            EdgeAction::SerifLink2,
                             edge_ix,
                             None,
                             None,
@@ -555,7 +555,7 @@ fn align_remaining_edges(
                     let [lower_bound_ix, upper_bound_ix] = latin_remaining_bounds(edges, edge_ix);
                     recorder.record_edge(
                         axis.dim,
-                        Action::SerifAnchor,
+                        EdgeAction::SerifAnchor,
                         edge_ix,
                         None,
                         None,
@@ -677,7 +677,16 @@ fn adjust_link(
         let new_pos = edge2.pos;
         edges[edge_ix].pos = new_pos;
         if let Some(recorder) = recorder.as_mut() {
-            recorder.record_edge(dim, Action::Bound, edge_ix, None, None, None, None, None);
+            recorder.record_edge(
+                dim,
+                EdgeAction::Bound,
+                edge_ix,
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
         }
     }
     Some(())
@@ -756,7 +765,7 @@ fn stem_width(
     {
         return width;
     }
-    let is_vertical = metrics.dim == Axis::VERTICAL;
+    let is_vertical = metrics.dim == Dimension::Vertical;
     let sign = if width < 0 { -1 } else { 1 };
     let mut dist = width.abs();
     if (is_vertical && scale.flags & Scale::VERTICAL_SNAP == 0)
@@ -909,7 +918,7 @@ fn align_linked_edge(
     if let Some(recorder) = recorder.as_mut() {
         recorder.record_edge(
             axis.dim,
-            Action::Link,
+            EdgeAction::Link,
             base_edge_ix,
             Some(stem_edge_ix),
             None,
@@ -951,7 +960,7 @@ fn hint_normal_stem_cjk(
     let threshold_delta = if do_stem_adjust {
         0
     } else {
-        let delta = if axis.dim == Axis::VERTICAL {
+        let delta = if axis.dim == Dimension::Vertical {
             MAX_HORIZONTAL_GAP
         } else {
             MAX_VERTICAL_GAP
@@ -1133,11 +1142,12 @@ mod tests {
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
         let mut axes = [
-            Axis::new(Axis::HORIZONTAL, outline.orientation),
-            Axis::new(Axis::VERTICAL, outline.orientation),
+            Axis::new(Dimension::Horizontal, outline.orientation),
+            Axis::new(Dimension::Vertical, outline.orientation),
         ];
-        for (dim, axis) in axes.iter_mut().enumerate() {
+        for axis in axes.iter_mut() {
             topo::compute_segments(&mut outline, axis, class.script.group);
+            let dim = axis.dim;
             topo::link_segments(
                 &outline,
                 axis,
@@ -1152,7 +1162,7 @@ mod tests {
                 scaled_metrics.axes[1].scale,
                 class.script.group,
             );
-            if dim == Axis::VERTICAL {
+            if dim == Dimension::Vertical {
                 topo::compute_blue_edges(
                     axis,
                     &scale,
@@ -1171,12 +1181,12 @@ mod tests {
             );
         }
         // Only pos and flags fields are modified by edge hinting
-        let h_edges = axes[Axis::HORIZONTAL]
+        let h_edges = axes[Dimension::Horizontal]
             .edges
             .iter()
             .map(|edge| (edge.pos, edge.flags))
             .collect::<Vec<_>>();
-        let v_edges = axes[Axis::VERTICAL]
+        let v_edges = axes[Dimension::Vertical]
             .edges
             .iter()
             .map(|edge| (edge.pos, edge.flags))

--- a/skrifa/src/outline/autohint/hint/edges.rs
+++ b/skrifa/src/outline/autohint/hint/edges.rs
@@ -9,6 +9,7 @@ use super::super::{
     recorder::{EdgeAction, HintsRecorder},
     style::ScriptGroup,
     topo::{Axis, Dimension, Edge, TopoFlags},
+    ScaleFlags,
 };
 
 /// Main Latin grid-fitting routine.
@@ -761,7 +762,7 @@ fn stem_width(
     base_flags: TopoFlags,
     stem_flags: TopoFlags,
 ) -> i32 {
-    if scale.flags & Scale::STEM_ADJUST == 0
+    if !scale.flags.contains(ScaleFlags::STEM_ADJUST)
         || (group == ScriptGroup::Default && metrics.width_metrics.is_extra_light)
     {
         return width;
@@ -769,8 +770,8 @@ fn stem_width(
     let is_vertical = metrics.dim == Dimension::Vertical;
     let sign = if width < 0 { -1 } else { 1 };
     let mut dist = width.abs();
-    if (is_vertical && scale.flags & Scale::VERTICAL_SNAP == 0)
-        || (!is_vertical && scale.flags & Scale::HORIZONTAL_SNAP == 0)
+    if (is_vertical && !scale.flags.contains(ScaleFlags::VERTICAL_SNAP))
+        || (!is_vertical && !scale.flags.contains(ScaleFlags::HORIZONTAL_SNAP))
     {
         // Do smooth hinting
         if group == ScriptGroup::Default {
@@ -853,7 +854,7 @@ fn stem_width(
             } else {
                 dist = 64;
             }
-        } else if scale.flags & Scale::MONO != 0 {
+        } else if scale.flags.contains(ScaleFlags::MONO) {
             // Mono horizontal hinting: snap to integer with different
             // threshold
             if dist < 64 {
@@ -957,7 +958,7 @@ fn hint_normal_stem_cjk(
     const MAX_DELTA_ABS: i32 = 14;
     let edge = axis.edges[edge_ix];
     let edge2 = axis.edges[edge2_ix];
-    let do_stem_adjust = scale.flags & Scale::STEM_ADJUST != 0;
+    let do_stem_adjust = scale.flags.contains(ScaleFlags::STEM_ADJUST);
     let threshold_delta = if do_stem_adjust {
         0
     } else {

--- a/skrifa/src/outline/autohint/hint/edges.rs
+++ b/skrifa/src/outline/autohint/hint/edges.rs
@@ -8,7 +8,7 @@ use super::super::{
     metrics::{fixed_mul_div, pix_floor, pix_round, Scale, ScaledAxisMetrics, ScaledWidth},
     recorder::{EdgeAction, HintsRecorder},
     style::ScriptGroup,
-    topo::{Axis, Dimension, Edge},
+    topo::{Axis, Dimension, Edge, TopoFlags},
 };
 
 /// Main Latin grid-fitting routine.
@@ -77,7 +77,7 @@ fn align_edges_to_blues(
         {
             let edges = axis.edges.as_mut_slice();
             let edge = &edges[edge_ix];
-            if edge.flags & Edge::DONE != 0 {
+            if edge.flags.contains(TopoFlags::DONE) {
                 continue;
             }
             let edge2_ix = edge.link_ix.map(|x| x as usize);
@@ -85,9 +85,9 @@ fn align_edges_to_blues(
             // If we have two neutral zones, skip one of them.
             if let (true, Some(edge2)) = (edge.blue_edge.is_some(), edge2) {
                 if edge2.blue_edge.is_some() {
-                    let skip_ix = if edge2.flags & Edge::NEUTRAL != 0 {
+                    let skip_ix = if edge2.flags.contains(TopoFlags::NEUTRAL) {
                         edge2_ix
-                    } else if edge.flags & Edge::NEUTRAL != 0 {
+                    } else if edge.flags.contains(TopoFlags::NEUTRAL) {
                         Some(edge_ix)
                     } else {
                         None
@@ -95,7 +95,7 @@ fn align_edges_to_blues(
                     if let Some(skip_ix) = skip_ix {
                         let skip_edge = &mut edges[skip_ix];
                         skip_edge.blue_edge = None;
-                        skip_edge.flags &= !Edge::NEUTRAL;
+                        skip_edge.flags &= !TopoFlags::NEUTRAL;
                     }
                 }
             }
@@ -114,12 +114,12 @@ fn align_edges_to_blues(
             // Skip if edge1 was already positioned by a previous iteration
             // (e.g. edge[i] has no blue but its linked-edge does, and that
             // linked-edge was already processed when the loop visited it directly).
-            if edges[edge1_ix].flags & Edge::DONE != 0 {
+            if edges[edge1_ix].flags.contains(TopoFlags::DONE) {
                 continue;
             }
             let edge1 = &mut edges[edge1_ix];
             edge1.pos = blue.fitted;
-            edge1.flags |= Edge::DONE;
+            edge1.flags |= TopoFlags::DONE;
             if let Some(recorder) = recorder.as_mut() {
                 let action = if anchor_ix.is_none() {
                     EdgeAction::BlueAnchor
@@ -139,7 +139,7 @@ fn align_edges_to_blues(
             }
             if let Some(edge2_ix) = edge2_ix {
                 if edges[edge2_ix].blue_edge.is_none() {
-                    edges[edge2_ix].flags |= Edge::DONE;
+                    edges[edge2_ix].flags |= TopoFlags::DONE;
                     linked_edge_to_align = Some((edge1_ix, edge2_ix));
                 }
             }
@@ -191,7 +191,7 @@ fn align_stem_edges(
                 .unwrap_or((0, false));
             (edge.flags, link_ix, edge.pos, edge2_pos, edge2_has_blue)
         };
-        if edge_flags & Edge::DONE != 0 {
+        if edge_flags.contains(TopoFlags::DONE) {
             continue;
         }
         // Skip all non-stem edges
@@ -220,7 +220,7 @@ fn align_stem_edges(
                 edge_ix,
                 recorder.as_deref_mut(),
             );
-            axis.edges[edge_ix].flags |= Edge::DONE;
+            axis.edges[edge_ix].flags |= TopoFlags::DONE;
             continue;
         }
         let edges = axis.edges.as_mut_slice();
@@ -244,7 +244,7 @@ fn align_stem_edges(
                     edge.flags,
                     edge2.flags,
                 );
-                if edge2.flags & Edge::DONE != 0 {
+                if edge2.flags.contains(TopoFlags::DONE) {
                     let new_pos = edge2.pos - cur_len;
                     edges[edge_ix].pos = new_pos;
                     if let Some(recorder) = recorder.as_mut() {
@@ -305,8 +305,8 @@ fn align_stem_edges(
                         );
                     }
                 }
-                edges[edge_ix].flags |= Edge::DONE;
-                edges[edge2_ix].flags |= Edge::DONE;
+                edges[edge_ix].flags |= TopoFlags::DONE;
+                edges[edge2_ix].flags |= TopoFlags::DONE;
                 if edge_ix > 0 {
                     adjust_link(
                         edges,
@@ -355,7 +355,7 @@ fn align_stem_edges(
                 } else {
                     edges[edge_ix].pos = pix_round(edge.opos);
                 }
-                edges[edge_ix].flags |= Edge::DONE;
+                edges[edge_ix].flags |= TopoFlags::DONE;
                 if let Some(recorder) = recorder.as_mut() {
                     recorder.record_edge(
                         axis.dim,
@@ -384,7 +384,7 @@ fn align_stem_edges(
             // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L1937>
             if edge2_ix < edge_ix {
                 last_stem_pos = Some(edge_pos);
-                edges[edge_ix].flags |= Edge::DONE;
+                edges[edge_ix].flags |= TopoFlags::DONE;
                 align_linked_edge(
                     axis,
                     metrics,
@@ -402,9 +402,9 @@ fn align_stem_edges(
                 hint_normal_stem_cjk(axis, metrics, group, scale, edge_ix, edge2_ix, delta);
             }
             anchor_ix = Some(edge_ix);
-            axis.edges[edge_ix].flags |= Edge::DONE;
+            axis.edges[edge_ix].flags |= TopoFlags::DONE;
             let edge2 = &mut axis.edges[edge2_ix];
-            edge2.flags |= Edge::DONE;
+            edge2.flags |= TopoFlags::DONE;
             last_stem_pos = Some(edge2.pos);
         }
     }
@@ -440,11 +440,11 @@ fn hint_lowercase_m(edges: &mut [Edge], group: ScriptGroup) {
         let link_ix = edge3.link_ix.map(|ix| ix as usize);
         let edge3 = &mut edges[edge3_ix];
         edge3.pos -= delta;
-        edge3.flags |= Edge::DONE;
+        edge3.flags |= TopoFlags::DONE;
         if let Some(link_ix) = link_ix {
             let link = &mut edges[link_ix];
             link.pos -= delta;
-            link.flags |= Edge::DONE;
+            link.flags |= TopoFlags::DONE;
         }
         // Move serifs along with the stem
         if edges.len() == 12 {
@@ -475,7 +475,7 @@ fn align_remaining_edges(
                     .unwrap_or(1000);
                 (edge.flags, edge.opos, edge.serif_ix, delta)
             };
-            if edge_flags & Edge::DONE != 0 {
+            if edge_flags.contains(TopoFlags::DONE) {
                 continue;
             }
             if delta < 64 + 16 {
@@ -566,7 +566,7 @@ fn align_remaining_edges(
                 }
             }
             let edges = &mut axis.edges;
-            edges[edge_ix].flags |= Edge::DONE;
+            edges[edge_ix].flags |= TopoFlags::DONE;
             adjust_link(
                 edges,
                 axis.dim,
@@ -588,11 +588,11 @@ fn align_remaining_edges(
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L2119>
         for edge_ix in 0..axis.edges.len() {
             let edge = &mut axis.edges[edge_ix];
-            if edge.flags & Edge::DONE != 0 {
+            if edge.flags.contains(TopoFlags::DONE) {
                 continue;
             }
             if let Some(serif_ix) = edge.serif_ix.map(|ix| ix as usize) {
-                edge.flags |= Edge::DONE;
+                edge.flags |= TopoFlags::DONE;
                 align_serif_edge(axis, serif_ix, edge_ix);
                 serif_count = serif_count.saturating_sub(1);
             }
@@ -603,7 +603,7 @@ fn align_remaining_edges(
         for edge_ix in 0..axis.edges.len() {
             let edges = axis.edges.as_mut_slice();
             let edge = &edges[edge_ix];
-            if edge.flags & Edge::DONE != 0 {
+            if edge.flags.contains(TopoFlags::DONE) {
                 continue;
             }
             let [before_ix, after_ix] = find_bounding_completed_edges(edges, edge_ix);
@@ -655,7 +655,7 @@ fn adjust_link(
     let (edge2, prev_edge) = if link_dir == LinkDir::Next {
         let edge2 = edges.get(edge_ix + 1)?;
         // Don't adjust next edge if it's not done yet
-        if edge2.flags & Edge::DONE == 0 {
+        if !edge2.flags.contains(TopoFlags::DONE) {
             return None;
         }
         (edge2, edges.get(edge_ix.checked_sub(1)?)?)
@@ -694,8 +694,9 @@ fn adjust_link(
 
 fn latin_remaining_bounds(edges: &[Edge], edge_ix: usize) -> [Option<usize>; 2] {
     let lower_bound_ix = edge_ix.checked_sub(1);
-    let upper_bound_ix = (edge_ix + 1 < edges.len() && edges[edge_ix + 1].flags & Edge::DONE != 0)
-        .then_some(edge_ix + 1);
+    let upper_bound_ix = (edge_ix + 1 < edges.len()
+        && edges[edge_ix + 1].flags.contains(TopoFlags::DONE))
+    .then_some(edge_ix + 1);
     [lower_bound_ix, upper_bound_ix]
 }
 
@@ -708,13 +709,13 @@ fn find_bounding_completed_edges(edges: &[Edge], ix: usize) -> [Option<usize>; 2
         .iter()
         .enumerate()
         .rev()
-        .filter_map(|(ix, edge)| (edge.flags & Edge::DONE != 0).then_some(ix))
+        .filter_map(|(ix, edge)| edge.flags.contains(TopoFlags::DONE).then_some(ix))
         .next();
     let after_ix = edges
         .iter()
         .enumerate()
         .skip(ix + 1)
-        .filter_map(|(ix, edge)| (edge.flags & Edge::DONE != 0).then_some(ix))
+        .filter_map(|(ix, edge)| edge.flags.contains(TopoFlags::DONE).then_some(ix))
         .next();
     [before_ix, after_ix]
 }
@@ -757,8 +758,8 @@ fn stem_width(
     scale: &Scale,
     width: i32,
     base_delta: i32,
-    base_flags: u8,
-    stem_flags: u8,
+    base_flags: TopoFlags,
+    stem_flags: TopoFlags,
 ) -> i32 {
     if scale.flags & Scale::STEM_ADJUST == 0
         || (group == ScriptGroup::Default && metrics.width_metrics.is_extra_light)
@@ -773,10 +774,10 @@ fn stem_width(
     {
         // Do smooth hinting
         if group == ScriptGroup::Default {
-            if (stem_flags & Edge::SERIF != 0) && is_vertical && (dist < 3 * 64) {
+            if stem_flags.contains(TopoFlags::SERIF) && is_vertical && (dist < 3 * 64) {
                 // Don't touch widths of serifs
                 return dist * sign;
-            } else if base_flags & Edge::ROUND != 0 {
+            } else if base_flags.contains(TopoFlags::ROUND) {
                 if dist < 80 {
                     dist = 64;
                 }
@@ -965,7 +966,7 @@ fn hint_normal_stem_cjk(
         } else {
             MAX_VERTICAL_GAP
         };
-        if edge.flags & Edge::ROUND != 0 && edge2.flags & Edge::ROUND != 0 {
+        if edge.flags.contains(TopoFlags::ROUND) && edge2.flags.contains(TopoFlags::ROUND) {
             delta
         } else {
             delta / 3
@@ -1064,16 +1065,16 @@ mod tests {
     #[test]
     fn edge_hinting_default() {
         let expected_h_edges = [
-            (0, Edge::DONE | Edge::ROUND),
-            (133, Edge::DONE),
-            (187, Edge::DONE),
-            (192, Edge::DONE | Edge::ROUND),
+            (0, TopoFlags::DONE | TopoFlags::ROUND),
+            (133, TopoFlags::DONE),
+            (187, TopoFlags::DONE),
+            (192, TopoFlags::DONE | TopoFlags::ROUND),
         ];
         let expected_v_edges = [
-            (-256, Edge::DONE),
-            (463, Edge::DONE),
-            (576, Edge::DONE | Edge::ROUND | Edge::SERIF),
-            (633, Edge::DONE),
+            (-256, TopoFlags::DONE),
+            (463, TopoFlags::DONE),
+            (576, TopoFlags::DONE | TopoFlags::ROUND | TopoFlags::SERIF),
+            (633, TopoFlags::DONE),
         ];
         check_edges(
             font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS,
@@ -1087,26 +1088,26 @@ mod tests {
     #[test]
     fn edge_hinting_cjk() {
         let expected_h_edges = [
-            (128, Edge::DONE),
-            (193, Edge::DONE),
-            (473, 0),
-            (594, 0),
-            (704, Edge::DONE),
-            (673, Edge::DONE),
-            (767, Edge::DONE),
-            (832, Edge::DONE),
-            (896, Edge::DONE),
+            (128, TopoFlags::DONE),
+            (193, TopoFlags::DONE),
+            (473, TopoFlags::NORMAL),
+            (594, TopoFlags::NORMAL),
+            (704, TopoFlags::DONE),
+            (673, TopoFlags::DONE),
+            (767, TopoFlags::DONE),
+            (832, TopoFlags::DONE),
+            (896, TopoFlags::DONE),
         ];
         let expected_v_edges = [
-            (-64, Edge::DONE | Edge::ROUND),
-            (15, Edge::ROUND),
-            (142, Edge::ROUND),
-            (546, Edge::DONE),
-            (624, Edge::DONE),
-            (576, Edge::DONE),
-            (720, Edge::DONE),
-            (768, Edge::DONE),
-            (799, Edge::ROUND),
+            (-64, TopoFlags::DONE | TopoFlags::ROUND),
+            (15, TopoFlags::ROUND),
+            (142, TopoFlags::ROUND),
+            (546, TopoFlags::DONE),
+            (624, TopoFlags::DONE),
+            (576, TopoFlags::DONE),
+            (720, TopoFlags::DONE),
+            (768, TopoFlags::DONE),
+            (799, TopoFlags::ROUND),
         ];
         check_edges(
             font_test_data::NOTOSERIFTC_AUTOHINT_METRICS,
@@ -1121,8 +1122,8 @@ mod tests {
         font_data: &[u8],
         glyph_id: GlyphId,
         class: usize,
-        expected_h_edges: &[(i32, u8)],
-        expected_v_edges: &[(i32, u8)],
+        expected_h_edges: &[(i32, TopoFlags)],
+        expected_v_edges: &[(i32, TopoFlags)],
     ) {
         let font = FontRef::new(font_data).unwrap();
         let shaper = Shaper::new(&font, ShaperMode::Nominal);

--- a/skrifa/src/outline/autohint/hint/edges.rs
+++ b/skrifa/src/outline/autohint/hint/edges.rs
@@ -1129,7 +1129,7 @@ mod tests {
         let shaper = Shaper::new(&font, ShaperMode::Nominal);
         let class = &style::STYLE_CLASSES[class];
         let unscaled_metrics =
-            metrics::compute_unscaled_style_metrics(&shaper, Default::default(), class);
+            metrics::compute_unscaled_style_metrics(&shaper, &[], class, Default::default());
         let scale = metrics::Scale::new(
             16.0,
             font.head().unwrap().units_per_em() as i32,
@@ -1137,11 +1137,12 @@ mod tests {
             Default::default(),
             class.script.group,
         );
-        let scaled_metrics = metrics::scale_style_metrics(&unscaled_metrics, scale);
+        let scaled_metrics =
+            metrics::scale_style_metrics(&unscaled_metrics, scale, Default::default());
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(glyph_id).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let mut axes = [
             Axis::new(Dimension::Horizontal, outline.orientation),
             Axis::new(Dimension::Vertical, outline.orientation),

--- a/skrifa/src/outline/autohint/hint/mod.rs
+++ b/skrifa/src/outline/autohint/hint/mod.rs
@@ -6,6 +6,7 @@ mod outline;
 use super::{
     metrics::{scale_style_metrics, Scale, UnscaledStyleMetrics},
     outline::Outline,
+    recorder::HintsRecorder,
     style::{GlyphStyle, ScriptGroup},
     topo::{self, Axis},
 };
@@ -39,6 +40,45 @@ pub(crate) fn hint_outline(
     scale: &Scale,
     glyph_style: Option<GlyphStyle>,
 ) -> HintedMetrics {
+    hint_outline_impl(outline, metrics, scale, glyph_style, None).hinted_metrics
+}
+
+pub(crate) struct HintedPlan {
+    pub hinted_metrics: HintedMetrics,
+    #[allow(dead_code)]
+    pub vertical_axis: Option<Axis>,
+}
+
+#[allow(dead_code)] // used in tests
+#[cfg(feature = "autohinter")]
+pub(crate) fn hint_outline_with_recorder(
+    outline: &mut Outline,
+    metrics: &UnscaledStyleMetrics,
+    scale: &Scale,
+    glyph_style: Option<GlyphStyle>,
+    recorder: Option<&mut HintsRecorder>,
+) -> HintedMetrics {
+    hint_outline_impl(outline, metrics, scale, glyph_style, recorder).hinted_metrics
+}
+
+#[cfg(feature = "autohinter")]
+pub(crate) fn hint_outline_with_plan(
+    outline: &mut Outline,
+    metrics: &UnscaledStyleMetrics,
+    scale: &Scale,
+    glyph_style: Option<GlyphStyle>,
+    recorder: Option<&mut HintsRecorder>,
+) -> HintedPlan {
+    hint_outline_impl(outline, metrics, scale, glyph_style, recorder)
+}
+
+fn hint_outline_impl(
+    outline: &mut Outline,
+    metrics: &UnscaledStyleMetrics,
+    scale: &Scale,
+    glyph_style: Option<GlyphStyle>,
+    mut recorder: Option<&mut HintsRecorder>,
+) -> HintedPlan {
     let scaled_metrics = scale_style_metrics(metrics, *scale);
     let scale = &scaled_metrics.scale;
     let mut axis = Axis::default();
@@ -49,11 +89,15 @@ pub(crate) fn hint_outline(
         ..Default::default()
     };
     let group = metrics.style_class().script.group;
+    let mut vertical_axis = None;
     // For default script group, we don't proceed with hinting if we're
     // missing alignment zones. FreeType swaps in a "dummy" hinter here
     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afglobal.c#L475>
     if group == ScriptGroup::Default && scaled_metrics.axes[1].blues.is_empty() {
-        return hinted_metrics;
+        return HintedPlan {
+            hinted_metrics,
+            vertical_axis,
+        };
     }
     for dim in 0..2 {
         if (dim == Axis::HORIZONTAL && scale.flags & Scale::NO_HORIZONTAL != 0)
@@ -100,9 +144,10 @@ pub(crate) fn hint_outline(
             group,
             scale,
             hint_top_to_bottom,
+            recorder.as_deref_mut(),
         );
         outline::align_edge_points(outline, &axis, group, scale);
-        outline::align_strong_points(outline, &mut axis);
+        outline::align_strong_points(outline, &mut axis, recorder.as_deref_mut());
         outline::align_weak_points(outline, dim);
         if dim == 0 && axis.edges.len() > 1 {
             let left = axis.edges.first().unwrap();
@@ -114,6 +159,12 @@ pub(crate) fn hint_outline(
                 right_opos: right.opos,
             });
         }
+        if dim == Axis::VERTICAL {
+            vertical_axis = Some(axis.clone());
+        }
     }
-    hinted_metrics
+    HintedPlan {
+        hinted_metrics,
+        vertical_axis,
+    }
 }

--- a/skrifa/src/outline/autohint/hint/mod.rs
+++ b/skrifa/src/outline/autohint/hint/mod.rs
@@ -9,6 +9,7 @@ use super::{
     recorder::HintsRecorder,
     style::{GlyphStyle, ScriptGroup},
     topo::{self, Axis, Dimension},
+    QuirksMode,
 };
 
 /// Captures adjusted horizontal scale and outer edge positions to be used
@@ -65,7 +66,12 @@ fn hint_outline_impl(
     glyph_style: Option<GlyphStyle>,
     mut recorder: Option<&mut HintsRecorder>,
 ) -> HintedPlan {
-    let scaled_metrics = scale_style_metrics(metrics, *scale);
+    let quirks = if recorder.is_some() {
+        QuirksMode::Aot
+    } else {
+        QuirksMode::Jit
+    };
+    let scaled_metrics = scale_style_metrics(metrics, *scale, quirks);
     let scale = &scaled_metrics.scale;
     let mut axis = Axis::default();
     let hint_top_to_bottom = metrics.style_class().script.hint_top_to_bottom;

--- a/skrifa/src/outline/autohint/hint/mod.rs
+++ b/skrifa/src/outline/autohint/hint/mod.rs
@@ -9,7 +9,7 @@ use super::{
     recorder::HintsRecorder,
     style::{GlyphStyle, ScriptGroup},
     topo::{self, Axis, Dimension},
-    QuirksMode,
+    QuirksMode, ScaleFlags,
 };
 
 /// Captures adjusted horizontal scale and outer edge positions to be used
@@ -92,8 +92,8 @@ fn hint_outline_impl(
         };
     }
     for dim in [Dimension::Horizontal, Dimension::Vertical] {
-        if (dim == Dimension::Horizontal && scale.flags & Scale::NO_HORIZONTAL != 0)
-            || (dim == Dimension::Vertical && scale.flags & Scale::NO_VERTICAL != 0)
+        if (dim == Dimension::Horizontal && scale.flags.contains(ScaleFlags::NO_HORIZONTAL))
+            || (dim == Dimension::Vertical && scale.flags.contains(ScaleFlags::NO_VERTICAL))
         {
             continue;
         }

--- a/skrifa/src/outline/autohint/hint/mod.rs
+++ b/skrifa/src/outline/autohint/hint/mod.rs
@@ -45,31 +45,17 @@ pub(crate) fn hint_outline(
 
 pub(crate) struct HintedPlan {
     pub hinted_metrics: HintedMetrics,
-    #[allow(dead_code)]
-    pub vertical_axis: Option<Axis>,
+    pub axes: [Option<Axis>; 2],
 }
 
-#[allow(dead_code)] // used in tests
-#[cfg(feature = "autohinter")]
 pub(crate) fn hint_outline_with_recorder(
     outline: &mut Outline,
     metrics: &UnscaledStyleMetrics,
     scale: &Scale,
     glyph_style: Option<GlyphStyle>,
-    recorder: Option<&mut HintsRecorder>,
-) -> HintedMetrics {
-    hint_outline_impl(outline, metrics, scale, glyph_style, recorder).hinted_metrics
-}
-
-#[cfg(feature = "autohinter")]
-pub(crate) fn hint_outline_with_plan(
-    outline: &mut Outline,
-    metrics: &UnscaledStyleMetrics,
-    scale: &Scale,
-    glyph_style: Option<GlyphStyle>,
-    recorder: Option<&mut HintsRecorder>,
+    recorder: &mut HintsRecorder,
 ) -> HintedPlan {
-    hint_outline_impl(outline, metrics, scale, glyph_style, recorder)
+    hint_outline_impl(outline, metrics, scale, glyph_style, Some(recorder))
 }
 
 fn hint_outline_impl(
@@ -89,14 +75,14 @@ fn hint_outline_impl(
         ..Default::default()
     };
     let group = metrics.style_class().script.group;
-    let mut vertical_axis = None;
+    let mut axes = [const { None }; 2];
     // For default script group, we don't proceed with hinting if we're
     // missing alignment zones. FreeType swaps in a "dummy" hinter here
     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afglobal.c#L475>
     if group == ScriptGroup::Default && scaled_metrics.axes[1].blues.is_empty() {
         return HintedPlan {
             hinted_metrics,
-            vertical_axis,
+            axes,
         };
     }
     for dim in [Dimension::Horizontal, Dimension::Vertical] {
@@ -159,12 +145,12 @@ fn hint_outline_impl(
                 right_opos: right.opos,
             });
         }
-        if dim == Dimension::Vertical {
-            vertical_axis = Some(axis.clone());
+        if recorder.is_some() {
+            axes[dim as usize] = Some(axis.clone());
         }
     }
     HintedPlan {
         hinted_metrics,
-        vertical_axis,
+        axes,
     }
 }

--- a/skrifa/src/outline/autohint/hint/mod.rs
+++ b/skrifa/src/outline/autohint/hint/mod.rs
@@ -8,7 +8,7 @@ use super::{
     outline::Outline,
     recorder::HintsRecorder,
     style::{GlyphStyle, ScriptGroup},
-    topo::{self, Axis},
+    topo::{self, Axis, Dimension},
 };
 
 /// Captures adjusted horizontal scale and outer edge positions to be used
@@ -99,9 +99,9 @@ fn hint_outline_impl(
             vertical_axis,
         };
     }
-    for dim in 0..2 {
-        if (dim == Axis::HORIZONTAL && scale.flags & Scale::NO_HORIZONTAL != 0)
-            || (dim == Axis::VERTICAL && scale.flags & Scale::NO_VERTICAL != 0)
+    for dim in [Dimension::Horizontal, Dimension::Vertical] {
+        if (dim == Dimension::Horizontal && scale.flags & Scale::NO_HORIZONTAL != 0)
+            || (dim == Dimension::Vertical && scale.flags & Scale::NO_VERTICAL != 0)
         {
             continue;
         }
@@ -121,7 +121,7 @@ fn hint_outline_impl(
             scaled_metrics.scale.y_scale,
             group,
         );
-        if dim == Axis::VERTICAL {
+        if dim == Dimension::Vertical {
             if group != ScriptGroup::Default
                 || glyph_style
                     .map(|style| !style.is_non_base())
@@ -149,7 +149,7 @@ fn hint_outline_impl(
         outline::align_edge_points(outline, &axis, group, scale);
         outline::align_strong_points(outline, &mut axis, recorder.as_deref_mut());
         outline::align_weak_points(outline, dim);
-        if dim == 0 && axis.edges.len() > 1 {
+        if dim == Dimension::Horizontal && axis.edges.len() > 1 {
             let left = axis.edges.first().unwrap();
             let right = axis.edges.last().unwrap();
             hinted_metrics.edge_metrics = Some(EdgeMetrics {
@@ -159,7 +159,7 @@ fn hint_outline_impl(
                 right_opos: right.opos,
             });
         }
-        if dim == Axis::VERTICAL {
+        if dim == Dimension::Vertical {
             vertical_axis = Some(axis.clone());
         }
     }

--- a/skrifa/src/outline/autohint/hint/outline.rs
+++ b/skrifa/src/outline/autohint/hint/outline.rs
@@ -17,6 +17,7 @@
 use super::super::{
     metrics::{fixed_div, fixed_mul, Scale},
     outline::{Outline, Point},
+    recorder::HintsRecorder,
     style::ScriptGroup,
     topo::{Axis, Dimension},
 };
@@ -76,7 +77,11 @@ pub(crate) fn align_edge_points(
 /// Align the strong points; equivalent to the TrueType `IP` instruction.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.c#L1399>
-pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Option<()> {
+pub(crate) fn align_strong_points(
+    outline: &mut Outline,
+    axis: &mut Axis,
+    mut recorder: Option<&mut HintsRecorder>,
+) -> Option<()> {
     if axis.edges.is_empty() {
         return Some(());
     }
@@ -87,7 +92,7 @@ pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Opt
         PointMarker::TOUCHED_Y
     };
     let points = outline.points.as_mut_slice();
-    'points: for point in points {
+    'points: for (point_ix, point) in points.iter_mut().enumerate() {
         // Skip points that are already touched; do weak interpolation in the
         // next pass
         if point
@@ -106,6 +111,9 @@ pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Opt
         let edge = edges.first()?;
         let delta = edge.fpos as i32 - u;
         if delta >= 0 {
+            if let Some(recorder) = recorder.as_mut() {
+                recorder.record_ip_before(dim, point_ix);
+            }
             store_point(point, dim, edge.pos - (edge.opos - ou));
             continue;
         }
@@ -113,6 +121,9 @@ pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Opt
         let edge = edges.last()?;
         let delta = u - edge.fpos as i32;
         if delta >= 0 {
+            if let Some(recorder) = recorder.as_mut() {
+                recorder.record_ip_after(dim, point_ix);
+            }
             store_point(point, dim, edge.pos + (ou - edge.opos));
             continue;
         }
@@ -129,6 +140,9 @@ pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Opt
                 .find(|(_ix, edge)| edge.fpos as i32 >= u)
             {
                 if edge.fpos as i32 == u {
+                    if let Some(recorder) = recorder.as_mut() {
+                        recorder.record_ip_on(dim, point_ix, min_ix);
+                    }
                     store_point(point, dim, edge.pos);
                     continue 'points;
                 }
@@ -148,6 +162,9 @@ pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Opt
                     Ordering::Greater => min_ix = mid_ix + 1,
                     Ordering::Equal => {
                         // We are on an edge
+                        if let Some(recorder) = recorder.as_mut() {
+                            recorder.record_ip_on(dim, point_ix, mid_ix);
+                        }
                         store_point(point, dim, edge.pos);
                         continue 'points;
                     }
@@ -171,6 +188,9 @@ pub(crate) fn align_strong_points(outline: &mut Outline, axis: &mut Axis) -> Opt
             } else {
                 edge_before.scale
             };
+            if let Some(recorder) = recorder.as_mut() {
+                recorder.record_ip_between(dim, point_ix, before_ix, min_ix);
+            }
             store_point(point, dim, before_pos + fixed_mul(u - before_fpos, scale));
         }
     }
@@ -360,6 +380,7 @@ mod tests {
     use super::{
         super::super::{
             metrics::{compute_unscaled_style_metrics, Scale},
+            recorder::{Action, HintRecord, HintsRecorder},
             shape::{Shaper, ShaperMode},
             style,
         },
@@ -435,6 +456,55 @@ mod tests {
             }),
         };
         assert_eq!(metrics, expected_metrics);
+    }
+
+    #[test]
+    fn recorder_collects_edge_and_point_actions() {
+        let font = FontRef::new(font_test_data::NOTOSERIFHEBREW_AUTOHINT_METRICS).unwrap();
+        let shaper = Shaper::new(&font, ShaperMode::Nominal);
+        let glyph = font.outline_glyphs().get(GlyphId::new(9)).unwrap();
+        let mut outline = Outline::default();
+        outline.fill(&glyph, Default::default()).unwrap();
+        let metrics = compute_unscaled_style_metrics(
+            &shaper,
+            Default::default(),
+            &style::STYLE_CLASSES[style::StyleClass::HEBR],
+        );
+        let scale = Scale::new(
+            16.0,
+            font.head().unwrap().units_per_em() as i32,
+            Style::Normal,
+            Default::default(),
+            metrics.style_class().script.group,
+        );
+        let mut recorder = HintsRecorder::default();
+
+        super::super::hint_outline_with_recorder(
+            &mut outline,
+            &metrics,
+            &scale,
+            None,
+            Some(&mut recorder),
+        );
+
+        assert!(recorder
+            .records
+            .iter()
+            .any(|record| matches!(record, HintRecord::Edge(edge) if edge.blue.is_some())));
+        assert!(recorder.records.iter().any(|record| {
+            matches!(
+                record,
+                HintRecord::Edge(edge)
+                    if matches!(edge.action, Action::Blue | Action::BlueAnchor | Action::Anchor | Action::Stem | Action::Adjust)
+            )
+        }));
+        assert!(recorder.records.iter().any(|record| {
+            matches!(
+                record,
+                HintRecord::Point(point)
+                    if matches!(point.action, Action::IpBefore | Action::IpAfter | Action::IpOn | Action::IpBetween)
+            )
+        }));
     }
 
     #[test]

--- a/skrifa/src/outline/autohint/hint/outline.rs
+++ b/skrifa/src/outline/autohint/hint/outline.rs
@@ -464,11 +464,12 @@ mod tests {
         let shaper = Shaper::new(&font, ShaperMode::Nominal);
         let glyph = font.outline_glyphs().get(GlyphId::new(9)).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let metrics = compute_unscaled_style_metrics(
             &shaper,
-            Default::default(),
+            &[],
             &style::STYLE_CLASSES[style::StyleClass::HEBR],
+            Default::default(),
         );
         let scale = Scale::new(
             16.0,
@@ -716,8 +717,8 @@ mod tests {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(gid).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, coords).unwrap();
-        let metrics = compute_unscaled_style_metrics(&shaper, coords, style);
+        outline.fill(&glyph, coords, Default::default()).unwrap();
+        let metrics = compute_unscaled_style_metrics(&shaper, coords, style, Default::default());
         let scale = Scale::new(
             size,
             font.head().unwrap().units_per_em() as i32,

--- a/skrifa/src/outline/autohint/hint/outline.rs
+++ b/skrifa/src/outline/autohint/hint/outline.rs
@@ -20,6 +20,7 @@ use super::super::{
     recorder::HintsRecorder,
     style::ScriptGroup,
     topo::{Axis, Dimension},
+    ScaleFlags,
 };
 use core::cmp::Ordering;
 use raw::tables::glyf::PointMarker;
@@ -39,8 +40,8 @@ pub(crate) fn align_edge_points(
     // Snapping is configurable for CJK
     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L2195>
     let snap = group == ScriptGroup::Default
-        || ((axis.dim == Dimension::Horizontal && scale.flags & Scale::HORIZONTAL_SNAP != 0)
-            || (axis.dim == Dimension::Vertical && scale.flags & Scale::VERTICAL_SNAP != 0));
+        || (axis.dim == Dimension::Horizontal && scale.flags.contains(ScaleFlags::HORIZONTAL_SNAP))
+        || (axis.dim == Dimension::Vertical && scale.flags.contains(ScaleFlags::VERTICAL_SNAP));
     for segment in segments {
         let Some(edge) = segment.edge(edges) else {
             continue;

--- a/skrifa/src/outline/autohint/hint/outline.rs
+++ b/skrifa/src/outline/autohint/hint/outline.rs
@@ -39,8 +39,8 @@ pub(crate) fn align_edge_points(
     // Snapping is configurable for CJK
     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L2195>
     let snap = group == ScriptGroup::Default
-        || ((axis.dim == Axis::HORIZONTAL && scale.flags & Scale::HORIZONTAL_SNAP != 0)
-            || (axis.dim == Axis::VERTICAL && scale.flags & Scale::VERTICAL_SNAP != 0));
+        || ((axis.dim == Dimension::Horizontal && scale.flags & Scale::HORIZONTAL_SNAP != 0)
+            || (axis.dim == Dimension::Vertical && scale.flags & Scale::VERTICAL_SNAP != 0));
     for segment in segments {
         let Some(edge) = segment.edge(edges) else {
             continue;
@@ -50,7 +50,7 @@ pub(crate) fn align_edge_points(
         let last_ix = segment.last();
         loop {
             let point = points.get_mut(point_ix)?;
-            if axis.dim == Axis::HORIZONTAL {
+            if axis.dim == Dimension::Horizontal {
                 if snap {
                     point.x = edge.pos;
                 } else {
@@ -86,7 +86,7 @@ pub(crate) fn align_strong_points(
         return Some(());
     }
     let dim = axis.dim;
-    let touch_flag = if dim == Axis::HORIZONTAL {
+    let touch_flag = if dim == Dimension::Horizontal {
         PointMarker::TOUCHED_X
     } else {
         PointMarker::TOUCHED_Y
@@ -101,7 +101,7 @@ pub(crate) fn align_strong_points(
         {
             continue;
         }
-        let (u, ou) = if dim == Axis::VERTICAL {
+        let (u, ou) = if dim == Dimension::Vertical {
             (point.fy, point.oy)
         } else {
             (point.fx, point.ox)
@@ -201,7 +201,7 @@ pub(crate) fn align_strong_points(
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.c#L1673>
 pub(crate) fn align_weak_points(outline: &mut Outline, dim: Dimension) -> Option<()> {
-    let touch_marker = if dim == Axis::HORIZONTAL {
+    let touch_marker = if dim == Dimension::Horizontal {
         for point in &mut outline.points {
             point.u = point.x;
             point.v = point.ox;
@@ -277,7 +277,7 @@ pub(crate) fn align_weak_points(outline: &mut Outline, dim: Dimension) -> Option
         }
     }
     // Save interpolated values
-    if dim == Axis::HORIZONTAL {
+    if dim == Dimension::Horizontal {
         for point in &mut outline.points {
             point.x = point.u;
         }
@@ -291,7 +291,7 @@ pub(crate) fn align_weak_points(outline: &mut Outline, dim: Dimension) -> Option
 
 #[inline(always)]
 fn store_point(point: &mut Point, dim: Dimension, u: i32) {
-    if dim == Axis::HORIZONTAL {
+    if dim == Dimension::Horizontal {
         point.x = u;
         point.flags.set_marker(PointMarker::TOUCHED_X);
     } else {
@@ -380,7 +380,7 @@ mod tests {
     use super::{
         super::super::{
             metrics::{compute_unscaled_style_metrics, Scale},
-            recorder::{Action, HintRecord, HintsRecorder},
+            recorder::{EdgeAction, Hint, HintsRecorder, PointAction},
             shape::{Shaper, ShaperMode},
             style,
         },
@@ -490,19 +490,19 @@ mod tests {
         assert!(recorder
             .records
             .iter()
-            .any(|record| matches!(record, HintRecord::Edge(edge) if edge.blue.is_some())));
+            .any(|record| matches!(record, Hint::Edge(edge) if edge.blue.is_some())));
         assert!(recorder.records.iter().any(|record| {
             matches!(
                 record,
-                HintRecord::Edge(edge)
-                    if matches!(edge.action, Action::Blue | Action::BlueAnchor | Action::Anchor | Action::Stem | Action::Adjust)
+                Hint::Edge(edge)
+                    if matches!(edge.action, EdgeAction::Blue | EdgeAction::BlueAnchor | EdgeAction::Anchor | EdgeAction::Stem | EdgeAction::Adjust)
             )
         }));
         assert!(recorder.records.iter().any(|record| {
             matches!(
                 record,
-                HintRecord::Point(point)
-                    if matches!(point.action, Action::IpBefore | Action::IpAfter | Action::IpOn | Action::IpBetween)
+                Hint::Point(point)
+                    if matches!(point.action, PointAction::IpBefore | PointAction::IpAfter | PointAction::IpOn | PointAction::IpBetween)
             )
         }));
     }

--- a/skrifa/src/outline/autohint/hint/outline.rs
+++ b/skrifa/src/outline/autohint/hint/outline.rs
@@ -380,7 +380,7 @@ mod tests {
     use super::{
         super::super::{
             metrics::{compute_unscaled_style_metrics, Scale},
-            recorder::{EdgeAction, Hint, HintsRecorder, PointAction},
+            recorder::{EdgeAction, HintAction, HintsRecorder, PointAction},
             shape::{Shaper, ShaperMode},
             style,
         },
@@ -484,24 +484,24 @@ mod tests {
             &metrics,
             &scale,
             None,
-            Some(&mut recorder),
+            &mut recorder,
         );
 
         assert!(recorder
-            .records
+            .actions
             .iter()
-            .any(|record| matches!(record, Hint::Edge(edge) if edge.blue.is_some())));
-        assert!(recorder.records.iter().any(|record| {
+            .any(|record| matches!(record, HintAction::Edge(edge) if edge.blue.is_some())));
+        assert!(recorder.actions.iter().any(|record| {
             matches!(
                 record,
-                Hint::Edge(edge)
+                HintAction::Edge(edge)
                     if matches!(edge.action, EdgeAction::Blue | EdgeAction::BlueAnchor | EdgeAction::Anchor | EdgeAction::Stem | EdgeAction::Adjust)
             )
         }));
-        assert!(recorder.records.iter().any(|record| {
+        assert!(recorder.actions.iter().any(|record| {
             matches!(
                 record,
-                Hint::Point(point)
+                HintAction::Point(point)
                     if matches!(point.action, PointAction::IpBefore | PointAction::IpAfter | PointAction::IpOn | PointAction::IpBetween)
             )
         }));

--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -47,6 +47,35 @@ impl GlyphStyles {
             Self(Default::default())
         }
     }
+
+    #[cfg(feature = "autohinter")]
+    /// Returns the skrifa-internal style index for `glyph_id`, if the glyph
+    /// has been assigned to a style.  The index is into the `STYLE_CLASSES`
+    /// array.  Returns `None` for unassigned glyphs.
+    pub fn style_index(&self, glyph_id: u32) -> Option<usize> {
+        use raw::types::GlyphId;
+        self.0
+            .style(GlyphId::new(glyph_id))
+            .and_then(|s| s.style_index().map(|v| v as usize))
+    }
+
+    #[cfg(feature = "autohinter")]
+    /// Returns `true` if `glyph_id` represents an ASCII digit ('0'–'9').
+    pub fn is_digit(&self, glyph_id: u32) -> bool {
+        use raw::types::GlyphId;
+        self.0
+            .style(GlyphId::new(glyph_id))
+            .is_some_and(|s| s.is_digit())
+    }
+
+    #[cfg(feature = "autohinter")]
+    /// Returns `true` if `glyph_id` is a non-base (mark/combining) character.
+    pub fn is_non_base(&self, glyph_id: u32) -> bool {
+        use raw::types::GlyphId;
+        self.0
+            .style(GlyphId::new(glyph_id))
+            .is_some_and(|s| s.is_non_base())
+    }
 }
 
 #[derive(Clone)]

--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -10,11 +10,11 @@ use super::{
     metrics::{fixed_mul, pix_round, Scale, UnscaledStyleMetricsSet},
     outline::Outline,
     shape::{Shaper, ShaperMode},
-    style::GlyphStyleMap,
+    style::{GlyphStyle, GlyphStyleMap},
 };
 use alloc::sync::Arc;
 use raw::{
-    types::{F26Dot6, F2Dot14},
+    types::{F26Dot6, F2Dot14, GlyphId},
     FontRef, TableProvider,
 };
 
@@ -48,33 +48,9 @@ impl GlyphStyles {
         }
     }
 
-    #[cfg(feature = "autohinter")]
-    /// Returns the skrifa-internal style index for `glyph_id`, if the glyph
-    /// has been assigned to a style.  The index is into the `STYLE_CLASSES`
-    /// array.  Returns `None` for unassigned glyphs.
-    pub fn style_index(&self, glyph_id: u32) -> Option<usize> {
-        use raw::types::GlyphId;
-        self.0
-            .style(GlyphId::new(glyph_id))
-            .and_then(|s| s.style_index().map(|v| v as usize))
-    }
-
-    #[cfg(feature = "autohinter")]
-    /// Returns `true` if `glyph_id` represents an ASCII digit ('0'–'9').
-    pub fn is_digit(&self, glyph_id: u32) -> bool {
-        use raw::types::GlyphId;
-        self.0
-            .style(GlyphId::new(glyph_id))
-            .is_some_and(|s| s.is_digit())
-    }
-
-    #[cfg(feature = "autohinter")]
-    /// Returns `true` if `glyph_id` is a non-base (mark/combining) character.
-    pub fn is_non_base(&self, glyph_id: u32) -> bool {
-        use raw::types::GlyphId;
-        self.0
-            .style(GlyphId::new(glyph_id))
-            .is_some_and(|s| s.is_non_base())
+    /// Returns the style for the given glyph.
+    pub fn get(&self, gid: GlyphId) -> Option<GlyphStyle> {
+        self.0.style(gid)
     }
 }
 

--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -123,7 +123,7 @@ impl Instance {
             metrics.style_class().script.group,
         );
         let mut outline = Outline::default();
-        outline.fill(glyph, coords)?;
+        outline.fill(glyph, coords, super::QuirksMode::default())?;
         let hinted_metrics = super::hint::hint_outline(&mut outline, &metrics, &scale, Some(style));
         let h_advance = outline.advance;
         let mut pp1x = 0;

--- a/skrifa/src/outline/autohint/instance.rs
+++ b/skrifa/src/outline/autohint/instance.rs
@@ -1,7 +1,5 @@
 //! Autohinting state for a font instance.
 
-use crate::{attribute::Style, prelude::Size, MetadataProvider};
-
 use super::{
     super::{
         pen::PathStyle, AdjustedMetrics, DrawError, OutlineGlyph, OutlineGlyphCollection,
@@ -11,7 +9,9 @@ use super::{
     outline::Outline,
     shape::{Shaper, ShaperMode},
     style::{GlyphStyle, GlyphStyleMap},
+    ScaleFlags,
 };
+use crate::{attribute::Style, prelude::Size, MetadataProvider};
 use alloc::sync::Arc;
 use raw::{
     types::{F26Dot6, F2Dot14, GlyphId},
@@ -132,7 +132,7 @@ impl Instance {
         // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afloader.c#L422>
         if !is_light {
             if let (true, Some(edge_metrics)) = (
-                scale.flags & Scale::NO_ADVANCE == 0,
+                !scale.flags.contains(ScaleFlags::NO_ADVANCE),
                 hinted_metrics.edge_metrics,
             ) {
                 let old_rsb = pp2x - edge_metrics.right_opos;

--- a/skrifa/src/outline/autohint/metrics/blues.rs
+++ b/skrifa/src/outline/autohint/metrics/blues.rs
@@ -27,7 +27,7 @@ const BLUE_STRING_MAX_LEN: usize = 51;
 /// Defines the zone(s) that are associated with a blue value.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 #[repr(transparent)]
-pub(crate) struct BlueZones(u16);
+pub struct BlueZones(u16);
 
 impl BlueZones {
     // These properties ostensibly come from

--- a/skrifa/src/outline/autohint/metrics/blues.rs
+++ b/skrifa/src/outline/autohint/metrics/blues.rs
@@ -53,11 +53,11 @@ impl BlueZones {
     // Used for generated data structures because the bit-or operator
     // cannot be const.
     #[must_use]
-    pub const fn union(self, other: Self) -> Self {
+    pub(crate) const fn union(self, other: Self) -> Self {
         Self(self.0 | other.0)
     }
 
-    pub fn is_top_like(self) -> bool {
+    pub(crate) fn is_top_like(self) -> bool {
         self & (Self::TOP | Self::SUB_TOP) != Self::NONE
     }
 
@@ -77,15 +77,15 @@ impl BlueZones {
         self.contains(Self::X_HEIGHT)
     }
 
-    pub fn is_long(self) -> bool {
+    pub(crate) fn is_long(self) -> bool {
         self.contains(Self::LONG)
     }
 
-    pub fn is_horizontal(self) -> bool {
+    pub(crate) fn is_horizontal(self) -> bool {
         self.contains(Self::HORIZONTAL)
     }
 
-    pub fn is_right(self) -> bool {
+    pub(crate) fn is_right(self) -> bool {
         self.contains(Self::RIGHT)
     }
 
@@ -131,27 +131,38 @@ impl core::ops::BitAndAssign for BlueZones {
     }
 }
 
+/// An unscaled alignment zone.
 // FreeType keeps a single array of blue values per metrics set
 // and mutates when the scale factor changes. We'll separate them so
 // that we can reuse unscaled metrics as immutable state without
 // recomputing them (which is the expensive part).
 // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L77>
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-pub(crate) struct UnscaledBlue {
+pub struct UnscaledBlue {
+    /// Position of the blue.
     pub position: i32,
+    /// Overshoot value of the blue.
     pub overshoot: i32,
+    /// Maximum extent of outlines used to compute this blue.
     pub ascender: i32,
+    /// Minimum extent of outlines used to compute this blue.
     pub descender: i32,
+    /// Active zones for this blue.
     pub zones: BlueZones,
 }
 
 pub(crate) type UnscaledBlues = SmallVec<UnscaledBlue, MAX_BLUES>;
 
+/// A scaled alignment zone.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-pub(crate) struct ScaledBlue {
+pub struct ScaledBlue {
+    /// Scaled position of the blue.
     pub position: ScaledWidth,
+    /// Scaled overshoot for the blue.
     pub overshoot: ScaledWidth,
+    /// Active zones for this blue.
     pub zones: BlueZones,
+    /// True if the blue is active.
     pub is_active: bool,
 }
 

--- a/skrifa/src/outline/autohint/metrics/mod.rs
+++ b/skrifa/src/outline/autohint/metrics/mod.rs
@@ -19,6 +19,169 @@ use std::sync::{Arc, RwLock};
 pub(crate) use blues::{BlueZones, ScaledBlue, ScaledBlues, UnscaledBlue, UnscaledBlues};
 pub(crate) use scale::{compute_unscaled_style_metrics, scale_style_metrics};
 
+#[cfg(feature = "autohinter")]
+/// Public snapshot of a single unscaled blue zone.
+#[derive(Clone, Debug, Default)]
+pub struct ExportedUnscaledBlue {
+    pub reference: i32,
+    pub shoot: i32,
+    pub is_adjustment: bool,
+}
+
+#[cfg(feature = "autohinter")]
+/// Public snapshot of unscaled style metrics needed by ttfautohint.
+#[derive(Clone, Debug, Default)]
+pub struct ExportedUnscaledStyleMetrics {
+    pub digits_have_same_width: bool,
+    pub horizontal_widths: Vec<i32>,
+    pub vertical_widths: Vec<i32>,
+    pub blues: Vec<ExportedUnscaledBlue>,
+}
+
+#[cfg(feature = "autohinter")]
+/// Public snapshot of a single scaled width entry.
+#[derive(Clone, Debug, Default)]
+pub struct ExportedScaledWidth {
+    pub scaled: i32,
+    pub fitted: i32,
+}
+
+#[cfg(feature = "autohinter")]
+/// Public snapshot of a single scaled blue zone.
+#[derive(Clone, Debug, Default)]
+pub struct ExportedScaledBlue {
+    pub reference_scaled: i32,
+    pub reference_fitted: i32,
+    pub shoot_scaled: i32,
+    pub shoot_fitted: i32,
+    pub is_active: bool,
+    pub is_top: bool,
+    pub is_sub_top: bool,
+    pub is_neutral: bool,
+    pub is_adjustment: bool,
+}
+
+#[cfg(feature = "autohinter")]
+/// Public snapshot of scaled style metrics needed by ttfautohint.
+#[derive(Clone, Debug, Default)]
+pub struct ExportedScaledStyleMetrics {
+    pub digits_have_same_width: bool,
+    pub x_scale: i32,
+    pub y_scale: i32,
+    pub x_delta: i32,
+    pub y_delta: i32,
+    pub horizontal_widths: Vec<ExportedScaledWidth>,
+    pub vertical_widths: Vec<ExportedScaledWidth>,
+    pub blues: Vec<ExportedScaledBlue>,
+}
+
+#[cfg(feature = "autohinter")]
+/// Compute unscaled style metrics for a style class and expose a stable,
+/// allocation-owned representation suitable for FFI consumers.
+pub fn compute_unscaled_style_metrics_exported(
+    font: &FontRef,
+    coords: &[F2Dot14],
+    style: &StyleClass,
+) -> ExportedUnscaledStyleMetrics {
+    let shaper_mode = if cfg!(feature = "autohint_shaping") {
+        ShaperMode::BestEffort
+    } else {
+        ShaperMode::Nominal
+    };
+    let shaper = Shaper::new(font, shaper_mode);
+    let metrics = compute_unscaled_style_metrics(&shaper, coords, style);
+
+    ExportedUnscaledStyleMetrics {
+        digits_have_same_width: metrics.digits_have_same_width,
+        horizontal_widths: metrics.axes[0].widths.iter().copied().collect(),
+        vertical_widths: metrics.axes[1].widths.iter().copied().collect(),
+        blues: metrics.axes[1]
+            .blues
+            .iter()
+            .map(|blue| ExportedUnscaledBlue {
+                reference: blue.position,
+                shoot: blue.overshoot,
+                is_adjustment: blue.zones.contains(BlueZones::ADJUSTMENT),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(feature = "autohinter")]
+#[allow(clippy::too_many_arguments)]
+/// Compute scaled style metrics for a style class and expose a stable,
+/// allocation-owned representation.
+pub fn compute_scaled_style_metrics_exported(
+    font: &FontRef,
+    coords: &[F2Dot14],
+    style: &StyleClass,
+    x_scale: i32,
+    y_scale: i32,
+    x_delta: i32,
+    y_delta: i32,
+    flags: u32,
+    units_per_em: i32,
+) -> ExportedScaledStyleMetrics {
+    let shaper_mode = if cfg!(feature = "autohint_shaping") {
+        ShaperMode::BestEffort
+    } else {
+        ShaperMode::Nominal
+    };
+    let shaper = Shaper::new(font, shaper_mode);
+    let unscaled = compute_unscaled_style_metrics(&shaper, coords, style);
+    let scaled = scale_style_metrics(
+        &unscaled,
+        Scale {
+            x_scale,
+            y_scale,
+            x_delta,
+            y_delta,
+            size: 0.0,
+            units_per_em,
+            flags,
+        },
+    );
+
+    ExportedScaledStyleMetrics {
+        digits_have_same_width: unscaled.digits_have_same_width,
+        x_scale: scaled.scale.x_scale,
+        y_scale: scaled.scale.y_scale,
+        x_delta: scaled.scale.x_delta,
+        y_delta: scaled.scale.y_delta,
+        horizontal_widths: scaled.axes[0]
+            .widths
+            .iter()
+            .map(|width| ExportedScaledWidth {
+                scaled: width.scaled,
+                fitted: width.fitted,
+            })
+            .collect(),
+        vertical_widths: scaled.axes[1]
+            .widths
+            .iter()
+            .map(|width| ExportedScaledWidth {
+                scaled: width.scaled,
+                fitted: width.fitted,
+            })
+            .collect(),
+        blues: scaled.axes[1]
+            .blues
+            .iter()
+            .map(|blue| ExportedScaledBlue {
+                reference_scaled: blue.position.scaled,
+                reference_fitted: blue.position.fitted,
+                shoot_scaled: blue.overshoot.scaled,
+                shoot_fitted: blue.overshoot.fitted,
+                is_active: blue.is_active,
+                is_top: blue.zones.contains(BlueZones::TOP),
+                is_sub_top: blue.zones.contains(BlueZones::SUB_TOP),
+                is_neutral: blue.zones.contains(BlueZones::NEUTRAL),
+                is_adjustment: blue.zones.contains(BlueZones::ADJUSTMENT),
+            })
+            .collect(),
+    }
+}
+
 /// Maximum number of widths, same for Latin and CJK.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L65>

--- a/skrifa/src/outline/autohint/metrics/mod.rs
+++ b/skrifa/src/outline/autohint/metrics/mod.rs
@@ -246,10 +246,93 @@ pub struct ScaledWidth {
 
 pub(crate) type ScaledWidths = SmallVec<ScaledWidth, MAX_WIDTHS>;
 
+/// Flags that define how scaling and hinting is applied.
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+pub struct ScaleFlags(pub(crate) u32);
+
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aftypes.h#L115>
+// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L143>
+impl ScaleFlags {
+    /// Stem width snapping.
+    pub const HORIZONTAL_SNAP: Self = Self(1 << 0);
+    /// Stem height snapping.
+    pub const VERTICAL_SNAP: Self = Self(1 << 1);
+    /// Stem width/height adjustment.
+    pub const STEM_ADJUST: Self = Self(1 << 2);
+    /// Monochrome rendering.
+    pub const MONO: Self = Self(1 << 3);
+    /// Disable horizontal hinting.
+    pub const NO_HORIZONTAL: Self = Self(1 << 4);
+    /// Disable vertical hinting.
+    pub const NO_VERTICAL: Self = Self(1 << 5);
+    /// Disable advance hinting.
+    pub const NO_ADVANCE: Self = Self(1 << 6);
+}
+
+impl ScaleFlags {
+    /// Creates new flags, truncating the given bits to valid values.
+    pub const fn from_bits_truncate(bits: u32) -> Self {
+        Self(bits & 0b1111111)
+    }
+
+    /// Returns the underlying flag bits.
+    pub const fn to_bits(self) -> u32 {
+        self.0
+    }
+
+    /// Returns true if `self` contains all flags in `other`.
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Returns true if `self` contains any flags in `other`.
+    pub const fn intersects(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+impl core::ops::Not for ScaleFlags {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self(!self.0)
+    }
+}
+
+impl core::ops::BitOr for ScaleFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for ScaleFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl core::ops::BitAnd for ScaleFlags {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl core::ops::BitAndAssign for ScaleFlags {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
 /// Captures scaling parameters which may be modified during metrics
 /// computation.
 #[derive(Copy, Clone, Default, Debug)]
 pub struct Scale {
+    /// Flags that determine hinting functionality.
+    pub flags: ScaleFlags,
     /// Font unit to 26.6 scale in the X direction.
     pub x_scale: i32,
     /// Font unit to 26.6 scale in the Y direction.
@@ -262,8 +345,6 @@ pub struct Scale {
     pub size: f32,
     /// From the source font.
     pub units_per_em: i32,
-    /// Flags that determine hinting functionality.
-    pub flags: u32,
 }
 
 impl Scale {
@@ -277,41 +358,41 @@ impl Scale {
     ) -> Self {
         let scale =
             (Fixed::from_bits((size * 64.0) as i32) / Fixed::from_bits(units_per_em)).to_bits();
-        let mut flags = 0;
+        let mut flags = ScaleFlags::default();
         let is_italic = font_style != Style::Normal;
         let is_mono = target == Target::Mono;
         let is_light = target.is_light() || target.preserve_linear_metrics();
         // Snap vertical stems for monochrome and horizontal LCD rendering.
         if is_mono || target.is_lcd() {
-            flags |= Self::HORIZONTAL_SNAP;
+            flags |= ScaleFlags::HORIZONTAL_SNAP;
         }
         // Snap horizontal stems for monochrome and vertical LCD rendering.
         if is_mono || target.is_vertical_lcd() {
-            flags |= Self::VERTICAL_SNAP;
+            flags |= ScaleFlags::VERTICAL_SNAP;
         }
         // Adjust stems to full pixels unless in LCD or light modes.
         if !(target.is_lcd() || is_light) {
-            flags |= Self::STEM_ADJUST;
+            flags |= ScaleFlags::STEM_ADJUST;
         }
         if is_mono {
-            flags |= Self::MONO;
+            flags |= ScaleFlags::MONO;
         }
         if group == ScriptGroup::Default {
             // Disable horizontal hinting completely for LCD, light hinting
             // and italic fonts
             // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L2674>
             if target.is_lcd() || is_light || is_italic {
-                flags |= Self::NO_HORIZONTAL;
+                flags |= ScaleFlags::NO_HORIZONTAL;
             }
         } else {
             // CJK doesn't hint advances
             // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L1432>
-            flags |= Self::NO_ADVANCE;
+            flags |= ScaleFlags::NO_ADVANCE;
         }
         // CJK doesn't hint advances
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L1432>
         if group != ScriptGroup::Default {
-            flags |= Self::NO_ADVANCE;
+            flags |= ScaleFlags::NO_ADVANCE;
         }
         Self {
             x_scale: scale,
@@ -323,27 +404,6 @@ impl Scale {
             flags,
         }
     }
-}
-
-/// Scaler flags that determine hinting settings.
-///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aftypes.h#L115>
-/// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L143>
-impl Scale {
-    /// Stem width snapping.
-    pub const HORIZONTAL_SNAP: u32 = 1 << 0;
-    /// Stem height snapping.
-    pub const VERTICAL_SNAP: u32 = 1 << 1;
-    /// Stem width/height adjustment.
-    pub const STEM_ADJUST: u32 = 1 << 2;
-    /// Monochrome rendering.
-    pub const MONO: u32 = 1 << 3;
-    /// Disable horizontal hinting.
-    pub const NO_HORIZONTAL: u32 = 1 << 4;
-    /// Disable vertical hinting.
-    pub const NO_VERTICAL: u32 = 1 << 5;
-    /// Disable advance hinting.
-    pub const NO_ADVANCE: u32 = 1 << 6;
 }
 
 // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.c#L59>

--- a/skrifa/src/outline/autohint/metrics/mod.rs
+++ b/skrifa/src/outline/autohint/metrics/mod.rs
@@ -9,6 +9,7 @@ use super::{
     shape::{Shaper, ShaperMode},
     style::{GlyphStyleMap, ScriptGroup, StyleClass},
     topo::Dimension,
+    QuirksMode,
 };
 use crate::{attribute::Style, collections::SmallVec, FontRef};
 use alloc::vec::Vec;
@@ -145,11 +146,9 @@ impl UnscaledStyleMetricsSet {
         // over allocating memory.
         let shaper = Shaper::new(font, shaper_mode);
         let mut vec = Vec::with_capacity(style_map.metrics_count());
-        vec.extend(
-            style_map
-                .metrics_styles()
-                .map(|style| compute_unscaled_style_metrics(&shaper, coords, style)),
-        );
+        vec.extend(style_map.metrics_styles().map(|style| {
+            compute_unscaled_style_metrics(&shaper, coords, style, QuirksMode::default())
+        }));
         Self::Precomputed(vec)
     }
 
@@ -188,7 +187,12 @@ impl UnscaledStyleMetricsSet {
                 // metrics.
                 let shaper = Shaper::new(font, shaper_mode);
                 let style_class = style.style_class()?;
-                let metrics = compute_unscaled_style_metrics(&shaper, coords, style_class);
+                let metrics = compute_unscaled_style_metrics(
+                    &shaper,
+                    coords,
+                    style_class,
+                    QuirksMode::default(),
+                );
                 let mut entry = lazy.write().unwrap();
                 *entry.get_mut(index)? = Some(metrics.clone());
                 Some(metrics)

--- a/skrifa/src/outline/autohint/metrics/mod.rs
+++ b/skrifa/src/outline/autohint/metrics/mod.rs
@@ -16,171 +16,9 @@ use raw::types::{F2Dot14, Fixed, GlyphId};
 #[cfg(feature = "std")]
 use std::sync::{Arc, RwLock};
 
-pub(crate) use blues::{BlueZones, ScaledBlue, ScaledBlues, UnscaledBlue, UnscaledBlues};
+pub use blues::{BlueZones, ScaledBlue, UnscaledBlue};
+pub(crate) use blues::{ScaledBlues, UnscaledBlues};
 pub(crate) use scale::{compute_unscaled_style_metrics, scale_style_metrics};
-
-#[cfg(feature = "autohinter")]
-/// Public snapshot of a single unscaled blue zone.
-#[derive(Clone, Debug, Default)]
-pub struct ExportedUnscaledBlue {
-    pub reference: i32,
-    pub shoot: i32,
-    pub is_adjustment: bool,
-}
-
-#[cfg(feature = "autohinter")]
-/// Public snapshot of unscaled style metrics needed by ttfautohint.
-#[derive(Clone, Debug, Default)]
-pub struct ExportedUnscaledStyleMetrics {
-    pub digits_have_same_width: bool,
-    pub horizontal_widths: Vec<i32>,
-    pub vertical_widths: Vec<i32>,
-    pub blues: Vec<ExportedUnscaledBlue>,
-}
-
-#[cfg(feature = "autohinter")]
-/// Public snapshot of a single scaled width entry.
-#[derive(Clone, Debug, Default)]
-pub struct ExportedScaledWidth {
-    pub scaled: i32,
-    pub fitted: i32,
-}
-
-#[cfg(feature = "autohinter")]
-/// Public snapshot of a single scaled blue zone.
-#[derive(Clone, Debug, Default)]
-pub struct ExportedScaledBlue {
-    pub reference_scaled: i32,
-    pub reference_fitted: i32,
-    pub shoot_scaled: i32,
-    pub shoot_fitted: i32,
-    pub is_active: bool,
-    pub is_top: bool,
-    pub is_sub_top: bool,
-    pub is_neutral: bool,
-    pub is_adjustment: bool,
-}
-
-#[cfg(feature = "autohinter")]
-/// Public snapshot of scaled style metrics needed by ttfautohint.
-#[derive(Clone, Debug, Default)]
-pub struct ExportedScaledStyleMetrics {
-    pub digits_have_same_width: bool,
-    pub x_scale: i32,
-    pub y_scale: i32,
-    pub x_delta: i32,
-    pub y_delta: i32,
-    pub horizontal_widths: Vec<ExportedScaledWidth>,
-    pub vertical_widths: Vec<ExportedScaledWidth>,
-    pub blues: Vec<ExportedScaledBlue>,
-}
-
-#[cfg(feature = "autohinter")]
-/// Compute unscaled style metrics for a style class and expose a stable,
-/// allocation-owned representation suitable for FFI consumers.
-pub fn compute_unscaled_style_metrics_exported(
-    font: &FontRef,
-    coords: &[F2Dot14],
-    style: &StyleClass,
-) -> ExportedUnscaledStyleMetrics {
-    let shaper_mode = if cfg!(feature = "autohint_shaping") {
-        ShaperMode::BestEffort
-    } else {
-        ShaperMode::Nominal
-    };
-    let shaper = Shaper::new(font, shaper_mode);
-    let metrics = compute_unscaled_style_metrics(&shaper, coords, style);
-
-    ExportedUnscaledStyleMetrics {
-        digits_have_same_width: metrics.digits_have_same_width,
-        horizontal_widths: metrics.axes[0].widths.iter().copied().collect(),
-        vertical_widths: metrics.axes[1].widths.iter().copied().collect(),
-        blues: metrics.axes[1]
-            .blues
-            .iter()
-            .map(|blue| ExportedUnscaledBlue {
-                reference: blue.position,
-                shoot: blue.overshoot,
-                is_adjustment: blue.zones.contains(BlueZones::ADJUSTMENT),
-            })
-            .collect(),
-    }
-}
-
-#[cfg(feature = "autohinter")]
-#[allow(clippy::too_many_arguments)]
-/// Compute scaled style metrics for a style class and expose a stable,
-/// allocation-owned representation.
-pub fn compute_scaled_style_metrics_exported(
-    font: &FontRef,
-    coords: &[F2Dot14],
-    style: &StyleClass,
-    x_scale: i32,
-    y_scale: i32,
-    x_delta: i32,
-    y_delta: i32,
-    flags: u32,
-    units_per_em: i32,
-) -> ExportedScaledStyleMetrics {
-    let shaper_mode = if cfg!(feature = "autohint_shaping") {
-        ShaperMode::BestEffort
-    } else {
-        ShaperMode::Nominal
-    };
-    let shaper = Shaper::new(font, shaper_mode);
-    let unscaled = compute_unscaled_style_metrics(&shaper, coords, style);
-    let scaled = scale_style_metrics(
-        &unscaled,
-        Scale {
-            x_scale,
-            y_scale,
-            x_delta,
-            y_delta,
-            size: 0.0,
-            units_per_em,
-            flags,
-        },
-    );
-
-    ExportedScaledStyleMetrics {
-        digits_have_same_width: unscaled.digits_have_same_width,
-        x_scale: scaled.scale.x_scale,
-        y_scale: scaled.scale.y_scale,
-        x_delta: scaled.scale.x_delta,
-        y_delta: scaled.scale.y_delta,
-        horizontal_widths: scaled.axes[0]
-            .widths
-            .iter()
-            .map(|width| ExportedScaledWidth {
-                scaled: width.scaled,
-                fitted: width.fitted,
-            })
-            .collect(),
-        vertical_widths: scaled.axes[1]
-            .widths
-            .iter()
-            .map(|width| ExportedScaledWidth {
-                scaled: width.scaled,
-                fitted: width.fitted,
-            })
-            .collect(),
-        blues: scaled.axes[1]
-            .blues
-            .iter()
-            .map(|blue| ExportedScaledBlue {
-                reference_scaled: blue.position.scaled,
-                reference_fitted: blue.position.fitted,
-                shoot_scaled: blue.overshoot.scaled,
-                shoot_fitted: blue.overshoot.fitted,
-                is_active: blue.is_active,
-                is_top: blue.zones.contains(BlueZones::TOP),
-                is_sub_top: blue.zones.contains(BlueZones::SUB_TOP),
-                is_neutral: blue.zones.contains(BlueZones::NEUTRAL),
-                is_adjustment: blue.zones.contains(BlueZones::ADJUSTMENT),
-            })
-            .collect(),
-    }
-}
 
 /// Maximum number of widths, same for Latin and CJK.
 ///
@@ -195,14 +33,27 @@ pub(crate) const MAX_WIDTHS: usize = 16;
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L88>
 /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.h#L73>
 #[derive(Clone, Default, Debug)]
-pub(crate) struct UnscaledAxisMetrics {
+pub struct UnscaledAxisMetrics {
+    /// The dimension of this axis.
     pub dim: Dimension,
-    pub widths: UnscaledWidths,
+    pub(crate) widths: UnscaledWidths,
+    /// The unscaled width metrics for the axis.
     pub width_metrics: WidthMetrics,
-    pub blues: UnscaledBlues,
+    pub(crate) blues: UnscaledBlues,
 }
 
 impl UnscaledAxisMetrics {
+    /// Returns the set of unscaled widths.
+    pub fn widths(&self) -> &[i32] {
+        self.widths.as_slice()
+    }
+
+    /// Returns the set of unscaled blues.
+    pub fn blues(&self) -> &[UnscaledBlue] {
+        self.blues.as_slice()
+    }
+
+    /// Returns the largest width, if any.
     pub fn max_width(&self) -> Option<i32> {
         self.widths.last().copied()
     }
@@ -210,38 +61,63 @@ impl UnscaledAxisMetrics {
 
 /// Scaled metrics for a single axis.
 #[derive(Clone, Default, Debug)]
-pub(crate) struct ScaledAxisMetrics {
+pub struct ScaledAxisMetrics {
+    /// The dimension of this axis.
     pub dim: Dimension,
     /// Font unit to 26.6 scale in the axis direction.
     pub scale: i32,
     /// 1/64 pixel delta in the axis direction.
     pub delta: i32,
-    pub widths: ScaledWidths,
+    pub(crate) widths: ScaledWidths,
+    /// The scaled width metrics.
     pub width_metrics: WidthMetrics,
-    pub blues: ScaledBlues,
+    pub(crate) blues: ScaledBlues,
+}
+
+impl ScaledAxisMetrics {
+    /// Returns the set of scaled widths.
+    pub fn widths(&self) -> &[ScaledWidth] {
+        self.widths.as_slice()
+    }
+
+    /// Returns the set of scaled blues.
+    pub fn blues(&self) -> &[ScaledBlue] {
+        self.blues.as_slice()
+    }
 }
 
 /// Unscaled metrics for a single style and script.
-///
-/// This is the union of the root, Latin and CJK style metrics but
-/// the latter two are actually identical.
-///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aftypes.h#L413>
-/// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L109>
-/// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.h#L95>
+//
+// This is the union of the root, Latin and CJK style metrics but
+// the latter two are actually identical.
+//
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aftypes.h#L413>
+// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.h#L109>
+// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.h#L95>
 #[derive(Clone, Default, Debug)]
-pub(crate) struct UnscaledStyleMetrics {
+pub struct UnscaledStyleMetrics {
     /// Index of style class.
-    pub class_ix: u16,
+    pub(crate) class_ix: u16,
     /// Monospaced digits?
     pub digits_have_same_width: bool,
     /// Per-dimension unscaled metrics.
-    pub axes: [UnscaledAxisMetrics; 2],
+    pub(crate) axes: [UnscaledAxisMetrics; 2],
 }
 
 impl UnscaledStyleMetrics {
+    /// Returns the associated style class.
     pub fn style_class(&self) -> &'static StyleClass {
         &super::style::STYLE_CLASSES[self.class_ix as usize]
+    }
+
+    /// Returns unscaled metrics for the horizontal axis.
+    pub fn horizontal_metrics(&self) -> &UnscaledAxisMetrics {
+        &self.axes[0]
+    }
+
+    /// Returns unscaled metrics for the vertical axis.
+    pub fn vertical_metrics(&self) -> &UnscaledAxisMetrics {
+        &self.axes[1]
     }
 }
 
@@ -323,15 +199,28 @@ impl UnscaledStyleMetricsSet {
 
 /// Scaled metrics for a single style and script.
 #[derive(Clone, Default, Debug)]
-pub(crate) struct ScaledStyleMetrics {
+pub struct ScaledStyleMetrics {
     /// Multidimensional scaling factors and deltas.
     pub scale: Scale,
     /// Per-dimension scaled metrics.
-    pub axes: [ScaledAxisMetrics; 2],
+    pub(crate) axes: [ScaledAxisMetrics; 2],
 }
 
+impl ScaledStyleMetrics {
+    /// Returns unscaled metrics for the horizontal axis.
+    pub fn horizontal_metrics(&self) -> &ScaledAxisMetrics {
+        &self.axes[0]
+    }
+
+    /// Returns unscaled metrics for the vertical axis.
+    pub fn vertical_metrics(&self) -> &ScaledAxisMetrics {
+        &self.axes[1]
+    }
+}
+
+/// Metrics for the set of stems along a single axis.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-pub(crate) struct WidthMetrics {
+pub struct WidthMetrics {
     /// Used for creating edges.
     pub edge_distance_threshold: i32,
     /// Default stem thickness.
@@ -342,8 +231,9 @@ pub(crate) struct WidthMetrics {
 
 pub(crate) type UnscaledWidths = SmallVec<i32, MAX_WIDTHS>;
 
+/// A scaled stem width.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-pub(crate) struct ScaledWidth {
+pub struct ScaledWidth {
     /// Width after applying scale.
     pub scaled: i32,
     /// Grid-fitted width.
@@ -355,7 +245,7 @@ pub(crate) type ScaledWidths = SmallVec<ScaledWidth, MAX_WIDTHS>;
 /// Captures scaling parameters which may be modified during metrics
 /// computation.
 #[derive(Copy, Clone, Default, Debug)]
-pub(crate) struct Scale {
+pub struct Scale {
     /// Font unit to 26.6 scale in the X direction.
     pub x_scale: i32,
     /// Font unit to 26.6 scale in the Y direction.

--- a/skrifa/src/outline/autohint/metrics/scale.rs
+++ b/skrifa/src/outline/autohint/metrics/scale.rs
@@ -156,14 +156,23 @@ fn scale_default_axis_metrics(
             }
         }
     }
-    // Now scale the widths
+    // Now scale the widths. FreeType ensures there is always at least one
+    // width entry (the standard width), even if width extraction found none.
     axis.width_metrics = width_metrics;
-    for unscaled_width in widths {
-        let scaled = fixed_mul(axis.scale, *unscaled_width);
+    if widths.is_empty() {
+        let scaled = fixed_mul(axis.scale, axis.width_metrics.standard_width);
         axis.widths.push(ScaledWidth {
             scaled,
             fitted: scaled,
         });
+    } else {
+        for unscaled_width in widths {
+            let scaled = fixed_mul(axis.scale, *unscaled_width);
+            axis.widths.push(ScaledWidth {
+                scaled,
+                fitted: scaled,
+            });
+        }
     }
     // Compute extra light property: this is a standard width that is
     // less than 5/8 pixels

--- a/skrifa/src/outline/autohint/metrics/scale.rs
+++ b/skrifa/src/outline/autohint/metrics/scale.rs
@@ -12,12 +12,31 @@ use super::super::{
         ScaledBlue, ScaledStyleMetrics, ScaledWidth, UnscaledAxisMetrics, UnscaledBlue,
         UnscaledStyleMetrics, WidthMetrics,
     },
-    shape::Shaper,
+    shape::{Shaper, ShaperMode},
     style::{ScriptGroup, StyleClass},
-    topo::{Axis, Dimension},
+    topo::Dimension,
 };
-use crate::{prelude::Size, MetadataProvider};
+use crate::{instance::NormalizedCoord, prelude::Size, FontRef, MetadataProvider};
 use raw::types::F2Dot14;
+
+impl UnscaledStyleMetrics {
+    /// Creates a set of metrics for the given font, normalized coordinates
+    /// and style class.
+    pub fn new(font: &FontRef, coords: &[NormalizedCoord], style: &StyleClass) -> Self {
+        let shaper_mode = if cfg!(feature = "autohint_shaping") {
+            ShaperMode::BestEffort
+        } else {
+            ShaperMode::Nominal
+        };
+        let shaper = Shaper::new(font, shaper_mode);
+        compute_unscaled_style_metrics(&shaper, coords, style)
+    }
+
+    /// Applies the given scale to this set of style metrics.
+    pub fn scale(&self, scale: Scale) -> ScaledStyleMetrics {
+        scale_style_metrics(self, scale)
+    }
+}
 
 /// Computes unscaled metrics for the Latin writing system.
 ///
@@ -36,11 +55,11 @@ pub(crate) fn compute_unscaled_style_metrics(
             class_ix: style.index as u16,
             axes: [
                 UnscaledAxisMetrics {
-                    dim: Axis::HORIZONTAL,
+                    dim: Dimension::Horizontal,
                     ..Default::default()
                 },
                 UnscaledAxisMetrics {
-                    dim: Axis::VERTICAL,
+                    dim: Dimension::Vertical,
                     ..Default::default()
                 },
             ],
@@ -69,13 +88,13 @@ pub(crate) fn compute_unscaled_style_metrics(
         digits_have_same_width,
         axes: [
             UnscaledAxisMetrics {
-                dim: Axis::HORIZONTAL,
+                dim: Dimension::Horizontal,
                 blues: hblues,
                 width_metrics: hwidths.0,
                 widths: hwidths.1,
             },
             UnscaledAxisMetrics {
-                dim: Axis::VERTICAL,
+                dim: Dimension::Vertical,
                 blues: vblues,
                 width_metrics: vwidths.0,
                 widths: vwidths.1,
@@ -126,7 +145,7 @@ fn scale_default_axis_metrics(
         dim,
         ..Default::default()
     };
-    if dim == Axis::HORIZONTAL {
+    if dim == Dimension::Horizontal {
         axis.scale = scale.x_scale;
         axis.delta = scale.x_delta;
     } else {
@@ -141,7 +160,7 @@ fn scale_default_axis_metrics(
         let unscaled_blue = &blues[blue_ix];
         let scaled = fixed_mul(axis.scale, unscaled_blue.overshoot);
         let fitted = (scaled + 40) & !63;
-        if scaled != fitted && dim == Axis::VERTICAL {
+        if scaled != fitted && dim == Dimension::Vertical {
             let new_scale = fixed_mul_div(axis.scale, fitted, scaled);
             // Scaling should not adjust by more than 2 pixels
             let mut max_height = scale.units_per_em;
@@ -178,7 +197,7 @@ fn scale_default_axis_metrics(
     // less than 5/8 pixels
     axis.width_metrics.is_extra_light =
         fixed_mul(axis.width_metrics.standard_width, axis.scale) < (32 + 8);
-    if dim == Axis::VERTICAL {
+    if dim == Dimension::Vertical {
         // And scale the blue zones
         for unscaled_blue in blues {
             let scaled_position = fixed_mul(axis.scale, unscaled_blue.position) + axis.delta;
@@ -253,7 +272,7 @@ fn scale_cjk_axis_metrics(
         ..Default::default()
     };
     axis.dim = dim;
-    if dim == Axis::HORIZONTAL {
+    if dim == Dimension::Horizontal {
         axis.scale = scale.x_scale;
         axis.delta = scale.x_delta;
     } else {

--- a/skrifa/src/outline/autohint/metrics/scale.rs
+++ b/skrifa/src/outline/autohint/metrics/scale.rs
@@ -15,6 +15,7 @@ use super::super::{
     shape::{Shaper, ShaperMode},
     style::{ScriptGroup, StyleClass},
     topo::Dimension,
+    QuirksMode,
 };
 use crate::{instance::NormalizedCoord, prelude::Size, FontRef, MetadataProvider};
 use raw::types::F2Dot14;
@@ -29,12 +30,12 @@ impl UnscaledStyleMetrics {
             ShaperMode::Nominal
         };
         let shaper = Shaper::new(font, shaper_mode);
-        compute_unscaled_style_metrics(&shaper, coords, style)
+        compute_unscaled_style_metrics(&shaper, coords, style, QuirksMode::Aot)
     }
 
     /// Applies the given scale to this set of style metrics.
     pub fn scale(&self, scale: Scale) -> ScaledStyleMetrics {
-        scale_style_metrics(self, scale)
+        scale_style_metrics(self, scale, QuirksMode::Aot)
     }
 }
 
@@ -45,6 +46,7 @@ pub(crate) fn compute_unscaled_style_metrics(
     shaper: &Shaper,
     coords: &[F2Dot14],
     style: &StyleClass,
+    quirks: QuirksMode,
 ) -> UnscaledStyleMetrics {
     let charmap = shaper.charmap();
     // We don't attempt to produce any metrics if we don't have a Unicode
@@ -66,7 +68,7 @@ pub(crate) fn compute_unscaled_style_metrics(
             ..Default::default()
         };
     }
-    let [hwidths, vwidths] = super::widths::compute_widths(shaper, coords, style);
+    let [hwidths, vwidths] = super::widths::compute_widths(shaper, coords, style, quirks);
     let [hblues, vblues] = super::blues::compute_unscaled_blues(shaper, coords, style);
     let glyph_metrics = shaper.font().glyph_metrics(Size::unscaled(), coords);
     let mut digit_advance = None;
@@ -109,6 +111,7 @@ pub(crate) fn compute_unscaled_style_metrics(
 pub(crate) fn scale_style_metrics(
     unscaled_metrics: &UnscaledStyleMetrics,
     mut scale: Scale,
+    quirks: QuirksMode,
 ) -> ScaledStyleMetrics {
     let scale_axis_fn = if unscaled_metrics.style_class().script.group == ScriptGroup::Default {
         scale_default_axis_metrics
@@ -122,6 +125,7 @@ pub(crate) fn scale_style_metrics(
             axis.width_metrics,
             &axis.blues,
             &mut scale,
+            quirks,
         )
     };
     let axes = [
@@ -140,6 +144,7 @@ fn scale_default_axis_metrics(
     width_metrics: WidthMetrics,
     blues: &[UnscaledBlue],
     scale: &mut Scale,
+    quirks: QuirksMode,
 ) -> ScaledAxisMetrics {
     let mut axis = ScaledAxisMetrics {
         dim,
@@ -178,7 +183,7 @@ fn scale_default_axis_metrics(
     // Now scale the widths. FreeType ensures there is always at least one
     // width entry (the standard width), even if width extraction found none.
     axis.width_metrics = width_metrics;
-    if widths.is_empty() {
+    if widths.is_empty() && quirks == QuirksMode::Aot {
         let scaled = fixed_mul(axis.scale, axis.width_metrics.standard_width);
         axis.widths.push(ScaledWidth {
             scaled,
@@ -266,6 +271,7 @@ fn scale_cjk_axis_metrics(
     width_metrics: WidthMetrics,
     blues: &[UnscaledBlue],
     scale: &mut Scale,
+    _quirks: QuirksMode,
 ) -> ScaledAxisMetrics {
     let mut axis = ScaledAxisMetrics {
         dim,
@@ -410,7 +416,12 @@ mod tests {
         let font = FontRef::new(font_data).unwrap();
         let class = &style::STYLE_CLASSES[style_class];
         let shaper = Shaper::new(&font, ShaperMode::Nominal);
-        let unscaled_metrics = compute_unscaled_style_metrics(&shaper, Default::default(), class);
+        let unscaled_metrics = compute_unscaled_style_metrics(
+            &shaper,
+            Default::default(),
+            class,
+            QuirksMode::default(),
+        );
         let scale = Scale::new(
             16.0,
             font.head().unwrap().units_per_em() as i32,
@@ -418,7 +429,7 @@ mod tests {
             Default::default(),
             class.script.group,
         );
-        scale_style_metrics(&unscaled_metrics, scale)
+        scale_style_metrics(&unscaled_metrics, scale, QuirksMode::default())
     }
 
     fn check_axis(

--- a/skrifa/src/outline/autohint/metrics/widths.rs
+++ b/skrifa/src/outline/autohint/metrics/widths.rs
@@ -6,7 +6,7 @@ use super::super::{
     outline::Outline,
     shape::{ShapedCluster, Shaper},
     style::{ScriptGroup, StyleClass},
-    topo::{compute_segments, link_segments, Axis},
+    topo::{compute_segments, link_segments, Axis, Dimension},
 };
 use crate::MetadataProvider;
 use raw::{types::F2Dot14, TableProvider};
@@ -51,7 +51,10 @@ pub(super) fn compute_widths(
     if let Some(glyph) = glyph {
         if outline.fill(&glyph, coords).is_ok() && !outline.points.is_empty() {
             // Now process each dimension
-            for (dim, (_metrics, widths)) in result.iter_mut().enumerate() {
+            for (dim, (_metrics, widths)) in [Dimension::Horizontal, Dimension::Vertical]
+                .into_iter()
+                .zip(result.iter_mut())
+            {
                 axis.reset(dim, outline.orientation);
                 // Segment computation for widths always uses the default
                 // script group

--- a/skrifa/src/outline/autohint/metrics/widths.rs
+++ b/skrifa/src/outline/autohint/metrics/widths.rs
@@ -7,6 +7,7 @@ use super::super::{
     shape::{ShapedCluster, Shaper},
     style::{ScriptGroup, StyleClass},
     topo::{compute_segments, link_segments, Axis, Dimension},
+    QuirksMode,
 };
 use crate::MetadataProvider;
 use raw::{types::F2Dot14, TableProvider};
@@ -21,6 +22,7 @@ pub(super) fn compute_widths(
     shaper: &Shaper,
     coords: &[F2Dot14],
     style: &StyleClass,
+    quirks: QuirksMode,
 ) -> [(WidthMetrics, UnscaledWidths); 2] {
     let mut result: [(WidthMetrics, UnscaledWidths); 2] = Default::default();
     let font = shaper.font();
@@ -49,7 +51,7 @@ pub(super) fn compute_widths(
         })
         .next();
     if let Some(glyph) = glyph {
-        if outline.fill(&glyph, coords).is_ok() && !outline.points.is_empty() {
+        if outline.fill(&glyph, coords, quirks).is_ok() && !outline.points.is_empty() {
             // Now process each dimension
             for (dim, (_metrics, widths)) in [Dimension::Horizontal, Dimension::Vertical]
                 .into_iter()
@@ -199,7 +201,7 @@ mod tests {
         let shaper = Shaper::new(&font, ShaperMode::Nominal);
         let script = &style::STYLE_CLASSES[style_class];
         let [(hori_metrics, hori_widths), (vert_metrics, vert_widths)] =
-            compute_widths(&shaper, Default::default(), script);
+            compute_widths(&shaper, Default::default(), script, QuirksMode::default());
         assert_eq!(hori_metrics, expected[0].0);
         assert_eq!(hori_widths.as_slice(), expected[0].1);
         assert_eq!(vert_metrics, expected[1].0);

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -4,12 +4,300 @@ mod hint;
 mod instance;
 mod metrics;
 mod outline;
+mod recorder;
 mod shape;
 mod style;
 mod topo;
 
 pub use instance::GlyphStyles;
 pub(crate) use instance::Instance;
+#[cfg(feature = "autohinter")]
+pub use metrics::{
+    compute_scaled_style_metrics_exported, compute_unscaled_style_metrics_exported,
+    ExportedScaledBlue, ExportedScaledStyleMetrics, ExportedScaledWidth, ExportedUnscaledBlue,
+    ExportedUnscaledStyleMetrics,
+};
+
+#[cfg(feature = "autohinter")]
+pub use style::{SCRIPT_CLASSES, STYLE_CLASSES};
+
+#[cfg(feature = "autohinter")]
+use crate::outline::{SmoothMode, Target};
+#[cfg(feature = "autohinter")]
+use crate::{FontRef, MetadataProvider};
+#[cfg(feature = "autohinter")]
+use alloc::vec::Vec;
+#[cfg(feature = "autohinter")]
+use raw::types::{F2Dot14, GlyphId};
+
+#[cfg(feature = "autohinter")]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub struct ExportedHintRecord {
+    pub action: u8,
+    pub dim: u8,
+    pub point_ix: u16,
+    pub edge_ix: u16,
+    pub edge2_ix: u16,
+    pub edge3_ix: u16,
+    pub lower_bound_ix: u16,
+    pub upper_bound_ix: u16,
+}
+
+#[cfg(feature = "autohinter")]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub struct ExportedHintSegment {
+    pub flags: u8,
+    pub dir: i8,
+    pub pos: i16,
+    pub delta: i16,
+    pub min_coord: i16,
+    pub max_coord: i16,
+    pub height: i16,
+    pub score: i32,
+    pub len: i32,
+    pub link_ix: u16,
+    pub serif_ix: u16,
+    pub first_ix: u16,
+    pub last_ix: u16,
+    pub edge_ix: u16,
+    pub edge_next_ix: u16,
+}
+
+#[cfg(feature = "autohinter")]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub struct ExportedHintEdge {
+    pub fpos: i16,
+    pub opos: i32,
+    pub pos: i32,
+    pub flags: u8,
+    pub dir: i8,
+    pub link_ix: u16,
+    pub serif_ix: u16,
+    pub scale: i32,
+    pub first_ix: u16,
+    pub last_ix: u16,
+    pub has_blue: u8,
+    pub blue_scaled: i32,
+    pub blue_fitted: i32,
+    pub blue_ix: u16,
+    pub blue_is_shoot: u8,
+}
+
+#[cfg(feature = "autohinter")]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct ExportedHintPlan {
+    pub records: Vec<ExportedHintRecord>,
+    pub segments: Vec<ExportedHintSegment>,
+    pub edges: Vec<ExportedHintEdge>,
+}
+
+#[cfg(feature = "autohinter")]
+pub fn compute_hint_plan_exported(
+    font: &FontRef,
+    coords: &[F2Dot14],
+    glyph_id: u32,
+    style_index: usize,
+    is_non_base: bool,
+    is_digit: bool,
+    ppem: f32,
+) -> Option<ExportedHintPlan> {
+    let style_class = STYLE_CLASSES.get(style_index)?;
+    let outline_glyph = font.outline_glyphs().get(GlyphId::new(glyph_id))?;
+
+    let shaper_mode = if cfg!(feature = "autohint_shaping") {
+        shape::ShaperMode::BestEffort
+    } else {
+        shape::ShaperMode::Nominal
+    };
+    let shaper = shape::Shaper::new(font, shaper_mode);
+    let metrics = metrics::compute_unscaled_style_metrics(&shaper, coords, style_class);
+
+    let mut outline = outline::Outline::default();
+    outline.fill(&outline_glyph, coords).ok()?;
+
+    let glyph_style = style::GlyphStyle::from_parts(style_index as u16, is_non_base, is_digit);
+    let scale = metrics::Scale::new(
+        ppem,
+        outline_glyph.units_per_em() as i32,
+        font.attributes().style,
+        Target::Smooth {
+            mode: SmoothMode::Normal,
+            symmetric_rendering: true,
+            preserve_linear_metrics: false,
+        },
+        metrics.style_class().script.group,
+    );
+
+    let mut recorder = recorder::HintsRecorder::default();
+    let hinted_plan = hint::hint_outline_with_plan(
+        &mut outline,
+        &metrics,
+        &scale,
+        Some(glyph_style),
+        Some(&mut recorder),
+    );
+
+    let vertical_axis = hinted_plan.vertical_axis;
+    let records = export_records(recorder.records);
+    let (segments, edges) = if let Some(axis) = vertical_axis {
+        let segments = axis.segments.iter().copied().map(export_segment).collect();
+        let edges = axis.edges.iter().copied().map(export_edge).collect();
+        (segments, edges)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    Some(ExportedHintPlan {
+        records,
+        segments,
+        edges,
+    })
+}
+
+#[cfg(feature = "autohinter")]
+pub fn compute_hint_records_exported(
+    font: &FontRef,
+    coords: &[F2Dot14],
+    glyph_id: u32,
+    style_index: usize,
+    is_non_base: bool,
+    is_digit: bool,
+    ppem: f32,
+) -> Option<Vec<ExportedHintRecord>> {
+    Some(
+        compute_hint_plan_exported(
+            font,
+            coords,
+            glyph_id,
+            style_index,
+            is_non_base,
+            is_digit,
+            ppem,
+        )?
+        .records,
+    )
+}
+
+#[cfg(feature = "autohinter")]
+fn export_records(records: Vec<recorder::HintRecord>) -> Vec<ExportedHintRecord> {
+    let mut out = Vec::with_capacity(records.len());
+    for record in records {
+        match record {
+            recorder::HintRecord::Point(point) => {
+                // Skip horizontal hints: C's TA_compare_record_hint filters
+                // out TA_DIMENSION_HORZ (= 0) and only records vertical hints.
+                if point.dim == topo::Axis::HORIZONTAL {
+                    continue;
+                }
+                out.push(ExportedHintRecord {
+                    action: action_code(point.action),
+                    dim: point.dim as u8,
+                    point_ix: point.point_ix,
+                    edge_ix: point.edge_ix.unwrap_or(u16::MAX),
+                    edge2_ix: point.edge2_ix.unwrap_or(u16::MAX),
+                    edge3_ix: u16::MAX,
+                    lower_bound_ix: u16::MAX,
+                    upper_bound_ix: u16::MAX,
+                });
+            }
+            recorder::HintRecord::Edge(edge) => {
+                // Skip horizontal hints (same reason as above).
+                if edge.dim == topo::Axis::HORIZONTAL {
+                    continue;
+                }
+                out.push(ExportedHintRecord {
+                    action: action_code(edge.action),
+                    dim: edge.dim as u8,
+                    point_ix: u16::MAX,
+                    edge_ix: edge.edge_ix,
+                    edge2_ix: edge.edge2_ix.unwrap_or(u16::MAX),
+                    edge3_ix: edge.edge3_ix.unwrap_or(u16::MAX),
+                    lower_bound_ix: edge.lower_bound_ix.unwrap_or(u16::MAX),
+                    upper_bound_ix: edge.upper_bound_ix.unwrap_or(u16::MAX),
+                });
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(feature = "autohinter")]
+fn export_segment(segment: topo::Segment) -> ExportedHintSegment {
+    ExportedHintSegment {
+        flags: segment.flags,
+        dir: segment.dir as i8,
+        pos: segment.pos,
+        delta: segment.delta,
+        min_coord: segment.min_coord,
+        max_coord: segment.max_coord,
+        height: segment.height,
+        score: segment.score,
+        len: segment.len,
+        link_ix: segment.link_ix.unwrap_or(u16::MAX),
+        serif_ix: segment.serif_ix.unwrap_or(u16::MAX),
+        first_ix: segment.first_ix,
+        last_ix: segment.last_ix,
+        edge_ix: segment.edge_ix.unwrap_or(u16::MAX),
+        edge_next_ix: segment.edge_next_ix.unwrap_or(u16::MAX),
+    }
+}
+
+#[cfg(feature = "autohinter")]
+fn export_edge(edge: topo::Edge) -> ExportedHintEdge {
+    let (has_blue, blue_scaled, blue_fitted) = if let Some(blue) = edge.blue_edge {
+        (1, blue.scaled, blue.fitted)
+    } else {
+        (0, 0, 0)
+    };
+    let (blue_ix, blue_is_shoot) = if let Some(blue) = edge.blue_provenance {
+        (blue.blue_ix, u8::from(blue.is_shoot))
+    } else {
+        (u16::MAX, 0)
+    };
+
+    ExportedHintEdge {
+        fpos: edge.fpos,
+        opos: edge.opos,
+        pos: edge.pos,
+        flags: edge.flags,
+        dir: edge.dir as i8,
+        link_ix: edge.link_ix.unwrap_or(u16::MAX),
+        serif_ix: edge.serif_ix.unwrap_or(u16::MAX),
+        scale: edge.scale,
+        first_ix: edge.first_ix,
+        last_ix: edge.last_ix,
+        has_blue,
+        blue_scaled,
+        blue_fitted,
+        blue_ix,
+        blue_is_shoot,
+    }
+}
+
+#[cfg(feature = "autohinter")]
+fn action_code(action: recorder::Action) -> u8 {
+    // Values must match the C TA_Action enum's base variant for each family,
+    // as produced by TA_compare_normalize_action() in tabytecode.c,
+    // so that the exported records can be compared directly via memcmp.
+    match action {
+        recorder::Action::IpBefore => 0,     // ta_ip_before
+        recorder::Action::IpAfter => 1,      // ta_ip_after
+        recorder::Action::IpOn => 2,         // ta_ip_on
+        recorder::Action::IpBetween => 3,    // ta_ip_between
+        recorder::Action::Blue => 4,         // ta_blue
+        recorder::Action::BlueAnchor => 5,   // ta_blue_anchor
+        recorder::Action::Anchor => 6,       // ta_anchor
+        recorder::Action::Adjust => 10,      // ta_adjust
+        recorder::Action::Link => 22,        // ta_link
+        recorder::Action::Stem => 26,        // ta_stem
+        recorder::Action::Serif => 38,       // ta_serif
+        recorder::Action::SerifAnchor => 45, // ta_serif_anchor
+        recorder::Action::SerifLink1 => 52,  // ta_serif_link1
+        recorder::Action::SerifLink2 => 59,  // ta_serif_link2
+        recorder::Action::Bound => 66,       // ta_bound
+    }
+}
 
 /// All constants are defined based on a UPEM of 2048.
 ///

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -11,12 +11,14 @@ mod topo;
 
 pub use instance::GlyphStyles;
 pub(crate) use instance::Instance;
-#[cfg(feature = "autohinter")]
 pub use metrics::{
-    compute_scaled_style_metrics_exported, compute_unscaled_style_metrics_exported,
-    ExportedScaledBlue, ExportedScaledStyleMetrics, ExportedScaledWidth, ExportedUnscaledBlue,
-    ExportedUnscaledStyleMetrics,
+    BlueZones, Scale, ScaledAxisMetrics, ScaledBlue, ScaledStyleMetrics, ScaledWidth,
+    UnscaledAxisMetrics, UnscaledBlue, UnscaledStyleMetrics, WidthMetrics,
 };
+pub use outline::Direction;
+pub use recorder::{EdgeAction, EdgeHint, Hint, PointAction, PointHint};
+pub use style::{GlyphStyle, ScriptClass, ScriptGroup, StyleClass};
+pub use topo::{BlueProvenance, Dimension};
 
 #[cfg(feature = "autohinter")]
 pub use style::{SCRIPT_CLASSES, STYLE_CLASSES};
@@ -29,19 +31,6 @@ use crate::{FontRef, MetadataProvider};
 use alloc::vec::Vec;
 #[cfg(feature = "autohinter")]
 use raw::types::{F2Dot14, GlyphId};
-
-#[cfg(feature = "autohinter")]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub struct ExportedHintRecord {
-    pub action: u8,
-    pub dim: u8,
-    pub point_ix: u16,
-    pub edge_ix: u16,
-    pub edge2_ix: u16,
-    pub edge3_ix: u16,
-    pub lower_bound_ix: u16,
-    pub upper_bound_ix: u16,
-}
 
 #[cfg(feature = "autohinter")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
@@ -83,143 +72,75 @@ pub struct ExportedHintEdge {
     pub blue_is_shoot: u8,
 }
 
+/// Plan for hinting an outline.
 #[cfg(feature = "autohinter")]
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
-pub struct ExportedHintPlan {
-    pub records: Vec<ExportedHintRecord>,
+pub struct HintPlan {
+    pub hints: Vec<Hint>,
     pub segments: Vec<ExportedHintSegment>,
     pub edges: Vec<ExportedHintEdge>,
 }
 
 #[cfg(feature = "autohinter")]
-pub fn compute_hint_plan_exported(
-    font: &FontRef,
-    coords: &[F2Dot14],
-    glyph_id: u32,
-    style_index: usize,
-    is_non_base: bool,
-    is_digit: bool,
-    ppem: f32,
-) -> Option<ExportedHintPlan> {
-    let style_class = STYLE_CLASSES.get(style_index)?;
-    let outline_glyph = font.outline_glyphs().get(GlyphId::new(glyph_id))?;
+impl HintPlan {
+    /// Creates a new hint plan.
+    pub fn new(
+        font: &FontRef,
+        coords: &[F2Dot14],
+        ppem: f32,
+        glyph_id: u32,
+        glyph_style: GlyphStyle,
+    ) -> Option<Self> {
+        let style_class = glyph_style.style_class()?;
+        let outline_glyph = font.outline_glyphs().get(GlyphId::new(glyph_id))?;
 
-    let shaper_mode = if cfg!(feature = "autohint_shaping") {
-        shape::ShaperMode::BestEffort
-    } else {
-        shape::ShaperMode::Nominal
-    };
-    let shaper = shape::Shaper::new(font, shaper_mode);
-    let metrics = metrics::compute_unscaled_style_metrics(&shaper, coords, style_class);
+        let shaper_mode = if cfg!(feature = "autohint_shaping") {
+            shape::ShaperMode::BestEffort
+        } else {
+            shape::ShaperMode::Nominal
+        };
+        let shaper = shape::Shaper::new(font, shaper_mode);
+        let metrics = metrics::compute_unscaled_style_metrics(&shaper, coords, style_class);
 
-    let mut outline = outline::Outline::default();
-    outline.fill(&outline_glyph, coords).ok()?;
+        let mut outline = outline::Outline::default();
+        outline.fill(&outline_glyph, coords).ok()?;
 
-    let glyph_style = style::GlyphStyle::from_parts(style_index as u16, is_non_base, is_digit);
-    let scale = metrics::Scale::new(
-        ppem,
-        outline_glyph.units_per_em() as i32,
-        font.attributes().style,
-        Target::Smooth {
-            mode: SmoothMode::Normal,
-            symmetric_rendering: true,
-            preserve_linear_metrics: false,
-        },
-        metrics.style_class().script.group,
-    );
-
-    let mut recorder = recorder::HintsRecorder::default();
-    let hinted_plan = hint::hint_outline_with_plan(
-        &mut outline,
-        &metrics,
-        &scale,
-        Some(glyph_style),
-        Some(&mut recorder),
-    );
-
-    let vertical_axis = hinted_plan.vertical_axis;
-    let records = export_records(recorder.records);
-    let (segments, edges) = if let Some(axis) = vertical_axis {
-        let segments = axis.segments.iter().copied().map(export_segment).collect();
-        let edges = axis.edges.iter().copied().map(export_edge).collect();
-        (segments, edges)
-    } else {
-        (Vec::new(), Vec::new())
-    };
-
-    Some(ExportedHintPlan {
-        records,
-        segments,
-        edges,
-    })
-}
-
-#[cfg(feature = "autohinter")]
-pub fn compute_hint_records_exported(
-    font: &FontRef,
-    coords: &[F2Dot14],
-    glyph_id: u32,
-    style_index: usize,
-    is_non_base: bool,
-    is_digit: bool,
-    ppem: f32,
-) -> Option<Vec<ExportedHintRecord>> {
-    Some(
-        compute_hint_plan_exported(
-            font,
-            coords,
-            glyph_id,
-            style_index,
-            is_non_base,
-            is_digit,
+        let scale = metrics::Scale::new(
             ppem,
-        )?
-        .records,
-    )
-}
+            outline_glyph.units_per_em() as i32,
+            font.attributes().style,
+            Target::Smooth {
+                mode: SmoothMode::Normal,
+                symmetric_rendering: true,
+                preserve_linear_metrics: false,
+            },
+            metrics.style_class().script.group,
+        );
 
-#[cfg(feature = "autohinter")]
-fn export_records(records: Vec<recorder::HintRecord>) -> Vec<ExportedHintRecord> {
-    let mut out = Vec::with_capacity(records.len());
-    for record in records {
-        match record {
-            recorder::HintRecord::Point(point) => {
-                // Skip horizontal hints: C's TA_compare_record_hint filters
-                // out TA_DIMENSION_HORZ (= 0) and only records vertical hints.
-                if point.dim == topo::Axis::HORIZONTAL {
-                    continue;
-                }
-                out.push(ExportedHintRecord {
-                    action: action_code(point.action),
-                    dim: point.dim as u8,
-                    point_ix: point.point_ix,
-                    edge_ix: point.edge_ix.unwrap_or(u16::MAX),
-                    edge2_ix: point.edge2_ix.unwrap_or(u16::MAX),
-                    edge3_ix: u16::MAX,
-                    lower_bound_ix: u16::MAX,
-                    upper_bound_ix: u16::MAX,
-                });
-            }
-            recorder::HintRecord::Edge(edge) => {
-                // Skip horizontal hints (same reason as above).
-                if edge.dim == topo::Axis::HORIZONTAL {
-                    continue;
-                }
-                out.push(ExportedHintRecord {
-                    action: action_code(edge.action),
-                    dim: edge.dim as u8,
-                    point_ix: u16::MAX,
-                    edge_ix: edge.edge_ix,
-                    edge2_ix: edge.edge2_ix.unwrap_or(u16::MAX),
-                    edge3_ix: edge.edge3_ix.unwrap_or(u16::MAX),
-                    lower_bound_ix: edge.lower_bound_ix.unwrap_or(u16::MAX),
-                    upper_bound_ix: edge.upper_bound_ix.unwrap_or(u16::MAX),
-                });
-            }
-        }
+        let mut recorder = recorder::HintsRecorder::default();
+        let hinted_plan = hint::hint_outline_with_plan(
+            &mut outline,
+            &metrics,
+            &scale,
+            Some(glyph_style),
+            Some(&mut recorder),
+        );
+
+        let vertical_axis = hinted_plan.vertical_axis;
+        let (segments, edges) = if let Some(axis) = vertical_axis {
+            let segments = axis.segments.iter().copied().map(export_segment).collect();
+            let edges = axis.edges.iter().copied().map(export_edge).collect();
+            (segments, edges)
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        Some(Self {
+            hints: recorder.records,
+            segments,
+            edges,
+        })
     }
-
-    out
 }
 
 #[cfg(feature = "autohinter")]
@@ -275,29 +196,38 @@ fn export_edge(edge: topo::Edge) -> ExportedHintEdge {
     }
 }
 
-#[cfg(feature = "autohinter")]
-fn action_code(action: recorder::Action) -> u8 {
-    // Values must match the C TA_Action enum's base variant for each family,
-    // as produced by TA_compare_normalize_action() in tabytecode.c,
-    // so that the exported records can be compared directly via memcmp.
-    match action {
-        recorder::Action::IpBefore => 0,     // ta_ip_before
-        recorder::Action::IpAfter => 1,      // ta_ip_after
-        recorder::Action::IpOn => 2,         // ta_ip_on
-        recorder::Action::IpBetween => 3,    // ta_ip_between
-        recorder::Action::Blue => 4,         // ta_blue
-        recorder::Action::BlueAnchor => 5,   // ta_blue_anchor
-        recorder::Action::Anchor => 6,       // ta_anchor
-        recorder::Action::Adjust => 10,      // ta_adjust
-        recorder::Action::Link => 22,        // ta_link
-        recorder::Action::Stem => 26,        // ta_stem
-        recorder::Action::Serif => 38,       // ta_serif
-        recorder::Action::SerifAnchor => 45, // ta_serif_anchor
-        recorder::Action::SerifLink1 => 52,  // ta_serif_link1
-        recorder::Action::SerifLink2 => 59,  // ta_serif_link2
-        recorder::Action::Bound => 66,       // ta_bound
-    }
-}
+// #[cfg(feature = "autohinter")]
+// fn point_action_code(action: recorder::PointAction) -> u8 {
+//     // Values must match the C TA_Action enum's base variant for each family,
+//     // as produced by TA_compare_normalize_action() in tabytecode.c,
+//     // so that the exported records can be compared directly via memcmp.
+//     match action {
+//         recorder::PointAction::IpBefore => 0,  // ta_ip_before
+//         recorder::PointAction::IpAfter => 1,   // ta_ip_after
+//         recorder::PointAction::IpOn => 2,      // ta_ip_on
+//         recorder::PointAction::IpBetween => 3, // ta_ip_between
+//     }
+// }
+
+// #[cfg(feature = "autohinter")]
+// fn edge_action_code(action: recorder::EdgeAction) -> u8 {
+//     // Values must match the C TA_Action enum's base variant for each family,
+//     // as produced by TA_compare_normalize_action() in tabytecode.c,
+//     // so that the exported records can be compared directly via memcmp.
+//     match action {
+//         recorder::EdgeAction::Blue => 4,         // ta_blue
+//         recorder::EdgeAction::BlueAnchor => 5,   // ta_blue_anchor
+//         recorder::EdgeAction::Anchor => 6,       // ta_anchor
+//         recorder::EdgeAction::Adjust => 10,      // ta_adjust
+//         recorder::EdgeAction::Link => 22,        // ta_link
+//         recorder::EdgeAction::Stem => 26,        // ta_stem
+//         recorder::EdgeAction::Serif => 38,       // ta_serif
+//         recorder::EdgeAction::SerifAnchor => 45, // ta_serif_anchor
+//         recorder::EdgeAction::SerifLink1 => 52,  // ta_serif_link1
+//         recorder::EdgeAction::SerifLink2 => 59,  // ta_serif_link2
+//         recorder::EdgeAction::Bound => 66,       // ta_bound
+//     }
+// }
 
 /// All constants are defined based on a UPEM of 2048.
 ///

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -16,72 +16,23 @@ pub use metrics::{
     UnscaledAxisMetrics, UnscaledBlue, UnscaledStyleMetrics, WidthMetrics,
 };
 pub use outline::Direction;
-pub use recorder::{EdgeAction, EdgeHint, Hint, PointAction, PointHint};
+pub use recorder::{EdgeAction, EdgeHint, HintAction, PointAction, PointHint};
 pub use style::{GlyphStyle, ScriptClass, ScriptGroup, StyleClass};
-pub use topo::{BlueProvenance, Dimension};
-
-#[cfg(feature = "autohinter")]
 pub use style::{SCRIPT_CLASSES, STYLE_CLASSES};
+pub use topo::{Axis, BlueProvenance, Dimension, Edge, Segment, TopoFlags};
 
-#[cfg(feature = "autohinter")]
 use crate::outline::{SmoothMode, Target};
-#[cfg(feature = "autohinter")]
 use crate::{FontRef, MetadataProvider};
-#[cfg(feature = "autohinter")]
 use alloc::vec::Vec;
-#[cfg(feature = "autohinter")]
 use raw::types::{F2Dot14, GlyphId};
 
-#[cfg(feature = "autohinter")]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub struct ExportedHintSegment {
-    pub flags: u8,
-    pub dir: i8,
-    pub pos: i16,
-    pub delta: i16,
-    pub min_coord: i16,
-    pub max_coord: i16,
-    pub height: i16,
-    pub score: i32,
-    pub len: i32,
-    pub link_ix: u16,
-    pub serif_ix: u16,
-    pub first_ix: u16,
-    pub last_ix: u16,
-    pub edge_ix: u16,
-    pub edge_next_ix: u16,
-}
-
-#[cfg(feature = "autohinter")]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub struct ExportedHintEdge {
-    pub fpos: i16,
-    pub opos: i32,
-    pub pos: i32,
-    pub flags: u8,
-    pub dir: i8,
-    pub link_ix: u16,
-    pub serif_ix: u16,
-    pub scale: i32,
-    pub first_ix: u16,
-    pub last_ix: u16,
-    pub has_blue: u8,
-    pub blue_scaled: i32,
-    pub blue_fitted: i32,
-    pub blue_ix: u16,
-    pub blue_is_shoot: u8,
-}
-
 /// Plan for hinting an outline.
-#[cfg(feature = "autohinter")]
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct HintPlan {
-    pub hints: Vec<Hint>,
-    pub segments: Vec<ExportedHintSegment>,
-    pub edges: Vec<ExportedHintEdge>,
+    hints: Vec<HintAction>,
+    axes: [Option<Axis>; 2],
 }
 
-#[cfg(feature = "autohinter")]
 impl HintPlan {
     /// Creates a new hint plan.
     pub fn new(
@@ -118,83 +69,88 @@ impl HintPlan {
         );
 
         let mut recorder = recorder::HintsRecorder::default();
-        let hinted_plan = hint::hint_outline_with_plan(
+        let hinted_plan = hint::hint_outline_with_recorder(
             &mut outline,
             &metrics,
             &scale,
             Some(glyph_style),
-            Some(&mut recorder),
+            &mut recorder,
         );
 
-        let vertical_axis = hinted_plan.vertical_axis;
-        let (segments, edges) = if let Some(axis) = vertical_axis {
-            let segments = axis.segments.iter().copied().map(export_segment).collect();
-            let edges = axis.edges.iter().copied().map(export_edge).collect();
-            (segments, edges)
-        } else {
-            (Vec::new(), Vec::new())
-        };
-
         Some(Self {
-            hints: recorder.records,
-            segments,
-            edges,
+            hints: recorder.actions,
+            axes: hinted_plan.axes,
         })
     }
-}
 
-#[cfg(feature = "autohinter")]
-fn export_segment(segment: topo::Segment) -> ExportedHintSegment {
-    ExportedHintSegment {
-        flags: segment.flags,
-        dir: segment.dir as i8,
-        pos: segment.pos,
-        delta: segment.delta,
-        min_coord: segment.min_coord,
-        max_coord: segment.max_coord,
-        height: segment.height,
-        score: segment.score,
-        len: segment.len,
-        link_ix: segment.link_ix.unwrap_or(u16::MAX),
-        serif_ix: segment.serif_ix.unwrap_or(u16::MAX),
-        first_ix: segment.first_ix,
-        last_ix: segment.last_ix,
-        edge_ix: segment.edge_ix.unwrap_or(u16::MAX),
-        edge_next_ix: segment.edge_next_ix.unwrap_or(u16::MAX),
+    /// Returns the collection of hinting actions.
+    pub fn actions(&self) -> &[HintAction] {
+        &self.hints
+    }
+
+    /// Returns the topological analysis of the horizontal axis.
+    pub fn horizontal_axis(&self) -> Option<&Axis> {
+        self.axes[Dimension::Horizontal].as_ref()
+    }
+
+    // Returns the topological analysis of the vertical axis.
+    pub fn vertical_axis(&self) -> Option<&Axis> {
+        self.axes[Dimension::Vertical].as_ref()
     }
 }
 
-#[cfg(feature = "autohinter")]
-fn export_edge(edge: topo::Edge) -> ExportedHintEdge {
-    let (has_blue, blue_scaled, blue_fitted) = if let Some(blue) = edge.blue_edge {
-        (1, blue.scaled, blue.fitted)
-    } else {
-        (0, 0, 0)
-    };
-    let (blue_ix, blue_is_shoot) = if let Some(blue) = edge.blue_provenance {
-        (blue.blue_ix, u8::from(blue.is_shoot))
-    } else {
-        (u16::MAX, 0)
-    };
+// #[cfg(feature = "autohinter")]
+// fn export_segment(segment: topo::Segment) -> ExportedHintSegment {
+//     ExportedHintSegment {
+//         flags: segment.flags.to_bits(),
+//         dir: segment.dir as i8,
+//         pos: segment.pos,
+//         delta: segment.delta,
+//         min_coord: segment.min_coord,
+//         max_coord: segment.max_coord,
+//         height: segment.height,
+//         score: segment.score,
+//         len: segment.len,
+//         link_ix: segment.link_ix.unwrap_or(u16::MAX),
+//         serif_ix: segment.serif_ix.unwrap_or(u16::MAX),
+//         first_ix: segment.first_ix,
+//         last_ix: segment.last_ix,
+//         edge_ix: segment.edge_ix.unwrap_or(u16::MAX),
+//         edge_next_ix: segment.edge_next_ix.unwrap_or(u16::MAX),
+//     }
+// }
 
-    ExportedHintEdge {
-        fpos: edge.fpos,
-        opos: edge.opos,
-        pos: edge.pos,
-        flags: edge.flags,
-        dir: edge.dir as i8,
-        link_ix: edge.link_ix.unwrap_or(u16::MAX),
-        serif_ix: edge.serif_ix.unwrap_or(u16::MAX),
-        scale: edge.scale,
-        first_ix: edge.first_ix,
-        last_ix: edge.last_ix,
-        has_blue,
-        blue_scaled,
-        blue_fitted,
-        blue_ix,
-        blue_is_shoot,
-    }
-}
+// #[cfg(feature = "autohinter")]
+// fn export_edge(edge: topo::Edge) -> ExportedHintEdge {
+//     let (has_blue, blue_scaled, blue_fitted) = if let Some(blue) = edge.blue_edge {
+//         (1, blue.scaled, blue.fitted)
+//     } else {
+//         (0, 0, 0)
+//     };
+//     let (blue_ix, blue_is_shoot) = if let Some(blue) = edge.blue_provenance {
+//         (blue.index, u8::from(blue.is_shoot))
+//     } else {
+//         (u16::MAX, 0)
+//     };
+
+//     ExportedHintEdge {
+//         fpos: edge.fpos,
+//         opos: edge.opos,
+//         pos: edge.pos,
+//         flags: edge.flags.to_bits(),
+//         dir: edge.dir as i8,
+//         link_ix: edge.link_ix.unwrap_or(u16::MAX),
+//         serif_ix: edge.serif_ix.unwrap_or(u16::MAX),
+//         scale: edge.scale,
+//         first_ix: edge.first_ix,
+//         last_ix: edge.last_ix,
+//         has_blue,
+//         blue_scaled,
+//         blue_fitted,
+//         blue_ix,
+//         blue_is_shoot,
+//     }
+// }
 
 // #[cfg(feature = "autohinter")]
 // fn point_action_code(action: recorder::PointAction) -> u8 {

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -26,6 +26,16 @@ use crate::{FontRef, MetadataProvider};
 use alloc::vec::Vec;
 use raw::types::{F2Dot14, GlyphId};
 
+/// Controls quirks for the different autohinters.
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+enum QuirksMode {
+    /// Just in time hinter; matches FreeType.
+    #[default]
+    Jit,
+    /// Ahead of time hinter; matches ttfautohint.
+    Aot,
+}
+
 /// Plan for hinting an outline.
 #[derive(Clone, Debug, Default)]
 pub struct HintPlan {
@@ -51,10 +61,11 @@ impl HintPlan {
             shape::ShaperMode::Nominal
         };
         let shaper = shape::Shaper::new(font, shaper_mode);
-        let metrics = metrics::compute_unscaled_style_metrics(&shaper, coords, style_class);
+        let metrics =
+            metrics::compute_unscaled_style_metrics(&shaper, coords, style_class, QuirksMode::Aot);
 
         let mut outline = outline::Outline::default();
-        outline.fill(&outline_glyph, coords).ok()?;
+        outline.fill(&outline_glyph, coords, QuirksMode::Aot).ok()?;
 
         let scale = metrics::Scale::new(
             ppem,

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -12,7 +12,7 @@ mod topo;
 pub use instance::GlyphStyles;
 pub(crate) use instance::Instance;
 pub use metrics::{
-    BlueZones, Scale, ScaledAxisMetrics, ScaledBlue, ScaledStyleMetrics, ScaledWidth,
+    BlueZones, Scale, ScaleFlags, ScaledAxisMetrics, ScaledBlue, ScaledStyleMetrics, ScaledWidth,
     UnscaledAxisMetrics, UnscaledBlue, UnscaledStyleMetrics, WidthMetrics,
 };
 pub use outline::Direction;

--- a/skrifa/src/outline/autohint/mod.rs
+++ b/skrifa/src/outline/autohint/mod.rs
@@ -21,7 +21,7 @@ pub use style::{GlyphStyle, ScriptClass, ScriptGroup, StyleClass};
 pub use style::{SCRIPT_CLASSES, STYLE_CLASSES};
 pub use topo::{Axis, BlueProvenance, Dimension, Edge, Segment, TopoFlags};
 
-use crate::outline::{SmoothMode, Target};
+use crate::outline::{DrawError, Target};
 use crate::{FontRef, MetadataProvider};
 use alloc::vec::Vec;
 use raw::types::{F2Dot14, GlyphId};
@@ -49,11 +49,17 @@ impl HintPlan {
         font: &FontRef,
         coords: &[F2Dot14],
         ppem: f32,
-        glyph_id: u32,
+        target: Target,
+        glyph_id: GlyphId,
         glyph_style: GlyphStyle,
-    ) -> Option<Self> {
-        let style_class = glyph_style.style_class()?;
-        let outline_glyph = font.outline_glyphs().get(GlyphId::new(glyph_id))?;
+    ) -> Result<Self, DrawError> {
+        let style_class = glyph_style
+            .style_class()
+            .ok_or(DrawError::GlyphNotFound(glyph_id))?;
+        let outline_glyph = font
+            .outline_glyphs()
+            .get(glyph_id)
+            .ok_or(DrawError::GlyphNotFound(glyph_id))?;
 
         let shaper_mode = if cfg!(feature = "autohint_shaping") {
             shape::ShaperMode::BestEffort
@@ -65,17 +71,13 @@ impl HintPlan {
             metrics::compute_unscaled_style_metrics(&shaper, coords, style_class, QuirksMode::Aot);
 
         let mut outline = outline::Outline::default();
-        outline.fill(&outline_glyph, coords, QuirksMode::Aot).ok()?;
+        outline.fill(&outline_glyph, coords, QuirksMode::Aot)?;
 
         let scale = metrics::Scale::new(
             ppem,
             outline_glyph.units_per_em() as i32,
             font.attributes().style,
-            Target::Smooth {
-                mode: SmoothMode::Normal,
-                symmetric_rendering: true,
-                preserve_linear_metrics: false,
-            },
+            target,
             metrics.style_class().script.group,
         );
 
@@ -88,7 +90,7 @@ impl HintPlan {
             &mut recorder,
         );
 
-        Some(Self {
+        Ok(Self {
             hints: recorder.actions,
             axes: hinted_plan.axes,
         })
@@ -104,97 +106,11 @@ impl HintPlan {
         self.axes[Dimension::Horizontal].as_ref()
     }
 
-    // Returns the topological analysis of the vertical axis.
+    /// Returns the topological analysis of the vertical axis.
     pub fn vertical_axis(&self) -> Option<&Axis> {
         self.axes[Dimension::Vertical].as_ref()
     }
 }
-
-// #[cfg(feature = "autohinter")]
-// fn export_segment(segment: topo::Segment) -> ExportedHintSegment {
-//     ExportedHintSegment {
-//         flags: segment.flags.to_bits(),
-//         dir: segment.dir as i8,
-//         pos: segment.pos,
-//         delta: segment.delta,
-//         min_coord: segment.min_coord,
-//         max_coord: segment.max_coord,
-//         height: segment.height,
-//         score: segment.score,
-//         len: segment.len,
-//         link_ix: segment.link_ix.unwrap_or(u16::MAX),
-//         serif_ix: segment.serif_ix.unwrap_or(u16::MAX),
-//         first_ix: segment.first_ix,
-//         last_ix: segment.last_ix,
-//         edge_ix: segment.edge_ix.unwrap_or(u16::MAX),
-//         edge_next_ix: segment.edge_next_ix.unwrap_or(u16::MAX),
-//     }
-// }
-
-// #[cfg(feature = "autohinter")]
-// fn export_edge(edge: topo::Edge) -> ExportedHintEdge {
-//     let (has_blue, blue_scaled, blue_fitted) = if let Some(blue) = edge.blue_edge {
-//         (1, blue.scaled, blue.fitted)
-//     } else {
-//         (0, 0, 0)
-//     };
-//     let (blue_ix, blue_is_shoot) = if let Some(blue) = edge.blue_provenance {
-//         (blue.index, u8::from(blue.is_shoot))
-//     } else {
-//         (u16::MAX, 0)
-//     };
-
-//     ExportedHintEdge {
-//         fpos: edge.fpos,
-//         opos: edge.opos,
-//         pos: edge.pos,
-//         flags: edge.flags.to_bits(),
-//         dir: edge.dir as i8,
-//         link_ix: edge.link_ix.unwrap_or(u16::MAX),
-//         serif_ix: edge.serif_ix.unwrap_or(u16::MAX),
-//         scale: edge.scale,
-//         first_ix: edge.first_ix,
-//         last_ix: edge.last_ix,
-//         has_blue,
-//         blue_scaled,
-//         blue_fitted,
-//         blue_ix,
-//         blue_is_shoot,
-//     }
-// }
-
-// #[cfg(feature = "autohinter")]
-// fn point_action_code(action: recorder::PointAction) -> u8 {
-//     // Values must match the C TA_Action enum's base variant for each family,
-//     // as produced by TA_compare_normalize_action() in tabytecode.c,
-//     // so that the exported records can be compared directly via memcmp.
-//     match action {
-//         recorder::PointAction::IpBefore => 0,  // ta_ip_before
-//         recorder::PointAction::IpAfter => 1,   // ta_ip_after
-//         recorder::PointAction::IpOn => 2,      // ta_ip_on
-//         recorder::PointAction::IpBetween => 3, // ta_ip_between
-//     }
-// }
-
-// #[cfg(feature = "autohinter")]
-// fn edge_action_code(action: recorder::EdgeAction) -> u8 {
-//     // Values must match the C TA_Action enum's base variant for each family,
-//     // as produced by TA_compare_normalize_action() in tabytecode.c,
-//     // so that the exported records can be compared directly via memcmp.
-//     match action {
-//         recorder::EdgeAction::Blue => 4,         // ta_blue
-//         recorder::EdgeAction::BlueAnchor => 5,   // ta_blue_anchor
-//         recorder::EdgeAction::Anchor => 6,       // ta_anchor
-//         recorder::EdgeAction::Adjust => 10,      // ta_adjust
-//         recorder::EdgeAction::Link => 22,        // ta_link
-//         recorder::EdgeAction::Stem => 26,        // ta_stem
-//         recorder::EdgeAction::Serif => 38,       // ta_serif
-//         recorder::EdgeAction::SerifAnchor => 45, // ta_serif_anchor
-//         recorder::EdgeAction::SerifLink1 => 52,  // ta_serif_link1
-//         recorder::EdgeAction::SerifLink2 => 59,  // ta_serif_link2
-//         recorder::EdgeAction::Bound => 66,       // ta_bound
-//     }
-// }
 
 /// All constants are defined based on a UPEM of 2048.
 ///

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -451,21 +451,10 @@ impl Outline {
 
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/base/ftcalc.c#L1026>
 fn is_corner_flat(in_x: i32, in_y: i32, out_x: i32, out_y: i32) -> bool {
-    let ax = in_x + out_x;
-    let ay = in_y + out_y;
-    fn hypot(x: i32, y: i32) -> i32 {
-        let x = x.abs();
-        let y = y.abs();
-        if x > y {
-            x + ((3 * y) >> 3)
-        } else {
-            y + ((3 * x) >> 3)
-        }
-    }
-    let d_in = hypot(in_x, in_y);
-    let d_out = hypot(out_x, out_y);
-    let d_hypot = hypot(ax, ay);
-    (d_in + d_out - d_hypot) < (d_hypot >> 4)
+    let d_in = in_x.abs() + in_y.abs();
+    let d_out = out_x.abs() + out_y.abs();
+    let d_corner = (in_x + out_x).abs() + (in_y + out_y).abs();
+    (d_in + d_out - d_corner) < (d_corner >> 4)
 }
 
 #[derive(Copy, Clone, Default, Debug)]

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -8,6 +8,7 @@ use super::{
         DrawError, LocationRef, OutlineGlyph, OutlinePen,
     },
     metrics::Scale,
+    QuirksMode,
 };
 use crate::collections::SmallVec;
 use core::ops::Range;
@@ -163,7 +164,12 @@ pub(crate) struct Outline {
 
 impl Outline {
     /// Fills the outline from the given glyph.
-    pub fn fill(&mut self, glyph: &OutlineGlyph, coords: &[F2Dot14]) -> Result<(), DrawError> {
+    pub fn fill(
+        &mut self,
+        glyph: &OutlineGlyph,
+        coords: &[F2Dot14],
+        quirks: QuirksMode,
+    ) -> Result<(), DrawError> {
         self.clear();
         let advance = glyph.draw_unscaled(LocationRef::new(coords), None, self)?;
         self.advance = advance;
@@ -174,7 +180,11 @@ impl Outline {
         self.mark_near_points(near_limit);
         self.compute_directions(near_limit);
         self.simplify_topology();
-        self.check_remaining_weak_points();
+        if quirks == QuirksMode::Aot {
+            self.check_remaining_weak_points(is_corner_flat_aot);
+        } else {
+            self.check_remaining_weak_points(is_corner_flat_jit);
+        }
         self.compute_orientation();
         Ok(())
     }
@@ -378,7 +388,7 @@ impl Outline {
     /// Check for remaining weak points.
     ///
     /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.c#L1226>
-    fn check_remaining_weak_points(&mut self) {
+    fn check_remaining_weak_points(&mut self, is_corner_flat: impl Fn(i32, i32, i32, i32) -> bool) {
         let points = self.points.as_mut_slice();
         for i in 0..points.len() {
             let point = points[i];
@@ -454,12 +464,32 @@ impl Outline {
     }
 }
 
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/base/ftcalc.c#L1026>
-fn is_corner_flat(in_x: i32, in_y: i32, out_x: i32, out_y: i32) -> bool {
+/// Offline or "ahead of time" version from ttfautohint.
+fn is_corner_flat_aot(in_x: i32, in_y: i32, out_x: i32, out_y: i32) -> bool {
     let d_in = in_x.abs() + in_y.abs();
     let d_out = out_x.abs() + out_y.abs();
     let d_corner = (in_x + out_x).abs() + (in_y + out_y).abs();
     (d_in + d_out - d_corner) < (d_corner >> 4)
+}
+
+/// Runtime or "just in time" hinted version from FT.
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/base/ftcalc.c#L1026>
+fn is_corner_flat_jit(in_x: i32, in_y: i32, out_x: i32, out_y: i32) -> bool {
+    let ax = in_x + out_x;
+    let ay = in_y + out_y;
+    fn hypot(x: i32, y: i32) -> i32 {
+        let x = x.abs();
+        let y = y.abs();
+        if x > y {
+            x + ((3 * y) >> 3)
+        } else {
+            y + ((3 * x) >> 3)
+        }
+    }
+    let d_in = hypot(in_x, in_y);
+    let d_out = hypot(out_x, out_y);
+    let d_hypot = hypot(ax, ay);
+    (d_in + d_out - d_hypot) < (d_hypot >> 4)
 }
 
 #[derive(Copy, Clone, Default, Debug)]
@@ -674,7 +704,7 @@ mod tests {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(GlyphId::from(glyph_id)).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         outline
     }
 
@@ -737,7 +767,7 @@ mod tests {
             let base_svg = base_svg.to_string();
             // Autohinter outline code path
             let mut outline = Outline::default();
-            outline.fill(&glyph, Default::default()).unwrap();
+            outline.fill(&glyph, &[], Default::default()).unwrap();
             // The to_path method uses the (x, y) coords which aren't filled
             // until we scale (and we aren't doing that here) so update
             // them with 26.6 values manually

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -21,15 +21,20 @@ use raw::{
 /// The values are such that `dir1 + dir2 == 0` when the directions are
 /// opposite.
 ///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L45>
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L45>
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 #[repr(i8)]
-pub(crate) enum Direction {
+pub enum Direction {
+    /// Undetermined direction.
     #[default]
     None = 4,
+    /// Toward the right.
     Right = 1,
+    /// Toward the left.
     Left = -1,
+    /// Toward the top.
     Up = 2,
+    /// Toward the bottom.
     Down = -2,
 }
 
@@ -66,7 +71,7 @@ impl Direction {
         (self as i8).abs() == (other as i8).abs()
     }
 
-    pub fn normalize(self) -> Self {
+    pub(crate) fn normalize(self) -> Self {
         // FreeType uses absolute value for this.
         match self {
             Self::Left => Self::Right,

--- a/skrifa/src/outline/autohint/recorder.rs
+++ b/skrifa/src/outline/autohint/recorder.rs
@@ -1,0 +1,132 @@
+use alloc::vec::Vec;
+
+use crate::outline::autohint::topo::{BlueProvenance, Dimension};
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Action {
+    IpBefore,
+    IpAfter,
+    IpOn,
+    IpBetween,
+    Blue,
+    BlueAnchor,
+    Anchor,
+    Adjust,
+    Link,
+    Stem,
+    Serif,
+    SerifAnchor,
+    SerifLink1,
+    SerifLink2,
+    Bound,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct PointHintRecord {
+    pub action: Action,
+    pub dim: Dimension,
+    pub point_ix: u16,
+    pub edge_ix: Option<u16>,
+    pub edge2_ix: Option<u16>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct EdgeHintRecord {
+    pub action: Action,
+    pub dim: Dimension,
+    pub edge_ix: u16,
+    pub edge2_ix: Option<u16>,
+    pub edge3_ix: Option<u16>,
+    pub lower_bound_ix: Option<u16>,
+    pub upper_bound_ix: Option<u16>,
+    pub blue: Option<BlueProvenance>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum HintRecord {
+    Point(PointHintRecord),
+    Edge(EdgeHintRecord),
+}
+
+#[derive(Clone, Default, PartialEq, Eq, Debug)]
+pub struct HintsRecorder {
+    pub records: Vec<HintRecord>,
+}
+
+impl HintsRecorder {
+    pub fn record_ip_before(&mut self, dim: Dimension, point_ix: usize) {
+        self.records.push(HintRecord::Point(PointHintRecord {
+            action: Action::IpBefore,
+            dim,
+            point_ix: narrow(point_ix),
+            edge_ix: None,
+            edge2_ix: None,
+        }));
+    }
+
+    pub fn record_ip_after(&mut self, dim: Dimension, point_ix: usize) {
+        self.records.push(HintRecord::Point(PointHintRecord {
+            action: Action::IpAfter,
+            dim,
+            point_ix: narrow(point_ix),
+            edge_ix: None,
+            edge2_ix: None,
+        }));
+    }
+
+    pub fn record_ip_on(&mut self, dim: Dimension, point_ix: usize, edge_ix: usize) {
+        self.records.push(HintRecord::Point(PointHintRecord {
+            action: Action::IpOn,
+            dim,
+            point_ix: narrow(point_ix),
+            edge_ix: Some(narrow(edge_ix)),
+            edge2_ix: None,
+        }));
+    }
+
+    pub fn record_ip_between(
+        &mut self,
+        dim: Dimension,
+        point_ix: usize,
+        before_edge_ix: usize,
+        after_edge_ix: usize,
+    ) {
+        self.records.push(HintRecord::Point(PointHintRecord {
+            action: Action::IpBetween,
+            dim,
+            point_ix: narrow(point_ix),
+            edge_ix: Some(narrow(before_edge_ix)),
+            edge2_ix: Some(narrow(after_edge_ix)),
+        }));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_edge(
+        &mut self,
+        dim: Dimension,
+        action: Action,
+        edge_ix: usize,
+        edge2_ix: Option<usize>,
+        edge3_ix: Option<usize>,
+        lower_bound_ix: Option<usize>,
+        upper_bound_ix: Option<usize>,
+        blue: Option<BlueProvenance>,
+    ) {
+        self.records.push(HintRecord::Edge(EdgeHintRecord {
+            action,
+            dim,
+            edge_ix: narrow(edge_ix),
+            edge2_ix: edge2_ix.map(narrow),
+            edge3_ix: edge3_ix.map(narrow),
+            lower_bound_ix: lower_bound_ix.map(narrow),
+            upper_bound_ix: upper_bound_ix.map(narrow),
+            blue,
+        }));
+    }
+}
+
+fn narrow(ix: usize) -> u16 {
+    debug_assert!(ix <= u16::MAX as usize);
+    ix as u16
+}

--- a/skrifa/src/outline/autohint/recorder.rs
+++ b/skrifa/src/outline/autohint/recorder.rs
@@ -1,6 +1,5 @@
-use alloc::vec::Vec;
-
 use crate::outline::autohint::topo::{BlueProvenance, Dimension};
+use alloc::vec::Vec;
 
 /// Hinting action for a point.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -31,65 +30,65 @@ pub enum EdgeAction {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct PointHint {
     pub action: PointAction,
-    pub dim: Dimension,
-    pub point_ix: u16,
-    pub edge_ix: Option<u16>,
-    pub edge2_ix: Option<u16>,
+    pub dimension: Dimension,
+    pub point_index: u16,
+    pub edge_index: Option<u16>,
+    pub edge2_index: Option<u16>,
 }
 
 /// Hinting information for an edge.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct EdgeHint {
     pub action: EdgeAction,
-    pub dim: Dimension,
-    pub edge_ix: u16,
-    pub edge2_ix: Option<u16>,
-    pub edge3_ix: Option<u16>,
-    pub lower_bound_ix: Option<u16>,
-    pub upper_bound_ix: Option<u16>,
+    pub dimension: Dimension,
+    pub edge_index: u16,
+    pub edge2_index: Option<u16>,
+    pub edge3_index: Option<u16>,
+    pub lower_bound_index: Option<u16>,
+    pub upper_bound_index: Option<u16>,
     pub blue: Option<BlueProvenance>,
 }
 
-/// Hinting information for a point or an edge.
+/// Hinting action for a point or an edge.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Hint {
+pub enum HintAction {
     Point(PointHint),
     Edge(EdgeHint),
 }
 
 #[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct HintsRecorder {
-    pub records: Vec<Hint>,
+    pub actions: Vec<HintAction>,
 }
 
 impl HintsRecorder {
     pub fn record_ip_before(&mut self, dim: Dimension, point_ix: usize) {
-        self.records.push(Hint::Point(PointHint {
+        self.actions.push(HintAction::Point(PointHint {
             action: PointAction::IpBefore,
-            dim,
-            point_ix: narrow(point_ix),
-            edge_ix: None,
-            edge2_ix: None,
+            dimension: dim,
+            point_index: narrow(point_ix),
+            edge_index: None,
+            edge2_index: None,
         }));
     }
 
     pub fn record_ip_after(&mut self, dim: Dimension, point_ix: usize) {
-        self.records.push(Hint::Point(PointHint {
+        self.actions.push(HintAction::Point(PointHint {
             action: PointAction::IpAfter,
-            dim,
-            point_ix: narrow(point_ix),
-            edge_ix: None,
-            edge2_ix: None,
+            dimension: dim,
+            point_index: narrow(point_ix),
+            edge_index: None,
+            edge2_index: None,
         }));
     }
 
     pub fn record_ip_on(&mut self, dim: Dimension, point_ix: usize, edge_ix: usize) {
-        self.records.push(Hint::Point(PointHint {
+        self.actions.push(HintAction::Point(PointHint {
             action: PointAction::IpOn,
-            dim,
-            point_ix: narrow(point_ix),
-            edge_ix: Some(narrow(edge_ix)),
-            edge2_ix: None,
+            dimension: dim,
+            point_index: narrow(point_ix),
+            edge_index: Some(narrow(edge_ix)),
+            edge2_index: None,
         }));
     }
 
@@ -100,12 +99,12 @@ impl HintsRecorder {
         before_edge_ix: usize,
         after_edge_ix: usize,
     ) {
-        self.records.push(Hint::Point(PointHint {
+        self.actions.push(HintAction::Point(PointHint {
             action: PointAction::IpBetween,
-            dim,
-            point_ix: narrow(point_ix),
-            edge_ix: Some(narrow(before_edge_ix)),
-            edge2_ix: Some(narrow(after_edge_ix)),
+            dimension: dim,
+            point_index: narrow(point_ix),
+            edge_index: Some(narrow(before_edge_ix)),
+            edge2_index: Some(narrow(after_edge_ix)),
         }));
     }
 
@@ -121,14 +120,14 @@ impl HintsRecorder {
         upper_bound_ix: Option<usize>,
         blue: Option<BlueProvenance>,
     ) {
-        self.records.push(Hint::Edge(EdgeHint {
+        self.actions.push(HintAction::Edge(EdgeHint {
             action,
-            dim,
-            edge_ix: narrow(edge_ix),
-            edge2_ix: edge2_ix.map(narrow),
-            edge3_ix: edge3_ix.map(narrow),
-            lower_bound_ix: lower_bound_ix.map(narrow),
-            upper_bound_ix: upper_bound_ix.map(narrow),
+            dimension: dim,
+            edge_index: narrow(edge_ix),
+            edge2_index: edge2_ix.map(narrow),
+            edge3_index: edge3_ix.map(narrow),
+            lower_bound_index: lower_bound_ix.map(narrow),
+            upper_bound_index: upper_bound_ix.map(narrow),
             blue,
         }));
     }

--- a/skrifa/src/outline/autohint/recorder.rs
+++ b/skrifa/src/outline/autohint/recorder.rs
@@ -2,13 +2,18 @@ use alloc::vec::Vec;
 
 use crate::outline::autohint::topo::{BlueProvenance, Dimension};
 
-#[allow(dead_code)]
+/// Hinting action for a point.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Action {
+pub enum PointAction {
     IpBefore,
     IpAfter,
     IpOn,
     IpBetween,
+}
+
+/// Hinting action for an edge.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum EdgeAction {
     Blue,
     BlueAnchor,
     Anchor,
@@ -22,18 +27,20 @@ pub enum Action {
     Bound,
 }
 
+/// Hinting information for a point.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct PointHintRecord {
-    pub action: Action,
+pub struct PointHint {
+    pub action: PointAction,
     pub dim: Dimension,
     pub point_ix: u16,
     pub edge_ix: Option<u16>,
     pub edge2_ix: Option<u16>,
 }
 
+/// Hinting information for an edge.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct EdgeHintRecord {
-    pub action: Action,
+pub struct EdgeHint {
+    pub action: EdgeAction,
     pub dim: Dimension,
     pub edge_ix: u16,
     pub edge2_ix: Option<u16>,
@@ -43,21 +50,22 @@ pub struct EdgeHintRecord {
     pub blue: Option<BlueProvenance>,
 }
 
+/// Hinting information for a point or an edge.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum HintRecord {
-    Point(PointHintRecord),
-    Edge(EdgeHintRecord),
+pub enum Hint {
+    Point(PointHint),
+    Edge(EdgeHint),
 }
 
 #[derive(Clone, Default, PartialEq, Eq, Debug)]
 pub struct HintsRecorder {
-    pub records: Vec<HintRecord>,
+    pub records: Vec<Hint>,
 }
 
 impl HintsRecorder {
     pub fn record_ip_before(&mut self, dim: Dimension, point_ix: usize) {
-        self.records.push(HintRecord::Point(PointHintRecord {
-            action: Action::IpBefore,
+        self.records.push(Hint::Point(PointHint {
+            action: PointAction::IpBefore,
             dim,
             point_ix: narrow(point_ix),
             edge_ix: None,
@@ -66,8 +74,8 @@ impl HintsRecorder {
     }
 
     pub fn record_ip_after(&mut self, dim: Dimension, point_ix: usize) {
-        self.records.push(HintRecord::Point(PointHintRecord {
-            action: Action::IpAfter,
+        self.records.push(Hint::Point(PointHint {
+            action: PointAction::IpAfter,
             dim,
             point_ix: narrow(point_ix),
             edge_ix: None,
@@ -76,8 +84,8 @@ impl HintsRecorder {
     }
 
     pub fn record_ip_on(&mut self, dim: Dimension, point_ix: usize, edge_ix: usize) {
-        self.records.push(HintRecord::Point(PointHintRecord {
-            action: Action::IpOn,
+        self.records.push(Hint::Point(PointHint {
+            action: PointAction::IpOn,
             dim,
             point_ix: narrow(point_ix),
             edge_ix: Some(narrow(edge_ix)),
@@ -92,8 +100,8 @@ impl HintsRecorder {
         before_edge_ix: usize,
         after_edge_ix: usize,
     ) {
-        self.records.push(HintRecord::Point(PointHintRecord {
-            action: Action::IpBetween,
+        self.records.push(Hint::Point(PointHint {
+            action: PointAction::IpBetween,
             dim,
             point_ix: narrow(point_ix),
             edge_ix: Some(narrow(before_edge_ix)),
@@ -105,7 +113,7 @@ impl HintsRecorder {
     pub fn record_edge(
         &mut self,
         dim: Dimension,
-        action: Action,
+        action: EdgeAction,
         edge_ix: usize,
         edge2_ix: Option<usize>,
         edge3_ix: Option<usize>,
@@ -113,7 +121,7 @@ impl HintsRecorder {
         upper_bound_ix: Option<usize>,
         blue: Option<BlueProvenance>,
     ) {
-        self.records.push(HintRecord::Edge(EdgeHintRecord {
+        self.records.push(Hint::Edge(EdgeHint {
             action,
             dim,
             edge_ix: narrow(edge_ix),

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -49,6 +49,18 @@ impl GlyphStyle {
         }
     }
 
+    #[cfg(feature = "autohinter")]
+    pub(crate) fn from_parts(style_index: u16, non_base: bool, digit: bool) -> Self {
+        let mut bits = style_index & Self::STYLE_INDEX_MASK;
+        if non_base {
+            bits |= Self::NON_BASE;
+        }
+        if digit {
+            bits |= Self::DIGIT;
+        }
+        Self(bits)
+    }
+
     fn maybe_assign(&mut self, other: Self) {
         // FreeType walks the style array in order so earlier styles
         // have precedence. Since we walk the cmap and binary search
@@ -307,7 +319,7 @@ impl Default for GlyphStyleMap {
 /// Determines which algorithms the autohinter will use while generating
 /// metrics and processing a glyph outline.
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
-pub(crate) enum ScriptGroup {
+pub enum ScriptGroup {
     /// All scripts that are not CJK or Indic.
     ///
     /// FreeType calls this Latin.
@@ -320,7 +332,7 @@ pub(crate) enum ScriptGroup {
 /// Defines the basic properties for each script supported by the
 /// autohinter.
 #[derive(Clone, Debug)]
-pub(crate) struct ScriptClass {
+pub struct ScriptClass {
     #[allow(unused)]
     pub name: &'static str,
     /// Group that defines how glyphs belonging to this script are hinted.
@@ -343,7 +355,7 @@ pub(crate) struct ScriptClass {
 /// in the cases where style coverage is determined by OpenType feature
 /// coverage.
 #[derive(Clone, Debug)]
-pub(crate) struct StyleClass {
+pub struct StyleClass {
     #[allow(unused)]
     pub name: &'static str,
     /// Index of self in the STYLE_CLASSES array.

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -44,7 +44,7 @@ impl GlyphStyle {
         StyleClass::from_index(self.style_index()?)
     }
 
-    /// Returns the index of teh style class for this class.
+    /// Returns the index of the style class for this class.
     pub const fn style_index(self) -> Option<u16> {
         let ix = self.0 & Self::STYLE_INDEX_MASK;
         if ix != Self::UNASSIGNED {

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -8,7 +8,7 @@ use raw::types::{GlyphId, Tag};
 /// Defines the script and style associated with a single glyph.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(transparent)]
-pub(crate) struct GlyphStyle(pub(super) u16);
+pub struct GlyphStyle(pub(super) u16);
 
 impl GlyphStyle {
     // The following flags roughly correspond to those defined in FreeType
@@ -24,41 +24,32 @@ impl GlyphStyle {
     // for a given script
     const FROM_GSUB_OUTPUT: u16 = 0x8000;
 
-    pub const fn is_unassigned(self) -> bool {
+    pub(super) const fn is_unassigned(self) -> bool {
         self.0 & Self::STYLE_INDEX_MASK == Self::UNASSIGNED
     }
 
+    /// Returns true if this glyph is a non-base (usually a mark).
     pub const fn is_non_base(self) -> bool {
         self.0 & Self::NON_BASE != 0
     }
 
+    /// Returns true if this glyph is a digit.
     pub const fn is_digit(self) -> bool {
         self.0 & Self::DIGIT != 0
     }
 
+    /// Returns the associated style class for this glyph.
     pub fn style_class(self) -> Option<&'static StyleClass> {
         StyleClass::from_index(self.style_index()?)
     }
 
-    pub fn style_index(self) -> Option<u16> {
+    pub(super) fn style_index(self) -> Option<u16> {
         let ix = self.0 & Self::STYLE_INDEX_MASK;
         if ix != Self::UNASSIGNED {
             Some(ix)
         } else {
             None
         }
-    }
-
-    #[cfg(feature = "autohinter")]
-    pub(crate) fn from_parts(style_index: u16, non_base: bool, digit: bool) -> Self {
-        let mut bits = style_index & Self::STYLE_INDEX_MASK;
-        if non_base {
-            bits |= Self::NON_BASE;
-        }
-        if digit {
-            bits |= Self::DIGIT;
-        }
-        Self(bits)
     }
 
     fn maybe_assign(&mut self, other: Self) {
@@ -333,12 +324,11 @@ pub enum ScriptGroup {
 /// autohinter.
 #[derive(Clone, Debug)]
 pub struct ScriptClass {
-    #[allow(unused)]
+    /// The name of the script class.
     pub name: &'static str,
     /// Group that defines how glyphs belonging to this script are hinted.
     pub group: ScriptGroup,
     /// Unicode tag for the script.
-    #[allow(unused)]
     pub tag: Tag,
     /// True if outline edges are processed top to bottom.
     pub hint_top_to_bottom: bool,
@@ -356,7 +346,7 @@ pub struct ScriptClass {
 /// coverage.
 #[derive(Clone, Debug)]
 pub struct StyleClass {
-    #[allow(unused)]
+    /// The name of the style class.
     pub name: &'static str,
     /// Index of self in the STYLE_CLASSES array.
     pub index: usize,

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -24,6 +24,13 @@ impl GlyphStyle {
     // for a given script
     const FROM_GSUB_OUTPUT: u16 = 0x8000;
 
+    /// Constructs a new glyph style from the given style index and properties.
+    pub const fn from_raw_parts(style_index: u16, is_non_base: bool, is_digit: bool) -> Self {
+        let base = is_non_base as u16 * Self::NON_BASE;
+        let digit = is_digit as u16 * Self::DIGIT;
+        Self((style_index & Self::STYLE_INDEX_MASK) | base | digit)
+    }
+
     /// Returns true if this glyph doesn't have an assigned style.
     pub const fn is_unassigned(self) -> bool {
         self.0 & Self::STYLE_INDEX_MASK == Self::UNASSIGNED

--- a/skrifa/src/outline/autohint/style.rs
+++ b/skrifa/src/outline/autohint/style.rs
@@ -24,7 +24,8 @@ impl GlyphStyle {
     // for a given script
     const FROM_GSUB_OUTPUT: u16 = 0x8000;
 
-    pub(super) const fn is_unassigned(self) -> bool {
+    /// Returns true if this glyph doesn't have an assigned style.
+    pub const fn is_unassigned(self) -> bool {
         self.0 & Self::STYLE_INDEX_MASK == Self::UNASSIGNED
     }
 
@@ -43,7 +44,8 @@ impl GlyphStyle {
         StyleClass::from_index(self.style_index()?)
     }
 
-    pub(super) fn style_index(self) -> Option<u16> {
+    /// Returns the index of teh style class for this class.
+    pub const fn style_index(self) -> Option<u16> {
         let ix = self.0 & Self::STYLE_INDEX_MASK;
         if ix != Self::UNASSIGNED {
             Some(ix)

--- a/skrifa/src/outline/autohint/topo/edges.rs
+++ b/skrifa/src/outline/autohint/topo/edges.rs
@@ -12,7 +12,7 @@ use super::{
         outline::Direction,
         style::ScriptGroup,
     },
-    Axis, Edge, Segment,
+    Axis, BlueProvenance, Edge, Segment,
 };
 
 /// Links segments to edges, using feature analysis for selection.
@@ -309,10 +309,12 @@ pub(crate) fn compute_blue_edges(
     for edge in &mut axis.edges {
         let mut best_blue = None;
         let mut best_is_neutral = false;
+        let mut best_blue_idx = None;
+        let mut best_blue_is_shoot = false;
         // Initial threshold as a fraction of em size with a max distance
         // of 0.5 pixels
         let mut best_dist = initial_best_dest;
-        for (unscaled_blue, blue) in unscaled_blues.iter().zip(blues) {
+        for (blue_ix, (unscaled_blue, blue)) in unscaled_blues.iter().zip(blues).enumerate() {
             // Ignore inactive blue zones
             if !blue.is_active {
                 continue;
@@ -342,6 +344,8 @@ pub(crate) fn compute_blue_edges(
                     best_dist = dist;
                     best_blue = Some(matching_blue);
                     best_is_neutral = is_neutral;
+                    best_blue_idx = Some(blue_ix as u16);
+                    best_blue_is_shoot = false;
                 }
                 if group == ScriptGroup::Default {
                     // Now compare to overshoot position for the default script
@@ -358,6 +362,8 @@ pub(crate) fn compute_blue_edges(
                                 best_dist = dist;
                                 best_blue = Some(blue.overshoot);
                                 best_is_neutral = is_neutral;
+                                best_blue_idx = Some(blue_ix as u16);
+                                best_blue_is_shoot = true;
                             }
                         }
                     }
@@ -366,6 +372,10 @@ pub(crate) fn compute_blue_edges(
         }
         if let Some(best_blue) = best_blue {
             edge.blue_edge = Some(best_blue);
+            edge.blue_provenance = Some(BlueProvenance {
+                blue_ix: best_blue_idx.unwrap_or_default(),
+                is_shoot: best_blue_is_shoot,
+            });
             if best_is_neutral {
                 edge.flags |= Edge::NEUTRAL;
             }
@@ -398,6 +408,7 @@ mod tests {
                 flags: Edge::ROUND,
                 dir: Direction::Up,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(3),
                 serif_ix: None,
                 scale: 0,
@@ -411,6 +422,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Up,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(2),
                 serif_ix: None,
                 scale: 0,
@@ -424,6 +436,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(1),
                 serif_ix: None,
                 scale: 0,
@@ -437,6 +450,7 @@ mod tests {
                 flags: Edge::ROUND,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(0),
                 serif_ix: None,
                 scale: 0,
@@ -455,6 +469,10 @@ mod tests {
                     scaled: -246,
                     fitted: -256,
                 }),
+                blue_provenance: Some(BlueProvenance {
+                    blue_ix: 2,
+                    is_shoot: false,
+                }),
                 link_ix: None,
                 serif_ix: Some(1),
                 scale: 0,
@@ -468,6 +486,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Left,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(2),
                 serif_ix: None,
                 scale: 0,
@@ -484,6 +503,10 @@ mod tests {
                     scaled: 606,
                     fitted: 576,
                 }),
+                blue_provenance: Some(BlueProvenance {
+                    blue_ix: 0,
+                    is_shoot: false,
+                }),
                 link_ix: Some(1),
                 serif_ix: None,
                 scale: 0,
@@ -497,6 +520,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Right,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: Some(2),
                 scale: 0,
@@ -523,6 +547,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Up,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(1),
                 serif_ix: None,
                 scale: 0,
@@ -536,6 +561,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(0),
                 serif_ix: None,
                 scale: 0,
@@ -549,6 +575,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: None,
                 scale: 0,
@@ -562,6 +589,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: None,
                 scale: 0,
@@ -575,6 +603,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Up,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(6),
                 serif_ix: None,
                 scale: 0,
@@ -588,6 +617,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Up,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: Some(7),
                 scale: 0,
@@ -601,6 +631,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(4),
                 serif_ix: None,
                 scale: 0,
@@ -614,6 +645,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Up,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(8),
                 serif_ix: None,
                 scale: 0,
@@ -627,6 +659,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Down,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(7),
                 serif_ix: None,
                 scale: 0,
@@ -645,6 +678,10 @@ mod tests {
                     scaled: -80,
                     fitted: -64,
                 }),
+                blue_provenance: Some(BlueProvenance {
+                    blue_ix: 1,
+                    is_shoot: false,
+                }),
                 link_ix: None,
                 serif_ix: None,
                 scale: 0,
@@ -658,6 +695,7 @@ mod tests {
                 flags: Edge::ROUND,
                 dir: Direction::Right,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: None,
                 scale: 0,
@@ -671,6 +709,7 @@ mod tests {
                 flags: Edge::ROUND,
                 dir: Direction::Left,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: None,
                 scale: 0,
@@ -684,6 +723,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Left,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: Some(5),
                 scale: 0,
@@ -697,6 +737,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Right,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(5),
                 serif_ix: None,
                 scale: 0,
@@ -710,6 +751,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Left,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(4),
                 serif_ix: None,
                 scale: 0,
@@ -723,6 +765,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Left,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(7),
                 serif_ix: None,
                 scale: 0,
@@ -736,6 +779,7 @@ mod tests {
                 flags: 0,
                 dir: Direction::Right,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: Some(6),
                 serif_ix: None,
                 scale: 0,
@@ -749,6 +793,7 @@ mod tests {
                 flags: Edge::ROUND,
                 dir: Direction::Left,
                 blue_edge: None,
+                blue_provenance: None,
                 link_ix: None,
                 serif_ix: None,
                 scale: 0,

--- a/skrifa/src/outline/autohint/topo/edges.rs
+++ b/skrifa/src/outline/autohint/topo/edges.rs
@@ -12,7 +12,7 @@ use super::{
         outline::Direction,
         style::ScriptGroup,
     },
-    Axis, BlueProvenance, Edge, Segment,
+    Axis, BlueProvenance, Dimension, Edge, Segment,
 };
 
 /// Links segments to edges, using feature analysis for selection.
@@ -30,13 +30,14 @@ pub(crate) fn compute_edges(
     // This is always passed as 0 in functions that take hinting direction
     // in CJK
     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afcjk.c#L1114>
-    let top_to_bottom_hinting = if axis.dim == Axis::HORIZONTAL || group != ScriptGroup::Default {
-        false
-    } else {
-        top_to_bottom_hinting
-    };
+    let top_to_bottom_hinting =
+        if axis.dim == Dimension::Horizontal || group != ScriptGroup::Default {
+            false
+        } else {
+            top_to_bottom_hinting
+        };
     // Ignore horizontal segments less than 1 pixel in length
-    let segment_length_threshold = if axis.dim == Axis::HORIZONTAL {
+    let segment_length_threshold = if axis.dim == Dimension::Horizontal {
         fixed_div(64, y_scale)
     } else {
         0
@@ -296,10 +297,10 @@ pub(crate) fn compute_blue_edges(
     // For the default script group, don't compute blues in the horizontal
     // direction
     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L3572>
-    if axis.dim != Axis::VERTICAL && group == ScriptGroup::Default {
+    if axis.dim != Dimension::Vertical && group == ScriptGroup::Default {
         return;
     }
-    let axis_scale = if axis.dim == Axis::HORIZONTAL {
+    let axis_scale = if axis.dim == Dimension::Horizontal {
         scale.x_scale
     } else {
         scale.y_scale
@@ -835,8 +836,8 @@ mod tests {
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
         let mut axes = [
-            Axis::new(Axis::HORIZONTAL, outline.orientation),
-            Axis::new(Axis::VERTICAL, outline.orientation),
+            Axis::new(Dimension::Horizontal, outline.orientation),
+            Axis::new(Dimension::Vertical, outline.orientation),
         ];
         for (dim, axis) in axes.iter_mut().enumerate() {
             segments::compute_segments(&mut outline, axis, class.script.group);
@@ -862,7 +863,10 @@ mod tests {
                 class.script.group,
             );
         }
-        assert_eq!(axes[Axis::HORIZONTAL].edges.as_slice(), expected_h_edges);
-        assert_eq!(axes[Axis::VERTICAL].edges.as_slice(), expected_v_edges);
+        assert_eq!(
+            axes[Dimension::Horizontal].edges.as_slice(),
+            expected_h_edges
+        );
+        assert_eq!(axes[Dimension::Vertical].edges.as_slice(), expected_v_edges);
     }
 }

--- a/skrifa/src/outline/autohint/topo/edges.rs
+++ b/skrifa/src/outline/autohint/topo/edges.rs
@@ -12,7 +12,7 @@ use super::{
         outline::Direction,
         style::ScriptGroup,
     },
-    Axis, BlueProvenance, Dimension, Edge, Segment,
+    Axis, BlueProvenance, Dimension, Edge, TopoFlags,
 };
 
 /// Links segments to edges, using feature analysis for selection.
@@ -216,7 +216,7 @@ fn compute_edge_properties(axis: &mut Axis) {
             let segment = &segments[segment_ix];
             let next_segment_ix = segment.edge_next_ix;
             // Check roundness
-            if segment.flags & Segment::ROUND != 0 {
+            if segment.flags.contains(TopoFlags::ROUND) {
                 roundness += 1;
             } else {
                 straightness += 1;
@@ -258,7 +258,7 @@ fn compute_edge_properties(axis: &mut Axis) {
                 };
                 if is_serif {
                     edges[edge_ix].serif_ix = edge2_ix;
-                    edges[edge2_ix.unwrap() as usize].flags |= Edge::SERIF;
+                    edges[edge2_ix.unwrap() as usize].flags |= TopoFlags::SERIF;
                 } else {
                     edges[edge_ix].link_ix = edge2_ix;
                 }
@@ -271,9 +271,9 @@ fn compute_edge_properties(axis: &mut Axis) {
                 .unwrap_or(last_segment_ix);
         }
         let edge = &mut edges[edge_ix];
-        edge.flags = Edge::NORMAL;
+        edge.flags = TopoFlags::NORMAL;
         if roundness > 0 && roundness >= straightness {
-            edge.flags |= Edge::ROUND;
+            edge.flags |= TopoFlags::ROUND;
         }
         // Drop serifs for linked edges
         if edge.serif_ix.is_some() && edge.link_ix.is_some() {
@@ -352,7 +352,7 @@ pub(crate) fn compute_blue_edges(
                     // Now compare to overshoot position for the default script
                     // group
                     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L2579>
-                    if edge.flags & Edge::ROUND != 0 && dist != 0 && !is_neutral {
+                    if edge.flags.contains(TopoFlags::ROUND) && dist != 0 && !is_neutral {
                         let is_under_ref = (edge.fpos as i32) < unscaled_blue.position;
                         if is_top ^ is_under_ref {
                             let dist = fixed_mul(
@@ -374,11 +374,11 @@ pub(crate) fn compute_blue_edges(
         if let Some(best_blue) = best_blue {
             edge.blue_edge = Some(best_blue);
             edge.blue_provenance = Some(BlueProvenance {
-                blue_ix: best_blue_idx.unwrap_or_default(),
+                index: best_blue_idx.unwrap_or_default(),
                 is_shoot: best_blue_is_shoot,
             });
             if best_is_neutral {
-                edge.flags |= Edge::NEUTRAL;
+                edge.flags |= TopoFlags::NEUTRAL;
             }
         }
     }
@@ -406,7 +406,7 @@ mod tests {
                 fpos: 15,
                 opos: 15,
                 pos: 15,
-                flags: Edge::ROUND,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Up,
                 blue_edge: None,
                 blue_provenance: None,
@@ -420,7 +420,7 @@ mod tests {
                 fpos: 123,
                 opos: 126,
                 pos: 126,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 blue_edge: None,
                 blue_provenance: None,
@@ -434,7 +434,7 @@ mod tests {
                 fpos: 186,
                 opos: 190,
                 pos: 190,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -448,7 +448,7 @@ mod tests {
                 fpos: 205,
                 opos: 210,
                 pos: 210,
-                flags: Edge::ROUND,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -464,14 +464,14 @@ mod tests {
                 fpos: -240,
                 opos: -246,
                 pos: -246,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 blue_edge: Some(ScaledWidth {
                     scaled: -246,
                     fitted: -256,
                 }),
                 blue_provenance: Some(BlueProvenance {
-                    blue_ix: 2,
+                    index: 2,
                     is_shoot: false,
                 }),
                 link_ix: None,
@@ -484,7 +484,7 @@ mod tests {
                 fpos: 481,
                 opos: 493,
                 pos: 493,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 blue_edge: None,
                 blue_provenance: None,
@@ -498,14 +498,14 @@ mod tests {
                 fpos: 592,
                 opos: 606,
                 pos: 606,
-                flags: Edge::ROUND | Edge::SERIF,
+                flags: TopoFlags::ROUND | TopoFlags::SERIF,
                 dir: Direction::Right,
                 blue_edge: Some(ScaledWidth {
                     scaled: 606,
                     fitted: 576,
                 }),
                 blue_provenance: Some(BlueProvenance {
-                    blue_ix: 0,
+                    index: 0,
                     is_shoot: false,
                 }),
                 link_ix: Some(1),
@@ -518,7 +518,7 @@ mod tests {
                 fpos: 647,
                 opos: 663,
                 pos: 663,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 blue_edge: None,
                 blue_provenance: None,
@@ -545,7 +545,7 @@ mod tests {
                 fpos: 138,
                 opos: 141,
                 pos: 141,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 blue_edge: None,
                 blue_provenance: None,
@@ -559,7 +559,7 @@ mod tests {
                 fpos: 201,
                 opos: 206,
                 pos: 206,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -573,7 +573,7 @@ mod tests {
                 fpos: 458,
                 opos: 469,
                 pos: 469,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -587,7 +587,7 @@ mod tests {
                 fpos: 569,
                 opos: 583,
                 pos: 583,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -601,7 +601,7 @@ mod tests {
                 fpos: 670,
                 opos: 686,
                 pos: 686,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 blue_edge: None,
                 blue_provenance: None,
@@ -615,7 +615,7 @@ mod tests {
                 fpos: 693,
                 opos: 710,
                 pos: 710,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 blue_edge: None,
                 blue_provenance: None,
@@ -629,7 +629,7 @@ mod tests {
                 fpos: 731,
                 opos: 749,
                 pos: 749,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -643,7 +643,7 @@ mod tests {
                 fpos: 849,
                 opos: 869,
                 pos: 869,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 blue_edge: None,
                 blue_provenance: None,
@@ -657,7 +657,7 @@ mod tests {
                 fpos: 911,
                 opos: 933,
                 pos: 933,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 blue_edge: None,
                 blue_provenance: None,
@@ -673,14 +673,14 @@ mod tests {
                 fpos: -78,
                 opos: -80,
                 pos: -80,
-                flags: Edge::ROUND,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Left,
                 blue_edge: Some(ScaledWidth {
                     scaled: -80,
                     fitted: -64,
                 }),
                 blue_provenance: Some(BlueProvenance {
-                    blue_ix: 1,
+                    index: 1,
                     is_shoot: false,
                 }),
                 link_ix: None,
@@ -693,7 +693,7 @@ mod tests {
                 fpos: 3,
                 opos: 3,
                 pos: 3,
-                flags: Edge::ROUND,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Right,
                 blue_edge: None,
                 blue_provenance: None,
@@ -707,7 +707,7 @@ mod tests {
                 fpos: 133,
                 opos: 136,
                 pos: 136,
-                flags: Edge::ROUND,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Left,
                 blue_edge: None,
                 blue_provenance: None,
@@ -721,7 +721,7 @@ mod tests {
                 fpos: 547,
                 opos: 560,
                 pos: 560,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 blue_edge: None,
                 blue_provenance: None,
@@ -735,7 +735,7 @@ mod tests {
                 fpos: 576,
                 opos: 590,
                 pos: 590,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 blue_edge: None,
                 blue_provenance: None,
@@ -749,7 +749,7 @@ mod tests {
                 fpos: 576,
                 opos: 590,
                 pos: 590,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 blue_edge: None,
                 blue_provenance: None,
@@ -763,7 +763,7 @@ mod tests {
                 fpos: 729,
                 opos: 746,
                 pos: 746,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 blue_edge: None,
                 blue_provenance: None,
@@ -777,7 +777,7 @@ mod tests {
                 fpos: 758,
                 opos: 776,
                 pos: 776,
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 blue_edge: None,
                 blue_provenance: None,
@@ -791,7 +791,7 @@ mod tests {
                 fpos: 788,
                 opos: 807,
                 pos: 807,
-                flags: Edge::ROUND,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Left,
                 blue_edge: None,
                 blue_provenance: None,

--- a/skrifa/src/outline/autohint/topo/edges.rs
+++ b/skrifa/src/outline/autohint/topo/edges.rs
@@ -821,8 +821,12 @@ mod tests {
         let font = FontRef::new(font_data).unwrap();
         let shaper = Shaper::new(&font, ShaperMode::Nominal);
         let class = &style::STYLE_CLASSES[style_class];
-        let unscaled_metrics =
-            metrics::compute_unscaled_style_metrics(&shaper, Default::default(), class);
+        let unscaled_metrics = metrics::compute_unscaled_style_metrics(
+            &shaper,
+            Default::default(),
+            class,
+            Default::default(),
+        );
         let scale = metrics::Scale::new(
             16.0,
             font.head().unwrap().units_per_em() as i32,
@@ -830,11 +834,12 @@ mod tests {
             Default::default(),
             class.script.group,
         );
-        let scaled_metrics = metrics::scale_style_metrics(&unscaled_metrics, scale);
+        let scaled_metrics =
+            metrics::scale_style_metrics(&unscaled_metrics, scale, Default::default());
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(glyph_id).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let mut axes = [
             Axis::new(Dimension::Horizontal, outline.orientation),
             Axis::new(Dimension::Vertical, outline.orientation),

--- a/skrifa/src/outline/autohint/topo/mod.rs
+++ b/skrifa/src/outline/autohint/topo/mod.rs
@@ -12,6 +12,12 @@ use crate::collections::SmallVec;
 pub(crate) use edges::{compute_blue_edges, compute_edges};
 pub(crate) use segments::{compute_segments, link_segments};
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub(crate) struct BlueProvenance {
+    pub blue_ix: u16,
+    pub is_shoot: bool,
+}
+
 /// Maximum number of segments and edges stored inline.
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L306>
@@ -210,6 +216,9 @@ pub(crate) struct Edge {
     pub dir: Direction,
     /// Present if this is a blue edge.
     pub blue_edge: Option<ScaledWidth>,
+    /// Retains which blue zone was selected and whether the overshoot
+    /// position won so recorders can reproduce CVT references later.
+    pub blue_provenance: Option<BlueProvenance>,
     /// Index of linked edge.
     pub link_ix: Option<u16>,
     /// Index of primary edge for serif.

--- a/skrifa/src/outline/autohint/topo/mod.rs
+++ b/skrifa/src/outline/autohint/topo/mod.rs
@@ -156,16 +156,12 @@ pub struct TopoFlags(pub(crate) u8);
 impl TopoFlags {
     /// Regular segment or edge.
     pub const NORMAL: Self = Self(0);
-
     /// Segment or edge has rounded geometry.
     pub const ROUND: Self = Self(1);
-
     /// Segment or edge represents a serif.
     pub const SERIF: Self = Self(2);
-
     /// Segment or edge has been successfully processed.
     pub const DONE: Self = Self(4);
-
     /// Segment or edge aligns to a neutral blue zone.
     pub const NEUTRAL: Self = Self(8);
 }

--- a/skrifa/src/outline/autohint/topo/mod.rs
+++ b/skrifa/src/outline/autohint/topo/mod.rs
@@ -15,7 +15,9 @@ pub(crate) use segments::{compute_segments, link_segments};
 /// Source for an alignment zone.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub struct BlueProvenance {
-    pub blue_ix: u16,
+    /// Index of the blue in the associated metrics.
+    pub index: u16,
+    /// Was the blue an overshoot?
     pub is_shoot: bool,
 }
 
@@ -45,28 +47,51 @@ impl<T> core::ops::Index<Dimension> for [T] {
 
 /// Segments and edges for one dimension of an outline.
 ///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L309>
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L309>
 #[derive(Clone, Default, Debug)]
-pub(crate) struct Axis {
+pub struct Axis {
     /// Either horizontal or vertical.
-    pub dim: Dimension,
+    pub(crate) dim: Dimension,
     /// Depends on dimension and outline orientation.
-    pub major_dir: Direction,
+    pub(crate) major_dir: Direction,
     /// Collection of segments for the axis.
-    pub segments: SmallVec<Segment, MAX_INLINE_SEGMENTS>,
+    pub(crate) segments: SmallVec<Segment, MAX_INLINE_SEGMENTS>,
     /// Collection of edges for the axis.
-    pub edges: SmallVec<Edge, MAX_INLINE_EDGES>,
+    pub(crate) edges: SmallVec<Edge, MAX_INLINE_EDGES>,
+}
+
+impl Axis {
+    /// Returns the dimension of the axis.
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Returns the dominant direction, depending on dimension and the
+    /// orientation of the outline.
+    pub fn major_direction(&self) -> Direction {
+        self.major_dir
+    }
+
+    /// Returns the collection of computed segments.
+    pub fn segments(&self) -> &[Segment] {
+        self.segments.as_slice()
+    }
+
+    /// Returns the collection of computed edges.
+    pub fn edges(&self) -> &[Edge] {
+        self.edges.as_slice()
+    }
 }
 
 impl Axis {
     #[cfg(test)]
-    pub fn new(dim: Dimension, orientation: Option<Orientation>) -> Self {
+    pub(crate) fn new(dim: Dimension, orientation: Option<Orientation>) -> Self {
         let mut axis = Self::default();
         axis.reset(dim, orientation);
         axis
     }
 
-    pub fn reset(&mut self, dim: Dimension, orientation: Option<Orientation>) {
+    pub(crate) fn reset(&mut self, dim: Dimension, orientation: Option<Orientation>) {
         self.dim = dim;
         self.major_dir = match (dim, orientation) {
             (Dimension::Horizontal, Some(Orientation::Clockwise)) => Direction::Down,
@@ -77,13 +102,11 @@ impl Axis {
         self.segments.clear();
         self.edges.clear();
     }
-}
 
-impl Axis {
     /// Inserts the given edge into the sorted edge list.
     ///
     /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.c#L197>
-    pub fn insert_edge(&mut self, edge: Edge, top_to_bottom_hinting: bool) {
+    pub(crate) fn insert_edge(&mut self, edge: Edge, top_to_bottom_hinting: bool) {
         self.edges.push(edge);
         let edges = self.edges.as_mut_slice();
         // If this is the first edge, we're done.
@@ -113,7 +136,7 @@ impl Axis {
     }
 
     /// Links the given segment and edge.
-    pub fn append_segment_to_edge(&mut self, segment_ix: usize, edge_ix: usize) {
+    pub(crate) fn append_segment_to_edge(&mut self, segment_ix: usize, edge_ix: usize) {
         let edge = &mut self.edges[edge_ix];
         let first_ix = edge.first_ix;
         let last_ix = edge.last_ix;
@@ -124,138 +147,327 @@ impl Axis {
     }
 }
 
+/// Flags that define the properties of segments and edges.
+///
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L227>
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+pub struct TopoFlags(pub(crate) u8);
+
+impl TopoFlags {
+    /// Regular segment or edge.
+    pub const NORMAL: Self = Self(0);
+
+    /// Segment or edge has rounded geometry.
+    pub const ROUND: Self = Self(1);
+
+    /// Segment or edge represents a serif.
+    pub const SERIF: Self = Self(2);
+
+    /// Segment or edge has been successfully processed.
+    pub const DONE: Self = Self(4);
+
+    /// Segment or edge aligns to a neutral blue zone.
+    pub const NEUTRAL: Self = Self(8);
+}
+
+impl TopoFlags {
+    /// Creates new flags, truncating the given bits to valid values.
+    pub const fn from_bits_truncate(bits: u8) -> Self {
+        Self(bits & 0b1111)
+    }
+
+    /// Returns the underlying flag bits.
+    pub const fn to_bits(self) -> u8 {
+        self.0
+    }
+
+    /// Returns true if `self` contains all flags in `other`.
+    pub const fn contains(self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Returns true if `self` contains any flags in `other`.
+    pub const fn intersects(self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+impl core::ops::Not for TopoFlags {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self(!self.0)
+    }
+}
+
+impl core::ops::BitOr for TopoFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for TopoFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl core::ops::BitAnd for TopoFlags {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl core::ops::BitAndAssign for TopoFlags {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
 /// Sequence of points with a single dominant direction.
 ///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L262>
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L262>
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub(crate) struct Segment {
+pub struct Segment {
     /// Flags describing the properties of the segment.
-    pub flags: u8,
+    pub(crate) flags: TopoFlags,
     /// Dominant direction of the segment.
-    pub dir: Direction,
+    pub(crate) dir: Direction,
     /// Position of the segment.
-    pub pos: i16,
+    pub(crate) pos: i16,
     /// Deviation from segment position.
-    pub delta: i16,
+    pub(crate) delta: i16,
     /// Minimum coordinate of the segment.
-    pub min_coord: i16,
+    pub(crate) min_coord: i16,
     /// Maximum coordinate of the segment.
-    pub max_coord: i16,
+    pub(crate) max_coord: i16,
     /// Hinted segment height.
-    pub height: i16,
+    pub(crate) height: i16,
     /// Used during stem matching.
-    pub score: i32,
+    pub(crate) score: i32,
     /// Used during stem matching.
-    pub len: i32,
+    pub(crate) len: i32,
     /// Index of best candidate for a stem link.
-    pub link_ix: Option<u16>,
+    pub(crate) link_ix: Option<u16>,
     /// Index of best candidate for a serif link.
-    pub serif_ix: Option<u16>,
+    pub(crate) serif_ix: Option<u16>,
     /// Index of first point in the outline.
-    pub first_ix: u16,
+    pub(crate) first_ix: u16,
     /// Index of last point in the outline.
-    pub last_ix: u16,
+    pub(crate) last_ix: u16,
     /// Index of edge that is associated with the segment.
-    pub edge_ix: Option<u16>,
+    pub(crate) edge_ix: Option<u16>,
     /// Index of next segment in edge's segment list.
-    pub edge_next_ix: Option<u16>,
-}
-
-/// Segment flags.
-///
-/// Note: these are the same as edge flags.
-///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L227>
-impl Segment {
-    pub const NORMAL: u8 = 0;
-    pub const ROUND: u8 = 1;
-    pub const SERIF: u8 = 2;
-    pub const DONE: u8 = 4;
-    pub const NEUTRAL: u8 = 8;
+    pub(crate) edge_next_ix: Option<u16>,
 }
 
 impl Segment {
-    pub fn first(&self) -> usize {
+    /// Returns flags describing the properties of the segment.
+    pub fn flags(&self) -> TopoFlags {
+        self.flags
+    }
+
+    /// Returns the dominant direction of the segment.
+    pub fn direction(&self) -> Direction {
+        self.dir
+    }
+
+    /// Returns the computed position of the segment.
+    pub fn position(&self) -> i16 {
+        self.pos
+    }
+
+    /// Returns the deviation from the computed position.
+    pub fn delta(&self) -> i16 {
+        self.delta
+    }
+
+    /// Returns the minimum coordinate of the segment.
+    pub fn min_coord(&self) -> i16 {
+        self.min_coord
+    }
+
+    /// Returns the maximum coordinate of the segment.
+    pub fn max_coord(&self) -> i16 {
+        self.max_coord
+    }
+
+    /// Returns the hinted height of the segment.
+    pub fn height(&self) -> i16 {
+        self.height
+    }
+
+    /// Returns the computed score of the segment; used during stem matching.
+    pub fn score(&self) -> i32 {
+        self.score
+    }
+
+    /// Returns the computed length of the segment; used during stem matching.
+    pub fn len(&self) -> i32 {
+        self.len
+    }
+
+    /// Returns the index of the best candidate for a stem link.
+    pub fn link_index(&self) -> Option<u16> {
+        self.link_ix
+    }
+
+    /// Returns the index of the best candidate for a serif link.
+    pub fn serif_index(&self) -> Option<u16> {
+        self.serif_ix
+    }
+
+    /// Returns the indices of first and last points that define the segment.
+    pub fn point_indices(&self) -> (u16, u16) {
+        (self.first_ix, self.last_ix)
+    }
+
+    /// Returns the index of edge that is associated with the segment.
+    pub fn edge_index(&self) -> Option<u16> {
+        self.edge_ix
+    }
+
+    /// Returns the index of next segment in the associated edge's segment
+    /// list.
+    pub fn next_in_edge_index(&self) -> Option<u16> {
+        self.edge_next_ix
+    }
+}
+
+impl Segment {
+    pub(crate) fn first(&self) -> usize {
         self.first_ix as usize
     }
 
-    pub fn first_point<'a>(&self, points: &'a [Point]) -> &'a Point {
+    pub(crate) fn first_point<'a>(&self, points: &'a [Point]) -> &'a Point {
         &points[self.first()]
     }
 
-    pub fn last(&self) -> usize {
+    pub(crate) fn last(&self) -> usize {
         self.last_ix as usize
     }
 
-    pub fn last_point<'a>(&self, points: &'a [Point]) -> &'a Point {
+    pub(crate) fn last_point<'a>(&self, points: &'a [Point]) -> &'a Point {
         &points[self.last()]
     }
 
-    pub fn edge<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
+    pub(crate) fn edge<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
         edges.get(self.edge_ix.map(|ix| ix as usize)?)
     }
 
     /// Returns the next segment in this segment's parent edge.
-    pub fn next_in_edge<'a>(&self, segments: &'a [Segment]) -> Option<&'a Segment> {
+    pub(crate) fn next_in_edge<'a>(&self, segments: &'a [Segment]) -> Option<&'a Segment> {
         segments.get(self.edge_next_ix.map(|ix| ix as usize)?)
     }
 
-    pub fn link<'a>(&self, segments: &'a [Segment]) -> Option<&'a Segment> {
+    pub(crate) fn link<'a>(&self, segments: &'a [Segment]) -> Option<&'a Segment> {
         segments.get(self.link_ix.map(|ix| ix as usize)?)
     }
 }
 
 /// Sequence of segments used for grid-fitting.
 ///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L286>
+// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L286>
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub(crate) struct Edge {
+pub struct Edge {
     /// Original, unscaled position in font units.
-    pub fpos: i16,
+    pub(crate) fpos: i16,
     /// Original, scaled position.
-    pub opos: i32,
+    pub(crate) opos: i32,
     /// Current position.
-    pub pos: i32,
+    pub(crate) pos: i32,
     /// Edge flags.
-    pub flags: u8,
+    pub(crate) flags: TopoFlags,
     /// Edge direction.
-    pub dir: Direction,
+    pub(crate) dir: Direction,
     /// Present if this is a blue edge.
-    pub blue_edge: Option<ScaledWidth>,
+    pub(crate) blue_edge: Option<ScaledWidth>,
     /// Retains which blue zone was selected and whether the overshoot
     /// position won so recorders can reproduce CVT references later.
-    pub blue_provenance: Option<BlueProvenance>,
+    pub(crate) blue_provenance: Option<BlueProvenance>,
     /// Index of linked edge.
-    pub link_ix: Option<u16>,
+    pub(crate) link_ix: Option<u16>,
     /// Index of primary edge for serif.
-    pub serif_ix: Option<u16>,
+    pub(crate) serif_ix: Option<u16>,
     /// Used to speed up edge interpolation.
-    pub scale: i32,
+    pub(crate) scale: i32,
     /// Index of first segment in edge.
-    pub first_ix: u16,
+    pub(crate) first_ix: u16,
     /// Index of last segment in edge.
-    pub last_ix: u16,
-}
-
-/// Edge flags.
-///
-/// Note: these are the same as segment flags.
-///
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/afhints.h#L227>
-impl Edge {
-    pub const NORMAL: u8 = Segment::NORMAL;
-    pub const ROUND: u8 = Segment::ROUND;
-    pub const SERIF: u8 = Segment::SERIF;
-    pub const DONE: u8 = Segment::DONE;
-    pub const NEUTRAL: u8 = Segment::NEUTRAL;
+    pub(crate) last_ix: u16,
 }
 
 impl Edge {
-    pub fn link<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
+    /// Returns the original unscaled position in font units.
+    pub fn original_position(&self) -> i16 {
+        self.fpos
+    }
+
+    /// Returns the original scaled position.
+    pub fn scaled_position(&self) -> i32 {
+        self.opos
+    }
+
+    /// Returns the hinted position.
+    pub fn position(&self) -> i32 {
+        self.pos
+    }
+
+    /// Returns flags that define the properties of the edge.
+    pub fn flags(&self) -> TopoFlags {
+        self.flags
+    }
+
+    /// Returns the dominant direction of the edge.
+    pub fn direction(&self) -> Direction {
+        self.dir
+    }
+
+    /// Returns the width of the captured blue zone.
+    pub fn blue_edge(&self) -> Option<ScaledWidth> {
+        self.blue_edge
+    }
+
+    /// Returns which blue zone was selected and whether the overshoot
+    /// position won so recorders can reproduce CVT references later.    
+    pub fn blue_provenance(&self) -> Option<BlueProvenance> {
+        self.blue_provenance
+    }
+
+    /// Returns the index of the linked edge.
+    pub fn link_index(&self) -> Option<u16> {
+        self.link_ix
+    }
+
+    /// Returns the index of the associated serif edge.
+    pub fn serif_index(&self) -> Option<u16> {
+        self.serif_ix
+    }
+
+    /// Returns the computed scale factor of the edge.
+    pub fn scale(&self) -> i32 {
+        self.scale
+    }
+
+    /// Returns the indices of the first and last segments that define the
+    /// edge.
+    ///
+    /// Use [`Segment::next_in_edge_index`] to walk the segment list.
+    pub fn segment_indices(&self) -> (u16, u16) {
+        (self.first_ix, self.last_ix)
+    }
+}
+
+impl Edge {
+    pub(crate) fn link<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
         edges.get(self.link_ix.map(|ix| ix as usize)?)
     }
 
-    pub fn serif<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
+    pub(crate) fn serif<'a>(&self, edges: &'a [Edge]) -> Option<&'a Edge> {
         edges.get(self.serif_ix.map(|ix| ix as usize)?)
     }
 }

--- a/skrifa/src/outline/autohint/topo/mod.rs
+++ b/skrifa/src/outline/autohint/topo/mod.rs
@@ -307,7 +307,7 @@ impl Segment {
     }
 
     /// Returns the computed length of the segment; used during stem matching.
-    pub fn len(&self) -> i32 {
+    pub fn length(&self) -> i32 {
         self.len
     }
 

--- a/skrifa/src/outline/autohint/topo/mod.rs
+++ b/skrifa/src/outline/autohint/topo/mod.rs
@@ -12,8 +12,9 @@ use crate::collections::SmallVec;
 pub(crate) use edges::{compute_blue_edges, compute_edges};
 pub(crate) use segments::{compute_segments, link_segments};
 
+/// Source for an alignment zone.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
-pub(crate) struct BlueProvenance {
+pub struct BlueProvenance {
     pub blue_ix: u16,
     pub is_shoot: bool,
 }
@@ -24,10 +25,23 @@ pub(crate) struct BlueProvenance {
 const MAX_INLINE_SEGMENTS: usize = 18;
 const MAX_INLINE_EDGES: usize = 12;
 
-/// Either horizontal or vertical.
-///
-/// A type alias because it's used as an index.
-pub type Dimension = usize;
+/// The dimension of an axis.
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+pub enum Dimension {
+    /// Metrics and geometry in the horizontal direction.
+    #[default]
+    Horizontal = 0,
+    /// Metrics and geometry in the vertical direction.
+    Vertical = 1,
+}
+
+impl<T> core::ops::Index<Dimension> for [T] {
+    type Output = T;
+
+    fn index(&self, index: Dimension) -> &Self::Output {
+        &self[index as usize]
+    }
+}
 
 /// Segments and edges for one dimension of an outline.
 ///
@@ -45,13 +59,6 @@ pub(crate) struct Axis {
 }
 
 impl Axis {
-    /// X coordinates, i.e. vertical segments and edges.
-    pub const HORIZONTAL: Dimension = 0;
-    /// Y coordinates, i.e. horizontal segments and edges.
-    pub const VERTICAL: Dimension = 1;
-}
-
-impl Axis {
     #[cfg(test)]
     pub fn new(dim: Dimension, orientation: Option<Orientation>) -> Self {
         let mut axis = Self::default();
@@ -62,11 +69,10 @@ impl Axis {
     pub fn reset(&mut self, dim: Dimension, orientation: Option<Orientation>) {
         self.dim = dim;
         self.major_dir = match (dim, orientation) {
-            (Self::HORIZONTAL, Some(Orientation::Clockwise)) => Direction::Down,
-            (Self::VERTICAL, Some(Orientation::Clockwise)) => Direction::Right,
-            (Self::HORIZONTAL, _) => Direction::Up,
-            (Self::VERTICAL, _) => Direction::Left,
-            _ => Direction::None,
+            (Dimension::Horizontal, Some(Orientation::Clockwise)) => Direction::Down,
+            (Dimension::Vertical, Some(Orientation::Clockwise)) => Direction::Right,
+            (Dimension::Horizontal, _) => Direction::Up,
+            (Dimension::Vertical, _) => Direction::Left,
         };
         self.segments.clear();
         self.edges.clear();

--- a/skrifa/src/outline/autohint/topo/segments.rs
+++ b/skrifa/src/outline/autohint/topo/segments.rs
@@ -11,7 +11,7 @@ use super::super::{
     metrics::fixed_div,
     outline::Outline,
     style::ScriptGroup,
-    topo::{Axis, Dimension, Segment},
+    topo::{Axis, Dimension, Segment, TopoFlags},
 };
 use raw::tables::glyf::PointFlags;
 
@@ -452,7 +452,7 @@ fn build_segments(outline: &mut Outline, axis: &mut Axis) -> bool {
                 if is_single_point_contour {
                     segment.pos = state.min_pos as i16;
                     if !point.is_on_curve() {
-                        segment.flags |= Segment::ROUND;
+                        segment.flags |= TopoFlags::ROUND;
                     }
                     segment.min_coord = point.v as i16;
                     segment.max_coord = point.v as i16;
@@ -508,7 +508,7 @@ fn _detect_round_segments_cjk(outline: &mut Outline, axis: &mut Axis) {
     // A segment is considered round if it doesn't have successive on-curve
     // points
     for segment in &mut axis.segments {
-        segment.flags &= !Segment::ROUND;
+        segment.flags &= !TopoFlags::ROUND;
         let mut point_ix = segment.first();
         let last_ix = segment.last();
         let first_point = &points[point_ix];
@@ -526,7 +526,7 @@ fn _detect_round_segments_cjk(outline: &mut Outline, axis: &mut Axis) {
             if point_ix == last_ix {
                 // We've reached the last point without two successive
                 // on-curves so we're round
-                segment.flags |= Segment::ROUND;
+                segment.flags |= TopoFlags::ROUND;
                 break;
             }
         }
@@ -575,7 +575,7 @@ impl State {
         if (!self.min_flags.is_on_curve() || !self.max_flags.is_on_curve())
             && (self.max_on_coord - self.min_on_coord) < flat_threshold
         {
-            segment.flags |= Segment::ROUND;
+            segment.flags |= TopoFlags::ROUND;
         }
         segment.min_coord = self.min_coord as i16;
         segment.max_coord = self.max_coord as i16;
@@ -602,7 +602,7 @@ mod tests {
         let segments = retain_segment_test_fields(&axis.segments);
         let expected = [
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 55,
                 delta: 0,
@@ -614,7 +614,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 112,
                 delta: 0,
@@ -626,7 +626,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 168,
                 delta: 0,
@@ -638,7 +638,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 109,
                 delta: 0,
@@ -650,7 +650,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 453,
                 delta: 0,
@@ -662,7 +662,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 1,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Up,
                 pos: 62,
                 delta: 0,
@@ -674,7 +674,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 1,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Down,
                 pos: 103,
                 delta: 0,
@@ -686,7 +686,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 507,
                 delta: 0,
@@ -714,7 +714,7 @@ mod tests {
         let segments = retain_segment_test_fields(&axis.segments);
         let expected = [
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 pos: 0,
                 delta: 0,
@@ -726,7 +726,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 504,
                 delta: 0,
@@ -738,7 +738,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 109,
                 delta: 0,
@@ -750,7 +750,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 pos: 483,
                 delta: 0,
@@ -762,7 +762,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 647,
                 delta: 0,
@@ -774,7 +774,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 592,
                 delta: 0,
@@ -802,7 +802,7 @@ mod tests {
         let segments = retain_segment_test_fields(&axis.segments);
         let expected = [
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 731,
                 delta: 0,
@@ -814,7 +814,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 670,
                 delta: 0,
@@ -826,7 +826,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 458,
                 delta: 0,
@@ -838,7 +838,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 911,
                 delta: 0,
@@ -850,7 +850,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 693,
                 delta: 0,
@@ -862,7 +862,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 849,
                 delta: 0,
@@ -874,7 +874,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 569,
                 delta: 0,
@@ -886,7 +886,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Down,
                 pos: 201,
                 delta: 0,
@@ -898,7 +898,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Up,
                 pos: 138,
                 delta: 0,
@@ -926,7 +926,7 @@ mod tests {
         let segments = retain_segment_test_fields(&axis.segments);
         let expected = [
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 758,
                 delta: 0,
@@ -938,7 +938,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 pos: 729,
                 delta: 0,
@@ -950,7 +950,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 1,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Left,
                 pos: 133,
                 delta: 0,
@@ -962,7 +962,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 757,
                 delta: 0,
@@ -974,7 +974,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 1,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Right,
                 pos: 3,
                 delta: 2,
@@ -986,7 +986,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Right,
                 pos: 576,
                 delta: 0,
@@ -998,7 +998,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 pos: 547,
                 delta: 0,
@@ -1010,7 +1010,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 0,
+                flags: TopoFlags::NORMAL,
                 dir: Direction::Left,
                 pos: 576,
                 delta: 0,
@@ -1022,7 +1022,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 1,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Left,
                 pos: -78,
                 delta: 0,
@@ -1034,7 +1034,7 @@ mod tests {
                 ..Default::default()
             },
             Segment {
-                flags: 1,
+                flags: TopoFlags::ROUND,
                 dir: Direction::Left,
                 pos: 788,
                 delta: 0,

--- a/skrifa/src/outline/autohint/topo/segments.rs
+++ b/skrifa/src/outline/autohint/topo/segments.rs
@@ -595,7 +595,7 @@ mod tests {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(GlyphId::new(8)).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let mut axis = Axis::new(Dimension::Horizontal, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
         link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
@@ -707,7 +707,7 @@ mod tests {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(GlyphId::new(8)).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let mut axis = Axis::new(Dimension::Vertical, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
         link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
@@ -795,7 +795,7 @@ mod tests {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(GlyphId::new(9)).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let mut axis = Axis::new(Dimension::Horizontal, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Cjk);
         link_segments(&outline, &mut axis, 67109, ScriptGroup::Cjk, None);
@@ -919,7 +919,7 @@ mod tests {
         let glyphs = font.outline_glyphs();
         let glyph = glyphs.get(GlyphId::new(9)).unwrap();
         let mut outline = Outline::default();
-        outline.fill(&glyph, Default::default()).unwrap();
+        outline.fill(&glyph, &[], Default::default()).unwrap();
         let mut axis = Axis::new(Dimension::Vertical, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Cjk);
         link_segments(&outline, &mut axis, 67109, ScriptGroup::Cjk, None);

--- a/skrifa/src/outline/autohint/topo/segments.rs
+++ b/skrifa/src/outline/autohint/topo/segments.rs
@@ -281,7 +281,7 @@ fn link_segments_cjk(outline: &Outline, axis: &mut Axis, scale: i32) {
 ///
 /// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/autofit/aflatin.c#L1562>
 fn assign_point_uvs(outline: &mut Outline, dim: Dimension) {
-    if dim == Axis::HORIZONTAL {
+    if dim == Dimension::Horizontal {
         for point in &mut outline.points {
             point.u = point.fx;
             point.v = point.fy;
@@ -596,7 +596,7 @@ mod tests {
         let glyph = glyphs.get(GlyphId::new(8)).unwrap();
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
-        let mut axis = Axis::new(Axis::HORIZONTAL, outline.orientation);
+        let mut axis = Axis::new(Dimension::Horizontal, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
         link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
         let segments = retain_segment_test_fields(&axis.segments);
@@ -708,7 +708,7 @@ mod tests {
         let glyph = glyphs.get(GlyphId::new(8)).unwrap();
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
-        let mut axis = Axis::new(Axis::VERTICAL, outline.orientation);
+        let mut axis = Axis::new(Dimension::Vertical, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Default);
         link_segments(&outline, &mut axis, 0, ScriptGroup::Default, None);
         let segments = retain_segment_test_fields(&axis.segments);
@@ -796,7 +796,7 @@ mod tests {
         let glyph = glyphs.get(GlyphId::new(9)).unwrap();
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
-        let mut axis = Axis::new(Axis::HORIZONTAL, outline.orientation);
+        let mut axis = Axis::new(Dimension::Horizontal, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Cjk);
         link_segments(&outline, &mut axis, 67109, ScriptGroup::Cjk, None);
         let segments = retain_segment_test_fields(&axis.segments);
@@ -920,7 +920,7 @@ mod tests {
         let glyph = glyphs.get(GlyphId::new(9)).unwrap();
         let mut outline = Outline::default();
         outline.fill(&glyph, Default::default()).unwrap();
-        let mut axis = Axis::new(Axis::VERTICAL, outline.orientation);
+        let mut axis = Axis::new(Dimension::Vertical, outline.orientation);
         compute_segments(&mut outline, &mut axis, ScriptGroup::Cjk);
         link_segments(&outline, &mut axis, 67109, ScriptGroup::Cjk, None);
         let segments = retain_segment_test_fields(&axis.segments);

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -507,6 +507,30 @@ impl<'a> OutlineGlyph<'a> {
         }
     }
 
+    #[cfg(feature = "autohinter")]
+    /// Pass a raw scaled outline to a callback with direct point access.
+    pub fn with_scaled_glyf_outline<R>(
+        &self,
+        size: Size,
+        location: impl Into<LocationRef<'a>>,
+        user_memory: Option<&mut [u8]>,
+        mut callback: impl FnMut(&glyf::ScaledOutline<'_, raw::types::F26Dot6>) -> Result<R, DrawError>,
+    ) -> Result<R, DrawError> {
+        let ppem = size.ppem();
+        let coords = location.into().effective_coords();
+
+        match &self.kind {
+            OutlineKind::Glyf(glyf, outline) => {
+                with_temporary_memory(self, Hinting::None, user_memory, |buf| {
+                    let scaled = FreeTypeScaler::unhinted(glyf, outline, buf, ppem, coords)?
+                        .scale(&outline.glyph, outline.glyph_id)?;
+                    callback(&scaled)
+                })
+            }
+            _ => Err(DrawError::NoSources),
+        }
+    }
+
     pub(crate) fn font(&self) -> &FontRef<'a> {
         match &self.kind {
             OutlineKind::Glyf(glyf, ..) => &glyf.font,

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -96,6 +96,16 @@ pub mod error;
 pub mod pen;
 
 pub use autohint::GlyphStyles;
+#[cfg(feature = "autohinter")]
+pub use autohint::{
+    compute_hint_plan_exported, compute_hint_records_exported,
+    compute_scaled_style_metrics_exported, compute_unscaled_style_metrics_exported,
+    ExportedHintEdge, ExportedHintPlan, ExportedHintRecord, ExportedHintSegment,
+    ExportedScaledBlue, ExportedScaledStyleMetrics, ExportedScaledWidth, ExportedUnscaledBlue,
+    ExportedUnscaledStyleMetrics,
+};
+#[cfg(feature = "autohinter")]
+pub use autohint::{SCRIPT_CLASSES, STYLE_CLASSES};
 pub use hint::{
     Engine, HintingInstance, HintingMode, HintingOptions, LcdLayout, SmoothMode, Target,
 };

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -507,7 +507,6 @@ impl<'a> OutlineGlyph<'a> {
         }
     }
 
-    #[cfg(feature = "autohinter")]
     /// Pass a raw scaled outline to a callback with direct point access.
     pub fn with_scaled_glyf_outline<R>(
         &self,

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -78,7 +78,7 @@
 //! # }
 //! ```
 
-mod autohint;
+pub mod autohint;
 mod cff;
 mod glyf;
 mod hint;
@@ -96,16 +96,6 @@ pub mod error;
 pub mod pen;
 
 pub use autohint::GlyphStyles;
-#[cfg(feature = "autohinter")]
-pub use autohint::{
-    compute_hint_plan_exported, compute_hint_records_exported,
-    compute_scaled_style_metrics_exported, compute_unscaled_style_metrics_exported,
-    ExportedHintEdge, ExportedHintPlan, ExportedHintRecord, ExportedHintSegment,
-    ExportedScaledBlue, ExportedScaledStyleMetrics, ExportedScaledWidth, ExportedUnscaledBlue,
-    ExportedUnscaledStyleMetrics,
-};
-#[cfg(feature = "autohinter")]
-pub use autohint::{SCRIPT_CLASSES, STYLE_CLASSES};
 pub use hint::{
     Engine, HintingInstance, HintingMode, HintingOptions, LcdLayout, SmoothMode, Target,
 };


### PR DESCRIPTION
These changes (mainly hidden behind a feature flag) allow for *non*-runtime auto hinters to record hinting decisions in ways that can be serialised to TrueType bytecode.