### PR TITLE
Bump incremental-font-transfer to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false
 skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.48.1", path = "write-fonts" }
 shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
-incremental-font-transfer = { version = "0.2.1", path = "incremental-font-transfer" }
+incremental-font-transfer = { version = "0.3.0", path = "incremental-font-transfer" }
 skera = { version = "0.2.0", path = "skera" }
 
 [workspace.metadata.release]

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental-font-transfer"
-version = "0.2.1"
+version = "0.3.0"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
This does a major bump on its transitive deps