### PR TITLE
[chore] bump patch for types; minor for read, write, skrifa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.11.1", path = "font-types" }
-read-fonts = { version = "0.38.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.11.2", path = "font-types" }
+read-fonts = { version = "0.39.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.41.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.46.0", path = "write-fonts" }
+skrifa = { version = "0.42.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.47.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 skera = { version = "0.1.1", path = "skera" }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.11.1"
+version = "0.11.2"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.38.0"
+version = "0.39.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.41.0"
+version = "0.42.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.46.0"
+version = "0.47.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for font-types from font-types-v0.11.1 to 0.11.2
             8fedc1b [font-types] one matrix to rule them all (#1791)
     Changes for read-fonts from read-fonts-v0.38.0 to 0.39.0
             3acc283 [read-fonts] a few small cff/type1 fixes (#1796)
             1160357 Move OutlinePen to read-fonts (#1793)
             8fedc1b [font-types] one matrix to rule them all (#1791)
             fc6d956 [read-fonts] always use alloc (#1789)
             0692708 [read-fonts] move generated AGL data (#1787)
             6991da3 [read-fonts] build cmap from glyph names/ids + AGL (#1786)
             73fa75c Move postscript code to top-level ps module (#1783)
             c416743 [read-fonts] handle Adobe glyph list (#1780)
             e6ab225 [read-fonts] return actual number of fonts in ttc (#1770)
     Changes for write-fonts from write-fonts-v0.46.0 to 0.47.0
             8fedc1b [font-types] one matrix to rule them all (#1791)
             73fa75c Move postscript code to top-level ps module (#1783)
     Changes for skrifa from skrifa-v0.41.0 to 0.42.0
             1160357 Move OutlinePen to read-fonts (#1793)
             8fedc1b [font-types] one matrix to rule them all (#1791)
             73fa75c Move postscript code to top-level ps module (#1783)
             e02dfeb [read-fonts] add new Transform type for PS fonts (#1774)
             94cae9f [skrifa] Correct default script capitalization
             15573e8 [skrifa] Regen the autohint styles
             dbabf02 [skrifa] Add Nyiakeng Puachue Hmong