### PR TITLE
Update thiserror to v2

### DIFF
--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -17,7 +17,7 @@ fnv = "1.0.7"
 hashbrown = "0.15.1"
 regex = "1.10.4"
 skrifa = { workspace = true }
-thiserror = "1.0.58"
+thiserror = "2.0"
 write-fonts = { workspace = true, features = ["read"] }
 
 


### PR DESCRIPTION
Importing `skera` into Chrome warns that we are introducing an older version of thiserror.