### PR TITLE
Add safety annotations to shared-brotli-patch-decoder

### DIFF
--- a/shared-brotli-patch-decoder/src/c_brotli.rs
+++ b/shared-brotli-patch-decoder/src/c_brotli.rs
@@ -4,34 +4,46 @@ use crate::sys::{
     BrotliDecoderDestroyInstance, BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR,
     BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT,
     BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT,
-    BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS,
+    BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS, BrotliDecoderState,
     BrotliSharedDictionaryType_BROTLI_SHARED_DICTIONARY_RAW, BROTLI_FALSE,
 };
 use core::ptr;
+use std::ptr::NonNull;
 
 pub fn shared_brotli_decode_c(
     encoded: &[u8],
     shared_dictionary: Option<&[u8]>,
     max_uncompressed_length: usize,
 ) -> Result<Vec<u8>, DecodeError> {
-    let decoder = unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) };
-    if decoder.is_null() {
-        return Err(DecodeError::InitFailure);
-    }
+    // Safety: Both `alloc_func` and `free_func` are `None` which is allowed. This also makes the
+    // `opaque` (3rd argument) irrelevant.
+    let decoder = NonNull::new(unsafe { BrotliDecoderCreateInstance(None, None, ptr::null_mut()) })
+        .ok_or(DecodeError::InitFailure)?;
+    let res = decode(decoder, encoded, shared_dictionary, max_uncompressed_length);
+    // Safety: decoder points to a valid decoder object.
+    unsafe { BrotliDecoderDestroyInstance(decoder.as_ptr()) }
+    res
+}
 
+#[inline(always)]
+fn decode(
+    decoder: NonNull<BrotliDecoderState>,
+    encoded: &[u8],
+    shared_dictionary: Option<&[u8]>,
+    max_uncompressed_length: usize,
+) -> Result<Vec<u8>, DecodeError> {
     if let Some(shared_dictionary) = shared_dictionary {
-        if unsafe {
+        // Safety: Decoder points to a valid `BrotliDecoderState` object. The shared dictionary
+        // pointer and length are valid as they come from a Rust slice.
+        let attach_dictionary_succeeded = unsafe {
             BrotliDecoderAttachDictionary(
-                decoder,
+                decoder.as_ptr(),
                 BrotliSharedDictionaryType_BROTLI_SHARED_DICTIONARY_RAW,
                 shared_dictionary.len(),
                 shared_dictionary.as_ptr(),
             )
-        } == BROTLI_FALSE
-        {
-            unsafe {
-                BrotliDecoderDestroyInstance(decoder);
-            }
+        };
+        if attach_dictionary_succeeded == BROTLI_FALSE {
             return Err(DecodeError::InvalidDictionary);
         }
     }
@@ -44,11 +56,14 @@ pub fn shared_brotli_decode_c(
     let mut available_out = sink.len();
     let mut total_out = 0;
 
-    let mut error: Option<DecodeError> = None;
     loop {
+        // Safety: All pointers are valid and non-null. `next_out` is a pointer with at
+        // `available_in` bytes available within `sink`. This is managed by
+        // `BrotliDecoderDecompressStream` itself and the variables are not mutated outside of this
+        // context.
         let result = unsafe {
             BrotliDecoderDecompressStream(
-                decoder,
+                decoder.as_ptr(),
                 &mut available_in,
                 &mut next_in,
                 &mut available_out,
@@ -61,32 +76,22 @@ pub fn shared_brotli_decode_c(
         match result {
             BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS => break,
             BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR => {
-                error = Some(DecodeError::InvalidStream);
-                break;
+                return Err(DecodeError::InvalidStream);
             }
             BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT if available_in == 0 => {
                 // Needs more input and none is available.
-                error = Some(DecodeError::InvalidStream);
-                break;
+                return Err(DecodeError::InvalidStream);
             }
             BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT if available_out == 0 => {
                 // Needs more output space, but none is available.
-                error = Some(DecodeError::MaxSizeExceeded);
-                break;
+                return Err(DecodeError::MaxSizeExceeded);
             }
             _ => continue,
         }
     }
 
-    unsafe {
-        BrotliDecoderDestroyInstance(decoder);
-    }
-    if let Some(error) = error {
-        return Err(error);
-    }
-
+    // There's is data left in the input stream, which is not allowed
     if available_in > 0 {
-        // There's is data left in the input stream, which is not allowed
         return Err(DecodeError::ExcessInputData);
     }
 
@@ -95,6 +100,5 @@ pub fn shared_brotli_decode_c(
     }
 
     sink.resize(total_out, 0);
-
     Ok(sink)
 }

--- a/shared-brotli-patch-decoder/src/sys.rs
+++ b/shared-brotli-patch-decoder/src/sys.rs
@@ -8,6 +8,7 @@
 
 use std::os::raw::{c_int, c_void};
 
+/// Opaque structure that holds decoder state.
 pub type BrotliDecoderState = c_void;
 
 // From brotli/c/include/brotli/decode.h
@@ -35,12 +36,62 @@ pub type brotli_free_func = Option<unsafe extern "C" fn(opaque: *mut c_void, add
 
 // Functions from brotli/c/include/brotli/decode.h
 extern "C" {
+    /// Creates an instance of [`BrotliDecoderState`] and initializes it.
+    ///
+    /// The instance can be used once for decoding and should then be destroyed with
+    /// [`BrotliDecoderDestroyInstance`]. It cannot be reused for a new decoding
+    /// session.
+    ///
+    /// # Safety
+    ///
+    /// `alloc_func` and `free_func` MUST be both `Some` or both `None`. In the
+    /// case they are both `None`, default memory allocators are used. `opaque` is
+    /// passed to `alloc_func` and `free_func` when they are called. `free_func`
+    /// has to return without doing anything when asked to free a null pointer.
+    ///
+    /// # Arguments
+    ///
+    /// * `alloc_func` - Custom memory allocation function.
+    /// * `free_func` - Custom memory free function.
+    /// * `opaque` - Custom memory manager handle.
+    ///
+    /// # Returns
+    ///
+    /// `null` if the instance cannot be allocated or initialized; otherwise, a
+    /// pointer to an initialized [`BrotliDecoderState`].
     pub fn BrotliDecoderCreateInstance(
         alloc_func: brotli_alloc_func,
         free_func: brotli_free_func,
         opaque: *mut c_void,
     ) -> *mut BrotliDecoderState;
 
+    /// Adds LZ77 prefix dictionary, adds or replaces built-in static dictionary and
+    /// transforms.
+    ///
+    /// Attached dictionary ownership is not transferred.
+    ///
+    /// # Note
+    ///
+    /// Dictionaries can NOT be attached after actual decoding is started.
+    ///
+    /// # Safety
+    ///
+    /// * `state` must be a valid pointer to a [`BrotliDecoderState`].
+    /// * `data` must point to a valid memory region of at least `data_size` bytes.
+    /// * The memory pointed to by `data` must be kept accessible until decoding
+    ///   is finished and the decoder instance is destroyed.
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - Decoder instance.
+    /// * `type_` - Dictionary data format.
+    /// * `data_size` - Length of memory region pointed by `data`.
+    /// * `data` - Dictionary data in format corresponding to `type_`.
+    ///
+    /// # Returns
+    ///
+    /// [`BROTLI_FALSE`] if the dictionary is corrupted, or the dictionary count
+    /// limit is reached; otherwise, [`BROTLI_TRUE`].
     pub fn BrotliDecoderAttachDictionary(
         state: *mut BrotliDecoderState,
         type_: BrotliSharedDictionaryType,
@@ -48,6 +99,57 @@ extern "C" {
         data: *const u8,
     ) -> BROTLI_BOOL;
 
+    /// Decompresses the input stream to the output stream.
+    ///
+    /// The values `available_in` and `available_out` must specify the number of
+    /// bytes addressable at `next_in` and `next_out` respectively.
+    ///
+    /// After each call, `available_in` will be decremented by the amount of input
+    /// bytes consumed, and the `next_in` pointer will be incremented by that
+    /// amount. Similarly, `available_out` will be decremented by the amount of
+    /// output bytes written, and the `next_out` pointer will be incremented by
+    /// that amount.
+    ///
+    /// `total_out`, if it is not a null-pointer, will be set to the number
+    /// of bytes decompressed since the last `state` initialization.
+    ///
+    /// # Note
+    ///
+    /// Input is never overconsumed, so `next_in` and `available_in` could be
+    /// passed to the next consumer after decoding is complete.
+    ///
+    /// # Safety
+    ///
+    /// * `state` must be a valid pointer to a [`BrotliDecoderState`].
+    /// * `available_in`, `next_in`, `available_out`, and `next_out` must all be
+    ///   valid, non-null pointers to their respective types.
+    /// * The memory region pointed to by `*next_in` must be at least
+    ///   `*available_in` bytes long.
+    /// * The memory region pointed to by `*next_out` must be at least
+    ///   `*available_out` bytes long, unless `*available_out` is 0, in which
+    ///   case `*next_out` may be `null`.
+    /// * `total_out` may be `null`; if not, it must be a valid pointer to a
+    ///   [`usize`].
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - Decoder instance.
+    /// * `available_in` - **in:** amount of available input; **out:** amount of unused input.
+    /// * `next_in` - **in/out:** pointer to the next compressed byte.
+    /// * `available_out` - **in:** length of output buffer; **out:** remaining size of output buffer.
+    /// * `next_out` - **in/out:** output buffer cursor; can be `null` if `available_out` is 0.
+    /// * `total_out` - **out:** number of bytes decompressed so far; can be `null`.
+    ///
+    /// # Returns
+    ///
+    /// * [`BrotliDecoderResult_BROTLI_DECODER_RESULT_ERROR`] - Input is corrupted,
+    ///   memory allocation failed, arguments were invalid, etc.
+    /// * [`BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT`] - Decoding
+    ///   is blocked until more input data is provided.
+    /// * [`BrotliDecoderResult_BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT`] - Decoding
+    ///   is blocked until more output space is provided.
+    /// * [`BrotliDecoderResult_BROTLI_DECODER_RESULT_SUCCESS`] - Decoding is
+    ///   finished; no more input might be consumed and no more output will be produced.
     pub fn BrotliDecoderDecompressStream(
         state: *mut BrotliDecoderState,
         available_in: *mut usize,
@@ -57,5 +159,15 @@ extern "C" {
         total_out: *mut usize,
     ) -> BrotliDecoderResult;
 
+    /// Deinitializes and frees a [`BrotliDecoderState`] instance.
+    ///
+    /// # Safety
+    ///
+    /// The `state` pointer must be either `null` or a pointer to a valid
+    /// [`BrotliDecoderState`] previously allocated with [`BrotliDecoderCreateInstance`].
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - Decoder instance to be cleaned up and deallocated.
     pub fn BrotliDecoderDestroyInstance(state: *mut BrotliDecoderState);
 }


### PR DESCRIPTION
- Adds "SAFTEY:" before all calls to `unsafe`.
- Splits up the function to make the lifetime of `BrotliDecoderCreateInstance` more obvious.
- `sys` comments populated based on [brotli/include/brotli/decode.h](https://source.chromium.org/chromium/chromium/src/+/main:third_party/brotli/include/brotli/decode.h?q=brotli%2Fdecode.h&ss=chromium)