### PR TITLE
[subset] add null checks to avoid err when an null offset is encountered

### DIFF
--- a/read-fonts/src/offset_array.rs
+++ b/read-fonts/src/offset_array.rs
@@ -85,6 +85,18 @@ where
                 .map(|off| off.get().resolve_with_args(data, &args))
         })
     }
+
+    /// Iterate over all of the offset targets.
+    ///
+    /// Offset is treated as nullable and each offset will be resolved as it is encountered.
+    pub(crate) fn iter_as_nullable(
+        &self,
+    ) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
+        self.iter().map(|off| match off {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        })
+    }
 }
 
 impl<'a, T, O> ArrayOfNullableOffsets<'a, T, O>

--- a/read-fonts/src/tables/colr/closure.rs
+++ b/read-fonts/src/tables/colr/closure.rs
@@ -1,5 +1,4 @@
 //! computing closure for the colr table
-
 use font_types::{GlyphId, GlyphId16};
 
 use crate::{collections::IntSet, tables::variations::NO_VARIATION_INDEX, ResolveOffset};
@@ -27,6 +26,10 @@ impl Colr<'_> {
         let Some(Ok(records)) = self.base_glyph_records() else {
             return;
         };
+
+        let Some(Ok(layers)) = self.layer_records() else {
+            return;
+        };
         for glyph_id in glyph_set.iter() {
             let Ok(glyph_id) = glyph_id.try_into() else {
                 continue;
@@ -38,8 +41,8 @@ impl Colr<'_> {
             let start = record.first_layer_index() as usize;
             let end = start + record.num_layers() as usize;
             for layer_index in start..end {
-                if let Ok((_gid, palette_id)) = self.v0_layer(layer_index) {
-                    palette_indices.insert(palette_id);
+                if let Some(layer) = layers.get(layer_index) {
+                    palette_indices.insert(layer.palette_index());
                 }
             }
         }
@@ -62,16 +65,15 @@ impl Colr<'_> {
         if let Some(Ok(base_glyph_list)) = self.base_glyph_list() {
             let base_glyph_records = base_glyph_list.base_glyph_paint_records();
             let offset_data = base_glyph_list.offset_data();
-            for paint_record in base_glyph_records {
-                let gid = paint_record.glyph_id();
+            for record in base_glyph_records {
+                let gid = record.glyph_id();
                 if !glyph_set.contains(GlyphId::from(gid)) {
                     continue;
                 }
-                if let Ok(paint) = paint_record.paint(offset_data) {
+                if let Ok(paint) = record.paint(offset_data) {
                     c.dispatch(&paint);
                 }
             }
-
             glyph_set.union(&c.glyph_set);
         }
 
@@ -93,6 +95,9 @@ impl Colr<'_> {
         let Some(Ok(records)) = self.base_glyph_records() else {
             return;
         };
+        let Some(Ok(layers)) = self.layer_records() else {
+            return;
+        };
         for glyph_id in glyph_set.iter() {
             let Ok(glyph_id) = glyph_id.try_into() else {
                 continue;
@@ -104,8 +109,8 @@ impl Colr<'_> {
             let start = record.first_layer_index() as usize;
             let end = start + record.num_layers() as usize;
             for layer_index in start..end {
-                if let Ok((gid, _palette_id)) = self.v0_layer(layer_index) {
-                    glyphset_colrv0.insert(GlyphId::from(gid));
+                if let Some(layer) = layers.get(layer_index) {
+                    glyphset_colrv0.insert(GlyphId::from(layer.glyph_id()));
                 }
             }
         }
@@ -166,9 +171,8 @@ impl<'a> Colrv1ClosureContext<'a> {
         false
     }
 
-    fn add_layer_indices(&mut self, first_layer_index: u32, last_layer_index: u32) {
-        self.layer_indices
-            .insert_range(first_layer_index..=last_layer_index);
+    fn add_layer_index(&mut self, layer_index: u32) {
+        self.layer_indices.insert(layer_index);
     }
 
     fn add_palette_index(&mut self, palette_index: u16) {
@@ -270,14 +274,16 @@ impl PaintColrLayers<'_> {
         };
         let first_layer_index = self.first_layer_index();
         let last_layer_index = first_layer_index + num_layers as u32 - 1;
-        c.add_layer_indices(first_layer_index, last_layer_index);
 
         let offset_data = layer_list.offset_data();
+        let paint_offsets = layer_list.paint_offsets();
         for layer_index in first_layer_index..=last_layer_index {
-            if let Some(paint_offset) = layer_list.paint_offsets().get(layer_index as usize) {
-                if let Ok(paint) = paint_offset.get().resolve::<Paint>(offset_data) {
-                    c.dispatch(&paint);
-                }
+            let Some(paint_offset) = paint_offsets.get(layer_index as usize) else {
+                break;
+            };
+            if let Ok(paint) = paint_offset.get().resolve::<Paint>(offset_data) {
+                c.add_layer_index(layer_index);
+                c.dispatch(&paint);
             }
         }
     }
@@ -308,8 +314,8 @@ impl PaintVarLinearGradient<'_> {
     fn v1_closure(&self, c: &mut Colrv1ClosureContext) {
         if let Ok(var_colorline) = self.color_line() {
             var_colorline.v1_closure(c);
+            c.add_variation_indices(self.var_index_base(), 6);
         }
-        c.add_variation_indices(self.var_index_base(), 6);
     }
 }
 
@@ -325,8 +331,8 @@ impl PaintVarRadialGradient<'_> {
     fn v1_closure(&self, c: &mut Colrv1ClosureContext) {
         if let Ok(var_colorline) = self.color_line() {
             var_colorline.v1_closure(c);
+            c.add_variation_indices(self.var_index_base(), 6);
         }
-        c.add_variation_indices(self.var_index_base(), 6);
     }
 }
 
@@ -342,15 +348,15 @@ impl PaintVarSweepGradient<'_> {
     fn v1_closure(&self, c: &mut Colrv1ClosureContext) {
         if let Ok(var_colorline) = self.color_line() {
             var_colorline.v1_closure(c);
+            c.add_variation_indices(self.var_index_base(), 4);
         }
-        c.add_variation_indices(self.var_index_base(), 4);
     }
 }
 
 impl PaintGlyph<'_> {
     fn v1_closure(&self, c: &mut Colrv1ClosureContext) {
-        c.add_glyph_id(self.glyph_id());
         if let Ok(paint) = self.paint() {
+            c.add_glyph_id(self.glyph_id());
             c.dispatch(&paint);
         }
     }
@@ -391,8 +397,8 @@ impl VarAffine2x3<'_> {
 impl PaintVarTransform<'_> {
     fn v1_closure(&self, c: &mut Colrv1ClosureContext) {
         if let Ok(paint) = self.paint() {
-            c.dispatch(&paint);
             if let Ok(affine2x3) = self.transform() {
+                c.dispatch(&paint);
                 affine2x3.v1_closure(c);
             }
         }

--- a/read-fonts/src/tables/gpos/closure.rs
+++ b/read-fonts/src/tables/gpos/closure.rs
@@ -18,6 +18,9 @@ impl Gpos<'_> {
         languages: &IntSet<Tag>,
         features: &IntSet<Tag>,
     ) -> Result<IntSet<u16>, ReadError> {
+        if self.script_list_offset().is_null() || self.feature_list_offset().is_null() {
+            return Ok(IntSet::empty());
+        }
         let feature_list = self.feature_list()?;
         let script_list = self.script_list()?;
         let head_ptr = self.offset_data().as_bytes().as_ptr() as usize;
@@ -26,6 +29,9 @@ impl Gpos<'_> {
 
     /// Return a set of lookups referenced by the specified features
     pub fn collect_lookups(&self, feature_indices: &IntSet<u16>) -> Result<IntSet<u16>, ReadError> {
+        if self.feature_list_offset().is_null() {
+            return Ok(IntSet::empty());
+        }
         let feature_list = self.feature_list()?;
         let mut lookup_indices = feature_list.collect_lookups(feature_indices)?;
 
@@ -42,6 +48,9 @@ impl Gpos<'_> {
         glyphs: &IntSet<GlyphId>,
         lookup_indices: &mut IntSet<u16>,
     ) -> Result<(), ReadError> {
+        if self.lookup_list_offset().is_null() {
+            return Ok(());
+        }
         let lookup_list = self.lookup_list()?;
         lookup_list.closure_lookups(glyphs, lookup_indices)
     }
@@ -58,7 +67,13 @@ impl PositionLookupList<'_> {
 
         let lookups = self.lookups();
         for idx in lookup_indices.iter() {
-            let lookup = lookups.get(idx as usize)?;
+            let lookup = match lookups.get(idx as usize) {
+                Err(ReadError::NullOffset) => {
+                    c.set_lookup_inactive(idx);
+                    continue;
+                }
+                other => other,
+            }?;
             lookup.closure_lookups(&mut c, idx)?;
         }
 
@@ -82,7 +97,6 @@ impl LookupClosure for PositionLookup<'_> {
             c.set_lookup_inactive(lookup_index);
             return Ok(());
         }
-
         self.subtables()?.closure_lookups(c, lookup_index)
     }
 }
@@ -130,12 +144,18 @@ impl Intersect for SinglePos<'_> {
 
 impl Intersect for SinglePosFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
 
 impl Intersect for SinglePosFormat2<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
@@ -151,6 +171,9 @@ impl Intersect for PairPos<'_> {
 
 impl Intersect for PairPosFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         let coverage = self.coverage()?;
         let pair_sets = self.pair_sets();
 
@@ -161,18 +184,23 @@ impl Intersect for PairPosFormat1<'_> {
                 let Some(i) = coverage.get(g) else {
                     continue;
                 };
-
-                let pair_set = pair_sets.get(i as usize)?;
+                let pair_set = match pair_sets.get(i as usize) {
+                    Err(ReadError::NullOffset) => continue,
+                    other => other,
+                }?;
                 if pair_set.intersects(glyph_set)? {
                     return Ok(true);
                 }
             }
         } else {
-            for (g, pair_set) in coverage.iter().zip(pair_sets.iter()) {
+            for (g, pair_set) in coverage.iter().zip(pair_sets.iter_as_nullable()) {
                 if !glyph_set.contains(GlyphId::from(g)) {
                     continue;
                 }
-                if pair_set?.intersects(glyph_set)? {
+                let Some(pair_set) = pair_set.transpose()? else {
+                    continue;
+                };
+                if pair_set.intersects(glyph_set)? {
                     return Ok(true);
                 }
             }
@@ -195,18 +223,30 @@ impl Intersect for PairSet<'_> {
 
 impl Intersect for PairPosFormat2<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null()
+            || self.class_def1_offset().is_null()
+            || self.class_def2_offset().is_null()
+        {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set) && self.class_def2()?.intersects(glyph_set)?)
     }
 }
 
 impl Intersect for CursivePosFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
 
 impl Intersect for MarkBasePosFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.mark_coverage_offset().is_null() || self.base_coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.mark_coverage()?.intersects(glyph_set)
             && self.base_coverage()?.intersects(glyph_set))
     }
@@ -214,6 +254,9 @@ impl Intersect for MarkBasePosFormat1<'_> {
 
 impl Intersect for MarkLigPosFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.mark_coverage_offset().is_null() || self.ligature_coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.mark_coverage()?.intersects(glyph_set)
             && self.ligature_coverage()?.intersects(glyph_set))
     }
@@ -221,6 +264,9 @@ impl Intersect for MarkLigPosFormat1<'_> {
 
 impl Intersect for MarkMarkPosFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.mark1_coverage_offset().is_null() || self.mark2_coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.mark1_coverage()?.intersects(glyph_set)
             && self.mark2_coverage()?.intersects(glyph_set))
     }

--- a/read-fonts/src/tables/gsub/closure.rs
+++ b/read-fonts/src/tables/gsub/closure.rs
@@ -194,6 +194,9 @@ impl Gsub<'_> {
         lookups: &IntSet<u16>,
         glyphs: &mut IntSet<GlyphId>,
     ) -> Result<(), ReadError> {
+        if self.lookup_list_offset().is_null() {
+            return Ok(());
+        }
         let lookup_list = self.lookup_list()?;
         let num_lookups = lookup_list.lookup_count();
         let lookup_offsets = lookup_list.lookups();
@@ -210,13 +213,19 @@ impl Gsub<'_> {
                     if !lookups.contains(i) {
                         continue;
                     }
-                    let lookup = lookup_offsets.get(i as usize)?;
+                    let lookup = match lookup_offsets.get(i as usize) {
+                        Err(ReadError::NullOffset) => continue,
+                        other => other,
+                    }?;
                     lookup.closure_glyphs(&mut ctx, &lookup_list, i)?;
                     ctx.flush();
                 }
             } else {
                 for i in lookups.iter() {
-                    let lookup = lookup_offsets.get(i as usize)?;
+                    let lookup = match lookup_offsets.get(i as usize) {
+                        Err(ReadError::NullOffset) => continue,
+                        other => other,
+                    }?;
                     lookup.closure_glyphs(&mut ctx, &lookup_list, i)?;
                     ctx.flush();
                 }
@@ -233,6 +242,9 @@ impl Gsub<'_> {
     ///
     /// Pass `&IntSet::all()` to get the lookups referenced by all features.
     pub fn collect_lookups(&self, feature_indices: &IntSet<u16>) -> Result<IntSet<u16>, ReadError> {
+        if self.feature_list_offset().is_null() {
+            return Ok(IntSet::empty());
+        }
         let feature_list = self.feature_list()?;
         let mut lookup_indices = feature_list.collect_lookups(feature_indices)?;
 
@@ -250,6 +262,9 @@ impl Gsub<'_> {
         languages: &IntSet<Tag>,
         features: &IntSet<Tag>,
     ) -> Result<IntSet<u16>, ReadError> {
+        if self.script_list_offset().is_null() || self.feature_list_offset().is_null() {
+            return Ok(IntSet::empty());
+        }
         let feature_list = self.feature_list()?;
         let script_list = self.script_list()?;
         let head_ptr = self.offset_data().as_bytes().as_ptr() as usize;
@@ -262,6 +277,9 @@ impl Gsub<'_> {
         glyphs: &IntSet<GlyphId>,
         lookup_indices: &mut IntSet<u16>,
     ) -> Result<(), ReadError> {
+        if self.lookup_list_offset().is_null() {
+            return Ok(());
+        }
         let lookup_list = self.lookup_list()?;
         lookup_list.closure_lookups(glyphs, lookup_indices)
     }
@@ -343,8 +361,13 @@ impl<'a, T: FontRead<'a> + GlyphClosure + 'a, Ext: ExtensionLookup<'a, T> + 'a> 
         lookup_list: &SubstitutionLookupList,
         lookup_index: u16,
     ) -> Result<(), ReadError> {
-        self.iter()
-            .try_for_each(|t| t?.closure_glyphs(ctx, lookup_list, lookup_index))
+        for t in self.iter().filter_map(|table| match table {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        }) {
+            t?.closure_glyphs(ctx, lookup_list, lookup_index)?;
+        }
+        Ok(())
     }
 }
 
@@ -370,6 +393,9 @@ impl GlyphClosure for SingleSubstFormat1<'_> {
         _lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(());
+        }
         let coverage = self.coverage()?;
         let num_glyphs = coverage.population();
         let mask = u16::MAX;
@@ -414,6 +440,9 @@ impl GlyphClosure for SingleSubstFormat2<'_> {
         _lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
+        if self.coverage_offset().is_null() || self.glyph_count() == 0 {
+            return Ok(());
+        }
         let coverage = self.coverage()?;
         let glyph_set = ctx.parent_active_glyphs();
         let subs_glyphs = self.substitute_glyph_ids();
@@ -448,6 +477,9 @@ impl GlyphClosure for MultipleSubstFormat1<'_> {
         _lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
+        if self.coverage_offset().is_null() || self.sequence_count() == 0 {
+            return Ok(());
+        }
         let coverage = self.coverage()?;
         let glyph_set = ctx.parent_active_glyphs();
         let sequences = self.sequences();
@@ -466,11 +498,11 @@ impl GlyphClosure for MultipleSubstFormat1<'_> {
         } else {
             coverage
                 .iter()
-                .zip(sequences.iter())
+                .zip(sequences.iter_as_nullable())
                 .filter_map(|(g, seq)| {
                     glyph_set
                         .contains(GlyphId::from(g))
-                        .then(|| seq.ok())
+                        .then(|| seq.transpose().ok().flatten())
                         .flatten()
                 })
                 .flat_map(|seq| {
@@ -493,6 +525,9 @@ impl GlyphClosure for AlternateSubstFormat1<'_> {
         _lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
+        if self.coverage_offset().is_null() || self.alternate_set_count() == 0 {
+            return Ok(());
+        }
         let coverage = self.coverage()?;
         let glyph_set = ctx.parent_active_glyphs();
         let alts = self.alternate_sets();
@@ -512,11 +547,11 @@ impl GlyphClosure for AlternateSubstFormat1<'_> {
         } else {
             coverage
                 .iter()
-                .zip(alts.iter())
+                .zip(alts.iter_as_nullable())
                 .filter_map(|(g, alt_set)| {
                     glyph_set
                         .contains(GlyphId::from(g))
-                        .then(|| alt_set.ok())
+                        .then(|| alt_set.transpose().ok().flatten())
                         .flatten()
                 })
                 .flat_map(|alt_set| {
@@ -540,6 +575,9 @@ impl GlyphClosure for LigatureSubstFormat1<'_> {
         _lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
+        if self.coverage_offset().is_null() || self.ligature_set_count() == 0 {
+            return Ok(());
+        }
         let coverage = self.coverage()?;
         let ligs = self.ligature_sets();
         let lig_set_idxes: Vec<usize> =
@@ -559,9 +597,14 @@ impl GlyphClosure for LigatureSubstFormat1<'_> {
             };
 
         for idx in lig_set_idxes {
-            let lig_set = ligs.get(idx)?;
-            for lig in lig_set.ligatures().iter() {
-                let lig = lig?;
+            let lig_set = match ligs.get(idx) {
+                Err(ReadError::NullOffset) => continue,
+                other => other,
+            }?;
+            for lig in lig_set.ligatures().iter_as_nullable() {
+                let Some(lig) = lig.transpose()? else {
+                    continue;
+                };
                 if lig.intersects(ctx.glyphs())? {
                     ctx.add(GlyphId::from(lig.ligature_glyph()));
                 }
@@ -661,12 +704,15 @@ impl GlyphClosure for ContextFormat1<'_> {
         lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
-        let coverage = self.coverage()?;
+        let Some(coverage) = self.coverage().transpose()? else {
+            return Ok(());
+        };
         let cov_active_glyphs = coverage.intersect_set(ctx.parent_active_glyphs());
         if cov_active_glyphs.is_empty() {
             return Ok(());
         }
 
+        let lookups = lookup_list.lookups();
         for (gid, rule_set) in coverage
             .iter()
             .zip(self.rule_sets())
@@ -684,7 +730,9 @@ impl GlyphClosure for ContextFormat1<'_> {
                 if ctx.lookup_limit_exceed() {
                     return Ok(());
                 }
-                let rule = rule?;
+                let Some(rule) = rule.transpose()? else {
+                    continue;
+                };
                 if !rule.intersects(ctx.glyphs())? {
                     continue;
                 }
@@ -699,6 +747,12 @@ impl GlyphClosure for ContextFormat1<'_> {
                 let mut seen_sequence_indices = IntSet::new();
 
                 for lookup_record in rule.lookup_records() {
+                    let lookup_index = lookup_record.lookup_list_index();
+                    let lookup = match lookups.get(lookup_index as usize) {
+                        Err(ReadError::NullOffset) => continue,
+                        other => other,
+                    }?;
+
                     let sequence_idx = lookup_record.sequence_index();
                     if sequence_idx as usize >= input_count {
                         continue;
@@ -716,8 +770,6 @@ impl GlyphClosure for ContextFormat1<'_> {
                         active_glyphs.insert(GlyphId::from(g));
                     };
 
-                    let lookup_index = lookup_record.lookup_list_index();
-                    let lookup = lookup_list.lookups().get(lookup_index as usize)?;
                     if lookup.may_have_non_1to1()? {
                         seen_sequence_indices.insert_range(sequence_idx..=input_count as u16);
                     }
@@ -737,25 +789,45 @@ impl GlyphClosure for ContextFormat2<'_> {
         lookup_list: &SubstitutionLookupList,
         _lookup_index: u16,
     ) -> Result<(), ReadError> {
-        let coverage = self.coverage()?;
+        let Some(coverage) = self.coverage().transpose()? else {
+            return Ok(());
+        };
         let cov_active_glyphs = coverage.intersect_set(ctx.parent_active_glyphs());
         if cov_active_glyphs.is_empty() {
             return Ok(());
         }
 
-        let input_class_def = self.input_class_def()?;
+        let Some(input_class_def) = self.input_class_def().transpose()? else {
+            return Ok(());
+        };
         let coverage_glyph_classes = input_class_def.intersect_classes(&cov_active_glyphs);
+        if coverage_glyph_classes.is_empty() {
+            return Ok(());
+        }
 
         let input_glyph_classes = input_class_def.intersect_classes(ctx.glyphs());
         let backtrack_classes = match self {
             Self::Plain(_) => IntSet::empty(),
-            Self::Chain(table) => table.backtrack_class_def()?.intersect_classes(ctx.glyphs()),
+            Self::Chain(table) => {
+                if table.backtrack_class_def_offset().is_null() {
+                    IntSet::empty()
+                } else {
+                    table.backtrack_class_def()?.intersect_classes(ctx.glyphs())
+                }
+            }
         };
         let lookahead_classes = match self {
             Self::Plain(_) => IntSet::empty(),
-            Self::Chain(table) => table.lookahead_class_def()?.intersect_classes(ctx.glyphs()),
+            Self::Chain(table) => {
+                if table.lookahead_class_def_offset().is_null() {
+                    IntSet::empty()
+                } else {
+                    table.lookahead_class_def()?.intersect_classes(ctx.glyphs())
+                }
+            }
         };
 
+        let lookups = lookup_list.lookups();
         for (i, rule_set) in self
             .rule_sets()
             .enumerate()
@@ -770,7 +842,9 @@ impl GlyphClosure for ContextFormat2<'_> {
                 if ctx.lookup_limit_exceed() {
                     return Ok(());
                 }
-                let rule = rule?;
+                let Some(rule) = rule.transpose()? else {
+                    continue;
+                };
                 if !rule.intersects(&input_glyph_classes, &backtrack_classes, &lookahead_classes) {
                     continue;
                 }
@@ -781,6 +855,11 @@ impl GlyphClosure for ContextFormat2<'_> {
                 let mut seen_sequence_indices = IntSet::new();
 
                 for lookup_record in rule.lookup_records() {
+                    let lookup_index = lookup_record.lookup_list_index();
+                    let lookup = match lookups.get(lookup_index as usize) {
+                        Err(ReadError::NullOffset) => continue,
+                        other => other,
+                    }?;
                     let sequence_idx = lookup_record.sequence_index();
                     if sequence_idx as usize >= input_count {
                         continue;
@@ -795,8 +874,6 @@ impl GlyphClosure for ContextFormat2<'_> {
                         input_class_def.intersected_class_glyphs(ctx.parent_active_glyphs(), c)
                     };
 
-                    let lookup_index = lookup_record.lookup_list_index();
-                    let lookup = lookup_list.lookups().get(lookup_index as usize)?;
                     if lookup.may_have_non_1to1()? {
                         seen_sequence_indices.insert_range(sequence_idx..=input_count as u16);
                     }
@@ -822,7 +899,14 @@ impl GlyphClosure for ContextFormat3<'_> {
         let mut seen_sequence_indices = IntSet::new();
         let input_coverages = self.coverages();
         let input_count = input_coverages.len();
+        let lookups = lookup_list.lookups();
         for record in self.lookup_records() {
+            let lookup_index = record.lookup_list_index();
+            let lookup = match lookups.get(lookup_index as usize) {
+                Err(ReadError::NullOffset) => continue,
+                other => other,
+            }?;
+
             let seq_idx = record.sequence_index();
             if seq_idx as usize >= input_count {
                 continue;
@@ -838,8 +922,6 @@ impl GlyphClosure for ContextFormat3<'_> {
                 cov.intersect_set(ctx.glyphs())
             };
 
-            let lookup_index = record.lookup_list_index();
-            let lookup = lookup_list.lookups().get(lookup_index as usize)?;
             if lookup.may_have_non_1to1()? {
                 seen_sequence_indices.insert_range(seq_idx..=input_count as u16);
             }
@@ -860,7 +942,13 @@ impl SubstitutionLookupList<'_> {
 
         let lookups = self.lookups();
         for idx in lookup_indices.iter() {
-            let lookup = lookups.get(idx as usize)?;
+            let lookup = match lookups.get(idx as usize) {
+                Err(ReadError::NullOffset) => {
+                    c.set_lookup_inactive(idx);
+                    continue;
+                }
+                other => other,
+            }?;
             lookup.closure_lookups(&mut c, idx)?;
         }
 
@@ -931,38 +1019,56 @@ impl Intersect for SingleSubst<'_> {
 
 impl Intersect for SingleSubstFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
 
 impl Intersect for SingleSubstFormat2<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
 
 impl Intersect for MultipleSubstFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
 
 impl Intersect for AlternateSubstFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         Ok(self.coverage()?.intersects(glyph_set))
     }
 }
 
 impl Intersect for LigatureSubstFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         let coverage = self.coverage()?;
         let lig_sets = self.ligature_sets();
         for lig_set in coverage
             .iter()
-            .zip(lig_sets.iter())
+            .zip(lig_sets.iter_as_nullable())
             .filter_map(|(g, lig_set)| glyph_set.contains(GlyphId::from(g)).then_some(lig_set))
         {
-            if lig_set?.intersects(glyph_set)? {
+            let Some(lig_set) = lig_set.transpose()? else {
+                continue;
+            };
+            if lig_set.intersects(glyph_set)? {
                 return Ok(true);
             }
         }
@@ -973,7 +1079,7 @@ impl Intersect for LigatureSubstFormat1<'_> {
 impl Intersect for LigatureSet<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
         let ligs = self.ligatures();
-        for lig in ligs.iter() {
+        for lig in ligs.iter_as_nullable().flatten() {
             if lig?.intersects(glyph_set)? {
                 return Ok(true);
             }
@@ -994,18 +1100,27 @@ impl Intersect for Ligature<'_> {
 
 impl Intersect for ReverseChainSingleSubstFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        if self.coverage_offset().is_null() {
+            return Ok(false);
+        }
         if !self.coverage()?.intersects(glyph_set) {
             return Ok(false);
         }
 
-        for coverage in self.backtrack_coverages().iter() {
-            if !coverage?.intersects(glyph_set) {
+        for coverage in self.backtrack_coverages().iter_as_nullable() {
+            let Some(coverage) = coverage.transpose()? else {
+                return Ok(false);
+            };
+            if !coverage.intersects(glyph_set) {
                 return Ok(false);
             }
         }
 
-        for coverage in self.lookahead_coverages().iter() {
-            if !coverage?.intersects(glyph_set) {
+        for coverage in self.lookahead_coverages().iter_as_nullable() {
+            let Some(coverage) = coverage.transpose()? else {
+                return Ok(false);
+            };
+            if !coverage.intersects(glyph_set) {
                 return Ok(false);
             }
         }

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -112,7 +112,7 @@ impl ScriptList<'_> {
         if scripts.is_inverted() {
             for record in script_records {
                 let tag = record.script_tag();
-                if !scripts.contains(tag) {
+                if !scripts.contains(tag) || record.script_offset().is_null() {
                     continue;
                 }
                 let script = record.script(font_data)?;
@@ -120,7 +120,11 @@ impl ScriptList<'_> {
             }
         } else {
             for idx in scripts.iter().filter_map(|tag| self.index_for_tag(tag)) {
-                let script = script_records[idx as usize].script(font_data)?;
+                let record = script_records[idx as usize];
+                if record.script_offset().is_null() {
+                    continue;
+                }
+                let script = record.script(font_data)?;
                 script.collect_features(&mut c, languages)?;
             }
         }
@@ -148,7 +152,7 @@ impl Script<'_> {
         if languages.is_inverted() {
             for record in lang_sys_records {
                 let tag = record.lang_sys_tag();
-                if !languages.contains(tag) {
+                if !languages.contains(tag) || record.lang_sys_offset().is_null() {
                     continue;
                 }
                 let lang_sys = record.lang_sys(font_data)?;
@@ -159,7 +163,11 @@ impl Script<'_> {
                 .iter()
                 .filter_map(|tag| self.lang_sys_index_for_tag(tag))
             {
-                let lang_sys = lang_sys_records[idx as usize].lang_sys(font_data)?;
+                let record = lang_sys_records[idx as usize];
+                if record.lang_sys_offset().is_null() {
+                    continue;
+                }
+                let lang_sys = record.lang_sys(font_data)?;
                 lang_sys.collect_features(c);
             }
         }
@@ -226,6 +234,9 @@ impl FeatureList<'_> {
                     .then(|| features_records.get(i as usize))
                     .flatten()
             }) {
+                if feature_rec.feature_offset().is_null() {
+                    continue;
+                }
                 lookup_idxes.extend_unsorted(feature_rec.feature(font_data)?.collect_lookups());
             }
         } else {
@@ -233,6 +244,9 @@ impl FeatureList<'_> {
                 .iter()
                 .filter_map(|i| features_records.get(i as usize))
             {
+                if feature_rec.feature_offset().is_null() {
+                    continue;
+                }
                 lookup_idxes.extend_unsorted(feature_rec.feature(font_data)?.collect_lookups());
             }
         }
@@ -260,6 +274,9 @@ impl FeatureVariations<'_> {
                 .iter()
                 .filter(|sub_rec| feature_indices.contains(sub_rec.feature_index()))
             {
+                if sub_record.alternate_feature_offset().is_null() {
+                    continue;
+                }
                 let sub_f = sub_record.alternate_feature(subs.offset_data())?;
                 out.extend_unsorted(sub_f.lookup_list_indices().iter().map(|i| i.get()));
             }
@@ -336,16 +353,16 @@ impl<'a> LookupClosureCtx<'a> {
         self.nesting_level_left -= 1;
         match self.lookup_list {
             LayoutLookupList::Gpos(lookuplist) => {
-                lookuplist
-                    .lookups()
-                    .get(lookup_index as usize)?
-                    .closure_lookups(self, lookup_index)?;
+                match lookuplist.lookups().get(lookup_index as usize) {
+                    Err(ReadError::NullOffset) => (),
+                    lookup => lookup?.closure_lookups(self, lookup_index)?,
+                }
             }
             LayoutLookupList::Gsub(lookuplist) => {
-                lookuplist
-                    .lookups()
-                    .get(lookup_index as usize)?
-                    .closure_lookups(self, lookup_index)?;
+                match lookuplist.lookups().get(lookup_index as usize) {
+                    Err(ReadError::NullOffset) => (),
+                    lookup => lookup?.closure_lookups(self, lookup_index)?,
+                }
             }
         }
         self.nesting_level_left += 1;
@@ -435,8 +452,11 @@ where
     Ext: ExtensionLookup<'a, T> + 'a,
 {
     fn closure_lookups(&self, c: &mut LookupClosureCtx, arg: u16) -> Result<(), ReadError> {
-        for sub in self.iter() {
-            sub?.closure_lookups(c, arg)?;
+        for t in self.iter().filter_map(|table| match table {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        }) {
+            t?.closure_lookups(c, arg)?;
         }
         Ok(())
     }
@@ -448,8 +468,11 @@ where
     Ext: ExtensionLookup<'a, T> + 'a,
 {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
-        for sub in self.iter() {
-            if sub?.intersects(glyph_set)? {
+        for t in self.iter().filter_map(|table| match table {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        }) {
+            if t?.intersects(glyph_set)? {
                 return Ok(true);
             }
         }
@@ -475,10 +498,15 @@ pub(crate) enum Format1Rule<'a> {
 }
 
 impl ContextFormat1<'_> {
-    pub(crate) fn coverage(&self) -> Result<CoverageTable<'_>, ReadError> {
+    pub(crate) fn coverage(&self) -> Option<Result<CoverageTable<'_>, ReadError>> {
         match self {
-            ContextFormat1::Plain(table) => table.coverage(),
-            ContextFormat1::Chain(table) => table.coverage(),
+            ContextFormat1::Plain(table) if !table.coverage_offset().is_null() => {
+                Some(table.coverage())
+            }
+            ContextFormat1::Chain(table) if !table.coverage_offset().is_null() => {
+                Some(table.coverage())
+            }
+            _ => None,
         }
     }
 
@@ -512,14 +540,14 @@ impl ContextFormat1<'_> {
 }
 
 impl Format1RuleSet<'_> {
-    pub(crate) fn rules(&self) -> impl Iterator<Item = Result<Format1Rule<'_>, ReadError>> {
+    pub(crate) fn rules(&self) -> impl Iterator<Item = Option<Result<Format1Rule<'_>, ReadError>>> {
         let (left, right) = match self {
             Self::Plain(table) => (
                 Some(
                     table
                         .seq_rules()
-                        .iter()
-                        .map(|rule| rule.map(Format1Rule::Plain)),
+                        .iter_as_nullable()
+                        .map(|rule| rule.map(|r| r.map(Format1Rule::Plain))),
                 ),
                 None,
             ),
@@ -528,8 +556,8 @@ impl Format1RuleSet<'_> {
                 Some(
                     table
                         .chained_seq_rules()
-                        .iter()
-                        .map(|rule| rule.map(Format1Rule::Chain)),
+                        .iter_as_nullable()
+                        .map(|rule| rule.map(|r| r.map(Format1Rule::Chain))),
                 ),
             ),
         };
@@ -604,17 +632,27 @@ pub(crate) enum Format2Rule<'a> {
 }
 
 impl ContextFormat2<'_> {
-    pub(crate) fn coverage(&self) -> Result<CoverageTable<'_>, ReadError> {
+    pub(crate) fn coverage(&self) -> Option<Result<CoverageTable<'_>, ReadError>> {
         match self {
-            ContextFormat2::Plain(table) => table.coverage(),
-            ContextFormat2::Chain(table) => table.coverage(),
+            ContextFormat2::Plain(table) if !table.coverage_offset().is_null() => {
+                Some(table.coverage())
+            }
+            ContextFormat2::Chain(table) if !table.coverage_offset().is_null() => {
+                Some(table.coverage())
+            }
+            _ => None,
         }
     }
 
-    pub(crate) fn input_class_def(&self) -> Result<ClassDef<'_>, ReadError> {
+    pub(crate) fn input_class_def(&self) -> Option<Result<ClassDef<'_>, ReadError>> {
         match self {
-            ContextFormat2::Plain(table_ref) => table_ref.class_def(),
-            ContextFormat2::Chain(table_ref) => table_ref.input_class_def(),
+            ContextFormat2::Plain(table_ref) if !table_ref.class_def_offset().is_null() => {
+                Some(table_ref.class_def())
+            }
+            ContextFormat2::Chain(table_ref) if !table_ref.input_class_def_offset().is_null() => {
+                Some(table_ref.input_class_def())
+            }
+            _ => None,
         }
     }
 
@@ -648,14 +686,14 @@ impl ContextFormat2<'_> {
 }
 
 impl Format2RuleSet<'_> {
-    pub(crate) fn rules(&self) -> impl Iterator<Item = Result<Format2Rule<'_>, ReadError>> {
+    pub(crate) fn rules(&self) -> impl Iterator<Item = Option<Result<Format2Rule<'_>, ReadError>>> {
         let (left, right) = match self {
             Format2RuleSet::Plain(table) => (
                 Some(
                     table
                         .class_seq_rules()
-                        .iter()
-                        .map(|rule| rule.map(Format2Rule::Plain)),
+                        .iter_as_nullable()
+                        .map(|rule| rule.map(|r| r.map(Format2Rule::Plain))),
                 ),
                 None,
             ),
@@ -664,8 +702,8 @@ impl Format2RuleSet<'_> {
                 Some(
                     table
                         .chained_class_seq_rules()
-                        .iter()
-                        .map(|rule| rule.map(Format2Rule::Chain)),
+                        .iter_as_nullable()
+                        .map(|rule| rule.map(|r| r.map(Format2Rule::Chain))),
                 ),
             ),
         };
@@ -765,11 +803,14 @@ impl ContextFormat3<'_> {
 
         for coverage in self
             .coverages()
-            .iter()
-            .chain(backtrack.into_iter().flat_map(|x| x.iter()))
-            .chain(lookahead.into_iter().flat_map(|x| x.iter()))
+            .iter_as_nullable()
+            .chain(backtrack.into_iter().flat_map(|x| x.iter_as_nullable()))
+            .chain(lookahead.into_iter().flat_map(|x| x.iter_as_nullable()))
         {
-            if !coverage?.intersects(glyphs) {
+            let Some(coverage) = coverage.transpose()? else {
+                return Ok(false);
+            };
+            if !coverage.intersects(glyphs) {
                 return Ok(false);
             }
         }
@@ -779,14 +820,19 @@ impl ContextFormat3<'_> {
 
 impl Intersect for ContextFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
-        let coverage = self.coverage()?;
+        let Some(coverage) = self.coverage().transpose()? else {
+            return Ok(false);
+        };
         for rule_set in coverage
             .iter()
             .zip(self.rule_sets())
             .filter_map(|(g, rule_set)| rule_set.filter(|_| glyph_set.contains(GlyphId::from(g))))
         {
             for rule in rule_set?.rules() {
-                if rule?.intersects(glyph_set)? {
+                let Some(rule) = rule.transpose()? else {
+                    continue;
+                };
+                if rule.intersects(glyph_set)? {
                     return Ok(true);
                 }
             }
@@ -797,7 +843,9 @@ impl Intersect for ContextFormat1<'_> {
 
 impl LookupClosure for ContextFormat1<'_> {
     fn closure_lookups(&self, c: &mut LookupClosureCtx, arg: u16) -> Result<(), ReadError> {
-        let coverage = self.coverage()?;
+        let Some(coverage) = self.coverage().transpose()? else {
+            return Ok(());
+        };
         let glyph_set = c.glyphs();
 
         let intersected_idxes: IntSet<u16> = coverage
@@ -814,7 +862,10 @@ impl LookupClosure for ContextFormat1<'_> {
                 return Ok(());
             }
             for rule in rule_set?.rules() {
-                rule?.closure_lookups(c, arg)?;
+                let Some(rule) = rule.transpose()? else {
+                    continue;
+                };
+                rule.closure_lookups(c, arg)?;
             }
         }
 
@@ -824,24 +875,39 @@ impl LookupClosure for ContextFormat1<'_> {
 
 impl Intersect for ContextFormat2<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
-        let coverage = self.coverage()?;
+        let Some(coverage) = self.coverage().transpose()? else {
+            return Ok(false);
+        };
         let retained_coverage_glyphs = coverage.intersect_set(glyph_set);
         if retained_coverage_glyphs.is_empty() {
             return Ok(false);
         }
 
-        let input_class_def = self.input_class_def()?;
+        let Some(input_class_def) = self.input_class_def().transpose()? else {
+            return Ok(false);
+        };
         let coverage_glyph_classes = input_class_def.intersect_classes(&retained_coverage_glyphs);
         let input_glyph_classes = input_class_def.intersect_classes(glyph_set);
 
         let backtrack_classes = match self {
             Self::Plain(_) => IntSet::empty(),
-            Self::Chain(table) => table.backtrack_class_def()?.intersect_classes(glyph_set),
+            Self::Chain(table) => {
+                if table.backtrack_class_def_offset().is_null() {
+                    IntSet::empty()
+                } else {
+                    table.backtrack_class_def()?.intersect_classes(glyph_set)
+                }
+            }
         };
-
         let lookahead_classes = match self {
             Self::Plain(_) => IntSet::empty(),
-            Self::Chain(table) => table.lookahead_class_def()?.intersect_classes(glyph_set),
+            Self::Chain(table) => {
+                if table.lookahead_class_def_offset().is_null() {
+                    IntSet::empty()
+                } else {
+                    table.lookahead_class_def()?.intersect_classes(glyph_set)
+                }
+            }
         };
 
         for rule_set in self.rule_sets().enumerate().filter_map(|(c, rule_set)| {
@@ -851,7 +917,10 @@ impl Intersect for ContextFormat2<'_> {
                 .flatten()
         }) {
             for rule in rule_set?.rules() {
-                if rule?.intersects(&input_glyph_classes, &backtrack_classes, &lookahead_classes) {
+                let Some(rule) = rule.transpose()? else {
+                    continue;
+                };
+                if rule.intersects(&input_glyph_classes, &backtrack_classes, &lookahead_classes) {
                     return Ok(true);
                 }
             }
@@ -862,25 +931,40 @@ impl Intersect for ContextFormat2<'_> {
 
 impl LookupClosure for ContextFormat2<'_> {
     fn closure_lookups(&self, c: &mut LookupClosureCtx, _arg: u16) -> Result<(), ReadError> {
+        let Some(coverage) = self.coverage().transpose()? else {
+            return Ok(());
+        };
         let glyph_set = c.glyphs();
-        let coverage = self.coverage()?;
         let retained_coverage_glyphs = coverage.intersect_set(glyph_set);
         if retained_coverage_glyphs.is_empty() {
             return Ok(());
         }
 
-        let input_class_def = self.input_class_def()?;
+        let Some(input_class_def) = self.input_class_def().transpose()? else {
+            return Ok(());
+        };
         let coverage_glyph_classes = input_class_def.intersect_classes(&retained_coverage_glyphs);
         let input_glyph_classes = input_class_def.intersect_classes(glyph_set);
 
         let backtrack_classes = match self {
             Self::Plain(_) => IntSet::empty(),
-            Self::Chain(table) => table.backtrack_class_def()?.intersect_classes(glyph_set),
+            Self::Chain(table) => {
+                if table.backtrack_class_def_offset().is_null() {
+                    IntSet::empty()
+                } else {
+                    table.backtrack_class_def()?.intersect_classes(glyph_set)
+                }
+            }
         };
-
         let lookahead_classes = match self {
             Self::Plain(_) => IntSet::empty(),
-            Self::Chain(table) => table.lookahead_class_def()?.intersect_classes(glyph_set),
+            Self::Chain(table) => {
+                if table.lookahead_class_def_offset().is_null() {
+                    IntSet::empty()
+                } else {
+                    table.lookahead_class_def()?.intersect_classes(glyph_set)
+                }
+            }
         };
 
         for rule_set in self.rule_sets().enumerate().filter_map(|(c, rule_set)| {
@@ -894,7 +978,9 @@ impl LookupClosure for ContextFormat2<'_> {
             }
 
             for rule in rule_set?.rules() {
-                let rule = rule?;
+                let Some(rule) = rule.transpose()? else {
+                    continue;
+                };
                 if c.lookup_limit_exceed()
                     || !rule.intersects(
                         &input_glyph_classes,

--- a/skera/src/base.rs
+++ b/skera/src/base.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     offset::{SerializeCopy, SerializeSubset},
-    offset_array::SubsetOffsetArray,
+    offset_array::IterNullableHelper,
     serialize::{SerializeErrorFlags, Serializer},
     CollectVariationIndices, Plan, Subset, SubsetError, SubsetTable,
 };
@@ -16,7 +16,7 @@ use write_fonts::{
         },
         FontData, FontRef, MinByteRange, TopLevelTable,
     },
-    types::{GlyphId, MajorMinor, Offset16, Offset32},
+    types::{FixedSize, GlyphId, MajorMinor, Offset16, Offset32},
     FontBuilder,
 };
 
@@ -38,13 +38,15 @@ impl Subset for Base<'_> {
             .embed(0_u16)
             .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
 
-        if !self.horiz_axis_offset().is_null() {
-            let Some(Ok(h_axis)) = self.horiz_axis() else {
-                return Err(SubsetError::SubsetTableError(Base::TAG));
-            };
-
-            Offset16::serialize_subset(&h_axis, s, plan, (), haxis_offset_pos)
-                .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
+        if let Some(h_axis) = self
+            .horiz_axis()
+            .transpose()
+            .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?
+        {
+            match Offset16::serialize_subset(&h_axis, s, plan, (), haxis_offset_pos) {
+                Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(_) => return Err(SubsetError::SubsetTableError(Base::TAG)),
+            }
         }
 
         //vertAxis offset
@@ -52,40 +54,42 @@ impl Subset for Base<'_> {
             .embed(0_u16)
             .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
 
-        if !self.vert_axis_offset().is_null() {
-            let Some(Ok(v_axis)) = self.vert_axis() else {
-                return Err(SubsetError::SubsetTableError(Base::TAG));
-            };
-
-            Offset16::serialize_subset(&v_axis, s, plan, (), vaxis_offset_pos)
-                .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
+        if let Some(v_axis) = self
+            .vert_axis()
+            .transpose()
+            .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?
+        {
+            match Offset16::serialize_subset(&v_axis, s, plan, (), vaxis_offset_pos) {
+                Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(_) => return Err(SubsetError::SubsetTableError(Base::TAG)),
+            }
         }
 
         //itemVarStore offset
-        match self.item_var_store() {
-            Some(Ok(var_store)) => {
-                let varstore_offset_pos = s
-                    .embed(0_u32)
-                    .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
+        if let Some(var_store) = self
+            .item_var_store()
+            .transpose()
+            .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?
+        {
+            let varstore_offset_pos = s
+                .embed(0_u32)
+                .map_err(|_| SubsetError::SubsetTableError(Base::TAG))?;
 
-                match Offset32::serialize_subset(
-                    &var_store,
-                    s,
-                    plan,
-                    (&plan.base_varstore_inner_maps, false),
-                    varstore_offset_pos,
-                ) {
-                    Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => Ok(()),
-                    Err(_) => Err(SubsetError::SubsetTableError(Base::TAG)),
-                }
+            match Offset32::serialize_subset(
+                &var_store,
+                s,
+                plan,
+                (&plan.base_varstore_inner_maps, false),
+                varstore_offset_pos,
+            ) {
+                Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => Ok(()),
+                Err(_) => Err(SubsetError::SubsetTableError(Base::TAG)),
             }
-            None => {
-                if self.version().minor > 0 {
-                    s.copy_assign(0, MajorMinor::new(1, 0));
-                }
-                Ok(())
+        } else {
+            if self.version().minor > 0 {
+                s.copy_assign(0, MajorMinor::new(1, 0));
             }
-            Some(Err(_)) => Err(SubsetError::SubsetTableError(Base::TAG)),
+            Ok(())
         }
     }
 }
@@ -99,20 +103,33 @@ impl SubsetTable<'_> for Axis<'_> {
         s: &mut Serializer,
         _args: (),
     ) -> Result<(), SerializeErrorFlags> {
+        if self.base_script_list_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
+        let snap = s.snapshot();
         let base_taglist_offset_pos = s.embed(0_u16)?;
         let base_scriptlist_offset_pos = s.embed(0_u16)?;
 
-        if !self.base_tag_list_offset().is_null() {
-            let Some(Ok(base_taglist)) = self.base_tag_list() else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(base_taglist) = self
+            .base_tag_list()
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_copy(&base_taglist, s, base_taglist_offset_pos)?;
         }
 
-        let Ok(base_scriptlist) = self.base_script_list() else {
-            return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-        };
-        Offset16::serialize_subset(&base_scriptlist, s, plan, (), base_scriptlist_offset_pos)
+        let base_scriptlist = self
+            .base_script_list()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;
+        match Offset16::serialize_subset(&base_scriptlist, s, plan, (), base_scriptlist_offset_pos)
+        {
+            Ok(()) => Ok(()),
+            Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => {
+                s.revert_snapshot(snap);
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -126,6 +143,7 @@ impl SubsetTable<'_> for BaseScriptList<'_> {
         s: &mut Serializer,
         _args: (),
     ) -> Result<(), SerializeErrorFlags> {
+        let snap = s.snapshot();
         let script_count_pos = s.embed(0_u16)?;
         let mut count: usize = 0;
         for script_record in self.base_script_records().iter() {
@@ -134,8 +152,16 @@ impl SubsetTable<'_> for BaseScriptList<'_> {
                 continue;
             }
 
-            script_record.subset(plan, s, self.offset_data())?;
-            count += 1;
+            match script_record.subset(plan, s, self.offset_data()) {
+                Ok(()) => count += 1,
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        if count == 0 {
+            s.revert_snapshot(snap);
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
         }
         s.check_assign::<u16>(
             script_count_pos,
@@ -155,11 +181,14 @@ impl<'a> SubsetTable<'a> for BaseScriptRecord {
         s: &mut Serializer,
         data: FontData,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.base_script_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.base_script_tag())?;
         let base_script_offset_pos = s.embed(0_u16)?;
-        let Ok(base_script) = self.base_script(data) else {
-            return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-        };
+        let base_script = self
+            .base_script(data)
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;
         Offset16::serialize_subset(&base_script, s, plan, (), base_script_offset_pos)
     }
 }
@@ -175,25 +204,39 @@ impl SubsetTable<'_> for BaseScript<'_> {
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
         let base_values_offset_pos = s.embed(0_u16)?;
-        if !self.base_values_offset().is_null() {
-            let Some(Ok(base_value)) = self.base_values() else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(base_value) = self
+            .base_values()
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(&base_value, s, plan, (), base_values_offset_pos)?;
         }
 
         let default_min_max_offset_pos = s.embed(0_u16)?;
-        if !self.default_min_max_offset().is_null() {
-            let Some(Ok(default_min_max)) = self.default_min_max() else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(default_min_max) = self
+            .default_min_max()
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(&default_min_max, s, plan, (), default_min_max_offset_pos)?;
         }
 
-        s.embed(self.base_lang_sys_count())?;
+        let base_lang_sys_count_pos = s.embed(0_u16)?;
+        if self.base_lang_sys_count() == 0 {
+            return Ok(());
+        }
 
+        let mut count = 0_u16;
         for record in self.base_lang_sys_records().iter() {
-            record.subset(plan, s, self.offset_data())?;
+            match record.subset(plan, s, self.offset_data()) {
+                Ok(()) => count += 1,
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        if count != 0 {
+            s.copy_assign(base_lang_sys_count_pos, count);
         }
         Ok(())
     }
@@ -210,17 +253,26 @@ impl SubsetTable<'_> for BaseValues<'_> {
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
         s.embed(self.default_baseline_index())?;
-        // base_coord count
-        let mut base_coord_count: u16 = 0;
-        let count_pos = s.embed(base_coord_count)?;
+        let base_coord_count = self.base_coord_count();
+        s.embed(base_coord_count)?;
 
-        let org_num_base_coords = self.base_coord_count() as usize;
-        let base_coords = self.base_coords();
-        for idx in 0..org_num_base_coords {
-            base_coords.subset_offset(idx, s, plan, ())?;
-            base_coord_count += 1;
+        if base_coord_count == 0 {
+            return Ok(());
         }
-        s.copy_assign(count_pos, base_coord_count);
+
+        let base_coords = self.base_coords();
+        let pos_start =
+            s.allocate_size(base_coord_count as usize * Offset16::RAW_BYTE_LEN, true)?;
+        for (idx, base_coord) in base_coords.iter_as_nullable().enumerate() {
+            let Some(base_coord) = base_coord
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                continue;
+            };
+            let offset_pos = pos_start + idx * Offset16::RAW_BYTE_LEN;
+            Offset16::serialize_subset(&base_coord, s, plan, (), offset_pos)?;
+        }
         Ok(())
     }
 }
@@ -236,18 +288,20 @@ impl SubsetTable<'_> for MinMax<'_> {
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
         let min_coord_offset_pos = s.embed(0_u16)?;
-        if !self.min_coord_offset().is_null() {
-            let Some(Ok(min_coord)) = self.min_coord() else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(min_coord) = self
+            .min_coord()
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(&min_coord, s, plan, (), min_coord_offset_pos)?;
         }
 
         let max_coord_offset_pos = s.embed(0_u16)?;
-        if !self.max_coord_offset().is_null() {
-            let Some(Ok(max_coord)) = self.max_coord() else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(max_coord) = self
+            .max_coord()
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(&max_coord, s, plan, (), max_coord_offset_pos)?;
         }
 
@@ -258,10 +312,16 @@ impl SubsetTable<'_> for MinMax<'_> {
             if !plan.layout_features.contains(feature_tag) {
                 continue;
             }
-            record.subset(plan, s, self.offset_data())?;
-            count += 1;
+            match record.subset(plan, s, self.offset_data()) {
+                Ok(()) => count += 1,
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => continue,
+                Err(e) => return Err(e),
+            }
         }
-        s.copy_assign(feat_min_max_count_pos, count);
+
+        if count != 0 {
+            s.copy_assign(feat_min_max_count_pos, count);
+        }
         Ok(())
     }
 }
@@ -276,21 +336,26 @@ impl<'a> SubsetTable<'a> for FeatMinMaxRecord {
         s: &mut Serializer,
         data: FontData,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.max_coord_offset().is_null() && self.min_coord_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.feature_table_tag())?;
 
         let min_coord_offset_pos = s.embed(0_u16)?;
-        if !self.min_coord_offset().is_null() {
-            let Some(Ok(min_coord)) = self.min_coord(data) else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(min_coord) = self
+            .min_coord(data)
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(&min_coord, s, plan, (), min_coord_offset_pos)?;
         }
 
         let max_coord_offset_pos = s.embed(0_u16)?;
-        if !self.max_coord_offset().is_null() {
-            let Some(Ok(max_coord)) = self.max_coord(data) else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
+        if let Some(max_coord) = self
+            .max_coord(data)
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(&max_coord, s, plan, (), max_coord_offset_pos)?;
         }
         Ok(())
@@ -307,6 +372,9 @@ impl<'a> SubsetTable<'a> for BaseLangSysRecord {
         s: &mut Serializer,
         data: FontData,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.min_max_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.base_lang_sys_tag())?;
 
         let min_max_offset_pos = s.embed(0_u16)?;
@@ -382,11 +450,11 @@ impl SubsetTable<'_> for BaseCoordFormat3<'_> {
         s.embed(self.coordinate())?;
 
         let device_offset_pos = s.embed(0_u16)?;
-        if !self.device_offset().is_null() {
-            let Some(Ok(device)) = self.device() else {
-                return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
-            };
-
+        if let Some(device) = self
+            .device()
+            .transpose()
+            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
+        {
             Offset16::serialize_subset(
                 &device,
                 s,
@@ -413,10 +481,9 @@ impl CollectVariationIndices for Base<'_> {
 
 impl CollectVariationIndices for Axis<'_> {
     fn collect_variation_indices(&self, plan: &Plan, varidx_set: &mut IntSet<u32>) {
-        let Ok(base_scriptlist) = self.base_script_list() else {
-            return;
-        };
-        base_scriptlist.collect_variation_indices(plan, varidx_set);
+        if let Ok(base_scriptlist) = self.base_script_list() {
+            base_scriptlist.collect_variation_indices(plan, varidx_set);
+        }
     }
 }
 
@@ -424,7 +491,9 @@ impl CollectVariationIndices for BaseScriptList<'_> {
     fn collect_variation_indices(&self, plan: &Plan, varidx_set: &mut IntSet<u32>) {
         for script_record in self.base_script_records().iter() {
             let script_tag = script_record.base_script_tag();
-            if !plan.layout_scripts.contains(script_tag) {
+            if !plan.layout_scripts.contains(script_tag)
+                || script_record.base_script_offset().is_null()
+            {
                 continue;
             }
 
@@ -447,6 +516,9 @@ impl CollectVariationIndices for BaseScript<'_> {
         }
 
         for record in self.base_lang_sys_records().iter() {
+            if record.min_max_offset().is_null() {
+                continue;
+            }
             if let Ok(min_max) = record.min_max(self.offset_data()) {
                 min_max.collect_variation_indices(plan, varidx_set);
             }
@@ -456,7 +528,7 @@ impl CollectVariationIndices for BaseScript<'_> {
 
 impl CollectVariationIndices for BaseValues<'_> {
     fn collect_variation_indices(&self, plan: &Plan, varidx_set: &mut IntSet<u32>) {
-        for base_coord in self.base_coords().iter().flatten() {
+        for base_coord in self.base_coords().iter_as_nullable().flatten().flatten() {
             base_coord.collect_variation_indices(plan, varidx_set);
         }
     }

--- a/skera/src/cblc.rs
+++ b/skera/src/cblc.rs
@@ -90,6 +90,8 @@ impl<'a> SubsetTable<'a> for BitmapSize {
 
         if self.start_glyph_index() > plan.glyphset.last().unwrap()
             || self.end_glyph_index() < plan.glyphset.first().unwrap()
+            || self.index_subtable_list_offset() == 0
+            || self.index_subtable_list_size() == 0
         {
             return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
         }
@@ -156,8 +158,11 @@ impl<'a> SubsetTable<'a> for IndexSubtableList<'a> {
         let mut table_list_size = 0;
         let init_len = s.length();
         // serialize subtables in reverse order
-        for idx in 0..src_num_records {
-            let record = records[src_num_records - 1 - idx];
+        for idx in (0..src_num_records).rev() {
+            let record = records[idx];
+            if record.index_subtable_offset().is_null() {
+                continue;
+            }
             let Ok(subtable) = record.index_subtable(self.offset_data()) else {
                 return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
             };

--- a/skera/src/colr.rs
+++ b/skera/src/colr.rs
@@ -49,11 +49,18 @@ impl Subset for Colr<'_> {
             .map_err(|_| SubsetError::SubsetTableError(Colr::TAG))?;
         let subset_to_v0 = downgrade_to_v0(base_glyph_list.as_ref(), plan);
 
-        serialize_v0(self, plan, s, subset_to_v0)
-            .map_err(|_| SubsetError::SubsetTableError(Colr::TAG))?;
-
-        if subset_to_v0 {
-            return Ok(());
+        match serialize_v0(self, plan, s, subset_to_v0) {
+            Ok(()) => {
+                if subset_to_v0 {
+                    return Ok(());
+                }
+            }
+            Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => {
+                if subset_to_v0 {
+                    return Err(SubsetError::SubsetTableError(Colr::TAG));
+                }
+            }
+            Err(_) => return Err(SubsetError::SubsetTableError(Colr::TAG)),
         }
 
         // set version to 1, format pos = 0
@@ -151,22 +158,31 @@ fn serialize_v0(
         .transpose()
         .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;
 
+    let layer_records = colr
+        .layer_records()
+        .transpose()
+        .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;
+
+    if base_glyph_records.is_none() || layer_records.is_none() {
+        if subset_to_v0 {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        } else {
+            // allocate V1 header: min byte size = 34
+            return s.allocate_size(34, false).map(|_| ());
+        }
+    }
+
+    let base_glyph_records = base_glyph_records.unwrap();
+    let layer_records = layer_records.unwrap();
+
     // allocate V0 header: min byte size = 14
     s.allocate_size(14, false)?;
-
     // if needed, allocate additional V1 header size = 20
     if !subset_to_v0 {
         s.allocate_size(20, false)?;
     }
 
-    // all v0 fields are 0, return
-    if base_glyph_records.is_none() {
-        return Ok(());
-    }
-
-    let base_glyph_records = base_glyph_records.unwrap();
     let num_bit_storage = 16 - num_records.leading_zeros() as usize;
-
     let glyph_set = &plan.glyphset_colred;
     let retained_record_idxes: Vec<usize> =
         if num_records as usize > glyph_set.len() as usize * num_bit_storage {
@@ -215,21 +231,13 @@ fn serialize_v0(
     s.copy_assign(12, num_layers);
 
     //serialize layer records, offset_pos = 8
-    let layer_records = colr
-        .layer_records()
-        .transpose()
-        .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?
-        .unwrap();
-
     Offset32::serialize_subset(
         &layer_records,
         s,
         plan,
         (base_glyph_records, &retained_record_idxes),
         8,
-    )?;
-
-    Ok(())
+    )
 }
 
 impl<'a> SubsetTable<'a> for &[BaseGlyph] {
@@ -315,6 +323,9 @@ impl SubsetTable<'_> for BaseGlyphList<'_> {
 
         let mut num = 0_u32;
         for paint_record in self.base_glyph_paint_records() {
+            if paint_record.paint_offset().is_null() {
+                continue;
+            }
             if !plan
                 .glyphset_colred
                 .contains(GlyphId::from(paint_record.glyph_id()))
@@ -401,12 +412,15 @@ impl SubsetTable<'_> for ClipList<'_> {
         let mut new_gids_set = IntSet::empty();
         let mut new_gids_offset_map = FnvHashMap::default();
         for clip in self.clips() {
+            let offset = clip.clip_box_offset();
+            if offset.is_null() {
+                continue;
+            }
             let start_gid = clip.start_glyph_id().to_u32();
             let end_gid = clip.end_glyph_id().to_u32();
             if end_gid < retained_first_gid || start_gid > retained_last_gid {
                 continue;
             }
-            let offset = clip.clip_box_offset();
             for gid in start_gid..=end_gid {
                 let g = GlyphId::from(gid);
                 if !glyph_set.contains(g) {
@@ -450,7 +464,9 @@ fn serialize_clips(
     let mut prev_offset = gids_offset_map.get(&start_gid).unwrap();
 
     for g in gids_set.iter().skip(1) {
-        let offset = gids_offset_map.get(&g).unwrap();
+        let offset = gids_offset_map
+            .get(&g)
+            .ok_or(SerializeErrorFlags::SERIALIZE_ERROR_OTHER)?;
         if g == prev_gid + 1 && offset == prev_offset {
             prev_gid = g;
             continue;
@@ -813,8 +829,10 @@ impl SubsetTable<'_> for PaintLinearGradient<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.color_line_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
-
         let Ok(color_line) = self.color_line() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -833,8 +851,10 @@ impl SubsetTable<'_> for PaintVarLinearGradient<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.color_line_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
-
         let Ok(color_line) = self.color_line() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -864,8 +884,10 @@ impl SubsetTable<'_> for PaintRadialGradient<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.color_line_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
-
         let Ok(color_line) = self.color_line() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -884,8 +906,10 @@ impl SubsetTable<'_> for PaintVarRadialGradient<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.color_line_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
-
         let Ok(color_line) = self.color_line() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -915,8 +939,10 @@ impl SubsetTable<'_> for PaintSweepGradient<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.color_line_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
-
         let Ok(color_line) = self.color_line() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -935,6 +961,9 @@ impl SubsetTable<'_> for PaintVarSweepGradient<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.color_line_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
 
         let Ok(color_line) = self.color_line() else {
@@ -966,6 +995,9 @@ impl SubsetTable<'_> for PaintGlyph<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.format())?;
         let offset_pos = s.embed_bytes(&[0_u8; 3])?;
 
@@ -1050,6 +1082,9 @@ impl SubsetTable<'_> for PaintTransform<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() || self.transform_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.format())?;
 
         let paint_pos = s.embed_bytes(&[0_u8; 3])?;
@@ -1077,6 +1112,9 @@ impl SubsetTable<'_> for PaintVarTransform<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() || self.transform_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.format())?;
 
         let paint_pos = s.embed_bytes(&[0_u8; 3])?;
@@ -1104,6 +1142,9 @@ impl SubsetTable<'_> for PaintTranslate<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1122,6 +1163,9 @@ impl SubsetTable<'_> for PaintVarTranslate<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1151,6 +1195,9 @@ impl SubsetTable<'_> for PaintScale<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1169,6 +1216,9 @@ impl SubsetTable<'_> for PaintVarScale<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1198,6 +1248,9 @@ impl SubsetTable<'_> for PaintScaleAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1216,6 +1269,9 @@ impl SubsetTable<'_> for PaintVarScaleAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1245,6 +1301,9 @@ impl SubsetTable<'_> for PaintScaleUniform<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1263,6 +1322,9 @@ impl SubsetTable<'_> for PaintVarScaleUniform<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1292,6 +1354,9 @@ impl SubsetTable<'_> for PaintScaleUniformAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1310,6 +1375,9 @@ impl SubsetTable<'_> for PaintVarScaleUniformAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1339,6 +1407,9 @@ impl SubsetTable<'_> for PaintRotate<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1357,6 +1428,9 @@ impl SubsetTable<'_> for PaintVarRotate<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1386,6 +1460,9 @@ impl SubsetTable<'_> for PaintRotateAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1404,6 +1481,9 @@ impl SubsetTable<'_> for PaintVarRotateAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1433,6 +1513,9 @@ impl SubsetTable<'_> for PaintSkew<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1451,6 +1534,9 @@ impl SubsetTable<'_> for PaintVarSkew<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1480,6 +1566,9 @@ impl SubsetTable<'_> for PaintSkewAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1498,6 +1587,9 @@ impl SubsetTable<'_> for PaintVarSkewAroundCenter<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.paint_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let start_pos = s.embed_bytes(self.min_table_bytes())?;
         let Ok(paint) = self.paint() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
@@ -1527,38 +1619,57 @@ impl SubsetTable<'_> for PaintComposite<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        let source_paint_offset = self.source_paint_offset();
+        let backdrop_paint_offset = self.backdrop_paint_offset();
+        if source_paint_offset.is_null() && backdrop_paint_offset.is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.format())?;
         let src_paint_pos = s.embed_bytes(&[0_u8; 3])?;
         s.embed(self.composite_mode())?;
         let backdrop_paint_pos = s.embed_bytes(&[0_u8; 3])?;
 
-        let Ok(src_paint) = self.source_paint() else {
-            return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
-        };
-        Offset24::serialize_subset(&src_paint, s, plan, (), src_paint_pos)?;
+        if !source_paint_offset.is_null() {
+            let Ok(src_paint) = self.source_paint() else {
+                return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
+            };
+            match Offset24::serialize_subset(&src_paint, s, plan, (), src_paint_pos) {
+                Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(e) => return Err(e),
+            }
+        }
 
-        let Ok(backdrop_paint) = self.backdrop_paint() else {
-            return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
-        };
-        Offset24::serialize_subset(&backdrop_paint, s, plan, (), backdrop_paint_pos)
+        if !backdrop_paint_offset.is_null() {
+            let Ok(backdrop_paint) = self.backdrop_paint() else {
+                return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
+            };
+            match Offset24::serialize_subset(&backdrop_paint, s, plan, (), backdrop_paint_pos) {
+                Ok(()) | Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => return Ok(()),
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
     }
 }
 
 // downgrade to v0 if we have no v1 glyphs to retain
 fn downgrade_to_v0(base_glyph_list: Option<&BaseGlyphList>, plan: &Plan) -> bool {
-    if base_glyph_list.is_none() {
-        return true;
-    }
-
-    for paint_record in base_glyph_list.unwrap().base_glyph_paint_records() {
-        if plan
-            .glyphset_colred
-            .contains(GlyphId::from(paint_record.glyph_id()))
-        {
-            return false;
+    if let Some(base_glyph_list) = base_glyph_list {
+        for paint_record in base_glyph_list.base_glyph_paint_records() {
+            if paint_record.paint_offset().is_null() {
+                continue;
+            }
+            if plan
+                .glyphset_colred
+                .contains(GlyphId::from(paint_record.glyph_id()))
+            {
+                return false;
+            }
         }
+        true
+    } else {
+        true
     }
-    true
 }
 
 #[cfg(test)]

--- a/skera/src/cpal.rs
+++ b/skera/src/cpal.rs
@@ -46,7 +46,7 @@ fn subset_v0(cpal: &Cpal, plan: &Plan, s: &mut Serializer) -> Result<(), Seriali
         .filter(|&n| *n != 0xFFFF)
         .copied()
         .collect();
-    if retained_entries.is_empty() || cpal.num_palettes() == 0 {
+    if retained_entries.is_empty() {
         return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
     }
 
@@ -92,12 +92,12 @@ fn subset_v1(cpal: &Cpal, plan: &Plan, s: &mut Serializer) -> Result<(), Seriali
     let palette_entry_labels_offset_pos = s.embed(0_u32)?;
 
     let num_palettes = cpal.num_palettes();
+    // v1 must have this field
+    let Some(palette_types_offset) = cpal.palette_types_array_offset() else {
+        return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
+    };
 
-    let palette_types_offset = cpal
-        .palette_types_array_offset()
-        .unwrap()
-        .offset()
-        .to_usize();
+    let palette_types_offset = palette_types_offset.offset().to_usize();
     if palette_types_offset != 0 {
         //size of PaletteType is 4
         let bytes_len = (num_palettes as usize) * 4;
@@ -110,11 +110,11 @@ fn subset_v1(cpal: &Cpal, plan: &Plan, s: &mut Serializer) -> Result<(), Seriali
         Offset32::serialize_copy_from_bytes(src_bytes, s, palette_types_offset_pos)?;
     }
 
-    let palette_labels_offset = cpal
-        .palette_labels_array_offset()
-        .unwrap()
-        .offset()
-        .to_usize();
+    // v1 must have this field
+    let Some(palette_labels_offset) = cpal.palette_labels_array_offset() else {
+        return Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR);
+    };
+    let palette_labels_offset = palette_labels_offset.offset().to_usize();
     if palette_labels_offset != 0 {
         let bytes_len = (num_palettes as usize) * NameId::RAW_BYTE_LEN;
         let src_bytes = cpal

--- a/skera/src/gdef.rs
+++ b/skera/src/gdef.rs
@@ -3,7 +3,7 @@
 use crate::{
     layout::ClassDefSubsetStruct,
     offset::{SerializeSerialize, SerializeSubset},
-    offset_array::SubsetOffsetArray,
+    offset_array::{IterNullableHelper, SubsetOffsetArray},
     serialize::{SerializeErrorFlags, Serializer},
     CollectVariationIndices, Plan, Subset, SubsetError, SubsetState, SubsetTable,
 };
@@ -18,9 +18,9 @@ use write_fonts::{
             layout::CoverageTable,
         },
         types::GlyphId,
-        FontRef, MinByteRange, TopLevelTable,
+        FontRef, MinByteRange, ReadError, TopLevelTable,
     },
-    types::{Offset16, Offset32},
+    types::{FixedSize, Offset16, Offset32},
     FontBuilder,
 };
 
@@ -265,6 +265,9 @@ impl SubsetTable<'_> for AttachList<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() || self.glyph_count() == 0 {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         //coverage offset
         let coverage_offset_pos = s.embed(0_u16)?;
         //glyph_count
@@ -289,9 +292,14 @@ impl SubsetTable<'_> for AttachList<'_> {
                 continue;
             };
 
-            attach_points.subset_offset(idx, s, plan, ())?;
-            count += 1;
-            retained_glyphs.push(*new_gid);
+            match attach_points.subset_offset(idx, s, plan, ()) {
+                Ok(()) => {
+                    count += 1;
+                    retained_glyphs.push(*new_gid);
+                }
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(e) => return Err(e),
+            }
         }
 
         if retained_glyphs.is_empty() {
@@ -325,6 +333,9 @@ impl SubsetTable<'_> for LigCaretList<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() || self.lig_glyph_count() == 0 {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         //coverage offset
         let coverage_offset_pos = s.embed(0_u16)?;
         //lig_glyph_count
@@ -349,9 +360,14 @@ impl SubsetTable<'_> for LigCaretList<'_> {
                 continue;
             };
 
-            lig_glyphs.subset_offset(idx, s, plan, ())?;
-            count += 1;
-            retained_glyphs.push(*new_gid);
+            match lig_glyphs.subset_offset(idx, s, plan, ()) {
+                Ok(()) => {
+                    count += 1;
+                    retained_glyphs.push(*new_gid);
+                }
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => continue,
+                Err(e) => return Err(e),
+            }
         }
 
         if retained_glyphs.is_empty() {
@@ -372,14 +388,31 @@ impl SubsetTable<'_> for LigGlyph<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.caret_count() == 0 {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         // caret count
         let caret_count_pos = s.embed(0_u16)?;
 
         let caret_values = self.caret_values();
         let mut count = 0_u16;
-        for idx in 0..caret_values.len() {
-            caret_values.subset_offset(idx, s, plan, ())?;
-            count += 1;
+        for caret_value in caret_values.iter() {
+            match caret_value {
+                Err(ReadError::NullOffset) => continue,
+                Err(_) => return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
+                Ok(caret_value) => {
+                    let snap = s.snapshot();
+                    let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+
+                    if let Err(e) =
+                        Offset16::serialize_subset(&caret_value, s, plan, (), offset_pos)
+                    {
+                        s.revert_snapshot(snap);
+                        return Err(e);
+                    }
+                    count += 1;
+                }
+            }
         }
 
         if count == 0 {
@@ -400,17 +433,19 @@ impl SubsetTable<'_> for MarkGlyphSets<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        let mark_glyph_set_count = self.mark_glyph_set_count() as usize;
+        if mark_glyph_set_count == 0 {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.format())?;
 
         let count_pos = s.embed(0_u16)?;
 
         let coverages = self.coverages();
-        let src_count = self.mark_glyph_set_count() as usize;
         let mut count = 0_u16;
 
-        // skip empty coverage, don't error out
-        for idx in 0..src_count {
-            match coverages.subset_offset(idx, s, plan, ()) {
+        for i in 0..mark_glyph_set_count {
+            match coverages.subset_offset(i, s, plan, ()) {
                 Ok(()) => {
                     count += 1;
                 }
@@ -482,10 +517,15 @@ impl SubsetTable<'_> for CaretValueFormat3<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.device_offset().is_null() {
+            s.embed(1_u16)?;
+            return s.embed(self.coordinate()).map(|_| ());
+        }
+
         s.embed(self.caret_value_format())?;
         s.embed(self.coordinate())?;
-        let device_offset_pos = s.embed(0_u16)?;
 
+        let device_offset_pos = s.embed(0_u16)?;
         let Ok(device) = self.device() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -514,7 +554,10 @@ impl CollectVariationIndices for LigCaretList<'_> {
         };
 
         let lig_glyphs = self.lig_glyphs();
-        for (gid, lig_glyph) in coverage.iter().zip(lig_glyphs.iter()) {
+        for (gid, lig_glyph) in coverage.iter().zip(lig_glyphs.iter_as_nullable()) {
+            let Some(lig_glyph) = lig_glyph else {
+                continue;
+            };
             let Ok(lig_glyph) = lig_glyph else {
                 return;
             };
@@ -528,7 +571,10 @@ impl CollectVariationIndices for LigCaretList<'_> {
 
 impl CollectVariationIndices for LigGlyph<'_> {
     fn collect_variation_indices(&self, plan: &Plan, varidx_set: &mut IntSet<u32>) {
-        for caret in self.caret_values().iter() {
+        for caret in self.caret_values().iter_as_nullable() {
+            let Some(caret) = caret else {
+                continue;
+            };
             let Ok(caret) = caret else {
                 return;
             };
@@ -561,7 +607,10 @@ impl CollectUsedMarkSets for Gdef<'_> {
 
 impl CollectUsedMarkSets for MarkGlyphSets<'_> {
     fn collect_used_mark_sets(&self, plan: &Plan, used_mark_sets: &mut IntSet<u16>) {
-        for (i, coverage) in self.coverages().iter().enumerate() {
+        for (i, coverage) in self.coverages().iter_as_nullable().enumerate() {
+            let Some(coverage) = coverage else {
+                continue;
+            };
             let Ok(coverage) = coverage else {
                 return;
             };

--- a/skera/src/gpos.rs
+++ b/skera/src/gpos.rs
@@ -27,7 +27,7 @@ use write_fonts::{
             layout::{ExtensionLookup, Intersect, LookupFlag, Subtables},
         },
         types::Tag,
-        FontRead, FontRef, TopLevelTable,
+        FontRead, FontRef, ReadError, TopLevelTable,
     },
     types::{MajorMinor, Offset16, Offset32},
     FontBuilder,
@@ -151,36 +151,42 @@ fn subset_gpos(
     s: &mut Serializer,
 ) -> Result<(), SerializeErrorFlags> {
     let version_pos = s.embed(gpos.version())?;
+    let mut c = SubsetLayoutContext::new(Gpos::TAG);
 
     // script_list
     let script_list_offset_pos = s.embed(0_u16)?;
 
-    let script_list = gpos
-        .script_list()
-        .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+    if !gpos.script_list_offset().is_null() {
+        let script_list = gpos
+            .script_list()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
-    let mut c = SubsetLayoutContext::new(Gpos::TAG);
-    Offset16::serialize_subset(&script_list, s, plan, &mut c, script_list_offset_pos)?;
+        Offset16::serialize_subset(&script_list, s, plan, &mut c, script_list_offset_pos)?;
+    }
 
     // feature list
     let feature_list_offset_pos = s.embed(0_u16)?;
-    let feature_list = gpos
-        .feature_list()
-        .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-    Offset16::serialize_subset(&feature_list, s, plan, &mut c, feature_list_offset_pos)?;
+    if !gpos.feature_list_offset().is_null() {
+        let feature_list = gpos
+            .feature_list()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+        Offset16::serialize_subset(&feature_list, s, plan, &mut c, feature_list_offset_pos)?;
+    }
 
     // lookup list
     let lookup_list_offset_pos = s.embed(0_u16)?;
-    let lookup_list = gpos
-        .lookup_list()
-        .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-    Offset16::serialize_subset(
-        &lookup_list,
-        s,
-        plan,
-        (state, font, &plan.gpos_lookups),
-        lookup_list_offset_pos,
-    )?;
+    if !gpos.lookup_list_offset().is_null() {
+        let lookup_list = gpos
+            .lookup_list()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+        Offset16::serialize_subset(
+            &lookup_list,
+            s,
+            plan,
+            (state, font, &plan.gpos_lookups),
+            lookup_list_offset_pos,
+        )?;
+    }
 
     if let Some(feature_variations) = gpos
         .feature_variations()
@@ -230,12 +236,15 @@ impl<'a> SubsetTable<'a> for PositionLookup<'_> {
             PositionSubtables::MarkToMark(_) => 6,
             PositionSubtables::Contextual(_) => 7,
             PositionSubtables::ChainContextual(_) => 8,
-            PositionSubtables::EmptyExtension => 9, // should we just skip this?
+            PositionSubtables::EmptyExtension => {
+                return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER))
+            }
         };
         s.embed(lookup_type)?;
 
         let lookup_flag = self.lookup_flag();
         let lookup_flag_pos = s.embed(lookup_flag)?;
+
         let lookup_count_pos = s.embed(0_u16)?;
         let lookup_count = subtables.subset(plan, s, args)?;
         s.copy_assign(lookup_count_pos, lookup_count);
@@ -290,10 +299,11 @@ impl CollectVariationIndices for Gpos<'_> {
                 return;
             };
 
-            let Ok(subtables) = lookup.subtables() else {
-                return;
-            };
-            subtables.collect_variation_indices(plan, varidx_set);
+            match lookup.subtables() {
+                Ok(subs) => subs.collect_variation_indices(plan, varidx_set),
+                Err(ReadError::NullOffset) => continue,
+                Err(_) => return,
+            }
         }
     }
 }
@@ -331,7 +341,10 @@ where
     Ext: ExtensionLookup<'a, T> + 'a,
 {
     fn collect_variation_indices(&self, plan: &Plan, varidx_set: &mut IntSet<u32>) {
-        for t in self.iter() {
+        for t in self.iter().filter_map(|table| match table {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        }) {
             let Ok(t) = t else {
                 return;
             };

--- a/skera/src/gpos/cursive_pos.rs
+++ b/skera/src/gpos/cursive_pos.rs
@@ -28,6 +28,9 @@ impl<'a> SubsetTable<'a> for CursivePosFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         s.embed(self.pos_format())?;
 
         //cov offset

--- a/skera/src/gpos/mark_array.rs
+++ b/skera/src/gpos/mark_array.rs
@@ -119,6 +119,9 @@ impl<'a> SubsetTable<'a> for MarkRecord {
         s.embed(*new_mark_class)?;
 
         let anchor_offset_pos = s.embed(0_u16)?;
+        if self.mark_anchor_offset().is_null() {
+            return Ok(());
+        }
         let mark_anchor = self
             .mark_anchor(font_data)
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gpos/mark_base_pos.rs
+++ b/skera/src/gpos/mark_base_pos.rs
@@ -76,6 +76,13 @@ impl<'a> SubsetTable<'a> for MarkBasePosFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.mark_coverage_offset().is_null()
+            || self.mark_array_offset().is_null()
+            || self.base_coverage_offset().is_null()
+            || self.base_array_offset().is_null()
+        {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let mark_coverage = self
             .mark_coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gpos/mark_lig_pos.rs
+++ b/skera/src/gpos/mark_lig_pos.rs
@@ -15,7 +15,7 @@ use write_fonts::read::{
         layout::CoverageTable,
     },
     types::{GlyphId, Offset16},
-    FontData, FontRef,
+    FontData, FontRef, ReadError,
 };
 
 impl CollectVariationIndices for MarkLigPosFormat1<'_> {
@@ -51,8 +51,10 @@ impl CollectVariationIndices for MarkLigPosFormat1<'_> {
         let lig_attaches = lig_array.ligature_attaches();
         let lig_attach_idxes = intersected_coverage_indices(&lig_coverage, glyph_set);
         for i in lig_attach_idxes.iter() {
-            let Ok(lig_attach) = lig_attaches.get(i as usize) else {
-                return;
+            let lig_attach = match lig_attaches.get(i as usize) {
+                Err(ReadError::NullOffset) => continue,
+                Err(_) => return,
+                Ok(lig_attach) => lig_attach,
             };
 
             let lig_attach_data = lig_attach.offset_data();
@@ -81,6 +83,13 @@ impl<'a> SubsetTable<'a> for MarkLigPosFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.mark_coverage_offset().is_null()
+            || self.mark_array_offset().is_null()
+            || self.ligature_coverage_offset().is_null()
+            || self.ligature_array_offset().is_null()
+        {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let mark_coverage = self
             .mark_coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gpos/mark_mark_pos.rs
+++ b/skera/src/gpos/mark_mark_pos.rs
@@ -73,6 +73,13 @@ impl<'a> SubsetTable<'a> for MarkMarkPosFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.mark1_coverage_offset().is_null()
+            || self.mark1_array_offset().is_null()
+            || self.mark2_coverage_offset().is_null()
+            || self.mark2_array_offset().is_null()
+        {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let mark1_coverage = self
             .mark1_coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gpos/pair_pos.rs
+++ b/skera/src/gpos/pair_pos.rs
@@ -58,7 +58,10 @@ fn compute_effective_pair_formats_1(
     let pair_sets = pair_pos.pair_sets();
     let partset_idxes = intersected_coverage_indices(&coverage, glyph_set);
     for i in partset_idxes.iter() {
-        let pair_set = pair_sets.get(i as usize)?;
+        let pair_set = match pair_sets.get(i as usize) {
+            Err(ReadError::NullOffset) => continue,
+            other => other,
+        }?;
         for pair_value_rec in pair_set.pair_value_records().iter() {
             let pair_value_rec = pair_value_rec?;
             let second_glyph = pair_value_rec.second_glyph();
@@ -144,6 +147,9 @@ impl<'a> SubsetTable<'a> for PairPosFormat1<'_> {
         s: &mut Serializer,
         args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let (subset_state, font) = args;
         let glyph_map = &plan.glyph_map_gsub;
         let glyph_set = &plan.glyphset_gsub;
@@ -188,10 +194,12 @@ impl<'a> SubsetTable<'a> for PairPosFormat1<'_> {
             return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
         }
 
-        for i in pairset_idxes.iter() {
+        let mut retained_glyphs = Vec::with_capacity(glyphs.len());
+        for (i, g) in pairset_idxes.iter().zip(glyphs) {
             match pair_sets.subset_offset(i as usize, s, plan, (new_format1, new_format2)) {
                 Ok(()) => {
                     pairset_count += 1;
+                    retained_glyphs.push(g);
                 }
                 Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
                 Err(e) => {
@@ -201,7 +209,7 @@ impl<'a> SubsetTable<'a> for PairPosFormat1<'_> {
         }
 
         s.copy_assign(pairset_count_pos, pairset_count);
-        Offset16::serialize_serialize::<CoverageTable>(s, &glyphs, cov_offset_pos)
+        Offset16::serialize_serialize::<CoverageTable>(s, &retained_glyphs, cov_offset_pos)
     }
 }
 
@@ -247,6 +255,12 @@ impl<'a> SubsetTable<'a> for PairPosFormat2<'_> {
         s: &mut Serializer,
         args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.coverage_offset().is_null()
+            || self.class_def1_offset().is_null()
+            || self.class_def2_offset().is_null()
+        {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let Ok(coverage) = self.coverage() else {
             return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR));
         };
@@ -443,10 +457,9 @@ impl CollectVariationIndices for PairPosFormat1<'_> {
         let pair_sets = self.pair_sets();
         let pairset_idxes = intersected_coverage_indices(&coverage, glyph_set);
         for i in pairset_idxes.iter() {
-            let Ok(pair_set) = pair_sets.get(i as usize) else {
-                return;
-            };
-            pair_set.collect_variation_indices(plan, varidx_set);
+            if let Ok(pair_set) = pair_sets.get(i as usize) {
+                pair_set.collect_variation_indices(plan, varidx_set);
+            }
         }
     }
 }

--- a/skera/src/gpos/single_pos.rs
+++ b/skera/src/gpos/single_pos.rs
@@ -47,6 +47,9 @@ impl<'a> SubsetTable<'a> for SinglePosFormat1<'_> {
         s: &mut Serializer,
         args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -153,6 +156,9 @@ impl<'a> SubsetTable<'a> for SinglePosFormat2<'_> {
         s: &mut Serializer,
         args: Self::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gsub.rs
+++ b/skera/src/gsub.rs
@@ -152,36 +152,41 @@ fn subset_gsub(
     s: &mut Serializer,
 ) -> Result<(), SerializeErrorFlags> {
     let version_pos = s.embed(gsub.version())?;
-
+    let mut c = SubsetLayoutContext::new(Gsub::TAG);
     // script_list
     let script_list_offset_pos = s.embed(0_u16)?;
 
-    let script_list = gsub
-        .script_list()
-        .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+    if !gsub.script_list_offset().is_null() {
+        let script_list = gsub
+            .script_list()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
-    let mut c = SubsetLayoutContext::new(Gsub::TAG);
-    Offset16::serialize_subset(&script_list, s, plan, &mut c, script_list_offset_pos)?;
+        Offset16::serialize_subset(&script_list, s, plan, &mut c, script_list_offset_pos)?;
+    }
 
     // feature list
     let feature_list_offset_pos = s.embed(0_u16)?;
-    let feature_list = gsub
-        .feature_list()
-        .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-    Offset16::serialize_subset(&feature_list, s, plan, &mut c, feature_list_offset_pos)?;
+    if !gsub.feature_list_offset().is_null() {
+        let feature_list = gsub
+            .feature_list()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+        Offset16::serialize_subset(&feature_list, s, plan, &mut c, feature_list_offset_pos)?;
+    }
 
     // lookup list
     let lookup_list_offset_pos = s.embed(0_u16)?;
-    let lookup_list = gsub
-        .lookup_list()
-        .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-    Offset16::serialize_subset(
-        &lookup_list,
-        s,
-        plan,
-        (state, font, &plan.gsub_lookups),
-        lookup_list_offset_pos,
-    )?;
+    if !gsub.lookup_list_offset().is_null() {
+        let lookup_list = gsub
+            .lookup_list()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+        Offset16::serialize_subset(
+            &lookup_list,
+            s,
+            plan,
+            (state, font, &plan.gsub_lookups),
+            lookup_list_offset_pos,
+        )?;
+    }
 
     if let Some(feature_variations) = gsub
         .feature_variations()
@@ -221,6 +226,7 @@ impl<'a> SubsetTable<'a> for SubstitutionLookup<'_> {
         let subtables = self
             .subtables()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+
         let lookup_type: u16 = match subtables {
             SubstitutionSubtables::Single(_) => 1,
             SubstitutionSubtables::Multiple(_) => 2,
@@ -229,7 +235,9 @@ impl<'a> SubsetTable<'a> for SubstitutionLookup<'_> {
             SubstitutionSubtables::Contextual(_) => 5,
             SubstitutionSubtables::ChainContextual(_) => 6,
             SubstitutionSubtables::Reverse(_) => 8,
-            SubstitutionSubtables::EmptyExtension => 9, // should we just skip this? probably?
+            SubstitutionSubtables::EmptyExtension => {
+                return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER))
+            }
         };
         s.embed(lookup_type)?;
 

--- a/skera/src/gsub/alternate_subst.rs
+++ b/skera/src/gsub/alternate_subst.rs
@@ -28,6 +28,9 @@ impl<'a> SubsetTable<'a> for AlternateSubstFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gsub/ligature_subst.rs
+++ b/skera/src/gsub/ligature_subst.rs
@@ -1,8 +1,8 @@
 //! impl subset() for LigatureSubst subtable
 use crate::{
     layout::intersected_glyphs_and_indices,
-    offset::SerializeSerialize,
-    offset_array::SubsetOffsetArray,
+    offset::{SerializeSerialize, SerializeSubset},
+    offset_array::{IterNullableHelper, SubsetOffsetArray},
     serialize::{ObjIdx, SerializeErrorFlags, Serializer},
     Plan, SubsetState, SubsetTable,
 };
@@ -18,7 +18,7 @@ use write_fonts::{
         types::GlyphId,
         FontRef, ReadError,
     },
-    types::Offset16,
+    types::{FixedSize, Offset16},
 };
 
 impl<'a> SubsetTable<'a> for LigatureSubstFormat1<'_> {
@@ -30,6 +30,9 @@ impl<'a> SubsetTable<'a> for LigatureSubstFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -50,9 +53,11 @@ impl<'a> SubsetTable<'a> for LigatureSubstFormat1<'_> {
         let mut retained_cov_glyphs = Vec::with_capacity(cap);
         let mut retained_lig_set_idxes = Vec::with_capacity(cap);
         for (g, idx) in cov_glyphs.iter().zip(lig_set_idxes.iter()) {
-            let lig_set = lig_sets
-                .get(idx as usize)
-                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+            let lig_set = match lig_sets.get(idx as usize) {
+                Err(ReadError::NullOffset) => continue,
+                Err(_) => return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
+                Ok(lig_set) => lig_set,
+            };
 
             if !intersects_lig_glyph(&lig_set, glyph_set)
                 .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
@@ -110,11 +115,18 @@ impl SubsetTable<'_> for LigatureSet<'_> {
         let mut lig_count = 0_u16;
 
         let ligs = self.ligatures();
-        let org_lig_count = self.ligature_count();
-        for idx in 0..org_lig_count as usize {
-            match ligs.subset_offset(idx, s, plan, coverage_idx) {
+        for lig in ligs.iter_as_nullable() {
+            let Some(lig) = lig
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                continue;
+            };
+            let snap = s.snapshot();
+            let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+            match Offset16::serialize_subset(&lig, s, plan, coverage_idx, offset_pos) {
                 Ok(()) => lig_count += 1,
-                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => s.revert_snapshot(snap),
                 Err(e) => return Err(e),
             }
         }
@@ -159,8 +171,10 @@ fn intersects_lig_glyph(
     lig_set: &LigatureSet,
     glyphs: &IntSet<GlyphId>,
 ) -> Result<bool, ReadError> {
-    for lig in lig_set.ligatures().iter() {
-        let lig = lig?;
+    for lig in lig_set.ligatures().iter_as_nullable() {
+        let Some(lig) = lig.transpose()? else {
+            continue;
+        };
         let lig_glyph = lig.ligature_glyph();
         if glyphs.contains(GlyphId::from(lig_glyph)) && lig.intersects(glyphs)? {
             return Ok(true);

--- a/skera/src/gsub/multiple_subst.rs
+++ b/skera/src/gsub/multiple_subst.rs
@@ -28,6 +28,9 @@ impl<'a> SubsetTable<'a> for MultipleSubstFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gsub/single_subst.rs
+++ b/skera/src/gsub/single_subst.rs
@@ -43,6 +43,9 @@ impl SubsetTable<'_> for SingleSubstFormat1<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -86,6 +89,9 @@ impl SubsetTable<'_> for SingleSubstFormat2<'_> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;

--- a/skera/src/gsubgpos.rs
+++ b/skera/src/gsubgpos.rs
@@ -2,7 +2,7 @@
 use crate::{
     layout::{intersected_glyphs_and_indices, ClassDefSubsetStruct},
     offset::{SerializeSerialize, SerializeSubset},
-    offset_array::SubsetOffsetArray,
+    offset_array::{IterNullableHelper, SubsetOffsetArray},
     serialize::{SerializeErrorFlags, Serializer},
     Plan, SubsetState, SubsetTable,
 };
@@ -49,6 +49,9 @@ impl<'a> SubsetTable<'a> for SequenceContextFormat1<'_> {
         s: &mut Serializer,
         lookup_map: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -105,11 +108,18 @@ impl<'a> SubsetTable<'a> for SequenceRuleSet<'_> {
         let mut seq_rule_count = 0_u16;
 
         let seq_rules = self.seq_rules();
-        let org_rule_count = self.seq_rule_count();
-        for i in 0..org_rule_count {
-            match seq_rules.subset_offset(i as usize, s, plan, lookup_map) {
+        for seq_rule in seq_rules.iter_as_nullable() {
+            let Some(seq_rule) = seq_rule
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                continue;
+            };
+            let snap = s.snapshot();
+            let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+            match Offset16::serialize_subset(&seq_rule, s, plan, lookup_map, offset_pos) {
                 Ok(()) => seq_rule_count += 1,
-                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => s.revert_snapshot(snap),
                 Err(e) => return Err(e),
             }
         }
@@ -229,6 +239,9 @@ impl<'a> SubsetTable<'a> for SequenceContextFormat2<'_> {
         s: &mut Serializer,
         lookup_map: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() || self.class_def_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -335,11 +348,18 @@ impl<'a> SubsetTable<'a> for ClassSequenceRuleSet<'_> {
         let mut seq_rule_count = 0_u16;
 
         let seq_rules = self.class_seq_rules();
-        let org_rule_count = self.class_seq_rule_count();
-        for i in 0..org_rule_count {
-            match seq_rules.subset_offset(i as usize, s, plan, args) {
+        for seq_rule in seq_rules.iter_as_nullable() {
+            let Some(seq_rule) = seq_rule
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                continue;
+            };
+            let snap = s.snapshot();
+            let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+            match Offset16::serialize_subset(&seq_rule, s, plan, args, offset_pos) {
                 Ok(()) => seq_rule_count += 1,
-                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => s.revert_snapshot(snap),
                 Err(e) => return Err(e),
             }
         }
@@ -396,9 +416,15 @@ impl<'a> SubsetTable<'a> for ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         s: &mut Serializer,
         _args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
-        for cov in self.iter() {
-            let cov =
-                cov.map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+        let snap = s.snapshot();
+        for cov in self.iter_as_nullable() {
+            let Some(cov) = cov
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                s.revert_snapshot(snap);
+                return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+            };
             let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
             Offset16::serialize_subset(&cov, s, plan, (), offset_pos)?;
         }
@@ -464,6 +490,9 @@ impl<'a> SubsetTable<'a> for ChainedSequenceContextFormat1<'_> {
         s: &mut Serializer,
         lookup_map: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -520,11 +549,19 @@ impl<'a> SubsetTable<'a> for ChainedSequenceRuleSet<'_> {
         let mut seq_rule_count = 0_u16;
 
         let seq_rules = self.chained_seq_rules();
-        let org_rule_count = self.chained_seq_rule_count();
-        for i in 0..org_rule_count {
-            match seq_rules.subset_offset(i as usize, s, plan, lookup_map) {
+        for seq_rule in seq_rules.iter_as_nullable() {
+            let Some(seq_rule) = seq_rule
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                continue;
+            };
+
+            let snap = s.snapshot();
+            let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+            match Offset16::serialize_subset(&seq_rule, s, plan, lookup_map, offset_pos) {
                 Ok(()) => seq_rule_count += 1,
-                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => s.revert_snapshot(snap),
                 Err(e) => return Err(e),
             }
         }
@@ -584,6 +621,9 @@ impl<'a> SubsetTable<'a> for ChainedSequenceContextFormat2<'_> {
         s: &mut Serializer,
         lookup_map: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.coverage_offset().is_null() || self.input_class_def_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let coverage = self
             .coverage()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
@@ -593,16 +633,8 @@ impl<'a> SubsetTable<'a> for ChainedSequenceContextFormat2<'_> {
             return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
         }
 
-        let backtrack_classdef = self
-            .backtrack_class_def()
-            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-
         let input_classdef = self
             .input_class_def()
-            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-
-        let lookahead_classdef = self
-            .lookahead_class_def()
             .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
         // format
@@ -614,20 +646,28 @@ impl<'a> SubsetTable<'a> for ChainedSequenceContextFormat2<'_> {
 
         // backtrack classdef offset
         let backtrack_classdef_offset_pos = s.embed(0_u16)?;
-        let Some(backtrack_class_map) = Offset16::serialize_subset(
-            &backtrack_classdef,
-            s,
-            plan,
-            &ClassDefSubsetStruct {
-                remap_class: true,
-                keep_empty_table: true,
-                use_class_zero: true,
-                glyph_filter: None,
-            },
-            backtrack_classdef_offset_pos,
-        )?
-        else {
-            return Err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER);
+        let backtrack_class_map = if !self.backtrack_class_def_offset().is_null() {
+            let backtrack_classdef = self
+                .backtrack_class_def()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+            let Some(backtrack_class_map) = Offset16::serialize_subset(
+                &backtrack_classdef,
+                s,
+                plan,
+                &ClassDefSubsetStruct {
+                    remap_class: true,
+                    keep_empty_table: true,
+                    use_class_zero: true,
+                    glyph_filter: None,
+                },
+                backtrack_classdef_offset_pos,
+            )?
+            else {
+                return Err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER);
+            };
+            backtrack_class_map
+        } else {
+            FnvHashMap::default()
         };
 
         // input classdef offset
@@ -655,20 +695,29 @@ impl<'a> SubsetTable<'a> for ChainedSequenceContextFormat2<'_> {
 
         // lookahead classdef offset
         let lookahead_classdef_offset_pos = s.embed(0_u16)?;
-        let Some(lookahead_class_map) = Offset16::serialize_subset(
-            &lookahead_classdef,
-            s,
-            plan,
-            &ClassDefSubsetStruct {
-                remap_class: true,
-                keep_empty_table: true,
-                use_class_zero: true,
-                glyph_filter: None,
-            },
-            lookahead_classdef_offset_pos,
-        )?
-        else {
-            return Err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER);
+        let lookahead_class_map = if !self.lookahead_class_def_offset().is_null() {
+            let lookahead_classdef = self
+                .lookahead_class_def()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+
+            let Some(lookahead_class_map) = Offset16::serialize_subset(
+                &lookahead_classdef,
+                s,
+                plan,
+                &ClassDefSubsetStruct {
+                    remap_class: true,
+                    keep_empty_table: true,
+                    use_class_zero: true,
+                    glyph_filter: None,
+                },
+                lookahead_classdef_offset_pos,
+            )?
+            else {
+                return Err(SerializeErrorFlags::SERIALIZE_ERROR_OTHER);
+            };
+            lookahead_class_map
+        } else {
+            FnvHashMap::default()
         };
 
         // seq ruleset count
@@ -744,11 +793,18 @@ impl<'a> SubsetTable<'a> for ChainedClassSequenceRuleSet<'_> {
         let mut seq_rule_count = 0_u16;
 
         let seq_rules = self.chained_class_seq_rules();
-        let org_rule_count = self.chained_class_seq_rule_count();
-        for i in 0..org_rule_count {
-            match seq_rules.subset_offset(i as usize, s, plan, args) {
+        for seq_rule in seq_rules.iter_as_nullable() {
+            let Some(seq_rule) = seq_rule
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                continue;
+            };
+            let snap = s.snapshot();
+            let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+            match Offset16::serialize_subset(&seq_rule, s, plan, args, offset_pos) {
                 Ok(()) => seq_rule_count += 1,
-                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
+                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => s.revert_snapshot(snap),
                 Err(e) => return Err(e),
             }
         }

--- a/skera/src/hvar.rs
+++ b/skera/src/hvar.rs
@@ -4,7 +4,7 @@ use crate::{
     offset::SerializeSubset,
     serialize::{SerializeErrorFlags, Serializer},
     variations::DeltaSetIndexMapSerializePlan,
-    IncBiMap, Plan, Subset, SubsetError, SubsetFlags,
+    IncBiMap, Plan, Serialize, Subset, SubsetError, SubsetFlags,
 };
 use fnv::FnvHashMap;
 use write_fonts::{
@@ -16,7 +16,7 @@ use write_fonts::{
         },
         FontRef, ReadError, TopLevelTable,
     },
-    types::Offset32,
+    types::{FixedSize, Offset32},
     FontBuilder,
 };
 
@@ -30,23 +30,33 @@ impl Subset for Hvar<'_> {
         s: &mut Serializer,
         _builder: &mut FontBuilder,
     ) -> Result<(), SubsetError> {
-        let var_store = self
-            .item_variation_store()
-            .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;
+        Self::serialize(s, (self, plan)).map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))
+    }
+}
 
-        let index_maps = self
+impl<'a> Serialize<'a> for Hvar<'_> {
+    type Args = (&'a Hvar<'a>, &'a Plan);
+    fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags> {
+        let (hvar, plan) = args;
+        s.embed(hvar.version())?;
+        if hvar.item_variation_store_offset().is_null() {
+            return s
+                .allocate_size(5 * Offset32::RAW_BYTE_LEN, true)
+                .map(|_| ());
+        }
+
+        let var_store = hvar
+            .item_variation_store()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+
+        let index_maps = hvar
             .listup_index_maps()
-            .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
         let hvar_subset_plan = HvarVvarSubsetPlan::new(plan, &var_store, &index_maps)
-            .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
-        s.embed(self.version())
-            .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;
-
-        let var_store_offset_pos = s
-            .embed(0_u32)
-            .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;
+        let var_store_offset_pos = s.embed(0_u32)?;
 
         Offset32::serialize_subset(
             &var_store,
@@ -54,8 +64,7 @@ impl Subset for Hvar<'_> {
             plan,
             (hvar_subset_plan.inner_maps(), true),
             var_store_offset_pos,
-        )
-        .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))?;
+        )?;
 
         serialize_index_maps(
             s,
@@ -63,7 +72,6 @@ impl Subset for Hvar<'_> {
             &index_maps,
             hvar_subset_plan.index_map_subset_plans(),
         )
-        .map_err(|_| SubsetError::SubsetTableError(Hvar::TAG))
     }
 }
 

--- a/skera/src/layout.rs
+++ b/skera/src/layout.rs
@@ -26,7 +26,7 @@ use write_fonts::{
             },
         },
         types::{GlyphId, GlyphId16, NameId},
-        FontData, FontRead, FontRef, MinByteRange, TopLevelTable,
+        FontData, FontRead, FontRef, MinByteRange, ReadError, TopLevelTable,
     },
     types::{FixedSize, Offset16, Offset32, Tag},
 };
@@ -817,6 +817,9 @@ pub(crate) fn collect_features_with_retained_subs(
         };
 
         for rec in subs.substitutions() {
+            if rec.alternate_feature_offset().is_null() {
+                continue;
+            }
             let Ok(sub_f) = rec.alternate_feature(subs.offset_data()) else {
                 return IntSet::empty();
             };
@@ -847,6 +850,9 @@ pub(crate) fn prune_features(
         let Some(feature_rec) = feature_records.get(i as usize) else {
             continue;
         };
+        if feature_rec.feature_offset().is_null() {
+            continue;
+        }
         let feature_tag = feature_rec.feature_tag();
         // never drop feature "pref"
         // ref: https://github.com/harfbuzz/harfbuzz/blob/fc6231726e514f96bfbb098283aab332fc6b45fb/src/hb-ot-layout-gsubgpos.hh#L4822
@@ -1032,6 +1038,9 @@ impl<'a> PruneLangSysContext<'a> {
             }
 
             for (i, langsys_rec) in script.lang_sys_records().iter().enumerate() {
+                if langsys_rec.lang_sys_offset().is_null() {
+                    continue;
+                }
                 let Ok(l) = langsys_rec.lang_sys(script.offset_data()) else {
                     return;
                 };
@@ -1047,6 +1056,9 @@ impl<'a> PruneLangSysContext<'a> {
             }
         } else {
             for (i, langsys_rec) in script.lang_sys_records().iter().enumerate() {
+                if langsys_rec.lang_sys_offset().is_null() {
+                    continue;
+                }
                 let Ok(l) = langsys_rec.lang_sys(script.offset_data()) else {
                     return;
                 };
@@ -1073,6 +1085,9 @@ impl<'a> PruneLangSysContext<'a> {
         layout_scripts: &IntSet<Tag>,
     ) -> (FnvHashMap<u16, IntSet<u16>>, IntSet<u16>) {
         for (i, script_rec) in script_list.script_records().iter().enumerate() {
+            if script_rec.script_offset().is_null() {
+                continue;
+            }
             let script_tag = script_rec.script_tag();
             if !layout_scripts.contains(script_tag) {
                 continue;
@@ -1175,6 +1190,9 @@ impl<'a> SubsetTable<'a> for ScriptList<'_> {
         let mut num_records = 0_u16;
         let font_data = self.offset_data();
         for (i, script_record) in self.script_records().iter().enumerate() {
+            if script_record.script_offset().is_null() {
+                continue;
+            }
             let tag = script_record.script_tag();
             if !plan.layout_scripts.contains(tag) {
                 continue;
@@ -1642,8 +1660,9 @@ impl SubsetTable<'_> for ConditionSet<'_> {
         let mut count = 0_u16;
 
         let conditions = self.conditions();
-        for i in 0..self.condition_count() {
-            match conditions.subset_offset(i as usize, s, plan, ()) {
+        let condition_count = self.condition_count() as usize;
+        for i in 0..condition_count {
+            match conditions.subset_offset(i, s, plan, ()) {
                 Ok(()) => count += 1,
                 Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => continue,
                 Err(e) => return Err(e),
@@ -1732,6 +1751,9 @@ impl<'a> SubsetTable<'a> for FeatureTableSubstitutionRecord {
         s: &mut Serializer,
         args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
+        if self.alternate_feature_offset().is_null() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
         let (feature_index_map, c, font_data) = args;
         let Some(new_feature_indx) = feature_index_map.get(&self.feature_index()) else {
             return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
@@ -1766,10 +1788,12 @@ where
         args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
         let mut count = 0_u16;
-        for sub in self.iter() {
+        for sub in self.iter().filter_map(|table| match table {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        }) {
             let sub =
                 sub.map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-
             if !sub
                 .intersects(&plan.glyphset_gsub)
                 .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?

--- a/skera/src/offset_array.rs
+++ b/skera/src/offset_array.rs
@@ -1,7 +1,7 @@
 //! Subset arrays of offsets
 use crate::{offset::SerializeSubset, Plan, SerializeErrorFlags, Serializer, SubsetTable};
 use write_fonts::{
-    read::{ArrayOfNullableOffsets, ArrayOfOffsets, FontReadWithArgs, Offset, ReadArgs},
+    read::{ArrayOfNullableOffsets, ArrayOfOffsets, FontReadWithArgs, Offset, ReadArgs, ReadError},
     types::{FixedSize, Scalar},
 };
 
@@ -28,9 +28,11 @@ where
         plan: &Plan,
         args: T::ArgsForSubset,
     ) -> Result<(), SerializeErrorFlags> {
-        let t = self
-            .get(idx)
-            .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;
+        let t = match self.get(idx) {
+            Err(ReadError::NullOffset) => return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY),
+            Ok(table) => table,
+            Err(_) => return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
+        };
         let snap = s.snapshot();
         let offset_pos = s.allocate_size(O::RAW_BYTE_LEN, true)?;
 
@@ -70,7 +72,26 @@ where
                 }
             }
             None => Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY),
-            Some(Err(_)) => Err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR),
+            Some(Err(_)) => Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
         }
+    }
+}
+
+pub(crate) trait IterNullableHelper<'a, T> {
+    fn iter_as_nullable(&self) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a;
+}
+
+impl<'a, T, O> IterNullableHelper<'a, T> for ArrayOfOffsets<'a, T, O>
+// these bounds have to match what is in the read-fonts impl block that has the normal `iter` method
+where
+    O: Scalar + Offset,
+    T: ReadArgs + FontReadWithArgs<'a>,
+    T::Args: Copy + 'static,
+{
+    fn iter_as_nullable(&self) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
+        self.iter().map(|off| match off {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        })
     }
 }

--- a/skera/src/sbix.rs
+++ b/skera/src/sbix.rs
@@ -7,7 +7,7 @@ use write_fonts::{
     read::{
         tables::sbix::{Sbix, Strike},
         types::Offset32,
-        ArrayOfOffsets, FontRef, MinByteRange, TopLevelTable,
+        ArrayOfOffsets, FontRef, MinByteRange, ReadError, TopLevelTable,
     },
     FontBuilder,
 };
@@ -51,11 +51,12 @@ impl<'a> SubsetTable<'a> for ArrayOfOffsets<'a, Strike<'a>, Offset32> {
         let mut obj_idxes = Vec::with_capacity(orig_num);
         let mut offset_positions = Vec::with_capacity(orig_num);
 
-        for idx in 0..orig_num {
-            let idx = orig_num - 1 - idx;
-            let t = self
-                .get(idx)
-                .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;
+        for idx in (0..orig_num).rev() {
+            let t = match self.get(idx) {
+                Err(ReadError::NullOffset) => continue,
+                other => other,
+            }
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
             let snap = s.snapshot();
             let offset_pos = s.allocate_size(Offset32::RAW_BYTE_LEN, true)?;
 

--- a/skera/src/variations.rs
+++ b/skera/src/variations.rs
@@ -32,6 +32,17 @@ impl<'a> SubsetTable<'a> for ItemVariationStore<'a> {
         }
         s.embed(self.format())?;
 
+        if self.variation_region_list_offset().is_null() {
+            if keep_empty {
+                // in case of null var_region_list, set vardata count = 0 and return
+                s.embed(Offset32::new(0))?;
+                s.embed(0_u16)?;
+                return Ok(());
+            } else {
+                return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+            }
+        }
+
         let var_region_list = self
             .variation_region_list()
             .map_err(|_| SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)?;

--- a/skera/src/vvar.rs
+++ b/skera/src/vvar.rs
@@ -3,15 +3,15 @@
 use crate::{
     hvar::{serialize_index_maps, HvarVvarSubsetPlan, ListupIndexMaps},
     offset::SerializeSubset,
-    serialize::Serializer,
-    Plan, Subset, SubsetError,
+    serialize::{SerializeErrorFlags, Serializer},
+    Plan, Serialize, Subset, SubsetError,
 };
 use write_fonts::{
     read::{
         tables::{variations::DeltaSetIndexMap, vvar::Vvar},
         FontRef, ReadError, TopLevelTable,
     },
-    types::Offset32,
+    types::{FixedSize, Offset32},
     FontBuilder,
 };
 
@@ -25,23 +25,32 @@ impl Subset for Vvar<'_> {
         s: &mut Serializer,
         _builder: &mut FontBuilder,
     ) -> Result<(), SubsetError> {
-        let var_store = self
-            .item_variation_store()
-            .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;
+        Self::serialize(s, (self, plan)).map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))
+    }
+}
 
-        let index_maps = self
+impl<'a> Serialize<'a> for Vvar<'_> {
+    type Args = (&'a Vvar<'a>, &'a Plan);
+    fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags> {
+        let (vvar, plan) = args;
+        s.embed(vvar.version())?;
+        if vvar.item_variation_store_offset().is_null() {
+            return s
+                .allocate_size(5 * Offset32::RAW_BYTE_LEN, true)
+                .map(|_| ());
+        }
+        let var_store = vvar
+            .item_variation_store()
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
+
+        let index_maps = vvar
             .listup_index_maps()
-            .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
         let vvar_subset_plan = HvarVvarSubsetPlan::new(plan, &var_store, &index_maps)
-            .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;
+            .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
 
-        s.embed(self.version())
-            .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;
-
-        let var_store_offset_pos = s
-            .embed(0_u32)
-            .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;
+        let var_store_offset_pos = s.embed(0_u32)?;
 
         Offset32::serialize_subset(
             &var_store,
@@ -49,8 +58,7 @@ impl Subset for Vvar<'_> {
             plan,
             (vvar_subset_plan.inner_maps(), true),
             var_store_offset_pos,
-        )
-        .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))?;
+        )?;
 
         serialize_index_maps(
             s,
@@ -58,7 +66,6 @@ impl Subset for Vvar<'_> {
             &index_maps,
             vvar_subset_plan.index_map_subset_plans(),
         )
-        .map_err(|_| SubsetError::SubsetTableError(Vvar::TAG))
     }
 }
 


### PR DESCRIPTION
add checks so that we do not emit ReadError in case of null offsets.
currently we see below repeated code patterns in a lot of places because we have nullable offset arrays and non-nullable offset arrays, once sanitize changes landed, I'll try to make a generic fn or trait for them. 
```
            match offset::serialize_subset() {
                Ok(()) => rule_set_count += 1,
                Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY) => (),
                Err(e) => return Err(e),
            }
```

I'll also remove those `iter_as_nullable()` methods once sanitize changes landed