### PR TITLE
[chore] Release shared-brotli-patch-decoder 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false
 # shaping support
 skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.48.1", path = "write-fonts" }
-shared-brotli-patch-decoder = { version = "0.1.2", path = "shared-brotli-patch-decoder", default-features = false }
-incremental-font-transfer = { version = "0.3.0", path = "incremental-font-transfer" }
+shared-brotli-patch-decoder = { version = "0.1.3", path = "shared-brotli-patch-decoder", default-features = false }
+incremental-font-transfer = { version = "0.3.1", path = "incremental-font-transfer" }
 skera = { version = "0.2.0", path = "skera" }
 
 [workspace.metadata.release]

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental-font-transfer"
-version = "0.3.0"
+version = "0.3.1"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-brotli-patch-decoder"
-version = "0.1.2"
+version = "0.1.3"
 description = "Wrapper around brotli-sys which allows for decoding shared brotli (https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/) encoded patch data."
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
     Changes for shared-brotli-patch-decoder from shared-brotli-patch-decoder-v0.1.2 to 0.1.3
             f620235 Add safety annotations to shared-brotli-patch-decoder (#1853)