### PR TITLE
[codegen] Generate default impls for tables

### DIFF
--- a/font-codegen/src/format_group.rs
+++ b/font-codegen/src/format_group.rs
@@ -85,6 +85,11 @@ pub(crate) fn generate(item: &TableFormat, items: &Items) -> syn::Result<TokenSt
         min_byte_arms.push(quote!(Self::#var_name(item) => item.min_byte_range(), ));
         min_table_byte_arms.push(quote!(Self::#var_name(item) => item.min_table_bytes(), ));
     }
+    let first_variant = item.variants.first().expect("format group needs variants");
+    // this attribute is currently used only once and we expect it to only ever
+    // be the last variant, but let's be defensive
+    assert!(first_variant.attrs.write_only.is_none(), "sanity check");
+    let first_var_name = &first_variant.name;
 
     Ok(quote! {
         #( #docs )*
@@ -92,6 +97,13 @@ pub(crate) fn generate(item: &TableFormat, items: &Items) -> syn::Result<TokenSt
         pub enum #name<'a> {
             #( #variants ),*
         }
+
+        impl Default for #name<'_> {
+            fn default() -> Self {
+                Self::#first_var_name(Default::default())
+            }
+        }
+
 
         #getters
 

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -55,6 +55,21 @@ impl Table {
     pub(crate) fn raw_name(&self) -> &syn::Ident {
         &self.name
     }
+
+    /// Returns the table's format value if it has a `#[format(N)]` field.
+    pub(crate) fn format_value_and_width(&self) -> Option<(u32, u8)> {
+        let fld = self.fields.iter().find(|fld| fld.attrs.format.is_some())?;
+        let format = fld.attrs.format.as_ref().unwrap().base10_parse().ok()?;
+        let fld_tokens = fld.typ.cooked_type_tokens();
+        let width = if fld_tokens == "u8" {
+            1
+        } else if fld_tokens == "u16" {
+            2
+        } else {
+            panic!("only expect format fields to be u8 or u16");
+        };
+        Some((format, width))
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -52,6 +52,21 @@ impl Table {
     pub(crate) fn raw_name(&self) -> &syn::Ident {
         &self.name
     }
+
+    /// Returns the table's format value if it has a `#[format(N)]` field.
+    pub(crate) fn format_value_and_width(&self) -> Option<(u32, u8)> {
+        let fld = self.fields.iter().find(|fld| fld.attrs.format.is_some())?;
+        let format = fld.attrs.format.as_ref().unwrap().base10_parse().ok()?;
+        let fld_tokens = fld.typ.cooked_type_tokens();
+        let width = if fld_tokens == "u8" {
+            1
+        } else if fld_tokens == "u16" {
+            2
+        } else {
+            panic!("only expect format fields to be u8 or u16");
+        };
+        Some((format, width))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -81,6 +81,49 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
         }
     });
 
+    let const_generic = generic.is_some().then(|| quote!(::<()>));
+    // Generate Default for all tables that don't require external args, skipping
+    // tables that have a 'format' field that is not expected to be 0 or 1.
+    let table_format = item.format_value_and_width();
+
+    // Choose the data constructor based on the table's format value: format=1 needs the
+    // first byte set to 1 so that reading back the format field yields the correct value.
+    let data_method = item
+        .attrs
+        .read_args
+        .is_none()
+        .then(|| match table_format {
+            Some((1, 1)) => Some(quote!(default_format_1_u8_table_data)),
+            Some((1, 2)) => Some(quote!(default_format_1_u16_table_data)),
+            None | Some((0, _)) => Some(quote!(default_table_data)),
+            _ => None,
+        })
+        .flatten();
+
+    let impl_default = data_method.map(|data_method| {
+        let phantom_init = generic.map(|_| quote!(offset_type: std::marker::PhantomData,));
+
+        let min_size_is_zero = min_valid_size.to_string() == "0";
+        // selectively allow this lint so we can assert 0 <= NULL_POOL_SIZE,
+        // which I prefer to elliding the assert
+        let size_check_allow =
+            min_size_is_zero.then(|| quote!(#[allow(clippy::absurd_extreme_comparisons)]));
+
+        quote! {
+            #size_check_allow
+            const _: () = assert!(#raw_name #const_generic ::MIN_SIZE <= NULL_POOL_SIZE);
+
+            impl Default for #raw_name<'_> {
+                fn default() -> Self {
+                    Self {
+                        data: FontData::#data_method(),
+                        #phantom_init
+                    }
+                }
+            }
+        }
+    });
+
     Ok(quote! {
         #optional_format_trait_impl
 
@@ -103,13 +146,14 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
         #[allow(clippy::needless_lifetimes)]
         impl<'a, #generic> #raw_name<'a, #generic> {
             pub const MIN_SIZE: usize = #min_valid_size;
-
             basic_table_impls!(impl_the_methods);
 
             #( #table_ref_getters )*
             #( #field_byte_range_fns )*
 
         }
+
+        #impl_default
 
         #debug
     })
@@ -815,11 +859,19 @@ pub(crate) fn generate_format_group(item: &TableFormat, items: &Items) -> syn::R
         min_table_byte_arms.push(quote!(Self::#var_name(item) => item.min_table_bytes(), ));
     }
 
+    let first_variant = item.variants.iter().find(|v| v.attrs.write_only.is_none());
+    let first_var_name = first_variant.map(|v| &v.name);
     Ok(quote! {
         #( #docs )*
         #[derive(Clone)]
         pub enum #name<'a> {
             #( #variants ),*
+        }
+
+        impl Default for #name<'_> {
+            fn default() -> Self {
+                Self::#first_var_name(Default::default())
+            }
         }
 
         #getters

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -63,6 +63,49 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
         }
     });
 
+    let const_generic = generic.is_some().then(|| quote!(::<()>));
+    // Generate Default for all tables that don't require external args, skipping
+    // tables that have a 'format' field that is not expected to be 0 or 1.
+    let table_format = item.format_value_and_width();
+
+    // Choose the data constructor based on the table's format value: format=1 needs the
+    // first byte set to 1 so that reading back the format field yields the correct value.
+    let data_method = item
+        .attrs
+        .read_args
+        .is_none()
+        .then(|| match table_format {
+            Some((1, 1)) => Some(quote!(default_format_1_u8_table_data)),
+            Some((1, 2)) => Some(quote!(default_format_1_u16_table_data)),
+            None | Some((0, _)) => Some(quote!(default_table_data)),
+            _ => None,
+        })
+        .flatten();
+
+    let impl_default = data_method.map(|data_method| {
+        let phantom_init = generic.map(|_| quote!(offset_type: std::marker::PhantomData,));
+
+        let min_size_is_zero = min_valid_size.to_string() == "0";
+        // selectively allow this lint so we can assert 0 <= NULL_POOL_SIZE,
+        // which I prefer to elliding the assert
+        let size_check_allow =
+            min_size_is_zero.then(|| quote!(#[allow(clippy::absurd_extreme_comparisons)]));
+
+        quote! {
+            #size_check_allow
+            const _: () = assert!(FontData::default_data_long_enough(#raw_name #const_generic ::MIN_SIZE));
+
+            impl Default for #raw_name<'_> {
+                fn default() -> Self {
+                    Self {
+                        data: FontData::#data_method(),
+                        #phantom_init
+                    }
+                }
+            }
+        }
+    });
+
     Ok(quote! {
         #optional_format_trait_impl
 
@@ -87,13 +130,14 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
         #[allow(clippy::needless_lifetimes)]
         impl<'a, #generic> #raw_name<'a, #generic> {
             pub const MIN_SIZE: usize = #min_valid_size;
-
             basic_table_impls!(impl_the_methods);
 
             #( #table_ref_getters )*
             #( #field_byte_range_fns )*
 
         }
+
+        #impl_default
 
         #debug
     })

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -121,6 +121,13 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
                     }
                 }
             }
+
+            impl #raw_name<'_> {
+                /// Returns `true` if this table was created from default (null) data.
+                pub fn is_default(&self) -> bool {
+                    self.data.as_bytes() == FontData::#data_method().as_bytes()
+                }
+            }
         }
     });
 
@@ -871,6 +878,13 @@ pub(crate) fn generate_format_group(item: &TableFormat, items: &Items) -> syn::R
         impl Default for #name<'_> {
             fn default() -> Self {
                 Self::#first_var_name(Default::default())
+            }
+        }
+
+        impl #name<'_> {
+            /// Returns `true` if this table was created from default (null) data.
+            pub fn is_default(&self) -> bool {
+                matches!(self, Self::#first_var_name(t) if t.is_default())
             }
         }
 

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -105,6 +105,16 @@ impl<'a> TableDirectory<'a> {
     }
 }
 
+const _: () = assert!(TableDirectory::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for TableDirectory<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for TableDirectory<'a> {
     fn type_name(&self) -> &str {
@@ -319,6 +329,16 @@ impl<'a> TTCHeader<'a> {
             ..(self.version().compatible((2u16, 0u16)))
                 .then(|| start + u32::RAW_BYTE_LEN)
                 .unwrap_or(start)
+    }
+}
+
+const _: () = assert!(TTCHeader::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for TTCHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -105,6 +105,16 @@ impl<'a> TableDirectory<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(TableDirectory::MIN_SIZE));
+
+impl Default for TableDirectory<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for TableDirectory<'a> {
     fn type_name(&self) -> &str {
@@ -319,6 +329,16 @@ impl<'a> TTCHeader<'a> {
             ..(self.version().compatible((2u16, 0u16)))
                 .then(|| start + u32::RAW_BYTE_LEN)
                 .unwrap_or(start)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(TTCHeader::MIN_SIZE));
+
+impl Default for TTCHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -115,6 +115,13 @@ impl Default for TableDirectory<'_> {
     }
 }
 
+impl TableDirectory<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for TableDirectory<'a> {
     fn type_name(&self) -> &str {
@@ -339,6 +346,13 @@ impl Default for TTCHeader<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl TTCHeader<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -17,6 +17,12 @@ pub enum Lookup<'a> {
     Format10(Lookup10<'a>),
 }
 
+impl Default for Lookup<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
+}
+
 impl<'a> Lookup<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -168,6 +174,16 @@ impl<'a> Lookup0<'a> {
     pub fn values_data_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(Lookup0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Lookup0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1033,6 +1049,16 @@ impl<'a> StateHeader<'a> {
     }
 }
 
+const _: () = assert!(StateHeader::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for StateHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for StateHeader<'a> {
     fn type_name(&self) -> &str {
@@ -1133,6 +1159,16 @@ impl<'a> ClassSubtable<'a> {
     }
 }
 
+const _: () = assert!(ClassSubtable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ClassSubtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClassSubtable<'a> {
     fn type_name(&self) -> &str {
@@ -1195,6 +1231,17 @@ impl<'a> RawBytes<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(RawBytes::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for RawBytes<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1316,6 +1363,16 @@ impl<'a> StxHeader<'a> {
     }
 }
 
+const _: () = assert!(StxHeader::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for StxHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for StxHeader<'a> {
     fn type_name(&self) -> &str {
@@ -1388,6 +1445,17 @@ impl<'a> RawWords<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+    }
+}
+
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(RawWords::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for RawWords<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -17,6 +17,12 @@ pub enum Lookup<'a> {
     Format10(Lookup10<'a>),
 }
 
+impl Default for Lookup<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
+}
+
 impl<'a> Lookup<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -168,6 +174,16 @@ impl<'a> Lookup0<'a> {
     pub fn values_data_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Lookup0::MIN_SIZE));
+
+impl Default for Lookup0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1033,6 +1049,16 @@ impl<'a> StateHeader<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(StateHeader::MIN_SIZE));
+
+impl Default for StateHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for StateHeader<'a> {
     fn type_name(&self) -> &str {
@@ -1133,6 +1159,16 @@ impl<'a> ClassSubtable<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(ClassSubtable::MIN_SIZE));
+
+impl Default for ClassSubtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClassSubtable<'a> {
     fn type_name(&self) -> &str {
@@ -1195,6 +1231,17 @@ impl<'a> RawBytes<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(RawBytes::MIN_SIZE));
+
+impl Default for RawBytes<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1316,6 +1363,16 @@ impl<'a> StxHeader<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(StxHeader::MIN_SIZE));
+
+impl Default for StxHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for StxHeader<'a> {
     fn type_name(&self) -> &str {
@@ -1388,6 +1445,17 @@ impl<'a> RawWords<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+    }
+}
+
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(RawWords::MIN_SIZE));
+
+impl Default for RawWords<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -23,6 +23,13 @@ impl Default for Lookup<'_> {
     }
 }
 
+impl Lookup<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format0 (t) if t . is_default ())
+    }
+}
+
 impl<'a> Lookup<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -184,6 +191,13 @@ impl Default for Lookup0<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Lookup0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1059,6 +1073,13 @@ impl Default for StateHeader<'_> {
     }
 }
 
+impl StateHeader<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for StateHeader<'a> {
     fn type_name(&self) -> &str {
@@ -1169,6 +1190,13 @@ impl Default for ClassSubtable<'_> {
     }
 }
 
+impl ClassSubtable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClassSubtable<'a> {
     fn type_name(&self) -> &str {
@@ -1242,6 +1270,13 @@ impl Default for RawBytes<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl RawBytes<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1373,6 +1408,13 @@ impl Default for StxHeader<'_> {
     }
 }
 
+impl StxHeader<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for StxHeader<'a> {
     fn type_name(&self) -> &str {
@@ -1456,6 +1498,13 @@ impl Default for RawWords<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl RawWords<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -95,6 +95,16 @@ impl<'a> Ankr<'a> {
     }
 }
 
+const _: () = assert!(Ankr::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Ankr<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ankr<'a> {
     fn type_name(&self) -> &str {
@@ -176,6 +186,16 @@ impl<'a> GlyphDataEntry<'a> {
         let num_points = self.num_points();
         let start = self.num_points_byte_range().end;
         start..start + (num_points as usize).saturating_mul(AnchorPoint::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(GlyphDataEntry::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for GlyphDataEntry<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -95,6 +95,16 @@ impl<'a> Ankr<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Ankr::MIN_SIZE));
+
+impl Default for Ankr<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ankr<'a> {
     fn type_name(&self) -> &str {
@@ -176,6 +186,16 @@ impl<'a> GlyphDataEntry<'a> {
         let num_points = self.num_points();
         let start = self.num_points_byte_range().end;
         start..start + (num_points as usize).saturating_mul(AnchorPoint::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(GlyphDataEntry::MIN_SIZE));
+
+impl Default for GlyphDataEntry<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -105,6 +105,13 @@ impl Default for Ankr<'_> {
     }
 }
 
+impl Ankr<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ankr<'a> {
     fn type_name(&self) -> &str {
@@ -196,6 +203,13 @@ impl Default for GlyphDataEntry<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl GlyphDataEntry<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -132,6 +132,16 @@ impl<'a> Avar<'a> {
     }
 }
 
+const _: () = assert!(Avar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Avar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Avar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -132,6 +132,16 @@ impl<'a> Avar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Avar::MIN_SIZE));
+
+impl Default for Avar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Avar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -142,6 +142,13 @@ impl Default for Avar<'_> {
     }
 }
 
+impl Avar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Avar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -110,6 +110,16 @@ impl<'a> Base<'a> {
     }
 }
 
+const _: () = assert!(Base::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Base<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Base<'a> {
     fn type_name(&self) -> &str {
@@ -210,6 +220,16 @@ impl<'a> Axis<'a> {
     }
 }
 
+const _: () = assert!(Axis::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Axis<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Axis<'a> {
     fn type_name(&self) -> &str {
@@ -295,6 +315,16 @@ impl<'a> BaseTagList<'a> {
     }
 }
 
+const _: () = assert!(BaseTagList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BaseTagList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseTagList<'a> {
     fn type_name(&self) -> &str {
@@ -370,6 +400,16 @@ impl<'a> BaseScriptList<'a> {
         let base_script_count = self.base_script_count();
         let start = self.base_script_count_byte_range().end;
         start..start + (base_script_count as usize).saturating_mul(BaseScriptRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(BaseScriptList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BaseScriptList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -547,6 +587,16 @@ impl<'a> BaseScript<'a> {
     }
 }
 
+const _: () = assert!(BaseScript::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BaseScript<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseScript<'a> {
     fn type_name(&self) -> &str {
@@ -718,6 +768,16 @@ impl<'a> BaseValues<'a> {
     }
 }
 
+const _: () = assert!(BaseValues::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BaseValues<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseValues<'a> {
     fn type_name(&self) -> &str {
@@ -850,6 +910,16 @@ impl<'a> MinMax<'a> {
     }
 }
 
+const _: () = assert!(MinMax::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MinMax<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MinMax<'a> {
     fn type_name(&self) -> &str {
@@ -972,6 +1042,12 @@ pub enum BaseCoord<'a> {
     Format1(BaseCoordFormat1<'a>),
     Format2(BaseCoordFormat2<'a>),
     Format3(BaseCoordFormat3<'a>),
+}
+
+impl Default for BaseCoord<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> BaseCoord<'a> {
@@ -1115,6 +1191,16 @@ impl<'a> BaseCoordFormat1<'a> {
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(BaseCoordFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BaseCoordFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -110,6 +110,16 @@ impl<'a> Base<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Base::MIN_SIZE));
+
+impl Default for Base<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Base<'a> {
     fn type_name(&self) -> &str {
@@ -210,6 +220,16 @@ impl<'a> Axis<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Axis::MIN_SIZE));
+
+impl Default for Axis<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Axis<'a> {
     fn type_name(&self) -> &str {
@@ -295,6 +315,16 @@ impl<'a> BaseTagList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BaseTagList::MIN_SIZE));
+
+impl Default for BaseTagList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseTagList<'a> {
     fn type_name(&self) -> &str {
@@ -370,6 +400,16 @@ impl<'a> BaseScriptList<'a> {
         let base_script_count = self.base_script_count();
         let start = self.base_script_count_byte_range().end;
         start..start + (base_script_count as usize).saturating_mul(BaseScriptRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(BaseScriptList::MIN_SIZE));
+
+impl Default for BaseScriptList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -547,6 +587,16 @@ impl<'a> BaseScript<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BaseScript::MIN_SIZE));
+
+impl Default for BaseScript<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseScript<'a> {
     fn type_name(&self) -> &str {
@@ -718,6 +768,16 @@ impl<'a> BaseValues<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BaseValues::MIN_SIZE));
+
+impl Default for BaseValues<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseValues<'a> {
     fn type_name(&self) -> &str {
@@ -850,6 +910,16 @@ impl<'a> MinMax<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(MinMax::MIN_SIZE));
+
+impl Default for MinMax<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MinMax<'a> {
     fn type_name(&self) -> &str {
@@ -972,6 +1042,12 @@ pub enum BaseCoord<'a> {
     Format1(BaseCoordFormat1<'a>),
     Format2(BaseCoordFormat2<'a>),
     Format3(BaseCoordFormat3<'a>),
+}
+
+impl Default for BaseCoord<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> BaseCoord<'a> {
@@ -1115,6 +1191,18 @@ impl<'a> BaseCoordFormat1<'a> {
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    BaseCoordFormat1::MIN_SIZE
+));
+
+impl Default for BaseCoordFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -120,6 +120,13 @@ impl Default for Base<'_> {
     }
 }
 
+impl Base<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Base<'a> {
     fn type_name(&self) -> &str {
@@ -230,6 +237,13 @@ impl Default for Axis<'_> {
     }
 }
 
+impl Axis<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Axis<'a> {
     fn type_name(&self) -> &str {
@@ -325,6 +339,13 @@ impl Default for BaseTagList<'_> {
     }
 }
 
+impl BaseTagList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseTagList<'a> {
     fn type_name(&self) -> &str {
@@ -410,6 +431,13 @@ impl Default for BaseScriptList<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl BaseScriptList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -597,6 +625,13 @@ impl Default for BaseScript<'_> {
     }
 }
 
+impl BaseScript<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseScript<'a> {
     fn type_name(&self) -> &str {
@@ -778,6 +813,13 @@ impl Default for BaseValues<'_> {
     }
 }
 
+impl BaseValues<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseValues<'a> {
     fn type_name(&self) -> &str {
@@ -920,6 +962,13 @@ impl Default for MinMax<'_> {
     }
 }
 
+impl MinMax<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MinMax<'a> {
     fn type_name(&self) -> &str {
@@ -1047,6 +1096,13 @@ pub enum BaseCoord<'a> {
 impl Default for BaseCoord<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl BaseCoord<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -1201,6 +1257,13 @@ impl Default for BaseCoordFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl BaseCoordFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -64,6 +64,16 @@ impl<'a> Cbdt<'a> {
     }
 }
 
+const _: () = assert!(Cbdt::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cbdt<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cbdt<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -64,6 +64,16 @@ impl<'a> Cbdt<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Cbdt::MIN_SIZE));
+
+impl Default for Cbdt<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cbdt<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -74,6 +74,13 @@ impl Default for Cbdt<'_> {
     }
 }
 
+impl Cbdt<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cbdt<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -87,6 +87,16 @@ impl<'a> Cblc<'a> {
     }
 }
 
+const _: () = assert!(Cblc::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cblc<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cblc<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -87,6 +87,16 @@ impl<'a> Cblc<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Cblc::MIN_SIZE));
+
+impl Default for Cblc<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cblc<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -97,6 +97,13 @@ impl Default for Cblc<'_> {
     }
 }
 
+impl Cblc<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cblc<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -105,6 +105,16 @@ impl<'a> CffHeader<'a> {
     }
 }
 
+const _: () = assert!(CffHeader::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CffHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CffHeader<'a> {
     fn type_name(&self) -> &str {
@@ -212,6 +222,16 @@ impl<'a> Index<'a> {
     }
 }
 
+const _: () = assert!(Index::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Index<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Index<'a> {
     fn type_name(&self) -> &str {
@@ -242,6 +262,12 @@ pub enum FdSelect<'a> {
     Format0(FdSelectFormat0<'a>),
     Format3(FdSelectFormat3<'a>),
     Format4(FdSelectFormat4<'a>),
+}
+
+impl Default for FdSelect<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
 }
 
 impl<'a> FdSelect<'a> {
@@ -376,6 +402,16 @@ impl<'a> FdSelectFormat0<'a> {
     pub fn fds_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FdSelectFormat0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for FdSelectFormat0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -717,6 +753,12 @@ pub enum CustomCharset<'a> {
     Format2(CharsetFormat2<'a>),
 }
 
+impl Default for CustomCharset<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
+}
+
 impl<'a> CustomCharset<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -852,6 +894,16 @@ impl<'a> CharsetFormat0<'a> {
     }
 }
 
+const _: () = assert!(CharsetFormat0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CharsetFormat0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CharsetFormat0<'a> {
     fn type_name(&self) -> &str {
@@ -932,6 +984,16 @@ impl<'a> CharsetFormat1<'a> {
             ..start
                 + self.data.len().saturating_sub(start) / CharsetRange1::RAW_BYTE_LEN
                     * CharsetRange1::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(CharsetFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CharsetFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -105,6 +105,16 @@ impl<'a> CffHeader<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(CffHeader::MIN_SIZE));
+
+impl Default for CffHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CffHeader<'a> {
     fn type_name(&self) -> &str {
@@ -212,6 +222,16 @@ impl<'a> Index<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Index::MIN_SIZE));
+
+impl Default for Index<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Index<'a> {
     fn type_name(&self) -> &str {
@@ -242,6 +262,12 @@ pub enum FdSelect<'a> {
     Format0(FdSelectFormat0<'a>),
     Format3(FdSelectFormat3<'a>),
     Format4(FdSelectFormat4<'a>),
+}
+
+impl Default for FdSelect<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
 }
 
 impl<'a> FdSelect<'a> {
@@ -376,6 +402,18 @@ impl<'a> FdSelectFormat0<'a> {
     pub fn fds_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    FdSelectFormat0::MIN_SIZE
+));
+
+impl Default for FdSelectFormat0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -717,6 +755,12 @@ pub enum CustomCharset<'a> {
     Format2(CharsetFormat2<'a>),
 }
 
+impl Default for CustomCharset<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
+}
+
 impl<'a> CustomCharset<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -852,6 +896,16 @@ impl<'a> CharsetFormat0<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(CharsetFormat0::MIN_SIZE));
+
+impl Default for CharsetFormat0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CharsetFormat0<'a> {
     fn type_name(&self) -> &str {
@@ -932,6 +986,16 @@ impl<'a> CharsetFormat1<'a> {
             ..start
                 + self.data.len().saturating_sub(start) / CharsetRange1::RAW_BYTE_LEN
                     * CharsetRange1::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(CharsetFormat1::MIN_SIZE));
+
+impl Default for CharsetFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -115,6 +115,13 @@ impl Default for CffHeader<'_> {
     }
 }
 
+impl CffHeader<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CffHeader<'a> {
     fn type_name(&self) -> &str {
@@ -232,6 +239,13 @@ impl Default for Index<'_> {
     }
 }
 
+impl Index<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Index<'a> {
     fn type_name(&self) -> &str {
@@ -267,6 +281,13 @@ pub enum FdSelect<'a> {
 impl Default for FdSelect<'_> {
     fn default() -> Self {
         Self::Format0(Default::default())
+    }
+}
+
+impl FdSelect<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format0 (t) if t . is_default ())
     }
 }
 
@@ -412,6 +433,13 @@ impl Default for FdSelectFormat0<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl FdSelectFormat0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -759,6 +787,13 @@ impl Default for CustomCharset<'_> {
     }
 }
 
+impl CustomCharset<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format0 (t) if t . is_default ())
+    }
+}
+
 impl<'a> CustomCharset<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -904,6 +939,13 @@ impl Default for CharsetFormat0<'_> {
     }
 }
 
+impl CharsetFormat0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CharsetFormat0<'a> {
     fn type_name(&self) -> &str {
@@ -994,6 +1036,13 @@ impl Default for CharsetFormat1<'_> {
         Self {
             data: FontData::default_format_1_u8_table_data(),
         }
+    }
+}
+
+impl CharsetFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u8_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -117,6 +117,16 @@ impl<'a> Cff2Header<'a> {
     }
 }
 
+const _: () = assert!(Cff2Header::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cff2Header<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cff2Header<'a> {
     fn type_name(&self) -> &str {
@@ -222,6 +232,16 @@ impl<'a> Index<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.offsets_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(Index::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Index<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -117,6 +117,16 @@ impl<'a> Cff2Header<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Cff2Header::MIN_SIZE));
+
+impl Default for Cff2Header<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cff2Header<'a> {
     fn type_name(&self) -> &str {
@@ -222,6 +232,16 @@ impl<'a> Index<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.offsets_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Index::MIN_SIZE));
+
+impl Default for Index<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -127,6 +127,13 @@ impl Default for Cff2Header<'_> {
     }
 }
 
+impl Cff2Header<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cff2Header<'a> {
     fn type_name(&self) -> &str {
@@ -242,6 +249,13 @@ impl Default for Index<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Index<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -75,6 +75,16 @@ impl<'a> Cmap<'a> {
     }
 }
 
+const _: () = assert!(Cmap::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cmap<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cmap<'a> {
     fn type_name(&self) -> &str {
@@ -233,6 +243,12 @@ pub enum CmapSubtable<'a> {
     Format12(Cmap12<'a>),
     Format13(Cmap13<'a>),
     Format14(Cmap14<'a>),
+}
+
+impl Default for CmapSubtable<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
 }
 
 impl<'a> CmapSubtable<'a> {
@@ -427,6 +443,16 @@ impl<'a> Cmap0<'a> {
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + (256_usize).saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Cmap0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cmap0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1898,6 +1924,16 @@ impl<'a> DefaultUvs<'a> {
     }
 }
 
+const _: () = assert!(DefaultUvs::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for DefaultUvs<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DefaultUvs<'a> {
     fn type_name(&self) -> &str {
@@ -1980,6 +2016,16 @@ impl<'a> NonDefaultUvs<'a> {
         let num_uvs_mappings = self.num_uvs_mappings();
         let start = self.num_uvs_mappings_byte_range().end;
         start..start + (num_uvs_mappings as usize).saturating_mul(UvsMapping::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(NonDefaultUvs::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for NonDefaultUvs<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -75,6 +75,16 @@ impl<'a> Cmap<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Cmap::MIN_SIZE));
+
+impl Default for Cmap<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cmap<'a> {
     fn type_name(&self) -> &str {
@@ -233,6 +243,12 @@ pub enum CmapSubtable<'a> {
     Format12(Cmap12<'a>),
     Format13(Cmap13<'a>),
     Format14(Cmap14<'a>),
+}
+
+impl Default for CmapSubtable<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
 }
 
 impl<'a> CmapSubtable<'a> {
@@ -427,6 +443,16 @@ impl<'a> Cmap0<'a> {
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
         start..start + (256_usize).saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Cmap0::MIN_SIZE));
+
+impl Default for Cmap0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1898,6 +1924,16 @@ impl<'a> DefaultUvs<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(DefaultUvs::MIN_SIZE));
+
+impl Default for DefaultUvs<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DefaultUvs<'a> {
     fn type_name(&self) -> &str {
@@ -1980,6 +2016,16 @@ impl<'a> NonDefaultUvs<'a> {
         let num_uvs_mappings = self.num_uvs_mappings();
         let start = self.num_uvs_mappings_byte_range().end;
         start..start + (num_uvs_mappings as usize).saturating_mul(UvsMapping::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(NonDefaultUvs::MIN_SIZE));
+
+impl Default for NonDefaultUvs<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -85,6 +85,13 @@ impl Default for Cmap<'_> {
     }
 }
 
+impl Cmap<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cmap<'a> {
     fn type_name(&self) -> &str {
@@ -248,6 +255,13 @@ pub enum CmapSubtable<'a> {
 impl Default for CmapSubtable<'_> {
     fn default() -> Self {
         Self::Format0(Default::default())
+    }
+}
+
+impl CmapSubtable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format0 (t) if t . is_default ())
     }
 }
 
@@ -453,6 +467,13 @@ impl Default for Cmap0<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Cmap0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1934,6 +1955,13 @@ impl Default for DefaultUvs<'_> {
     }
 }
 
+impl DefaultUvs<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DefaultUvs<'a> {
     fn type_name(&self) -> &str {
@@ -2026,6 +2054,13 @@ impl Default for NonDefaultUvs<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl NonDefaultUvs<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -227,6 +227,16 @@ impl<'a> Colr<'a> {
     }
 }
 
+const _: () = assert!(Colr::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Colr<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Colr<'a> {
     fn type_name(&self) -> &str {
@@ -445,6 +455,16 @@ impl<'a> BaseGlyphList<'a> {
     }
 }
 
+const _: () = assert!(BaseGlyphList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BaseGlyphList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseGlyphList<'a> {
     fn type_name(&self) -> &str {
@@ -591,6 +611,16 @@ impl<'a> LayerList<'a> {
     }
 }
 
+const _: () = assert!(LayerList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LayerList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LayerList<'a> {
     fn type_name(&self) -> &str {
@@ -692,6 +722,16 @@ impl<'a> ClipList<'a> {
     }
 }
 
+const _: () = assert!(ClipList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ClipList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClipList<'a> {
     fn type_name(&self) -> &str {
@@ -789,6 +829,12 @@ impl<'a> SomeRecord<'a> for Clip {
 pub enum ClipBox<'a> {
     Format1(ClipBoxFormat1<'a>),
     Format2(ClipBoxFormat2<'a>),
+}
+
+impl Default for ClipBox<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> ClipBox<'a> {
@@ -986,6 +1032,16 @@ impl<'a> ClipBoxFormat1<'a> {
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(ClipBoxFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ClipBoxFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 
@@ -1413,6 +1469,16 @@ impl<'a> ColorLine<'a> {
     }
 }
 
+const _: () = assert!(ColorLine::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ColorLine<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ColorLine<'a> {
     fn type_name(&self) -> &str {
@@ -1506,6 +1572,16 @@ impl<'a> VarColorLine<'a> {
         let num_stops = self.num_stops();
         let start = self.num_stops_byte_range().end;
         start..start + (num_stops as usize).saturating_mul(VarColorStop::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(VarColorLine::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for VarColorLine<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1621,6 +1697,12 @@ pub enum Paint<'a> {
     SkewAroundCenter(PaintSkewAroundCenter<'a>),
     VarSkewAroundCenter(PaintVarSkewAroundCenter<'a>),
     Composite(PaintComposite<'a>),
+}
+
+impl Default for Paint<'_> {
+    fn default() -> Self {
+        Self::ColrLayers(Default::default())
+    }
 }
 
 impl<'a> Paint<'a> {
@@ -1950,6 +2032,16 @@ impl<'a> PaintColrLayers<'a> {
     pub fn first_layer_index_byte_range(&self) -> Range<usize> {
         let start = self.num_layers_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(PaintColrLayers::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for PaintColrLayers<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 
@@ -3691,6 +3783,16 @@ impl<'a> Affine2x3<'a> {
     }
 }
 
+const _: () = assert!(Affine2x3::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Affine2x3<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Affine2x3<'a> {
     fn type_name(&self) -> &str {
@@ -3833,6 +3935,16 @@ impl<'a> VarAffine2x3<'a> {
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.dy_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(VarAffine2x3::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for VarAffine2x3<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -227,6 +227,16 @@ impl<'a> Colr<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Colr::MIN_SIZE));
+
+impl Default for Colr<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Colr<'a> {
     fn type_name(&self) -> &str {
@@ -445,6 +455,16 @@ impl<'a> BaseGlyphList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BaseGlyphList::MIN_SIZE));
+
+impl Default for BaseGlyphList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseGlyphList<'a> {
     fn type_name(&self) -> &str {
@@ -591,6 +611,16 @@ impl<'a> LayerList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(LayerList::MIN_SIZE));
+
+impl Default for LayerList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LayerList<'a> {
     fn type_name(&self) -> &str {
@@ -692,6 +722,16 @@ impl<'a> ClipList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(ClipList::MIN_SIZE));
+
+impl Default for ClipList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClipList<'a> {
     fn type_name(&self) -> &str {
@@ -789,6 +829,12 @@ impl<'a> SomeRecord<'a> for Clip {
 pub enum ClipBox<'a> {
     Format1(ClipBoxFormat1<'a>),
     Format2(ClipBoxFormat2<'a>),
+}
+
+impl Default for ClipBox<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> ClipBox<'a> {
@@ -986,6 +1032,16 @@ impl<'a> ClipBoxFormat1<'a> {
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
         start..start + FWord::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(ClipBoxFormat1::MIN_SIZE));
+
+impl Default for ClipBoxFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 
@@ -1413,6 +1469,16 @@ impl<'a> ColorLine<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(ColorLine::MIN_SIZE));
+
+impl Default for ColorLine<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ColorLine<'a> {
     fn type_name(&self) -> &str {
@@ -1506,6 +1572,16 @@ impl<'a> VarColorLine<'a> {
         let num_stops = self.num_stops();
         let start = self.num_stops_byte_range().end;
         start..start + (num_stops as usize).saturating_mul(VarColorStop::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(VarColorLine::MIN_SIZE));
+
+impl Default for VarColorLine<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1621,6 +1697,12 @@ pub enum Paint<'a> {
     SkewAroundCenter(PaintSkewAroundCenter<'a>),
     VarSkewAroundCenter(PaintVarSkewAroundCenter<'a>),
     Composite(PaintComposite<'a>),
+}
+
+impl Default for Paint<'_> {
+    fn default() -> Self {
+        Self::ColrLayers(Default::default())
+    }
 }
 
 impl<'a> Paint<'a> {
@@ -1950,6 +2032,18 @@ impl<'a> PaintColrLayers<'a> {
     pub fn first_layer_index_byte_range(&self) -> Range<usize> {
         let start = self.num_layers_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    PaintColrLayers::MIN_SIZE
+));
+
+impl Default for PaintColrLayers<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 
@@ -3691,6 +3785,16 @@ impl<'a> Affine2x3<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Affine2x3::MIN_SIZE));
+
+impl Default for Affine2x3<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Affine2x3<'a> {
     fn type_name(&self) -> &str {
@@ -3833,6 +3937,16 @@ impl<'a> VarAffine2x3<'a> {
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.dy_byte_range().end;
         start..start + u32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(VarAffine2x3::MIN_SIZE));
+
+impl Default for VarAffine2x3<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -237,6 +237,13 @@ impl Default for Colr<'_> {
     }
 }
 
+impl Colr<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Colr<'a> {
     fn type_name(&self) -> &str {
@@ -465,6 +472,13 @@ impl Default for BaseGlyphList<'_> {
     }
 }
 
+impl BaseGlyphList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseGlyphList<'a> {
     fn type_name(&self) -> &str {
@@ -621,6 +635,13 @@ impl Default for LayerList<'_> {
     }
 }
 
+impl LayerList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LayerList<'a> {
     fn type_name(&self) -> &str {
@@ -732,6 +753,13 @@ impl Default for ClipList<'_> {
     }
 }
 
+impl ClipList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClipList<'a> {
     fn type_name(&self) -> &str {
@@ -834,6 +862,13 @@ pub enum ClipBox<'a> {
 impl Default for ClipBox<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl ClipBox<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -1042,6 +1077,13 @@ impl Default for ClipBoxFormat1<'_> {
         Self {
             data: FontData::default_format_1_u8_table_data(),
         }
+    }
+}
+
+impl ClipBoxFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u8_table_data().as_bytes()
     }
 }
 
@@ -1479,6 +1521,13 @@ impl Default for ColorLine<'_> {
     }
 }
 
+impl ColorLine<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ColorLine<'a> {
     fn type_name(&self) -> &str {
@@ -1582,6 +1631,13 @@ impl Default for VarColorLine<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl VarColorLine<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1702,6 +1758,13 @@ pub enum Paint<'a> {
 impl Default for Paint<'_> {
     fn default() -> Self {
         Self::ColrLayers(Default::default())
+    }
+}
+
+impl Paint<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: ColrLayers (t) if t . is_default ())
     }
 }
 
@@ -2042,6 +2105,13 @@ impl Default for PaintColrLayers<'_> {
         Self {
             data: FontData::default_format_1_u8_table_data(),
         }
+    }
+}
+
+impl PaintColrLayers<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u8_table_data().as_bytes()
     }
 }
 
@@ -3793,6 +3863,13 @@ impl Default for Affine2x3<'_> {
     }
 }
 
+impl Affine2x3<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Affine2x3<'a> {
     fn type_name(&self) -> &str {
@@ -3945,6 +4022,13 @@ impl Default for VarAffine2x3<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl VarAffine2x3<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -213,6 +213,16 @@ impl<'a> Cpal<'a> {
     }
 }
 
+const _: () = assert!(Cpal::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cpal<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cpal<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -213,6 +213,16 @@ impl<'a> Cpal<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Cpal::MIN_SIZE));
+
+impl Default for Cpal<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cpal<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -223,6 +223,13 @@ impl Default for Cpal<'_> {
     }
 }
 
+impl Cpal<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cpal<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -99,6 +99,16 @@ impl<'a> Cvar<'a> {
     }
 }
 
+const _: () = assert!(Cvar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Cvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -99,6 +99,16 @@ impl<'a> Cvar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Cvar::MIN_SIZE));
+
+impl Default for Cvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -109,6 +109,13 @@ impl Default for Cvar<'_> {
     }
 }
 
+impl Cvar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Cvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -88,6 +88,16 @@ impl<'a> Dsig<'a> {
     }
 }
 
+const _: () = assert!(Dsig::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Dsig<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Dsig<'a> {
     fn type_name(&self) -> &str {
@@ -538,6 +548,16 @@ impl<'a> SignatureBlockFormat1<'a> {
         let signature_length = self.signature_length();
         let start = self.signature_length_byte_range().end;
         start..start + (signature_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(SignatureBlockFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SignatureBlockFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -88,6 +88,16 @@ impl<'a> Dsig<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Dsig::MIN_SIZE));
+
+impl Default for Dsig<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Dsig<'a> {
     fn type_name(&self) -> &str {
@@ -538,6 +548,18 @@ impl<'a> SignatureBlockFormat1<'a> {
         let signature_length = self.signature_length();
         let start = self.signature_length_byte_range().end;
         start..start + (signature_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    SignatureBlockFormat1::MIN_SIZE
+));
+
+impl Default for SignatureBlockFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -98,6 +98,13 @@ impl Default for Dsig<'_> {
     }
 }
 
+impl Dsig<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Dsig<'a> {
     fn type_name(&self) -> &str {
@@ -558,6 +565,13 @@ impl Default for SignatureBlockFormat1<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl SignatureBlockFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -64,6 +64,16 @@ impl<'a> Ebdt<'a> {
     }
 }
 
+const _: () = assert!(Ebdt::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Ebdt<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ebdt<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -64,6 +64,16 @@ impl<'a> Ebdt<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Ebdt::MIN_SIZE));
+
+impl Default for Ebdt<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ebdt<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -74,6 +74,13 @@ impl Default for Ebdt<'_> {
     }
 }
 
+impl Ebdt<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ebdt<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -87,6 +87,16 @@ impl<'a> Eblc<'a> {
     }
 }
 
+const _: () = assert!(Eblc::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Eblc<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Eblc<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -87,6 +87,16 @@ impl<'a> Eblc<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Eblc::MIN_SIZE));
+
+impl Default for Eblc<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Eblc<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -97,6 +97,13 @@ impl Default for Eblc<'_> {
     }
 }
 
+impl Eblc<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Eblc<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -88,6 +88,16 @@ impl<'a> Feat<'a> {
     }
 }
 
+const _: () = assert!(Feat::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Feat<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Feat<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -88,6 +88,16 @@ impl<'a> Feat<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Feat::MIN_SIZE));
+
+impl Default for Feat<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Feat<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -98,6 +98,13 @@ impl Default for Feat<'_> {
     }
 }
 
+impl Feat<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Feat<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -133,6 +133,16 @@ impl<'a> Fvar<'a> {
     }
 }
 
+const _: () = assert!(Fvar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Fvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Fvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -133,6 +133,16 @@ impl<'a> Fvar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Fvar::MIN_SIZE));
+
+impl Default for Fvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Fvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -143,6 +143,13 @@ impl Default for Fvar<'_> {
     }
 }
 
+impl Fvar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Fvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -76,6 +76,16 @@ impl<'a> Gasp<'a> {
     }
 }
 
+const _: () = assert!(Gasp::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Gasp<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gasp<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -76,6 +76,16 @@ impl<'a> Gasp<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Gasp::MIN_SIZE));
+
+impl Default for Gasp<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gasp<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -86,6 +86,13 @@ impl Default for Gasp<'_> {
     }
 }
 
+impl Gasp<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gasp<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -175,6 +175,16 @@ impl<'a> Gdef<'a> {
     }
 }
 
+const _: () = assert!(Gdef::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Gdef<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gdef<'a> {
     fn type_name(&self) -> &str {
@@ -355,6 +365,16 @@ impl<'a> AttachList<'a> {
     }
 }
 
+const _: () = assert!(AttachList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AttachList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AttachList<'a> {
     fn type_name(&self) -> &str {
@@ -446,6 +466,16 @@ impl<'a> AttachPoint<'a> {
         let point_count = self.point_count();
         let start = self.point_count_byte_range().end;
         start..start + (point_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(AttachPoint::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AttachPoint<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -551,6 +581,16 @@ impl<'a> LigCaretList<'a> {
     }
 }
 
+const _: () = assert!(LigCaretList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LigCaretList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigCaretList<'a> {
     fn type_name(&self) -> &str {
@@ -653,6 +693,16 @@ impl<'a> LigGlyph<'a> {
     }
 }
 
+const _: () = assert!(LigGlyph::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LigGlyph<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigGlyph<'a> {
     fn type_name(&self) -> &str {
@@ -694,6 +744,12 @@ pub enum CaretValue<'a> {
     Format1(CaretValueFormat1<'a>),
     Format2(CaretValueFormat2<'a>),
     Format3(CaretValueFormat3<'a>),
+}
+
+impl Default for CaretValue<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> CaretValue<'a> {
@@ -828,6 +884,16 @@ impl<'a> CaretValueFormat1<'a> {
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(CaretValueFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CaretValueFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1114,6 +1180,16 @@ impl<'a> MarkGlyphSets<'a> {
         let mark_glyph_set_count = self.mark_glyph_set_count();
         let start = self.mark_glyph_set_count_byte_range().end;
         start..start + (mark_glyph_set_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(MarkGlyphSets::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MarkGlyphSets<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -175,6 +175,16 @@ impl<'a> Gdef<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Gdef::MIN_SIZE));
+
+impl Default for Gdef<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gdef<'a> {
     fn type_name(&self) -> &str {
@@ -355,6 +365,16 @@ impl<'a> AttachList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(AttachList::MIN_SIZE));
+
+impl Default for AttachList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AttachList<'a> {
     fn type_name(&self) -> &str {
@@ -446,6 +466,16 @@ impl<'a> AttachPoint<'a> {
         let point_count = self.point_count();
         let start = self.point_count_byte_range().end;
         start..start + (point_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(AttachPoint::MIN_SIZE));
+
+impl Default for AttachPoint<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -551,6 +581,16 @@ impl<'a> LigCaretList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(LigCaretList::MIN_SIZE));
+
+impl Default for LigCaretList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigCaretList<'a> {
     fn type_name(&self) -> &str {
@@ -653,6 +693,16 @@ impl<'a> LigGlyph<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(LigGlyph::MIN_SIZE));
+
+impl Default for LigGlyph<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigGlyph<'a> {
     fn type_name(&self) -> &str {
@@ -694,6 +744,12 @@ pub enum CaretValue<'a> {
     Format1(CaretValueFormat1<'a>),
     Format2(CaretValueFormat2<'a>),
     Format3(CaretValueFormat3<'a>),
+}
+
+impl Default for CaretValue<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> CaretValue<'a> {
@@ -828,6 +884,18 @@ impl<'a> CaretValueFormat1<'a> {
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    CaretValueFormat1::MIN_SIZE
+));
+
+impl Default for CaretValueFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1114,6 +1182,16 @@ impl<'a> MarkGlyphSets<'a> {
         let mark_glyph_set_count = self.mark_glyph_set_count();
         let start = self.mark_glyph_set_count_byte_range().end;
         start..start + (mark_glyph_set_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(MarkGlyphSets::MIN_SIZE));
+
+impl Default for MarkGlyphSets<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -185,6 +185,13 @@ impl Default for Gdef<'_> {
     }
 }
 
+impl Gdef<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gdef<'a> {
     fn type_name(&self) -> &str {
@@ -375,6 +382,13 @@ impl Default for AttachList<'_> {
     }
 }
 
+impl AttachList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AttachList<'a> {
     fn type_name(&self) -> &str {
@@ -476,6 +490,13 @@ impl Default for AttachPoint<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl AttachPoint<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -591,6 +612,13 @@ impl Default for LigCaretList<'_> {
     }
 }
 
+impl LigCaretList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigCaretList<'a> {
     fn type_name(&self) -> &str {
@@ -703,6 +731,13 @@ impl Default for LigGlyph<'_> {
     }
 }
 
+impl LigGlyph<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigGlyph<'a> {
     fn type_name(&self) -> &str {
@@ -749,6 +784,13 @@ pub enum CaretValue<'a> {
 impl Default for CaretValue<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl CaretValue<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -894,6 +936,13 @@ impl Default for CaretValueFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl CaretValueFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -1190,6 +1239,13 @@ impl Default for MarkGlyphSets<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl MarkGlyphSets<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -32,6 +32,17 @@ impl<'a> Glyf<'a> {
     basic_table_impls!(impl_the_methods);
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(Glyf::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Glyf<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Glyf<'a> {
     fn type_name(&self) -> &str {
@@ -195,6 +206,16 @@ impl<'a> SimpleGlyph<'a> {
     pub fn glyph_data_byte_range(&self) -> Range<usize> {
         let start = self.instructions_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(SimpleGlyph::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SimpleGlyph<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -733,6 +754,16 @@ impl<'a> CompositeGlyph<'a> {
     }
 }
 
+const _: () = assert!(CompositeGlyph::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CompositeGlyph<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CompositeGlyph<'a> {
     fn type_name(&self) -> &str {
@@ -1142,6 +1173,12 @@ impl<'a> From<CompositeGlyphFlags> for FieldType<'a> {
 pub enum Glyph<'a> {
     Simple(SimpleGlyph<'a>),
     Composite(CompositeGlyph<'a>),
+}
+
+impl Default for Glyph<'_> {
+    fn default() -> Self {
+        Self::Simple(Default::default())
+    }
 }
 
 impl<'a> Glyph<'a> {

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -32,6 +32,17 @@ impl<'a> Glyf<'a> {
     basic_table_impls!(impl_the_methods);
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(Glyf::MIN_SIZE));
+
+impl Default for Glyf<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Glyf<'a> {
     fn type_name(&self) -> &str {
@@ -195,6 +206,16 @@ impl<'a> SimpleGlyph<'a> {
     pub fn glyph_data_byte_range(&self) -> Range<usize> {
         let start = self.instructions_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(SimpleGlyph::MIN_SIZE));
+
+impl Default for SimpleGlyph<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -733,6 +754,16 @@ impl<'a> CompositeGlyph<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(CompositeGlyph::MIN_SIZE));
+
+impl Default for CompositeGlyph<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CompositeGlyph<'a> {
     fn type_name(&self) -> &str {
@@ -1142,6 +1173,12 @@ impl<'a> From<CompositeGlyphFlags> for FieldType<'a> {
 pub enum Glyph<'a> {
     Simple(SimpleGlyph<'a>),
     Composite(CompositeGlyph<'a>),
+}
+
+impl Default for Glyph<'_> {
+    fn default() -> Self {
+        Self::Simple(Default::default())
+    }
 }
 
 impl<'a> Glyph<'a> {

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -43,6 +43,13 @@ impl Default for Glyf<'_> {
     }
 }
 
+impl Glyf<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Glyf<'a> {
     fn type_name(&self) -> &str {
@@ -216,6 +223,13 @@ impl Default for SimpleGlyph<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl SimpleGlyph<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -764,6 +778,13 @@ impl Default for CompositeGlyph<'_> {
     }
 }
 
+impl CompositeGlyph<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CompositeGlyph<'a> {
     fn type_name(&self) -> &str {
@@ -1178,6 +1199,13 @@ pub enum Glyph<'a> {
 impl Default for Glyph<'_> {
     fn default() -> Self {
         Self::Simple(Default::default())
+    }
+}
+
+impl Glyph<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Simple (t) if t . is_default ())
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -129,6 +129,16 @@ impl<'a> Gpos<'a> {
     }
 }
 
+const _: () = assert!(Gpos::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Gpos<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gpos<'a> {
     fn type_name(&self) -> &str {
@@ -606,6 +616,12 @@ pub enum AnchorTable<'a> {
     Format3(AnchorFormat3<'a>),
 }
 
+impl Default for AnchorTable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> AnchorTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -767,6 +783,16 @@ impl<'a> AnchorFormat1<'a> {
     pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(AnchorFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AnchorFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1096,6 +1122,16 @@ impl<'a> MarkArray<'a> {
     }
 }
 
+const _: () = assert!(MarkArray::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MarkArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MarkArray<'a> {
     fn type_name(&self) -> &str {
@@ -1183,6 +1219,12 @@ impl<'a> SomeRecord<'a> for MarkRecord {
 pub enum SinglePos<'a> {
     Format1(SinglePosFormat1<'a>),
     Format2(SinglePosFormat2<'a>),
+}
+
+impl Default for SinglePos<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> SinglePos<'a> {
@@ -1359,6 +1401,16 @@ impl<'a> SinglePosFormat1<'a> {
     pub fn value_record_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
         start..start + <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0)
+    }
+}
+
+const _: () = assert!(SinglePosFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SinglePosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1540,6 +1592,12 @@ impl<'a> std::fmt::Debug for SinglePosFormat2<'a> {
 pub enum PairPos<'a> {
     Format1(PairPosFormat1<'a>),
     Format2(PairPosFormat2<'a>),
+}
+
+impl Default for PairPos<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> PairPos<'a> {
@@ -1760,6 +1818,16 @@ impl<'a> PairPosFormat1<'a> {
         let pair_set_count = self.pair_set_count();
         let start = self.pair_set_count_byte_range().end;
         start..start + (pair_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(PairPosFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for PairPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -2531,6 +2599,16 @@ impl<'a> CursivePosFormat1<'a> {
     }
 }
 
+const _: () = assert!(CursivePosFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CursivePosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CursivePosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -2774,6 +2852,16 @@ impl<'a> MarkBasePosFormat1<'a> {
     pub fn base_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(MarkBasePosFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MarkBasePosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -3156,6 +3244,16 @@ impl<'a> MarkLigPosFormat1<'a> {
     pub fn ligature_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(MarkLigPosFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MarkLigPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -3667,6 +3765,16 @@ impl<'a> MarkMarkPosFormat1<'a> {
     }
 }
 
+const _: () = assert!(MarkMarkPosFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MarkMarkPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MarkMarkPosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -4016,6 +4124,17 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(ExtensionPosFormat1::<()>::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ExtensionPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -129,6 +129,16 @@ impl<'a> Gpos<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Gpos::MIN_SIZE));
+
+impl Default for Gpos<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gpos<'a> {
     fn type_name(&self) -> &str {
@@ -606,6 +616,12 @@ pub enum AnchorTable<'a> {
     Format3(AnchorFormat3<'a>),
 }
 
+impl Default for AnchorTable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> AnchorTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -767,6 +783,16 @@ impl<'a> AnchorFormat1<'a> {
     pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(AnchorFormat1::MIN_SIZE));
+
+impl Default for AnchorFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1096,6 +1122,16 @@ impl<'a> MarkArray<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(MarkArray::MIN_SIZE));
+
+impl Default for MarkArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MarkArray<'a> {
     fn type_name(&self) -> &str {
@@ -1183,6 +1219,12 @@ impl<'a> SomeRecord<'a> for MarkRecord {
 pub enum SinglePos<'a> {
     Format1(SinglePosFormat1<'a>),
     Format2(SinglePosFormat2<'a>),
+}
+
+impl Default for SinglePos<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> SinglePos<'a> {
@@ -1359,6 +1401,18 @@ impl<'a> SinglePosFormat1<'a> {
     pub fn value_record_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
         start..start + <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    SinglePosFormat1::MIN_SIZE
+));
+
+impl Default for SinglePosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1540,6 +1594,12 @@ impl<'a> std::fmt::Debug for SinglePosFormat2<'a> {
 pub enum PairPos<'a> {
     Format1(PairPosFormat1<'a>),
     Format2(PairPosFormat2<'a>),
+}
+
+impl Default for PairPos<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> PairPos<'a> {
@@ -1760,6 +1820,16 @@ impl<'a> PairPosFormat1<'a> {
         let pair_set_count = self.pair_set_count();
         let start = self.pair_set_count_byte_range().end;
         start..start + (pair_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(PairPosFormat1::MIN_SIZE));
+
+impl Default for PairPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -2531,6 +2601,18 @@ impl<'a> CursivePosFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    CursivePosFormat1::MIN_SIZE
+));
+
+impl Default for CursivePosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CursivePosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -2774,6 +2856,18 @@ impl<'a> MarkBasePosFormat1<'a> {
     pub fn base_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    MarkBasePosFormat1::MIN_SIZE
+));
+
+impl Default for MarkBasePosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -3156,6 +3250,18 @@ impl<'a> MarkLigPosFormat1<'a> {
     pub fn ligature_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    MarkLigPosFormat1::MIN_SIZE
+));
+
+impl Default for MarkLigPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -3667,6 +3773,18 @@ impl<'a> MarkMarkPosFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    MarkMarkPosFormat1::MIN_SIZE
+));
+
+impl Default for MarkMarkPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MarkMarkPosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -4012,6 +4130,19 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ExtensionPosFormat1::<()>::MIN_SIZE
+));
+
+impl Default for ExtensionPosFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -139,6 +139,13 @@ impl Default for Gpos<'_> {
     }
 }
 
+impl Gpos<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gpos<'a> {
     fn type_name(&self) -> &str {
@@ -622,6 +629,13 @@ impl Default for AnchorTable<'_> {
     }
 }
 
+impl AnchorTable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
+    }
+}
+
 impl<'a> AnchorTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -793,6 +807,13 @@ impl Default for AnchorFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl AnchorFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -1132,6 +1153,13 @@ impl Default for MarkArray<'_> {
     }
 }
 
+impl MarkArray<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MarkArray<'a> {
     fn type_name(&self) -> &str {
@@ -1224,6 +1252,13 @@ pub enum SinglePos<'a> {
 impl Default for SinglePos<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl SinglePos<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -1414,6 +1449,13 @@ impl Default for SinglePosFormat1<'_> {
     }
 }
 
+impl SinglePosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SinglePosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1597,6 +1639,13 @@ pub enum PairPos<'a> {
 impl Default for PairPos<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl PairPos<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -1828,6 +1877,13 @@ impl Default for PairPosFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl PairPosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -2609,6 +2665,13 @@ impl Default for CursivePosFormat1<'_> {
     }
 }
 
+impl CursivePosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CursivePosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -2862,6 +2925,13 @@ impl Default for MarkBasePosFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl MarkBasePosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -3254,6 +3324,13 @@ impl Default for MarkLigPosFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl MarkLigPosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -3775,6 +3852,13 @@ impl Default for MarkMarkPosFormat1<'_> {
     }
 }
 
+impl MarkMarkPosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MarkMarkPosFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -4135,6 +4219,13 @@ impl Default for ExtensionPosFormat1<'_> {
             data: FontData::default_format_1_u16_table_data(),
             offset_type: std::marker::PhantomData,
         }
+    }
+}
+
+impl ExtensionPosFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -130,6 +130,16 @@ impl<'a> Gsub<'a> {
     }
 }
 
+const _: () = assert!(Gsub::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Gsub<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gsub<'a> {
     fn type_name(&self) -> &str {
@@ -256,6 +266,12 @@ impl std::fmt::Debug for SubstitutionLookup<'_> {
 pub enum SingleSubst<'a> {
     Format1(SingleSubstFormat1<'a>),
     Format2(SingleSubstFormat2<'a>),
+}
+
+impl Default for SingleSubst<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> SingleSubst<'a> {
@@ -411,6 +427,16 @@ impl<'a> SingleSubstFormat1<'a> {
     pub fn delta_glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(SingleSubstFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SingleSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -654,6 +680,16 @@ impl<'a> MultipleSubstFormat1<'a> {
     }
 }
 
+const _: () = assert!(MultipleSubstFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MultipleSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultipleSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -747,6 +783,16 @@ impl<'a> Sequence<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Sequence::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Sequence<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -871,6 +917,16 @@ impl<'a> AlternateSubstFormat1<'a> {
     }
 }
 
+const _: () = assert!(AlternateSubstFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AlternateSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AlternateSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -966,6 +1022,16 @@ impl<'a> AlternateSet<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(AlternateSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AlternateSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1090,6 +1156,16 @@ impl<'a> LigatureSubstFormat1<'a> {
     }
 }
 
+const _: () = assert!(LigatureSubstFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LigatureSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigatureSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1190,6 +1266,16 @@ impl<'a> LigatureSet<'a> {
         let ligature_count = self.ligature_count();
         let start = self.ligature_count_byte_range().end;
         start..start + (ligature_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(LigatureSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LigatureSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1295,6 +1381,16 @@ impl<'a> Ligature<'a> {
             ..start
                 + (transforms::subtract(component_count, 1_usize))
                     .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Ligature::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Ligature<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1427,6 +1523,17 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(ExtensionSubstFormat1::<()>::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ExtensionSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
     }
 }
 
@@ -1687,6 +1794,16 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ReverseChainSingleSubstFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ReverseChainSingleSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -130,6 +130,16 @@ impl<'a> Gsub<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Gsub::MIN_SIZE));
+
+impl Default for Gsub<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gsub<'a> {
     fn type_name(&self) -> &str {
@@ -256,6 +266,12 @@ impl std::fmt::Debug for SubstitutionLookup<'_> {
 pub enum SingleSubst<'a> {
     Format1(SingleSubstFormat1<'a>),
     Format2(SingleSubstFormat2<'a>),
+}
+
+impl Default for SingleSubst<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> SingleSubst<'a> {
@@ -411,6 +427,18 @@ impl<'a> SingleSubstFormat1<'a> {
     pub fn delta_glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
         start..start + i16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    SingleSubstFormat1::MIN_SIZE
+));
+
+impl Default for SingleSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -654,6 +682,18 @@ impl<'a> MultipleSubstFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    MultipleSubstFormat1::MIN_SIZE
+));
+
+impl Default for MultipleSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultipleSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -747,6 +787,16 @@ impl<'a> Sequence<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Sequence::MIN_SIZE));
+
+impl Default for Sequence<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -871,6 +921,18 @@ impl<'a> AlternateSubstFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    AlternateSubstFormat1::MIN_SIZE
+));
+
+impl Default for AlternateSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AlternateSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -966,6 +1028,16 @@ impl<'a> AlternateSet<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(AlternateSet::MIN_SIZE));
+
+impl Default for AlternateSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1090,6 +1162,18 @@ impl<'a> LigatureSubstFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    LigatureSubstFormat1::MIN_SIZE
+));
+
+impl Default for LigatureSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigatureSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1190,6 +1274,16 @@ impl<'a> LigatureSet<'a> {
         let ligature_count = self.ligature_count();
         let start = self.ligature_count_byte_range().end;
         start..start + (ligature_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(LigatureSet::MIN_SIZE));
+
+impl Default for LigatureSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1295,6 +1389,16 @@ impl<'a> Ligature<'a> {
             ..start
                 + (transforms::subtract(component_count, 1_usize))
                     .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Ligature::MIN_SIZE));
+
+impl Default for Ligature<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1423,6 +1527,19 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
         start..start + Offset32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ExtensionSubstFormat1::<()>::MIN_SIZE
+));
+
+impl Default for ExtensionSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
     }
 }
 
@@ -1683,6 +1800,18 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ReverseChainSingleSubstFormat1::MIN_SIZE
+));
+
+impl Default for ReverseChainSingleSubstFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -140,6 +140,13 @@ impl Default for Gsub<'_> {
     }
 }
 
+impl Gsub<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gsub<'a> {
     fn type_name(&self) -> &str {
@@ -271,6 +278,13 @@ pub enum SingleSubst<'a> {
 impl Default for SingleSubst<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl SingleSubst<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -437,6 +451,13 @@ impl Default for SingleSubstFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl SingleSubstFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -690,6 +711,13 @@ impl Default for MultipleSubstFormat1<'_> {
     }
 }
 
+impl MultipleSubstFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultipleSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -793,6 +821,13 @@ impl Default for Sequence<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Sequence<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -927,6 +962,13 @@ impl Default for AlternateSubstFormat1<'_> {
     }
 }
 
+impl AlternateSubstFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AlternateSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1032,6 +1074,13 @@ impl Default for AlternateSet<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl AlternateSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1166,6 +1215,13 @@ impl Default for LigatureSubstFormat1<'_> {
     }
 }
 
+impl LigatureSubstFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigatureSubstFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1276,6 +1332,13 @@ impl Default for LigatureSet<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl LigatureSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1391,6 +1454,13 @@ impl Default for Ligature<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Ligature<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -1534,6 +1604,13 @@ impl Default for ExtensionSubstFormat1<'_> {
             data: FontData::default_format_1_u16_table_data(),
             offset_type: std::marker::PhantomData,
         }
+    }
+}
+
+impl ExtensionSubstFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -1804,6 +1881,13 @@ impl Default for ReverseChainSingleSubstFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl ReverseChainSingleSubstFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -159,6 +159,16 @@ impl<'a> Gvar<'a> {
     }
 }
 
+const _: () = assert!(Gvar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Gvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gvar<'a> {
     fn type_name(&self) -> &str {
@@ -680,6 +690,16 @@ impl<'a> GlyphVariationDataHeader<'a> {
     pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
         let start = self.serialized_data_offset_byte_range().end;
         start..start + self.data.len().saturating_sub(start)
+    }
+}
+
+const _: () = assert!(GlyphVariationDataHeader::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for GlyphVariationDataHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -159,6 +159,16 @@ impl<'a> Gvar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Gvar::MIN_SIZE));
+
+impl Default for Gvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gvar<'a> {
     fn type_name(&self) -> &str {
@@ -680,6 +690,18 @@ impl<'a> GlyphVariationDataHeader<'a> {
     pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
         let start = self.serialized_data_offset_byte_range().end;
         start..start + self.data.len().saturating_sub(start)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    GlyphVariationDataHeader::MIN_SIZE
+));
+
+impl Default for GlyphVariationDataHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -169,6 +169,13 @@ impl Default for Gvar<'_> {
     }
 }
 
+impl Gvar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Gvar<'a> {
     fn type_name(&self) -> &str {
@@ -700,6 +707,13 @@ impl Default for GlyphVariationDataHeader<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl GlyphVariationDataHeader<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -942,6 +942,16 @@ impl<'a> Head<'a> {
     }
 }
 
+const _: () = assert!(Head::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Head<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Head<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -942,6 +942,16 @@ impl<'a> Head<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Head::MIN_SIZE));
+
+impl Default for Head<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Head<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -952,6 +952,13 @@ impl Default for Head<'_> {
     }
 }
 
+impl Head<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Head<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -227,6 +227,16 @@ impl<'a> Hhea<'a> {
     }
 }
 
+const _: () = assert!(Hhea::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Hhea<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hhea<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -227,6 +227,16 @@ impl<'a> Hhea<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Hhea::MIN_SIZE));
+
+impl Default for Hhea<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hhea<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -237,6 +237,13 @@ impl Default for Hhea<'_> {
     }
 }
 
+impl Hhea<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hhea<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -126,6 +126,16 @@ impl<'a> Hvar<'a> {
     }
 }
 
+const _: () = assert!(Hvar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Hvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -126,6 +126,16 @@ impl<'a> Hvar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Hvar::MIN_SIZE));
+
+impl Default for Hvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -136,6 +136,13 @@ impl Default for Hvar<'_> {
     }
 }
 
+impl Hvar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -11,6 +11,12 @@ pub enum Ift<'a> {
     Format2(PatchMapFormat2<'a>),
 }
 
+impl Default for Ift<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> Ift<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -670,6 +676,16 @@ impl<'a> PatchMapFormat1<'a> {
                 .contains(PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET))
             .then(|| start + u32::RAW_BYTE_LEN)
             .unwrap_or(start)
+    }
+}
+
+const _: () = assert!(PatchMapFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for PatchMapFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 
@@ -1450,6 +1466,17 @@ impl<'a> MappingEntries<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(MappingEntries::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MappingEntries<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MappingEntries<'a> {
     fn type_name(&self) -> &str {
@@ -1626,6 +1653,16 @@ impl<'a> EntryData<'a> {
     pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self.child_indices_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(EntryData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for EntryData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2119,6 +2156,17 @@ impl<'a> IdStringData<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(IdStringData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for IdStringData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for IdStringData<'a> {
     fn type_name(&self) -> &str {
@@ -2226,6 +2274,16 @@ impl<'a> TableKeyedPatch<'a> {
         start
             ..start
                 + (transforms::add(patches_count, 1_usize)).saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(TableKeyedPatch::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for TableKeyedPatch<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2339,6 +2397,16 @@ impl<'a> TablePatch<'a> {
     pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(TablePatch::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for TablePatch<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2762,6 +2830,16 @@ impl<'a> GlyphKeyedPatch<'a> {
     pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(GlyphKeyedPatch::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for GlyphKeyedPatch<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -3301,6 +3379,17 @@ impl<'a> GlyphData<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(GlyphData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for GlyphData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -11,6 +11,12 @@ pub enum Ift<'a> {
     Format2(PatchMapFormat2<'a>),
 }
 
+impl Default for Ift<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> Ift<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -670,6 +676,18 @@ impl<'a> PatchMapFormat1<'a> {
                 .contains(PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET))
             .then(|| start + u32::RAW_BYTE_LEN)
             .unwrap_or(start)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    PatchMapFormat1::MIN_SIZE
+));
+
+impl Default for PatchMapFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
     }
 }
 
@@ -1450,6 +1468,17 @@ impl<'a> MappingEntries<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(MappingEntries::MIN_SIZE));
+
+impl Default for MappingEntries<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MappingEntries<'a> {
     fn type_name(&self) -> &str {
@@ -1626,6 +1655,16 @@ impl<'a> EntryData<'a> {
     pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self.child_indices_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(EntryData::MIN_SIZE));
+
+impl Default for EntryData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2119,6 +2158,17 @@ impl<'a> IdStringData<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(IdStringData::MIN_SIZE));
+
+impl Default for IdStringData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for IdStringData<'a> {
     fn type_name(&self) -> &str {
@@ -2226,6 +2276,18 @@ impl<'a> TableKeyedPatch<'a> {
         start
             ..start
                 + (transforms::add(patches_count, 1_usize)).saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    TableKeyedPatch::MIN_SIZE
+));
+
+impl Default for TableKeyedPatch<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2339,6 +2401,16 @@ impl<'a> TablePatch<'a> {
     pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(TablePatch::MIN_SIZE));
+
+impl Default for TablePatch<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2762,6 +2834,18 @@ impl<'a> GlyphKeyedPatch<'a> {
     pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    GlyphKeyedPatch::MIN_SIZE
+));
+
+impl Default for GlyphKeyedPatch<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -3301,6 +3385,17 @@ impl<'a> GlyphData<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(GlyphData::MIN_SIZE));
+
+impl Default for GlyphData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -17,6 +17,13 @@ impl Default for Ift<'_> {
     }
 }
 
+impl Ift<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
+    }
+}
+
 impl<'a> Ift<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -686,6 +693,13 @@ impl Default for PatchMapFormat1<'_> {
         Self {
             data: FontData::default_format_1_u8_table_data(),
         }
+    }
+}
+
+impl PatchMapFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u8_table_data().as_bytes()
     }
 }
 
@@ -1477,6 +1491,13 @@ impl Default for MappingEntries<'_> {
     }
 }
 
+impl MappingEntries<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MappingEntries<'a> {
     fn type_name(&self) -> &str {
@@ -1663,6 +1684,13 @@ impl Default for EntryData<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl EntryData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -2167,6 +2195,13 @@ impl Default for IdStringData<'_> {
     }
 }
 
+impl IdStringData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for IdStringData<'a> {
     fn type_name(&self) -> &str {
@@ -2284,6 +2319,13 @@ impl Default for TableKeyedPatch<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl TableKeyedPatch<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -2407,6 +2449,13 @@ impl Default for TablePatch<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl TablePatch<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -2840,6 +2889,13 @@ impl Default for GlyphKeyedPatch<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl GlyphKeyedPatch<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -3390,6 +3446,13 @@ impl Default for GlyphData<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl GlyphData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -70,6 +70,16 @@ impl<'a> OtKern<'a> {
     }
 }
 
+const _: () = assert!(OtKern::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for OtKern<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for OtKern<'a> {
     fn type_name(&self) -> &str {
@@ -155,6 +165,16 @@ impl<'a> AatKern<'a> {
     pub fn subtable_data_byte_range(&self) -> Range<usize> {
         let start = self.n_tables_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(AatKern::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AatKern<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -257,6 +277,16 @@ impl<'a> OtSubtable<'a> {
     }
 }
 
+const _: () = assert!(OtSubtable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for OtSubtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for OtSubtable<'a> {
     fn type_name(&self) -> &str {
@@ -354,6 +384,16 @@ impl<'a> AatSubtable<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_index_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(AatSubtable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AatSubtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -470,6 +510,16 @@ impl<'a> Subtable0<'a> {
     }
 }
 
+const _: () = assert!(Subtable0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Subtable0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Subtable0<'a> {
     fn type_name(&self) -> &str {
@@ -565,6 +615,16 @@ impl<'a> Subtable2ClassTable<'a> {
         let n_glyphs = self.n_glyphs();
         let start = self.n_glyphs_byte_range().end;
         start..start + (n_glyphs as usize).saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Subtable2ClassTable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Subtable2ClassTable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -731,6 +791,16 @@ impl<'a> Subtable3<'a> {
             ..start
                 + (transforms::add_multiply(left_class_count, 0_usize, right_class_count))
                     .saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Subtable3::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Subtable3<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -70,6 +70,16 @@ impl<'a> OtKern<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(OtKern::MIN_SIZE));
+
+impl Default for OtKern<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for OtKern<'a> {
     fn type_name(&self) -> &str {
@@ -155,6 +165,16 @@ impl<'a> AatKern<'a> {
     pub fn subtable_data_byte_range(&self) -> Range<usize> {
         let start = self.n_tables_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(AatKern::MIN_SIZE));
+
+impl Default for AatKern<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -257,6 +277,16 @@ impl<'a> OtSubtable<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(OtSubtable::MIN_SIZE));
+
+impl Default for OtSubtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for OtSubtable<'a> {
     fn type_name(&self) -> &str {
@@ -354,6 +384,16 @@ impl<'a> AatSubtable<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_index_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(AatSubtable::MIN_SIZE));
+
+impl Default for AatSubtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -470,6 +510,16 @@ impl<'a> Subtable0<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Subtable0::MIN_SIZE));
+
+impl Default for Subtable0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Subtable0<'a> {
     fn type_name(&self) -> &str {
@@ -565,6 +615,18 @@ impl<'a> Subtable2ClassTable<'a> {
         let n_glyphs = self.n_glyphs();
         let start = self.n_glyphs_byte_range().end;
         start..start + (n_glyphs as usize).saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    Subtable2ClassTable::MIN_SIZE
+));
+
+impl Default for Subtable2ClassTable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -731,6 +793,16 @@ impl<'a> Subtable3<'a> {
             ..start
                 + (transforms::add_multiply(left_class_count, 0_usize, right_class_count))
                     .saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Subtable3::MIN_SIZE));
+
+impl Default for Subtable3<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -80,6 +80,13 @@ impl Default for OtKern<'_> {
     }
 }
 
+impl OtKern<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for OtKern<'a> {
     fn type_name(&self) -> &str {
@@ -175,6 +182,13 @@ impl Default for AatKern<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl AatKern<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -287,6 +301,13 @@ impl Default for OtSubtable<'_> {
     }
 }
 
+impl OtSubtable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for OtSubtable<'a> {
     fn type_name(&self) -> &str {
@@ -394,6 +415,13 @@ impl Default for AatSubtable<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl AatSubtable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -520,6 +548,13 @@ impl Default for Subtable0<'_> {
     }
 }
 
+impl Subtable0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Subtable0<'a> {
     fn type_name(&self) -> &str {
@@ -625,6 +660,13 @@ impl Default for Subtable2ClassTable<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Subtable2ClassTable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -801,6 +843,13 @@ impl Default for Subtable3<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Subtable3<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -86,6 +86,16 @@ impl<'a> Kerx<'a> {
     }
 }
 
+const _: () = assert!(Kerx::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Kerx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Kerx<'a> {
     fn type_name(&self) -> &str {
@@ -185,6 +195,16 @@ impl<'a> Subtable<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_count_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(Subtable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Subtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -298,6 +318,16 @@ impl<'a> Subtable0<'a> {
         let n_pairs = self.n_pairs();
         let start = self.range_shift_byte_range().end;
         start..start + (n_pairs as usize).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Subtable0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Subtable0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -86,6 +86,16 @@ impl<'a> Kerx<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Kerx::MIN_SIZE));
+
+impl Default for Kerx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Kerx<'a> {
     fn type_name(&self) -> &str {
@@ -185,6 +195,16 @@ impl<'a> Subtable<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_count_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Subtable::MIN_SIZE));
+
+impl Default for Subtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -298,6 +318,16 @@ impl<'a> Subtable0<'a> {
         let n_pairs = self.n_pairs();
         let start = self.range_shift_byte_range().end;
         start..start + (n_pairs as usize).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Subtable0::MIN_SIZE));
+
+impl Default for Subtable0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -96,6 +96,13 @@ impl Default for Kerx<'_> {
     }
 }
 
+impl Kerx<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Kerx<'a> {
     fn type_name(&self) -> &str {
@@ -205,6 +212,13 @@ impl Default for Subtable<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Subtable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -328,6 +342,13 @@ impl Default for Subtable0<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Subtable0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -60,6 +60,16 @@ impl<'a> ScriptList<'a> {
     }
 }
 
+const _: () = assert!(ScriptList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ScriptList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ScriptList<'a> {
     fn type_name(&self) -> &str {
@@ -213,6 +223,16 @@ impl<'a> Script<'a> {
         let lang_sys_count = self.lang_sys_count();
         let start = self.lang_sys_count_byte_range().end;
         start..start + (lang_sys_count as usize).saturating_mul(LangSysRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(Script::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Script<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -374,6 +394,16 @@ impl<'a> LangSys<'a> {
     }
 }
 
+const _: () = assert!(LangSys::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LangSys<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LangSys<'a> {
     fn type_name(&self) -> &str {
@@ -456,6 +486,16 @@ impl<'a> FeatureList<'a> {
         let feature_count = self.feature_count();
         let start = self.feature_count_byte_range().end;
         start..start + (feature_count as usize).saturating_mul(FeatureRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FeatureList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for FeatureList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -758,6 +798,17 @@ impl<'a, T> LookupList<'a, T> {
     }
 }
 
+const _: () = assert!(LookupList::<()>::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for LookupList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, T> {
     fn type_name(&self) -> &str {
@@ -926,6 +977,17 @@ impl<'a, T> Lookup<'a, T> {
     }
 }
 
+const _: () = assert!(Lookup::<()>::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Lookup<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
     fn type_name(&self) -> &str {
@@ -1040,6 +1102,16 @@ impl<'a> CoverageFormat1<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(CoverageFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CoverageFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1227,6 +1299,12 @@ pub enum CoverageTable<'a> {
     Format2(CoverageFormat2<'a>),
 }
 
+impl Default for CoverageTable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> CoverageTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -1376,6 +1454,16 @@ impl<'a> ClassDefFormat1<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ClassDefFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ClassDefFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1559,6 +1647,12 @@ impl<'a> SomeRecord<'a> for ClassRangeRecord {
 pub enum ClassDef<'a> {
     Format1(ClassDefFormat1<'a>),
     Format2(ClassDefFormat2<'a>),
+}
+
+impl Default for ClassDef<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> ClassDef<'a> {
@@ -1770,6 +1864,16 @@ impl<'a> SequenceContextFormat1<'a> {
     }
 }
 
+const _: () = assert!(SequenceContextFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SequenceContextFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SequenceContextFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1870,6 +1974,16 @@ impl<'a> SequenceRuleSet<'a> {
         let seq_rule_count = self.seq_rule_count();
         let start = self.seq_rule_count_byte_range().end;
         start..start + (seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(SequenceRuleSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1987,6 +2101,16 @@ impl<'a> SequenceRule<'a> {
         let start = self.input_sequence_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(SequenceRule::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2248,6 +2372,16 @@ impl<'a> ClassSequenceRuleSet<'a> {
     }
 }
 
+const _: () = assert!(ClassSequenceRuleSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ClassSequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClassSequenceRuleSet<'a> {
     fn type_name(&self) -> &str {
@@ -2364,6 +2498,16 @@ impl<'a> ClassSequenceRule<'a> {
         let start = self.input_sequence_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ClassSequenceRule::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ClassSequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2552,6 +2696,12 @@ pub enum SequenceContext<'a> {
     Format3(SequenceContextFormat3<'a>),
 }
 
+impl Default for SequenceContext<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> SequenceContext<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -2727,6 +2877,16 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     }
 }
 
+const _: () = assert!(ChainedSequenceContextFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ChainedSequenceContextFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ChainedSequenceContextFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -2830,6 +2990,16 @@ impl<'a> ChainedSequenceRuleSet<'a> {
         let chained_seq_rule_count = self.chained_seq_rule_count();
         let start = self.chained_seq_rule_count_byte_range().end;
         start..start + (chained_seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ChainedSequenceRuleSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ChainedSequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2997,6 +3167,16 @@ impl<'a> ChainedSequenceRule<'a> {
         let start = self.seq_lookup_count_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ChainedSequenceRule::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ChainedSequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -3327,6 +3507,16 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     }
 }
 
+const _: () = assert!(ChainedClassSequenceRuleSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ChainedClassSequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ChainedClassSequenceRuleSet<'a> {
     fn type_name(&self) -> &str {
@@ -3492,6 +3682,16 @@ impl<'a> ChainedClassSequenceRule<'a> {
         let start = self.seq_lookup_count_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ChainedClassSequenceRule::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ChainedClassSequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -3789,6 +3989,12 @@ pub enum ChainedSequenceContext<'a> {
     Format3(ChainedSequenceContextFormat3<'a>),
 }
 
+impl Default for ChainedSequenceContext<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> ChainedSequenceContext<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -4002,6 +4208,16 @@ impl<'a> Device<'a> {
     }
 }
 
+const _: () = assert!(Device::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Device<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Device<'a> {
     fn type_name(&self) -> &str {
@@ -4093,6 +4309,16 @@ impl<'a> VariationIndex<'a> {
     }
 }
 
+const _: () = assert!(VariationIndex::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for VariationIndex<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VariationIndex<'a> {
     fn type_name(&self) -> &str {
@@ -4127,6 +4353,12 @@ impl<'a> std::fmt::Debug for VariationIndex<'a> {
 pub enum DeviceOrVariationIndex<'a> {
     Device(Device<'a>),
     VariationIndex(VariationIndex<'a>),
+}
+
+impl Default for DeviceOrVariationIndex<'_> {
+    fn default() -> Self {
+        Self::Device(Default::default())
+    }
 }
 
 impl<'a> DeviceOrVariationIndex<'a> {
@@ -4263,6 +4495,16 @@ impl<'a> FeatureVariations<'a> {
             ..start
                 + (feature_variation_record_count as usize)
                     .saturating_mul(FeatureVariationRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FeatureVariations::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for FeatureVariations<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -4441,6 +4683,16 @@ impl<'a> ConditionSet<'a> {
     }
 }
 
+const _: () = assert!(ConditionSet::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ConditionSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ConditionSet<'a> {
     fn type_name(&self) -> &str {
@@ -4487,6 +4739,12 @@ pub enum Condition<'a> {
     Format3And(ConditionFormat3<'a>),
     Format4Or(ConditionFormat4<'a>),
     Format5Negate(ConditionFormat5<'a>),
+}
+
+impl Default for Condition<'_> {
+    fn default() -> Self {
+        Self::Format1AxisRange(Default::default())
+    }
 }
 
 impl<'a> Condition<'a> {
@@ -4659,6 +4917,16 @@ impl<'a> ConditionFormat1<'a> {
     pub fn filter_range_max_value_byte_range(&self) -> Range<usize> {
         let start = self.filter_range_min_value_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(ConditionFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ConditionFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -5168,6 +5436,16 @@ impl<'a> FeatureTableSubstitution<'a> {
     }
 }
 
+const _: () = assert!(FeatureTableSubstitution::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for FeatureTableSubstitution<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for FeatureTableSubstitution<'a> {
     fn type_name(&self) -> &str {
@@ -5358,6 +5636,16 @@ impl<'a> SizeParams<'a> {
     }
 }
 
+const _: () = assert!(SizeParams::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SizeParams<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SizeParams<'a> {
     fn type_name(&self) -> &str {
@@ -5440,6 +5728,16 @@ impl<'a> StylisticSetParams<'a> {
     pub fn ui_name_id_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(StylisticSetParams::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for StylisticSetParams<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -5602,6 +5900,16 @@ impl<'a> CharacterVariantParams<'a> {
         let char_count = self.char_count();
         let start = self.char_count_byte_range().end;
         start..start + (char_count as usize).saturating_mul(Uint24::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(CharacterVariantParams::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CharacterVariantParams<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -60,6 +60,16 @@ impl<'a> ScriptList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(ScriptList::MIN_SIZE));
+
+impl Default for ScriptList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ScriptList<'a> {
     fn type_name(&self) -> &str {
@@ -213,6 +223,16 @@ impl<'a> Script<'a> {
         let lang_sys_count = self.lang_sys_count();
         let start = self.lang_sys_count_byte_range().end;
         start..start + (lang_sys_count as usize).saturating_mul(LangSysRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Script::MIN_SIZE));
+
+impl Default for Script<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -374,6 +394,16 @@ impl<'a> LangSys<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(LangSys::MIN_SIZE));
+
+impl Default for LangSys<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LangSys<'a> {
     fn type_name(&self) -> &str {
@@ -456,6 +486,16 @@ impl<'a> FeatureList<'a> {
         let feature_count = self.feature_count();
         let start = self.feature_count_byte_range().end;
         start..start + (feature_count as usize).saturating_mul(FeatureRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(FeatureList::MIN_SIZE));
+
+impl Default for FeatureList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -748,6 +788,19 @@ impl<'a, T> LookupList<'a, T> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    LookupList::<()>::MIN_SIZE
+));
+
+impl Default for LookupList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, T> {
     fn type_name(&self) -> &str {
@@ -912,6 +965,17 @@ impl<'a, T> Lookup<'a, T> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Lookup::<()>::MIN_SIZE));
+
+impl Default for Lookup<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
     fn type_name(&self) -> &str {
@@ -1026,6 +1090,18 @@ impl<'a> CoverageFormat1<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    CoverageFormat1::MIN_SIZE
+));
+
+impl Default for CoverageFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1213,6 +1289,12 @@ pub enum CoverageTable<'a> {
     Format2(CoverageFormat2<'a>),
 }
 
+impl Default for CoverageTable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> CoverageTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -1362,6 +1444,18 @@ impl<'a> ClassDefFormat1<'a> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
         start..start + (glyph_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ClassDefFormat1::MIN_SIZE
+));
+
+impl Default for ClassDefFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -1545,6 +1639,12 @@ impl<'a> SomeRecord<'a> for ClassRangeRecord {
 pub enum ClassDef<'a> {
     Format1(ClassDefFormat1<'a>),
     Format2(ClassDefFormat2<'a>),
+}
+
+impl Default for ClassDef<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> ClassDef<'a> {
@@ -1756,6 +1856,18 @@ impl<'a> SequenceContextFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    SequenceContextFormat1::MIN_SIZE
+));
+
+impl Default for SequenceContextFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SequenceContextFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1856,6 +1968,18 @@ impl<'a> SequenceRuleSet<'a> {
         let seq_rule_count = self.seq_rule_count();
         let start = self.seq_rule_count_byte_range().end;
         start..start + (seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    SequenceRuleSet::MIN_SIZE
+));
+
+impl Default for SequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -1973,6 +2097,16 @@ impl<'a> SequenceRule<'a> {
         let start = self.input_sequence_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(SequenceRule::MIN_SIZE));
+
+impl Default for SequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2234,6 +2368,18 @@ impl<'a> ClassSequenceRuleSet<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    ClassSequenceRuleSet::MIN_SIZE
+));
+
+impl Default for ClassSequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClassSequenceRuleSet<'a> {
     fn type_name(&self) -> &str {
@@ -2350,6 +2496,18 @@ impl<'a> ClassSequenceRule<'a> {
         let start = self.input_sequence_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ClassSequenceRule::MIN_SIZE
+));
+
+impl Default for ClassSequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2538,6 +2696,12 @@ pub enum SequenceContext<'a> {
     Format3(SequenceContextFormat3<'a>),
 }
 
+impl Default for SequenceContext<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> SequenceContext<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -2713,6 +2877,18 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    ChainedSequenceContextFormat1::MIN_SIZE
+));
+
+impl Default for ChainedSequenceContextFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ChainedSequenceContextFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -2816,6 +2992,18 @@ impl<'a> ChainedSequenceRuleSet<'a> {
         let chained_seq_rule_count = self.chained_seq_rule_count();
         let start = self.chained_seq_rule_count_byte_range().end;
         start..start + (chained_seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ChainedSequenceRuleSet::MIN_SIZE
+));
+
+impl Default for ChainedSequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -2983,6 +3171,18 @@ impl<'a> ChainedSequenceRule<'a> {
         let start = self.seq_lookup_count_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ChainedSequenceRule::MIN_SIZE
+));
+
+impl Default for ChainedSequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -3313,6 +3513,18 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    ChainedClassSequenceRuleSet::MIN_SIZE
+));
+
+impl Default for ChainedClassSequenceRuleSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ChainedClassSequenceRuleSet<'a> {
     fn type_name(&self) -> &str {
@@ -3478,6 +3690,18 @@ impl<'a> ChainedClassSequenceRule<'a> {
         let start = self.seq_lookup_count_byte_range().end;
         start
             ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ChainedClassSequenceRule::MIN_SIZE
+));
+
+impl Default for ChainedClassSequenceRule<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -3775,6 +3999,12 @@ pub enum ChainedSequenceContext<'a> {
     Format3(ChainedSequenceContextFormat3<'a>),
 }
 
+impl Default for ChainedSequenceContext<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> ChainedSequenceContext<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -3988,6 +4218,16 @@ impl<'a> Device<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Device::MIN_SIZE));
+
+impl Default for Device<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Device<'a> {
     fn type_name(&self) -> &str {
@@ -4079,6 +4319,16 @@ impl<'a> VariationIndex<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(VariationIndex::MIN_SIZE));
+
+impl Default for VariationIndex<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VariationIndex<'a> {
     fn type_name(&self) -> &str {
@@ -4113,6 +4363,12 @@ impl<'a> std::fmt::Debug for VariationIndex<'a> {
 pub enum DeviceOrVariationIndex<'a> {
     Device(Device<'a>),
     VariationIndex(VariationIndex<'a>),
+}
+
+impl Default for DeviceOrVariationIndex<'_> {
+    fn default() -> Self {
+        Self::Device(Default::default())
+    }
 }
 
 impl<'a> DeviceOrVariationIndex<'a> {
@@ -4249,6 +4505,18 @@ impl<'a> FeatureVariations<'a> {
             ..start
                 + (feature_variation_record_count as usize)
                     .saturating_mul(FeatureVariationRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    FeatureVariations::MIN_SIZE
+));
+
+impl Default for FeatureVariations<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -4427,6 +4695,16 @@ impl<'a> ConditionSet<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(ConditionSet::MIN_SIZE));
+
+impl Default for ConditionSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ConditionSet<'a> {
     fn type_name(&self) -> &str {
@@ -4473,6 +4751,12 @@ pub enum Condition<'a> {
     Format3And(ConditionFormat3<'a>),
     Format4Or(ConditionFormat4<'a>),
     Format5Negate(ConditionFormat5<'a>),
+}
+
+impl Default for Condition<'_> {
+    fn default() -> Self {
+        Self::Format1AxisRange(Default::default())
+    }
 }
 
 impl<'a> Condition<'a> {
@@ -4645,6 +4929,18 @@ impl<'a> ConditionFormat1<'a> {
     pub fn filter_range_max_value_byte_range(&self) -> Range<usize> {
         let start = self.filter_range_min_value_byte_range().end;
         start..start + F2Dot14::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ConditionFormat1::MIN_SIZE
+));
+
+impl Default for ConditionFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -5154,6 +5450,18 @@ impl<'a> FeatureTableSubstitution<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    FeatureTableSubstitution::MIN_SIZE
+));
+
+impl Default for FeatureTableSubstitution<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for FeatureTableSubstitution<'a> {
     fn type_name(&self) -> &str {
@@ -5344,6 +5652,16 @@ impl<'a> SizeParams<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(SizeParams::MIN_SIZE));
+
+impl Default for SizeParams<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SizeParams<'a> {
     fn type_name(&self) -> &str {
@@ -5426,6 +5744,18 @@ impl<'a> StylisticSetParams<'a> {
     pub fn ui_name_id_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + NameId::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    StylisticSetParams::MIN_SIZE
+));
+
+impl Default for StylisticSetParams<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -5588,6 +5918,18 @@ impl<'a> CharacterVariantParams<'a> {
         let char_count = self.char_count();
         let start = self.char_count_byte_range().end;
         start..start + (char_count as usize).saturating_mul(Uint24::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    CharacterVariantParams::MIN_SIZE
+));
+
+impl Default for CharacterVariantParams<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -70,6 +70,13 @@ impl Default for ScriptList<'_> {
     }
 }
 
+impl ScriptList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ScriptList<'a> {
     fn type_name(&self) -> &str {
@@ -233,6 +240,13 @@ impl Default for Script<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Script<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -404,6 +418,13 @@ impl Default for LangSys<'_> {
     }
 }
 
+impl LangSys<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LangSys<'a> {
     fn type_name(&self) -> &str {
@@ -496,6 +517,13 @@ impl Default for FeatureList<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl FeatureList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -809,6 +837,13 @@ impl Default for LookupList<'_> {
     }
 }
 
+impl LookupList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, T> {
     fn type_name(&self) -> &str {
@@ -988,6 +1023,13 @@ impl Default for Lookup<'_> {
     }
 }
 
+impl Lookup<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
     fn type_name(&self) -> &str {
@@ -1112,6 +1154,13 @@ impl Default for CoverageFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl CoverageFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -1305,6 +1354,13 @@ impl Default for CoverageTable<'_> {
     }
 }
 
+impl CoverageTable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
+    }
+}
+
 impl<'a> CoverageTable<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -1464,6 +1520,13 @@ impl Default for ClassDefFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl ClassDefFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -1652,6 +1715,13 @@ pub enum ClassDef<'a> {
 impl Default for ClassDef<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl ClassDef<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 
@@ -1874,6 +1944,13 @@ impl Default for SequenceContextFormat1<'_> {
     }
 }
 
+impl SequenceContextFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SequenceContextFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -1984,6 +2061,13 @@ impl Default for SequenceRuleSet<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl SequenceRuleSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -2111,6 +2195,13 @@ impl Default for SequenceRule<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl SequenceRule<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -2382,6 +2473,13 @@ impl Default for ClassSequenceRuleSet<'_> {
     }
 }
 
+impl ClassSequenceRuleSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ClassSequenceRuleSet<'a> {
     fn type_name(&self) -> &str {
@@ -2508,6 +2606,13 @@ impl Default for ClassSequenceRule<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl ClassSequenceRule<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -2702,6 +2807,13 @@ impl Default for SequenceContext<'_> {
     }
 }
 
+impl SequenceContext<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
+    }
+}
+
 impl<'a> SequenceContext<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -2887,6 +2999,13 @@ impl Default for ChainedSequenceContextFormat1<'_> {
     }
 }
 
+impl ChainedSequenceContextFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ChainedSequenceContextFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -3000,6 +3119,13 @@ impl Default for ChainedSequenceRuleSet<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl ChainedSequenceRuleSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -3177,6 +3303,13 @@ impl Default for ChainedSequenceRule<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl ChainedSequenceRule<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -3517,6 +3650,13 @@ impl Default for ChainedClassSequenceRuleSet<'_> {
     }
 }
 
+impl ChainedClassSequenceRuleSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ChainedClassSequenceRuleSet<'a> {
     fn type_name(&self) -> &str {
@@ -3692,6 +3832,13 @@ impl Default for ChainedClassSequenceRule<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl ChainedClassSequenceRule<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -3995,6 +4142,13 @@ impl Default for ChainedSequenceContext<'_> {
     }
 }
 
+impl ChainedSequenceContext<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
+    }
+}
+
 impl<'a> ChainedSequenceContext<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -4218,6 +4372,13 @@ impl Default for Device<'_> {
     }
 }
 
+impl Device<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Device<'a> {
     fn type_name(&self) -> &str {
@@ -4319,6 +4480,13 @@ impl Default for VariationIndex<'_> {
     }
 }
 
+impl VariationIndex<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VariationIndex<'a> {
     fn type_name(&self) -> &str {
@@ -4358,6 +4526,13 @@ pub enum DeviceOrVariationIndex<'a> {
 impl Default for DeviceOrVariationIndex<'_> {
     fn default() -> Self {
         Self::Device(Default::default())
+    }
+}
+
+impl DeviceOrVariationIndex<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Device (t) if t . is_default ())
     }
 }
 
@@ -4505,6 +4680,13 @@ impl Default for FeatureVariations<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl FeatureVariations<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -4693,6 +4875,13 @@ impl Default for ConditionSet<'_> {
     }
 }
 
+impl ConditionSet<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ConditionSet<'a> {
     fn type_name(&self) -> &str {
@@ -4744,6 +4933,13 @@ pub enum Condition<'a> {
 impl Default for Condition<'_> {
     fn default() -> Self {
         Self::Format1AxisRange(Default::default())
+    }
+}
+
+impl Condition<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1AxisRange (t) if t . is_default ())
     }
 }
 
@@ -4927,6 +5123,13 @@ impl Default for ConditionFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl ConditionFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 
@@ -5446,6 +5649,13 @@ impl Default for FeatureTableSubstitution<'_> {
     }
 }
 
+impl FeatureTableSubstitution<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for FeatureTableSubstitution<'a> {
     fn type_name(&self) -> &str {
@@ -5646,6 +5856,13 @@ impl Default for SizeParams<'_> {
     }
 }
 
+impl SizeParams<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SizeParams<'a> {
     fn type_name(&self) -> &str {
@@ -5738,6 +5955,13 @@ impl Default for StylisticSetParams<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl StylisticSetParams<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -5910,6 +6134,13 @@ impl Default for CharacterVariantParams<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl CharacterVariantParams<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -87,6 +87,16 @@ impl<'a> Ltag<'a> {
     }
 }
 
+const _: () = assert!(Ltag::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Ltag<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ltag<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -87,6 +87,16 @@ impl<'a> Ltag<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Ltag::MIN_SIZE));
+
+impl Default for Ltag<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ltag<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -97,6 +97,13 @@ impl Default for Ltag<'_> {
     }
 }
 
+impl Ltag<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Ltag<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -276,6 +276,16 @@ impl<'a> Maxp<'a> {
     }
 }
 
+const _: () = assert!(Maxp::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Maxp<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Maxp<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -276,6 +276,16 @@ impl<'a> Maxp<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Maxp::MIN_SIZE));
+
+impl Default for Maxp<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Maxp<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -286,6 +286,13 @@ impl Default for Maxp<'_> {
     }
 }
 
+impl Maxp<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Maxp<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -93,6 +93,16 @@ impl<'a> Meta<'a> {
     }
 }
 
+const _: () = assert!(Meta::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Meta<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Meta<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -93,6 +93,16 @@ impl<'a> Meta<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Meta::MIN_SIZE));
+
+impl Default for Meta<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Meta<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -103,6 +103,13 @@ impl Default for Meta<'_> {
     }
 }
 
+impl Meta<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Meta<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -86,6 +86,16 @@ impl<'a> Morx<'a> {
     }
 }
 
+const _: () = assert!(Morx::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Morx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Morx<'a> {
     fn type_name(&self) -> &str {
@@ -215,6 +225,16 @@ impl<'a> Chain<'a> {
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <Subtable as VarSize>::total_len_for_count(data, n_subtables as usize).unwrap_or(0)
+        }
+    }
+}
+
+const _: () = assert!(Chain::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Chain<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
         }
     }
 }
@@ -387,6 +407,16 @@ impl<'a> Subtable<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.sub_feature_flags_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(Subtable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Subtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -86,6 +86,16 @@ impl<'a> Morx<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Morx::MIN_SIZE));
+
+impl Default for Morx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Morx<'a> {
     fn type_name(&self) -> &str {
@@ -215,6 +225,16 @@ impl<'a> Chain<'a> {
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <Subtable as VarSize>::total_len_for_count(data, n_subtables as usize).unwrap_or(0)
+        }
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Chain::MIN_SIZE));
+
+impl Default for Chain<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
         }
     }
 }
@@ -387,6 +407,16 @@ impl<'a> Subtable<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.sub_feature_flags_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Subtable::MIN_SIZE));
+
+impl Default for Subtable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -96,6 +96,13 @@ impl Default for Morx<'_> {
     }
 }
 
+impl Morx<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Morx<'a> {
     fn type_name(&self) -> &str {
@@ -236,6 +243,13 @@ impl Default for Chain<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Chain<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -417,6 +431,13 @@ impl Default for Subtable<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Subtable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -114,6 +114,16 @@ impl<'a> Mvar<'a> {
     }
 }
 
+const _: () = assert!(Mvar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Mvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Mvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -114,6 +114,16 @@ impl<'a> Mvar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Mvar::MIN_SIZE));
+
+impl Default for Mvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Mvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -124,6 +124,13 @@ impl Default for Mvar<'_> {
     }
 }
 
+impl Mvar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Mvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -122,6 +122,16 @@ impl<'a> Name<'a> {
     }
 }
 
+const _: () = assert!(Name::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Name<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Name<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -122,6 +122,16 @@ impl<'a> Name<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Name::MIN_SIZE));
+
+impl Default for Name<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Name<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -132,6 +132,13 @@ impl Default for Name<'_> {
     }
 }
 
+impl Name<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Name<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -938,6 +938,16 @@ impl<'a> Os2<'a> {
     }
 }
 
+const _: () = assert!(Os2::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Os2<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Os2<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -938,6 +938,16 @@ impl<'a> Os2<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Os2::MIN_SIZE));
+
+impl Default for Os2<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Os2<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -948,6 +948,13 @@ impl Default for Os2<'_> {
     }
 }
 
+impl Os2<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Os2<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -219,6 +219,16 @@ impl<'a> Post<'a> {
     }
 }
 
+const _: () = assert!(Post::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Post<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Post<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -219,6 +219,16 @@ impl<'a> Post<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Post::MIN_SIZE));
+
+impl Default for Post<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Post<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -229,6 +229,13 @@ impl Default for Post<'_> {
     }
 }
 
+impl Post<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Post<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -652,6 +652,16 @@ impl<'a> GlyphData<'a> {
     }
 }
 
+const _: () = assert!(GlyphData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for GlyphData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for GlyphData<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -652,6 +652,16 @@ impl<'a> GlyphData<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(GlyphData::MIN_SIZE));
+
+impl Default for GlyphData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for GlyphData<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -662,6 +662,13 @@ impl Default for GlyphData<'_> {
     }
 }
 
+impl GlyphData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for GlyphData<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -155,6 +155,16 @@ impl<'a> Stat<'a> {
     }
 }
 
+const _: () = assert!(Stat::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Stat<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Stat<'a> {
     fn type_name(&self) -> &str {
@@ -375,6 +385,12 @@ pub enum AxisValue<'a> {
     Format4(AxisValueFormat4<'a>),
 }
 
+impl Default for AxisValue<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> AxisValue<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -574,6 +590,16 @@ impl<'a> AxisValueFormat1<'a> {
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(AxisValueFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for AxisValueFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -155,6 +155,16 @@ impl<'a> Stat<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Stat::MIN_SIZE));
+
+impl Default for Stat<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Stat<'a> {
     fn type_name(&self) -> &str {
@@ -375,6 +385,12 @@ pub enum AxisValue<'a> {
     Format4(AxisValueFormat4<'a>),
 }
 
+impl Default for AxisValue<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
+}
+
 impl<'a> AxisValue<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -574,6 +590,18 @@ impl<'a> AxisValueFormat1<'a> {
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
         start..start + Fixed::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    AxisValueFormat1::MIN_SIZE
+));
+
+impl Default for AxisValueFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -165,6 +165,13 @@ impl Default for Stat<'_> {
     }
 }
 
+impl Stat<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Stat<'a> {
     fn type_name(&self) -> &str {
@@ -391,6 +398,13 @@ impl Default for AxisValue<'_> {
     }
 }
 
+impl AxisValue<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
+    }
+}
+
 impl<'a> AxisValue<'a> {
     ///Return the `FontData` used to resolve offsets for this table.
     pub fn offset_data(&self) -> FontData<'a> {
@@ -600,6 +614,13 @@ impl Default for AxisValueFormat1<'_> {
         Self {
             data: FontData::default_format_1_u16_table_data(),
         }
+    }
+}
+
+impl AxisValueFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -76,6 +76,16 @@ impl<'a> Svg<'a> {
     }
 }
 
+const _: () = assert!(Svg::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Svg<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Svg<'a> {
     fn type_name(&self) -> &str {
@@ -153,6 +163,16 @@ impl<'a> SVGDocumentList<'a> {
         let num_entries = self.num_entries();
         let start = self.num_entries_byte_range().end;
         start..start + (num_entries as usize).saturating_mul(SVGDocumentRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(SVGDocumentList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SVGDocumentList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -76,6 +76,16 @@ impl<'a> Svg<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Svg::MIN_SIZE));
+
+impl Default for Svg<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Svg<'a> {
     fn type_name(&self) -> &str {
@@ -153,6 +163,18 @@ impl<'a> SVGDocumentList<'a> {
         let num_entries = self.num_entries();
         let start = self.num_entries_byte_range().end;
         start..start + (num_entries as usize).saturating_mul(SVGDocumentRecord::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    SVGDocumentList::MIN_SIZE
+));
+
+impl Default for SVGDocumentList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -86,6 +86,13 @@ impl Default for Svg<'_> {
     }
 }
 
+impl Svg<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Svg<'a> {
     fn type_name(&self) -> &str {
@@ -173,6 +180,13 @@ impl Default for SVGDocumentList<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl SVGDocumentList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -86,6 +86,16 @@ impl<'a> MajorMinorVersion<'a> {
     }
 }
 
+const _: () = assert!(MajorMinorVersion::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MajorMinorVersion<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MajorMinorVersion<'a> {
     fn type_name(&self) -> &str {
@@ -497,6 +507,16 @@ impl<'a> FlagDay<'a> {
             ..(self.flags().contains(GotFlags::BAR))
                 .then(|| start + u16::RAW_BYTE_LEN)
                 .unwrap_or(start)
+    }
+}
+
+const _: () = assert!(FlagDay::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for FlagDay<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -86,6 +86,18 @@ impl<'a> MajorMinorVersion<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    MajorMinorVersion::MIN_SIZE
+));
+
+impl Default for MajorMinorVersion<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MajorMinorVersion<'a> {
     fn type_name(&self) -> &str {
@@ -497,6 +509,16 @@ impl<'a> FlagDay<'a> {
             ..(self.flags().contains(GotFlags::BAR))
                 .then(|| start + u16::RAW_BYTE_LEN)
                 .unwrap_or(start)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(FlagDay::MIN_SIZE));
+
+impl Default for FlagDay<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -96,6 +96,13 @@ impl Default for MajorMinorVersion<'_> {
     }
 }
 
+impl MajorMinorVersion<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MajorMinorVersion<'a> {
     fn type_name(&self) -> &str {
@@ -517,6 +524,13 @@ impl Default for FlagDay<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl FlagDay<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -56,6 +56,16 @@ impl<'a> CountAll16<'a> {
     }
 }
 
+const _: () = assert!(CountAll16::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CountAll16<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CountAll16<'a> {
     fn type_name(&self) -> &str {
@@ -126,6 +136,16 @@ impl<'a> CountAll32<'a> {
     pub fn remainder_byte_range(&self) -> Range<usize> {
         let start = self.some_field_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(CountAll32::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for CountAll32<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -56,6 +56,16 @@ impl<'a> CountAll16<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(CountAll16::MIN_SIZE));
+
+impl Default for CountAll16<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CountAll16<'a> {
     fn type_name(&self) -> &str {
@@ -126,6 +136,16 @@ impl<'a> CountAll32<'a> {
     pub fn remainder_byte_range(&self) -> Range<usize> {
         let start = self.some_field_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(CountAll32::MIN_SIZE));
+
+impl Default for CountAll32<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -66,6 +66,13 @@ impl Default for CountAll16<'_> {
     }
 }
 
+impl CountAll16<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for CountAll16<'a> {
     fn type_name(&self) -> &str {
@@ -146,6 +153,13 @@ impl Default for CountAll32<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl CountAll32<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -70,6 +70,16 @@ impl<'a> Table1<'a> {
     }
 }
 
+const _: () = assert!(Table1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Table1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Table1<'a> {
     fn type_name(&self) -> &str {
@@ -264,6 +274,12 @@ pub enum MyTable<'a> {
     Format1(Table1<'a>),
     MyFormat22(Table2<'a>),
     Format3(Table3<'a>),
+}
+
+impl Default for MyTable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> MyTable<'a> {

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -70,6 +70,16 @@ impl<'a> Table1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Table1::MIN_SIZE));
+
+impl Default for Table1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Table1<'a> {
     fn type_name(&self) -> &str {
@@ -264,6 +274,12 @@ pub enum MyTable<'a> {
     Format1(Table1<'a>),
     MyFormat22(Table2<'a>),
     Format3(Table3<'a>),
+}
+
+impl Default for MyTable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> MyTable<'a> {

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -80,6 +80,13 @@ impl Default for Table1<'_> {
     }
 }
 
+impl Table1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Table1<'a> {
     fn type_name(&self) -> &str {
@@ -279,6 +286,13 @@ pub enum MyTable<'a> {
 impl Default for MyTable<'_> {
     fn default() -> Self {
         Self::Format1(Default::default())
+    }
+}
+
+impl MyTable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format1 (t) if t . is_default ())
     }
 }
 

--- a/read-fonts/generated/generated_test_generic_group.rs
+++ b/read-fonts/generated/generated_test_generic_group.rs
@@ -102,6 +102,17 @@ impl<'a, T> MyLookup<'a, T> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(MyLookup::<()>::MIN_SIZE));
+
+impl Default for MyLookup<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for MyLookup<'a, T> {
     fn type_name(&self) -> &str {
@@ -143,6 +154,12 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for MyLookup<'a, 
 pub enum MySubtable<'a> {
     Format1(MySubtableFormat1<'a>),
     Format2(MySubtableFormat2<'a>),
+}
+
+impl Default for MySubtable<'_> {
+    fn default() -> Self {
+        Self::Format1(Default::default())
+    }
 }
 
 impl<'a> MySubtable<'a> {
@@ -267,6 +284,18 @@ impl<'a> MySubtableFormat1<'a> {
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    MySubtableFormat1::MIN_SIZE
+));
+
+impl Default for MySubtableFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
     }
 }
 
@@ -492,6 +521,18 @@ impl<'a> ContainsLookupGroup<'a> {
     pub fn lookup_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
         start..start + Offset16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ContainsLookupGroup::MIN_SIZE
+));
+
+impl Default for ContainsLookupGroup<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -201,6 +201,16 @@ impl<'a> KindsOfOffsets<'a> {
     }
 }
 
+const _: () = assert!(KindsOfOffsets::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for KindsOfOffsets<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
     fn type_name(&self) -> &str {
@@ -406,6 +416,16 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 }
 
+const _: () = assert!(KindsOfArraysOfOffsets::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for KindsOfArraysOfOffsets<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
     fn type_name(&self) -> &str {
@@ -594,6 +614,16 @@ impl<'a> KindsOfArrays<'a> {
     }
 }
 
+const _: () = assert!(KindsOfArrays::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for KindsOfArrays<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfArrays<'a> {
     fn type_name(&self) -> &str {
@@ -705,6 +735,16 @@ impl<'a> VarLenHaver<'a> {
     }
 }
 
+const _: () = assert!(VarLenHaver::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for VarLenHaver<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VarLenHaver<'a> {
     fn type_name(&self) -> &str {
@@ -771,6 +811,16 @@ impl<'a> Dummy<'a> {
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(Dummy::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Dummy<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -201,6 +201,16 @@ impl<'a> KindsOfOffsets<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(KindsOfOffsets::MIN_SIZE));
+
+impl Default for KindsOfOffsets<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
     fn type_name(&self) -> &str {
@@ -406,6 +416,18 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    KindsOfArraysOfOffsets::MIN_SIZE
+));
+
+impl Default for KindsOfArraysOfOffsets<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
     fn type_name(&self) -> &str {
@@ -594,6 +616,16 @@ impl<'a> KindsOfArrays<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(KindsOfArrays::MIN_SIZE));
+
+impl Default for KindsOfArrays<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfArrays<'a> {
     fn type_name(&self) -> &str {
@@ -705,6 +737,16 @@ impl<'a> VarLenHaver<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(VarLenHaver::MIN_SIZE));
+
+impl Default for VarLenHaver<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VarLenHaver<'a> {
     fn type_name(&self) -> &str {
@@ -771,6 +813,16 @@ impl<'a> Dummy<'a> {
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
         start..start + u16::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Dummy::MIN_SIZE));
+
+impl Default for Dummy<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -211,6 +211,13 @@ impl Default for KindsOfOffsets<'_> {
     }
 }
 
+impl KindsOfOffsets<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
     fn type_name(&self) -> &str {
@@ -426,6 +433,13 @@ impl Default for KindsOfArraysOfOffsets<'_> {
     }
 }
 
+impl KindsOfArraysOfOffsets<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
     fn type_name(&self) -> &str {
@@ -624,6 +638,13 @@ impl Default for KindsOfArrays<'_> {
     }
 }
 
+impl KindsOfArrays<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for KindsOfArrays<'a> {
     fn type_name(&self) -> &str {
@@ -745,6 +766,13 @@ impl Default for VarLenHaver<'_> {
     }
 }
 
+impl VarLenHaver<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VarLenHaver<'a> {
     fn type_name(&self) -> &str {
@@ -821,6 +849,13 @@ impl Default for Dummy<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl Dummy<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_test_read_args.rs
+++ b/read-fonts/generated/generated_test_read_args.rs
@@ -347,6 +347,16 @@ impl<'a> Face<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Face::MIN_SIZE));
+
+impl Default for Face<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Face<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -95,6 +95,16 @@ impl<'a> BasicTable<'a> {
     }
 }
 
+const _: () = assert!(BasicTable::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for BasicTable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BasicTable<'a> {
     fn type_name(&self) -> &str {
@@ -371,6 +381,16 @@ impl<'a> VarLenItem<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(VarLenItem::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for VarLenItem<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -95,6 +95,16 @@ impl<'a> BasicTable<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BasicTable::MIN_SIZE));
+
+impl Default for BasicTable<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BasicTable<'a> {
     fn type_name(&self) -> &str {
@@ -371,6 +381,16 @@ impl<'a> VarLenItem<'a> {
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(VarLenItem::MIN_SIZE));
+
+impl Default for VarLenItem<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -105,6 +105,13 @@ impl Default for BasicTable<'_> {
     }
 }
 
+impl BasicTable<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BasicTable<'a> {
     fn type_name(&self) -> &str {
@@ -391,6 +398,13 @@ impl Default for VarLenItem<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl VarLenItem<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -107,6 +107,16 @@ impl<'a> Trak<'a> {
     }
 }
 
+const _: () = assert!(Trak::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Trak<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Trak<'a> {
     fn type_name(&self) -> &str {
@@ -211,6 +221,16 @@ impl<'a> TrackData<'a> {
         let n_tracks = self.n_tracks();
         let start = self.size_table_offset_byte_range().end;
         start..start + (n_tracks as usize).saturating_mul(TrackTableEntry::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(TrackData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for TrackData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -107,6 +107,16 @@ impl<'a> Trak<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Trak::MIN_SIZE));
+
+impl Default for Trak<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Trak<'a> {
     fn type_name(&self) -> &str {
@@ -211,6 +221,16 @@ impl<'a> TrackData<'a> {
         let n_tracks = self.n_tracks();
         let start = self.size_table_offset_byte_range().end;
         start..start + (n_tracks as usize).saturating_mul(TrackTableEntry::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(TrackData::MIN_SIZE));
+
+impl Default for TrackData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -117,6 +117,13 @@ impl Default for Trak<'_> {
     }
 }
 
+impl Trak<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Trak<'a> {
     fn type_name(&self) -> &str {
@@ -231,6 +238,13 @@ impl Default for TrackData<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl TrackData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -140,6 +140,16 @@ impl<'a> Varc<'a> {
     }
 }
 
+const _: () = assert!(Varc::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Varc<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Varc<'a> {
     fn type_name(&self) -> &str {
@@ -275,6 +285,16 @@ impl<'a> MultiItemVariationStore<'a> {
     }
 }
 
+const _: () = assert!(MultiItemVariationStore::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MultiItemVariationStore<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultiItemVariationStore<'a> {
     fn type_name(&self) -> &str {
@@ -377,6 +397,16 @@ impl<'a> SparseVariationRegionList<'a> {
     }
 }
 
+const _: () = assert!(SparseVariationRegionList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SparseVariationRegionList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SparseVariationRegionList<'a> {
     fn type_name(&self) -> &str {
@@ -464,6 +494,16 @@ impl<'a> SparseVariationRegion<'a> {
             ..start
                 + (region_axis_count as usize)
                     .saturating_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(SparseVariationRegion::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for SparseVariationRegion<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -622,6 +662,16 @@ impl<'a> MultiItemVariationData<'a> {
     }
 }
 
+const _: () = assert!(MultiItemVariationData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for MultiItemVariationData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultiItemVariationData<'a> {
     fn type_name(&self) -> &str {
@@ -702,6 +752,16 @@ impl<'a> ConditionList<'a> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
         start..start + (condition_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ConditionList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ConditionList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -140,6 +140,16 @@ impl<'a> Varc<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Varc::MIN_SIZE));
+
+impl Default for Varc<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Varc<'a> {
     fn type_name(&self) -> &str {
@@ -275,6 +285,18 @@ impl<'a> MultiItemVariationStore<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    MultiItemVariationStore::MIN_SIZE
+));
+
+impl Default for MultiItemVariationStore<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultiItemVariationStore<'a> {
     fn type_name(&self) -> &str {
@@ -377,6 +399,18 @@ impl<'a> SparseVariationRegionList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    SparseVariationRegionList::MIN_SIZE
+));
+
+impl Default for SparseVariationRegionList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SparseVariationRegionList<'a> {
     fn type_name(&self) -> &str {
@@ -464,6 +498,18 @@ impl<'a> SparseVariationRegion<'a> {
             ..start
                 + (region_axis_count as usize)
                     .saturating_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    SparseVariationRegion::MIN_SIZE
+));
+
+impl Default for SparseVariationRegion<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 
@@ -622,6 +668,18 @@ impl<'a> MultiItemVariationData<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    MultiItemVariationData::MIN_SIZE
+));
+
+impl Default for MultiItemVariationData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultiItemVariationData<'a> {
     fn type_name(&self) -> &str {
@@ -702,6 +760,16 @@ impl<'a> ConditionList<'a> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
         start..start + (condition_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(ConditionList::MIN_SIZE));
+
+impl Default for ConditionList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -150,6 +150,13 @@ impl Default for Varc<'_> {
     }
 }
 
+impl Varc<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Varc<'a> {
     fn type_name(&self) -> &str {
@@ -295,6 +302,13 @@ impl Default for MultiItemVariationStore<'_> {
     }
 }
 
+impl MultiItemVariationStore<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u16_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultiItemVariationStore<'a> {
     fn type_name(&self) -> &str {
@@ -407,6 +421,13 @@ impl Default for SparseVariationRegionList<'_> {
     }
 }
 
+impl SparseVariationRegionList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SparseVariationRegionList<'a> {
     fn type_name(&self) -> &str {
@@ -504,6 +525,13 @@ impl Default for SparseVariationRegion<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl SparseVariationRegion<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 
@@ -672,6 +700,13 @@ impl Default for MultiItemVariationData<'_> {
     }
 }
 
+impl MultiItemVariationData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u8_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for MultiItemVariationData<'a> {
     fn type_name(&self) -> &str {
@@ -762,6 +797,13 @@ impl Default for ConditionList<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl ConditionList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -295,6 +295,16 @@ impl<'a> DeltaSetIndexMapFormat0<'a> {
     }
 }
 
+const _: () = assert!(DeltaSetIndexMapFormat0::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for DeltaSetIndexMapFormat0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat0<'a> {
     fn type_name(&self) -> &str {
@@ -404,6 +414,16 @@ impl<'a> DeltaSetIndexMapFormat1<'a> {
     }
 }
 
+const _: () = assert!(DeltaSetIndexMapFormat1::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for DeltaSetIndexMapFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -433,6 +453,12 @@ impl<'a> std::fmt::Debug for DeltaSetIndexMapFormat1<'a> {
 pub enum DeltaSetIndexMap<'a> {
     Format0(DeltaSetIndexMapFormat0<'a>),
     Format1(DeltaSetIndexMapFormat1<'a>),
+}
+
+impl Default for DeltaSetIndexMap<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
 }
 
 impl<'a> DeltaSetIndexMap<'a> {
@@ -908,6 +934,16 @@ impl<'a> VariationRegionList<'a> {
     }
 }
 
+const _: () = assert!(VariationRegionList::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for VariationRegionList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VariationRegionList<'a> {
     fn type_name(&self) -> &str {
@@ -1154,6 +1190,16 @@ impl<'a> ItemVariationStore<'a> {
     }
 }
 
+const _: () = assert!(ItemVariationStore::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ItemVariationStore<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ItemVariationStore<'a> {
     fn type_name(&self) -> &str {
@@ -1296,6 +1342,16 @@ impl<'a> ItemVariationData<'a> {
                     region_index_count,
                 ))
                 .saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(ItemVariationData::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for ItemVariationData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -295,6 +295,18 @@ impl<'a> DeltaSetIndexMapFormat0<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    DeltaSetIndexMapFormat0::MIN_SIZE
+));
+
+impl Default for DeltaSetIndexMapFormat0<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat0<'a> {
     fn type_name(&self) -> &str {
@@ -404,6 +416,18 @@ impl<'a> DeltaSetIndexMapFormat1<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    DeltaSetIndexMapFormat1::MIN_SIZE
+));
+
+impl Default for DeltaSetIndexMapFormat1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u8_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -433,6 +457,12 @@ impl<'a> std::fmt::Debug for DeltaSetIndexMapFormat1<'a> {
 pub enum DeltaSetIndexMap<'a> {
     Format0(DeltaSetIndexMapFormat0<'a>),
     Format1(DeltaSetIndexMapFormat1<'a>),
+}
+
+impl Default for DeltaSetIndexMap<'_> {
+    fn default() -> Self {
+        Self::Format0(Default::default())
+    }
 }
 
 impl<'a> DeltaSetIndexMap<'a> {
@@ -908,6 +938,18 @@ impl<'a> VariationRegionList<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    VariationRegionList::MIN_SIZE
+));
+
+impl Default for VariationRegionList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VariationRegionList<'a> {
     fn type_name(&self) -> &str {
@@ -1154,6 +1196,18 @@ impl<'a> ItemVariationStore<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    ItemVariationStore::MIN_SIZE
+));
+
+impl Default for ItemVariationStore<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ItemVariationStore<'a> {
     fn type_name(&self) -> &str {
@@ -1296,6 +1350,18 @@ impl<'a> ItemVariationData<'a> {
                     region_index_count,
                 ))
                 .saturating_mul(u8::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(
+    ItemVariationData::MIN_SIZE
+));
+
+impl Default for ItemVariationData<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -305,6 +305,13 @@ impl Default for DeltaSetIndexMapFormat0<'_> {
     }
 }
 
+impl DeltaSetIndexMapFormat0<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat0<'a> {
     fn type_name(&self) -> &str {
@@ -424,6 +431,13 @@ impl Default for DeltaSetIndexMapFormat1<'_> {
     }
 }
 
+impl DeltaSetIndexMapFormat1<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_format_1_u8_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for DeltaSetIndexMapFormat1<'a> {
     fn type_name(&self) -> &str {
@@ -458,6 +472,13 @@ pub enum DeltaSetIndexMap<'a> {
 impl Default for DeltaSetIndexMap<'_> {
     fn default() -> Self {
         Self::Format0(Default::default())
+    }
+}
+
+impl DeltaSetIndexMap<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        matches ! (self , Self :: Format0 (t) if t . is_default ())
     }
 }
 
@@ -944,6 +965,13 @@ impl Default for VariationRegionList<'_> {
     }
 }
 
+impl VariationRegionList<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for VariationRegionList<'a> {
     fn type_name(&self) -> &str {
@@ -1200,6 +1228,13 @@ impl Default for ItemVariationStore<'_> {
     }
 }
 
+impl ItemVariationStore<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for ItemVariationStore<'a> {
     fn type_name(&self) -> &str {
@@ -1352,6 +1387,13 @@ impl Default for ItemVariationData<'_> {
         Self {
             data: FontData::default_table_data(),
         }
+    }
+}
+
+impl ItemVariationData<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
     }
 }
 

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -226,6 +226,16 @@ impl<'a> Vhea<'a> {
     }
 }
 
+const _: () = assert!(Vhea::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Vhea<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vhea<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -226,6 +226,16 @@ impl<'a> Vhea<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Vhea::MIN_SIZE));
+
+impl Default for Vhea<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vhea<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -236,6 +236,13 @@ impl Default for Vhea<'_> {
     }
 }
 
+impl Vhea<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vhea<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -92,6 +92,16 @@ impl<'a> Vorg<'a> {
     }
 }
 
+const _: () = assert!(Vorg::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Vorg<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vorg<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -92,6 +92,16 @@ impl<'a> Vorg<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Vorg::MIN_SIZE));
+
+impl Default for Vorg<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vorg<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -102,6 +102,13 @@ impl Default for Vorg<'_> {
     }
 }
 
+impl Vorg<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vorg<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -144,6 +144,16 @@ impl<'a> Vvar<'a> {
     }
 }
 
+const _: () = assert!(Vvar::MIN_SIZE <= NULL_POOL_SIZE);
+
+impl Default for Vvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -144,6 +144,16 @@ impl<'a> Vvar<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Vvar::MIN_SIZE));
+
+impl Default for Vvar<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -154,6 +154,13 @@ impl Default for Vvar<'_> {
     }
 }
 
+impl Vvar<'_> {
+    /// Returns `true` if this table was created from default (null) data.
+    pub fn is_default(&self) -> bool {
+        self.data.as_bytes() == FontData::default_table_data().as_bytes()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vvar<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/src/codegen_test.rs
+++ b/read-fonts/src/codegen_test.rs
@@ -14,6 +14,39 @@ pub mod records {
 
 pub mod formats {
     include!("../generated/generated_test_formats.rs");
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use font_test_data::bebuffer::BeBuffer;
+
+        #[test]
+        fn default_and_is_default_format_table() {
+            // Table1 has format = 1 (u16), so its default data starts with 0x00 0x01
+            let table = Table1::default();
+            assert!(table.is_default());
+            assert_eq!(table.format(), 1);
+        }
+
+        #[test]
+        fn is_default_false_for_real_data() {
+            // Table1::MIN_SIZE = u16 + u32 + u16 = 8 bytes
+            let buf = BeBuffer::new()
+                .push(1u16) // format
+                .push(42u32) // some_val
+                .push(0u16); // other_val
+            let table = Table1::read(buf.data().into()).unwrap();
+            assert!(!table.is_default());
+        }
+
+        #[test]
+        fn format_enum_default_is_first_variant() {
+            // MyTable's Default delegates to Table1 (first variant)
+            let table = MyTable::default();
+            assert!(matches!(table, MyTable::Format1(_)));
+            assert!(table.is_default());
+        }
+    }
 }
 
 pub mod read_args {

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -32,6 +32,55 @@ pub struct Cursor<'a> {
     data: FontData<'a>,
 }
 
+// we reuse a single buffer for all tables, but it gets padded with a u16
+// to accurately represent format-1 tables
+const ARR_LEN: usize = FontData::NULL_POOL_SIZE + u16::RAW_BYTE_LEN;
+
+/// This is [0, 1] ('1' in u16be) followed by NULL_POOL_SIZE zeros.
+///
+/// - this same array is reused both for format-1 tables (which need a leading 1)
+///   as well as all other tables, which don't.
+static EMPTY_TABLE_BYTES: [u8; ARR_LEN] = {
+    let mut arr = [0u8; ARR_LEN];
+    arr[1] = 1;
+    arr
+};
+
+impl FontData<'static> {
+    // https://github.com/harfbuzz/harfbuzz/blob/aba63bb5/src/hb-null.hh#L40
+    /// The number of bytes required to represent the largest table we have.
+    ///
+    /// This is checked by an assert at compile time, and can be increased as needed.
+    const NULL_POOL_SIZE: usize = 262;
+
+    /// Return all zeroes suitable for the default impl of a table.
+    pub(crate) fn default_table_data() -> Self {
+        FontData::new(&EMPTY_TABLE_BYTES[2..])
+    }
+
+    /// Return a [0x0, 0x01] byte pair (u16be) and then all zeros, to represent
+    /// the default impl of a format 1 table with u16 format.
+    pub(crate) fn default_format_1_u16_table_data() -> Self {
+        FontData::new(&EMPTY_TABLE_BYTES)
+    }
+
+    /// Return a single 0x01 and then all zeros, to represent the default impl
+    /// of a format 1 table with u8 format.
+    pub(crate) fn default_format_1_u8_table_data() -> Self {
+        FontData::new(&EMPTY_TABLE_BYTES[1..])
+    }
+
+    /// Return `true` if our default data can represent a table `n_bytes` long
+    ///
+    /// This is used in codegen'd asserts
+    // only used to evaluate anonymous const items (const_: () = ...) which isn't
+    // visible to the dead_code lint
+    #[expect(dead_code)]
+    pub(crate) const fn default_data_long_enough(n_bytes: usize) -> bool {
+        n_bytes <= Self::NULL_POOL_SIZE
+    }
+}
+
 impl<'a> FontData<'a> {
     /// Empty data, useful for some tests and examples
     pub const EMPTY: FontData<'static> = FontData { bytes: &[] };
@@ -315,5 +364,20 @@ impl<'a> From<&'a [u8]> for FontData<'a> {
 impl<'a> From<FontData<'a>> for std::borrow::Cow<'a, [u8]> {
     fn from(src: FontData<'a>) -> Self {
         src.bytes.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn how_does_big_endian_work_again() {
+        let data = FontData::default_format_1_u16_table_data();
+        assert_eq!(data.read_at(0), Ok(1u16));
+
+        assert_eq!(
+            FontData::default_format_1_u8_table_data().read_at(0),
+            Ok(1u8)
+        );
     }
 }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -112,7 +112,7 @@ pub(crate) mod codegen_prelude {
         ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
     };
     pub use crate::table_provider::TopLevelTable;
-    pub use crate::table_ref::MinByteRange;
+    pub use crate::table_ref::{MinByteRange, NULL_POOL_SIZE};
     pub use std::ops::Range;
 
     pub use types::*;

--- a/read-fonts/src/table_ref.rs
+++ b/read-fonts/src/table_ref.rs
@@ -1,5 +1,45 @@
 use std::ops::Range;
 
+use crate::types::FixedSize;
+use crate::FontData;
+
+// https://github.com/harfbuzz/harfbuzz/blob/aba63bb5/src/hb-null.hh#L40
+/// The number of bytes required to represent the largest table we have.
+///
+/// This is checked by an assert at compile time, and can be increased as needed.
+pub const NULL_POOL_SIZE: usize = 262;
+
+const ARR_LEN: usize = NULL_POOL_SIZE + u16::RAW_BYTE_LEN;
+
+/// This is [0, 1] ('1' in u16be) followed by NULL_POOL_SIZE zeros.
+///
+/// - this same array is reused both for format-1 tables (which need a leading 1)
+///   as well as all other tables, which don't.
+static EMPTY_TABLE_BYTES: [u8; ARR_LEN] = {
+    let mut arr = [0u8; ARR_LEN];
+    arr[1] = 1;
+    arr
+};
+
+impl FontData<'static> {
+    /// Return all zeroes suitable for the default impl of a table.
+    pub(crate) fn default_table_data() -> Self {
+        FontData::new(&EMPTY_TABLE_BYTES[2..])
+    }
+
+    /// Return a [0x0, 0x01] byte pair (u16be) and then all zeros, to represent
+    /// the default impl of a format 1 table with u16 format.
+    pub(crate) fn default_format_1_u16_table_data() -> Self {
+        FontData::new(&EMPTY_TABLE_BYTES)
+    }
+
+    /// Return a single 0x01 and then all zeros, to represent the default impl
+    /// of a format 1 table with u8 format.
+    pub(crate) fn default_format_1_u8_table_data() -> Self {
+        FontData::new(&EMPTY_TABLE_BYTES[1..])
+    }
+}
+
 /// Return the minimum range of the table bytes
 ///
 /// This trait is implemented in generated code, and we use this to get the
@@ -7,4 +47,19 @@ use std::ops::Range;
 pub trait MinByteRange<'a> {
     fn min_byte_range(&self) -> Range<usize>;
     fn min_table_bytes(&self) -> &'a [u8];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn how_does_big_endian_work_again() {
+        let data = FontData::default_format_1_u16_table_data();
+        assert_eq!(data.read_at(0), Ok(1u16));
+
+        assert_eq!(
+            FontData::default_format_1_u8_table_data().read_at(0),
+            Ok(1u8)
+        );
+    }
 }

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -928,4 +928,17 @@ mod tests {
         assert_eq!(bit_storage(0xffff), 16);
         assert_eq!(bit_storage(0xffff_ffff), 32);
     }
+
+    #[test]
+    fn default_coverage() {
+        let coverage = CoverageTable::default();
+        assert_eq!(coverage.iter().count(), 0)
+    }
+
+    #[test]
+    fn default_classdef() {
+        let classdef = ClassDef::default();
+        assert_eq!(classdef.population(), 0);
+        assert_eq!(classdef.iter().count(), 0);
+    }
 }


### PR DESCRIPTION
This generates impls of the Default trait for many font tables.

A table is skipped if it has a 'format' field with an expected  value other than `0` or `1`; in this case it is not expected that any API we generate parses this table directly, and it should only ever be read through a 'format group' enum.

If a table has format 1, we ensure that the first two bytes of the provided value would represent the value '1' as either a u8 or u16, depending on the format of the field. Otherwise the values are all zeros.