### PR TITLE
Bump shared-brotli-patch-decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false
 # shaping support
 skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.48.1", path = "write-fonts" }
-shared-brotli-patch-decoder = { version = "0.1.1", path = "shared-brotli-patch-decoder", default-features = false }
+shared-brotli-patch-decoder = { version = "0.1.2", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.3.0", path = "incremental-font-transfer" }
 skera = { version = "0.2.0", path = "skera" }
 

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-brotli-patch-decoder"
-version = "0.1.1"
+version = "0.1.2"
 description = "Wrapper around brotli-sys which allows for decoding shared brotli (https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/) encoded patch data."
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
- No changes to consumers, but fixes build on crates.io
  - https://github.com/googlefonts/fontations/pull/1837