### PR TITLE
Remove regex dependency

### DIFF
--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -24,7 +24,6 @@ cli = ["clap"]
 clap = { version = "4.5.4", features = ["derive"], optional = true }
 fnv = "1.0.7"
 hashbrown = "0.16.1"
-regex = "1.10.4"
 skrifa = { workspace = true }
 thiserror = "2.0"
 write-fonts = { workspace = true, features = ["read"] }

--- a/skera/src/parsing_util.rs
+++ b/skera/src/parsing_util.rs
@@ -46,25 +46,37 @@ pub fn parse_unicodes(unicode_str: &str) -> Result<IntSet<u32>, SubsetError> {
     if unicode_str.is_empty() {
         return Ok(result);
     }
-    let re = regex::Regex::new(r"[><\+,;&#}{\\xXuUnNiI\n\t\v\f\r]").unwrap();
-    let s = re.replace_all(unicode_str, " ");
-    for cp in s.split_whitespace() {
+    let unicode_str: String = unicode_str
+        .chars()
+        // Similar to fonttools, but 'x' and 'X' are left for `parse_hex` to deal with. This does
+        // mean we support things like "x12", but not "xx12".
+        .map(|c| match c {
+            '>' | '<' | '+' | ',' | ';' | '&' | '#' | '{' | '}' | '\\' | 'u' | 'U' | 'n' | 'N'
+            | 'i' | 'I' | '\n' | '\t' | '\x0B' | '\x0C' | '\r' => ' ',
+            _ => c,
+        })
+        .collect();
+    for cp in unicode_str.split_whitespace() {
         if let Some((start, end)) = cp.split_once('-') {
-            let start: u32 = u32::from_str_radix(start, 16)
-                .map_err(|_| SubsetError::InvalidUnicode(start.to_owned()))?;
-            let end: u32 = u32::from_str_radix(end, 16)
-                .map_err(|_| SubsetError::InvalidUnicode(end.to_owned()))?;
+            let (start, end) = (parse_hex(start)?, parse_hex(end)?);
             if start > end {
                 return Err(SubsetError::InvalidUnicodeRange { start, end });
             }
             result.extend(start..=end);
         } else {
-            let unicode: u32 = u32::from_str_radix(cp, 16)
-                .map_err(|_| SubsetError::InvalidUnicode(cp.to_owned()))?;
-            result.insert(unicode);
+            result.insert(parse_hex(cp)?);
         }
     }
     Ok(result)
+}
+
+fn parse_hex(hex: &str) -> Result<u32, SubsetError> {
+    let hex = hex
+        .trim_start_matches("0x")
+        .trim_start_matches("0X")
+        .trim_start_matches("x")
+        .trim_start_matches("X");
+    u32::from_str_radix(hex, 16).map_err(|_| SubsetError::InvalidUnicode(hex.to_owned()))
 }
 
 /// Parse a comma or whitespace list of things
@@ -136,6 +148,13 @@ fn test_parse_unicodes() {
     assert!(output.contains(99_u32));
 
     let output = parse_unicodes("u+61,U+65-67").unwrap();
+    assert_eq!(output.len(), 4);
+    assert!(output.contains(97_u32));
+    assert!(output.contains(101_u32));
+    assert!(output.contains(102_u32));
+    assert!(output.contains(103_u32));
+
+    let output = parse_unicodes("0x61,0x65-67").unwrap();
     assert_eq!(output.len(), 4);
     assert!(output.contains(97_u32));
     assert!(output.contains(101_u32));


### PR DESCRIPTION
There are some changes

- We no longer support `xx1234`, this was weird anyways.
- We now support `0x1234`, this would previously be parsed the same as `0,1234`