### PR TITLE
[chore] bump write-fonts to 0.48.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.48.0", path = "write-fonts" }
+write-fonts = { version = "0.48.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.2.1", path = "incremental-font-transfer" }
 skera = { version = "0.2.0", path = "skera" }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.48.0"
+version = "0.48.1"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
Includes three (non-breaking) changes since 0.48.0:
- Better handling of zero value deltas (#1840)
- Add ClassDef::is_empty (#1836)
- Restore GvarInputError as an alias (#1834)