### PR TITLE
Bump skera to 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ skrifa = { version = "0.42.0", path = "skrifa", default-features = false, featur
 write-fonts = { version = "0.47.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.2.1", path = "incremental-font-transfer" }
-skera = { version = "0.1.3", path = "skera" }
+skera = { version = "0.1.4", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -25,7 +25,7 @@ read-fonts = { workspace = true, features = ["ift"] }
 write-fonts = { workspace = true, features = ["ift"] }
 font-types = { workspace = true }
 skrifa = { workspace = true }
-skera = { workspace = true, default-features = false }
+skera = { workspace = true }
 shared-brotli-patch-decoder = { workspace = true, default-features = false }
 data-encoding = "2.6.0"
 data-encoding-macro = "0.1.15"

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.1.3"
+version = "0.1.4"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]


### PR DESCRIPTION
     Changes for skera from skera-v0.1.0 to 0.1.4
             5d1fa56      Changes for skera from skera-v0.1.0 to 0.1.4 25d75d7 Remove "cli" from default skera features (#1824)
             25d75d7 Remove "cli" from default skera features (#1824)
             f8413f0 Release skera 0.1.3 (#1822)
             0999020 Remove default features from hashbrown crate
             9e008eb Patch skera to version 0.1.2 (#1804)
             44d6a38 Remove regex dependency (#1803)
             67c179d skera: Add feature to enable CLI (#1801)
             49f2e86 [skera] Upgrade hashbrown to 0.16
             b35d8c6 Update thiserror to v2 (#1795)
             da1aa58 Fill out all license metadata (#1790)
             22dff8d [subset-repack] add tests for virtual links and repack_last
             5ee8a36 [subset-repacker] Split PairPos table
             7eb7169 [chore] Bump versions to release avar2 fixes (#1769)
             9803c4e [codegen] Minimal validation feedback
             b7d0ce3 [codegen] Unbreak klippa