### PR TITLE
[read] Make subtables() helper handle empty extensions

### DIFF
--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -75,6 +75,8 @@ pub enum PositionSubtables<'a> {
     MarkToMark(PosSubtables<'a, MarkMarkPosFormat1<'a>>),
     Contextual(PosSubtables<'a, PositionSequenceContext<'a>>),
     ChainContextual(PosSubtables<'a, PositionChainContext<'a>>),
+    /// An extension lookup did not have any subtables
+    EmptyExtension,
 }
 
 impl<'a> PositionLookup<'a> {
@@ -111,9 +113,19 @@ impl<'a> PositionLookup<'a> {
                 offsets, data,
             ))),
             9 => {
-                let first = offsets.first().ok_or(ReadError::OutOfBounds)?.get();
-                let ext: ExtensionPosFormat1<()> = first.resolve(data)?;
-                match ext.extension_lookup_type() {
+                // look through subtable offsets to try and find a lookup type.
+                // this is robust in the case where the first subtable offset is
+                // malformed, but a later one is okay.
+                let Some(lookup_type) = offsets.iter().find_map(|off| {
+                    off.get()
+                        .resolve::<ExtensionPosFormat1<()>>(data)
+                        .ok()
+                        .map(|ext| ext.extension_lookup_type())
+                }) else {
+                    return Ok(PositionSubtables::EmptyExtension);
+                };
+
+                match lookup_type {
                     1 => Ok(PositionSubtables::Single(Subtables::new_ext(offsets, data))),
                     2 => Ok(PositionSubtables::Pair(Subtables::new_ext(offsets, data))),
                     3 => Ok(PositionSubtables::Cursive(Subtables::new_ext(

--- a/read-fonts/src/tables/gpos/closure.rs
+++ b/read-fonts/src/tables/gpos/closure.rs
@@ -114,6 +114,7 @@ impl Intersect for PositionSubtables<'_> {
             PositionSubtables::MarkToMark(subtables) => subtables.intersects(glyph_set),
             PositionSubtables::Contextual(subtables) => subtables.intersects(glyph_set),
             PositionSubtables::ChainContextual(subtables) => subtables.intersects(glyph_set),
+            PositionSubtables::EmptyExtension => Ok(false),
         }
     }
 }

--- a/read-fonts/src/tables/gsub.rs
+++ b/read-fonts/src/tables/gsub.rs
@@ -46,6 +46,8 @@ pub enum SubstitutionSubtables<'a> {
     Contextual(SubSubtables<'a, SubstitutionSequenceContext<'a>>),
     ChainContextual(SubSubtables<'a, SubstitutionChainContext<'a>>),
     Reverse(SubSubtables<'a, ReverseChainSingleSubstFormat1<'a>>),
+    /// An extension lookup did not have any subtables
+    EmptyExtension,
 }
 
 impl<'a> SubstitutionLookup<'a> {
@@ -91,9 +93,19 @@ impl<'a> SubstitutionLookup<'a> {
                 offsets, data,
             ))),
             7 => {
-                let first = offsets.first().ok_or(ReadError::OutOfBounds)?.get();
-                let ext: ExtensionSubstFormat1<()> = first.resolve(data)?;
-                match ext.extension_lookup_type() {
+                // look through subtable offsets to try and find a lookup type.
+                // this is robust in the case where the first subtable offset is
+                // malformed, but a later one is okay.
+                let Some(lookup_type) = offsets.iter().find_map(|off| {
+                    off.get()
+                        .resolve::<ExtensionSubstFormat1<()>>(data)
+                        .ok()
+                        .map(|ext| ext.extension_lookup_type())
+                }) else {
+                    return Ok(SubstitutionSubtables::EmptyExtension);
+                };
+
+                match lookup_type {
                     1 => Ok(SubstitutionSubtables::Single(Subtables::new_ext(
                         offsets, data,
                     ))),

--- a/read-fonts/src/tables/gsub/closure.rs
+++ b/read-fonts/src/tables/gsub/closure.rs
@@ -316,6 +316,7 @@ impl GlyphClosure for SubstitutionSubtables<'_> {
             SubstitutionSubtables::ChainContextual(tables) => {
                 tables.closure_glyphs(ctx, lookup_list, lookup_index)
             }
+            SubstitutionSubtables::EmptyExtension => Ok(()),
         }
     }
 
@@ -328,6 +329,7 @@ impl GlyphClosure for SubstitutionSubtables<'_> {
             SubstitutionSubtables::Reverse(_) => Ok(false),
             SubstitutionSubtables::Contextual(_) => Ok(true),
             SubstitutionSubtables::ChainContextual(_) => Ok(true),
+            SubstitutionSubtables::EmptyExtension => Ok(false),
         }
     }
 }
@@ -913,6 +915,7 @@ impl Intersect for SubstitutionSubtables<'_> {
             SubstitutionSubtables::Contextual(subtables) => subtables.intersects(glyph_set),
             SubstitutionSubtables::ChainContextual(subtables) => subtables.intersects(glyph_set),
             SubstitutionSubtables::Reverse(subtables) => subtables.intersects(glyph_set),
+            SubstitutionSubtables::EmptyExtension => Ok(false),
         }
     }
 }

--- a/skera/src/gpos.rs
+++ b/skera/src/gpos.rs
@@ -230,6 +230,7 @@ impl<'a> SubsetTable<'a> for PositionLookup<'_> {
             PositionSubtables::MarkToMark(_) => 6,
             PositionSubtables::Contextual(_) => 7,
             PositionSubtables::ChainContextual(_) => 8,
+            PositionSubtables::EmptyExtension => 9, // should we just skip this?
         };
         s.embed(lookup_type)?;
 
@@ -272,6 +273,7 @@ impl<'a> SubsetTable<'a> for PositionSubtables<'a> {
             PositionSubtables::MarkToMark(subtables) => subtables.subset(plan, s, args),
             PositionSubtables::Contextual(subtables) => subtables.subset(plan, s, args),
             PositionSubtables::ChainContextual(subtables) => subtables.subset(plan, s, args),
+            PositionSubtables::EmptyExtension => Ok(0),
         }
     }
 }

--- a/skera/src/gsub.rs
+++ b/skera/src/gsub.rs
@@ -229,6 +229,7 @@ impl<'a> SubsetTable<'a> for SubstitutionLookup<'_> {
             SubstitutionSubtables::Contextual(_) => 5,
             SubstitutionSubtables::ChainContextual(_) => 6,
             SubstitutionSubtables::Reverse(_) => 8,
+            SubstitutionSubtables::EmptyExtension => 9, // should we just skip this? probably?
         };
         s.embed(lookup_type)?;
 
@@ -270,6 +271,7 @@ impl<'a> SubsetTable<'a> for SubstitutionSubtables<'a> {
             SubstitutionSubtables::Contextual(subtables) => subtables.subset(plan, s, args),
             SubstitutionSubtables::ChainContextual(subtables) => subtables.subset(plan, s, args),
             SubstitutionSubtables::Reverse(subtables) => subtables.subset(plan, s, args),
+            SubstitutionSubtables::EmptyExtension => Ok(0),
         }
     }
 }

--- a/skrifa/src/outline/autohint/shape.rs
+++ b/skrifa/src/outline/autohint/shape.rs
@@ -365,6 +365,7 @@ impl ClusterShaper<'_> {
             SubstitutionSubtables::Contextual(_tables) => {}
             SubstitutionSubtables::ChainContextual(_tables) => {}
             SubstitutionSubtables::Reverse(_tables) => {}
+            SubstitutionSubtables::EmptyExtension => {}
         }
         false
     }
@@ -613,6 +614,7 @@ impl<'a, 'b> GsubHandler<'a, 'b> {
                     }
                 }
             }
+            SubstitutionSubtables::EmptyExtension => (),
         }
         Ok(())
     }


### PR DESCRIPTION
As written, this method would incorrectly return a ReadError in the case where an extension lookup had no subtables, as well as the case where the first subtable offset of an extension lookup was malformed, including if it was null.

This addresses this by adding a new variant, 'EmptyExtension', that is returned in the case where either there are no subtable offsets, or they are all invalid.

This was motivated by ongoing subsetting work, where this failure mode was not acceptable.


@qxliu76 I believe this will remove the need for the `subtables_nullable` method in #1842, although during iteration if you get a `ReadError` for a particular subtable you'll need to check if the variant is `::NullOffset`.