### PR TITLE
Release shared-brotli-patch-decoder@0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ read-fonts = { version = "0.39.1", path = "read-fonts", default-features = false
 # shaping support
 skrifa = { version = "0.42.0", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.47.0", path = "write-fonts" }
-shared-brotli-patch-decoder = { version = "0.1.0", path = "shared-brotli-patch-decoder", default-features = false }
+shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.1.0", path = "incremental-font-transfer" }
 skera = { version = "0.1.2", path = "skera" }
 

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-brotli-patch-decoder"
-version = "0.1.0"
+version = "0.1.1"
 description = "Wrapper around brotli-sys which allows for decoding shared brotli (https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/) encoded patch data."
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Changes for shared-brotli-patch-decoder from shared-brotli-patch-decoder-v0.1.0 to 0.1.1

d9900329 Use our own brotli-sys integration (https://github.com/googlefonts/fontations/pull/1797)