### PR TITLE
Fix build for docs.rs

### DIFF
--- a/shared-brotli-patch-decoder/build.rs
+++ b/shared-brotli-patch-decoder/build.rs
@@ -4,6 +4,10 @@ fn main() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     println!("cargo:rerun-if-changed={}/build.rs", manifest_dir);
 
+    if std::env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
     #[cfg(feature = "c-brotli")]
     c_brotli::build_brotli();
 }


### PR DESCRIPTION
Fix build for docs.rs

- shared-brotli-patch-decoder fails to build on docs.rs since there is no compiler tooling.
- We skip compiling brotli. It is fine to not link in the symbols to generate docs.