### PR TITLE
[skera] Upgrade hashbrown to 0.16

### DIFF
--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
 fnv = "1.0.7"
-hashbrown = "0.15.1"
+hashbrown = "0.16.1"
 regex = "1.10.4"
 skrifa = { workspace = true }
 thiserror = "2.0"


### PR DESCRIPTION
Similar to https://github.com/googlefonts/fontations/pull/1795. Simple dep bump for `skera`.