### PR TITLE
Use custom brotli c bindings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,4 +204,3 @@ jobs:
         run: cargo run --release -p fauntlet -- compare-glyphs --print-paths --hinting-engine all --hinting-target all --exit-on-fail fauntlet/test_fonts/*.*tf
       - name: fauntlet compare type1
         run: cargo run --release -p fauntlet -- compare-glyphs --print-paths --exit-on-fail font-test-data/test_data/type1/*.pf*
-

--- a/resources/scripts/println_ignore.txt
+++ b/resources/scripts/println_ignore.txt
@@ -1,8 +1,9 @@
 font-codegen/src/bin/preprocessor.rs
+incremental-font-transfer/src/bin/ift_extend.rs
+incremental-font-transfer/src/bin/ift_graph.rs
 otexplorer/src/main.rs
 otexplorer/src/query.rs
 read-fonts/build.rs
+shared-brotli-patch-decoder/build.rs
 skera/src/main.rs
 skera/src/repack.rs
-incremental-font-transfer/src/bin/ift_extend.rs
-incremental-font-transfer/src/bin/ift_graph.rs

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -13,14 +13,16 @@ all-features = true
 
 [features]
 default = ["c-brotli"]
-c-brotli = ["dep:brotlic-sys"]
+c-brotli = ["cc"]
 rust-brotli = ["dep:brotli-decompressor"]
 
 
 [dependencies]
-brotlic-sys = {version = "0.2.2", optional = true}
 brotli-decompressor = {version = "5.0.0", optional = true}
 cfg-if = "1.0.0"
+
+[build-dependencies]
+cc = { version = "1.2", optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/shared-brotli-patch-decoder/build.rs
+++ b/shared-brotli-patch-decoder/build.rs
@@ -1,0 +1,59 @@
+// Note: We can rely on `brotlic-sys` once https://github.com/AronParker/brotlic/pull/5 is released
+// and merged.
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    println!("cargo:rerun-if-changed={}/build.rs", manifest_dir);
+
+    #[cfg(feature = "c-brotli")]
+    c_brotli::build_brotli();
+}
+
+#[cfg(feature = "c-brotli")]
+mod c_brotli {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    pub fn build_brotli() {
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+        let brotli_dir = out_dir.join("brotli");
+
+        if !brotli_dir.exists() {
+            let status = Command::new("git")
+                .args([
+                    "clone",
+                    "--depth",
+                    "1",
+                    "https://github.com/google/brotli.git",
+                    brotli_dir.to_str().unwrap(),
+                ])
+                .status()
+                .expect("Failed to execute git clone");
+
+            if !status.success() {
+                panic!("Failed to clone brotli repository");
+            }
+        }
+
+        compile_brotli(&brotli_dir);
+    }
+
+    fn compile_brotli(brotli_dir: &Path) {
+        cc::Build::new()
+            .include(brotli_dir.join("c/include"))
+            .files([
+                brotli_dir.join("c/common/constants.c"),
+                brotli_dir.join("c/common/context.c"),
+                brotli_dir.join("c/common/dictionary.c"),
+                brotli_dir.join("c/common/platform.c"),
+                brotli_dir.join("c/common/shared_dictionary.c"),
+                brotli_dir.join("c/common/transform.c"),
+                brotli_dir.join("c/dec/bit_reader.c"),
+                brotli_dir.join("c/dec/decode.c"),
+                brotli_dir.join("c/dec/huffman.c"),
+                brotli_dir.join("c/dec/state.c"),
+                brotli_dir.join("c/dec/prefix.c"),
+                brotli_dir.join("c/dec/static_init.c"),
+            ])
+            .compile("brotli");
+    }
+}

--- a/shared-brotli-patch-decoder/src/c_brotli.rs
+++ b/shared-brotli-patch-decoder/src/c_brotli.rs
@@ -1,5 +1,5 @@
 use crate::decode_error::DecodeError;
-use brotlic_sys::{
+use crate::sys::{
     BrotliDecoderAttachDictionary, BrotliDecoderCreateInstance, BrotliDecoderDecompressStream,
     BrotliDecoderDestroyInstance, BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR,
     BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT,

--- a/shared-brotli-patch-decoder/src/lib.rs
+++ b/shared-brotli-patch-decoder/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "c-brotli")]
 mod c_brotli;
 
+#[cfg(feature = "c-brotli")]
+mod sys;
+
 #[cfg(feature = "rust-brotli")]
 mod rust_brotli;
 

--- a/shared-brotli-patch-decoder/src/sys.rs
+++ b/shared-brotli-patch-decoder/src/sys.rs
@@ -1,0 +1,61 @@
+// Note: These manual bindings and the `cc` build dependency are a temporary measure.
+// We can revert to using `brotlic-sys` if https://github.com/AronParker/brotlic/pull/5
+// is ever merged.
+
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(non_upper_case_globals)]
+
+use std::os::raw::{c_int, c_void};
+
+pub type BrotliDecoderState = c_void;
+
+// From brotli/c/include/brotli/decode.h
+pub type BrotliDecoderResult = c_int;
+pub const BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR: BrotliDecoderResult = 0;
+pub const BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS: BrotliDecoderResult = 1;
+pub const BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: BrotliDecoderResult = 2;
+pub const BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: BrotliDecoderResult = 3;
+
+// From brotli/c/include/brotli/shared_dictionary.h
+pub type BrotliSharedDictionaryType = c_int;
+pub const BrotliSharedDictionaryType_BROTLI_SHARED_DICTIONARY_RAW: BrotliSharedDictionaryType = 0;
+pub const BrotliSharedDictionaryType_BROTLI_SHARED_DICTIONARY_SERIALIZED:
+    BrotliSharedDictionaryType = 1;
+
+// From brotli/c/include/brotli/types.h
+pub type BROTLI_BOOL = c_int;
+pub const BROTLI_TRUE: BROTLI_BOOL = 1;
+pub const BROTLI_FALSE: BROTLI_BOOL = 0;
+
+// From brotli/c/include/brotli/types.h
+pub type brotli_alloc_func =
+    Option<unsafe extern "C" fn(opaque: *mut c_void, size: usize) -> *mut c_void>;
+pub type brotli_free_func = Option<unsafe extern "C" fn(opaque: *mut c_void, address: *mut c_void)>;
+
+// Functions from brotli/c/include/brotli/decode.h
+extern "C" {
+    pub fn BrotliDecoderCreateInstance(
+        alloc_func: brotli_alloc_func,
+        free_func: brotli_free_func,
+        opaque: *mut c_void,
+    ) -> *mut BrotliDecoderState;
+
+    pub fn BrotliDecoderAttachDictionary(
+        state: *mut BrotliDecoderState,
+        type_: BrotliSharedDictionaryType,
+        data_size: usize,
+        data: *const u8,
+    ) -> BROTLI_BOOL;
+
+    pub fn BrotliDecoderDecompressStream(
+        state: *mut BrotliDecoderState,
+        available_in: *mut usize,
+        next_in: *mut *const u8,
+        available_out: *mut usize,
+        next_out: *mut *mut u8,
+        total_out: *mut usize,
+    ) -> BrotliDecoderResult;
+
+    pub fn BrotliDecoderDestroyInstance(state: *mut BrotliDecoderState);
+}


### PR DESCRIPTION
- The current `brotlic-sys` can't be imported into Chromium until the library exports a LICENSE file
  - Would happen after https://github.com/AronParker/brotlic/pull/5 is released
  - This PR unblocks importing into Chromium
- Changes
  - `sys.rs` contains bindings that are used in our shared-brotli-patch-decoder
  - `build.rs` downloads and compiles `brotli`. This won't be used in Chromium as we will have to re-implement it with Chromium's build system and brotli implementation