### PR TITLE
Make skera binary (and clap) optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,6 +102,9 @@ jobs:
           pip install -r resources/scripts/skera_ci_requirements.txt
           cargo test -p skera --all-targets --all-features
 
+      - name: cargo test skera (no cli)
+        run: cargo test -p skera --no-default-features
+
       - name: cargo test incremental-font-transfer
         run: cargo test -p incremental-font-transfer --all-targets --all-features
 

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -11,8 +11,17 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "skera"
+path = "src/main.rs"
+required-features = ["cli"]
+
+[features]
+default = ["cli"]
+cli = ["clap"]
+
 [dependencies]
-clap = { version = "4.5.4", features = ["derive"] }
+clap = { version = "4.5.4", features = ["derive"], optional = true }
 fnv = "1.0.7"
 hashbrown = "0.16.1"
 regex = "1.10.4"


### PR DESCRIPTION
Adds a `cli` feature that can disable the `skera` binary