### PR TITLE
[chore] Bump skera to version 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ skrifa = { version = "0.42.0", path = "skrifa", default-features = false, featur
 write-fonts = { version = "0.47.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
-skera = { version = "0.1.1", path = "skera" }
+skera = { version = "0.1.2", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.1.1"
+version = "0.1.2"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]


### PR DESCRIPTION
Changes for skera from skera-v0.1.1 to 0.1.2
44d6a38 Remove regex dependency (#1803)
67c179d skera: Add feature to enable CLI (#1801)
49f2e86 [skera] Upgrade hashbrown to 0.16
b35d8c6 Update thiserror to v2 (#1795)
da1aa58 Fill out all license metadata (#1790)
22dff8d [subset-repack] add tests for virtual links and repack_last
5ee8a36 [subset-repacker] Split PairPos table
7eb7169 [chore] Bump versions to release avar2 fixes (#1769)