### PR TITLE
[chore] bump read-fonts to 0.39.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.11.2", path = "font-types" }
-read-fonts = { version = "0.39.0", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.39.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.42.0", path = "skrifa", default-features = false, features = ["std"] }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.39.0"
+version = "0.39.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.39.0 to 0.39.1
             f7ed375 [read-fonts] parse more type1/cff metadata (#1810)