### PR TITLE
[chore] bump font-types to 0.11.3, write-fonts to 0.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.11.2", path = "font-types" }
+font-types = { version = "0.11.3", path = "font-types" }
 read-fonts = { version = "0.39.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.42.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.47.0", path = "write-fonts" }
+write-fonts = { version = "0.48.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.2.1", path = "incremental-font-transfer" }
 skera = { version = "0.1.4", path = "skera" }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.11.2"
+version = "0.11.3"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.47.0"
+version = "0.48.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
write-fonts cvar PR #1812 contained some breaking changes so I bumped minor, instead of patch.

```
     Changes for font-types from font-types-v0.11.2 to 0.11.3
             2e3d79f [chore] bump font-types to 0.11.3, write-fonts to 0.48.0
             55cccee Fix fixed-point division overflow using unsigned_abs()
     Changes for write-fonts from write-fonts-v0.47.0 to 0.48.0
             2e3d79f [chore] bump font-types to 0.11.3, write-fonts to 0.48.0
             e114e35 [write-fonts] Fix double-count bug in promotion logic
             6f9ade3 [write-fonts] Add offset-width penalty to update_distances
             4506c73 [write-fonts] Add regression test for missing offset-width penalty
             d1439f5 [write-fonts] Fix Dijkstra min-heap in update_distances
             711c662 [write-fonts] Add regression test for Dijkstra max-heap bug
             66989d1 Use generated cvar
             6f4f29e Trait bound not needed
             f31729f Update codegen plan to generate cvar, add generated output
             92ea293 Use raw identifier syntax when calling gen (#1817)
             b31747d Support writing cvar tables
             98cb617 Move common TVS construction routines from gvar variations
    
```