### PR TITLE
[chore] release read-fonts 0.39.2, skrifa 0.42.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ serde_json = "1.0"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.11.3", path = "font-types" }
-read-fonts = { version = "0.39.1", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.42.0", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.48.0", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.2.1", path = "incremental-font-transfer" }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.39.1"
+version = "0.39.2"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.42.0"
+version = "0.42.1"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.39.1 to 0.39.2
             8cba178 [read-fonts] t1: be less strict when parsing metrics (#1831)
     Changes for skrifa from skrifa-v0.42.0 to 0.42.1
             70aa739 Added decode logic for non-png cbdt bitmap. (#1839)