### PR TITLE
Update rand and rstest dev-dependencies

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -51,7 +51,7 @@ once_cell = { version = "1.21.4", default-features = false, features = [
 read-fonts = { path = ".", features = ["experimental_font_api"] }
 font-test-data = { workspace = true }
 criterion = { workspace = true }
-rand = "0.8.5"
+rand = { version = "0.10.1", features = ["thread_rng"] }
 serde_json = { workspace = true }
 
 [[bench]]

--- a/read-fonts/benches/bench_helper.rs
+++ b/read-fonts/benches/bench_helper.rs
@@ -1,13 +1,13 @@
 use read_fonts::collections::{IntSet, U32Set};
 
-use rand::Rng;
+use rand::RngExt;
 
 pub fn random_set(size: u32, max_value: u32) -> IntSet<u32> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut set = IntSet::<u32>::empty();
     for _ in 0..size {
         loop {
-            let candidate: u32 = rng.gen::<u32>() % max_value;
+            let candidate: u32 = rng.random::<u32>() % max_value;
             if set.insert(candidate) {
                 break;
             }
@@ -18,11 +18,11 @@ pub fn random_set(size: u32, max_value: u32) -> IntSet<u32> {
 
 #[allow(dead_code)]
 pub fn random_u32_set(size: u32, max_value: u32) -> U32Set {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut set = U32Set::empty();
     for _ in 0..size {
         loop {
-            let candidate: u32 = rng.gen::<u32>() % max_value;
+            let candidate: u32 = rng.random::<u32>() % max_value;
             if set.insert(candidate) {
                 break;
             }

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -39,7 +39,7 @@ font-test-data = { workspace = true }
 read-fonts = { workspace = true, features = [
   "codegen_test", "experimental_traverse"
 ] }
-rstest = "0.18.0"
+rstest = "0.26.1"
 bincode = { version = "2", features = ["serde"] }
 rand = { version = "0.10.1", features = ["thread_rng"] }
 

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -41,7 +41,7 @@ read-fonts = { workspace = true, features = [
 ] }
 rstest = "0.18.0"
 bincode = { version = "2", features = ["serde"] }
-rand = "0.8.5"
+rand = { version = "0.10.1", features = ["thread_rng"] }
 
 pretty_assertions.workspace = true
 env_logger.workspace = true

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -265,7 +265,6 @@ mod tests {
 
     use crate::{font_builder::checksum_and_padding, FontBuilder};
     use rand::seq::SliceRandom;
-    use rand::Rng;
     use rstest::rstest;
 
     #[test]
@@ -301,15 +300,17 @@ mod tests {
 
     #[test]
     fn validate_font_checksum() {
+        use rand::RngExt;
+
         // Add a dummy 'head' plus a couple of made-up tables containing random bytes
         // and verify that the total font checksum is always equal to the special
         // constant 0xB1B0AFBA, which should be the case if the FontBuilder computed
         // the head.checksum_adjustment correctly.
         let head_size = 54;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut builder = FontBuilder::default();
         for tag in [Tag::new(b"head"), Tag::new(b"FOO "), Tag::new(b"BAR ")] {
-            let data: Vec<u8> = (0..=head_size).map(|_| rng.r#gen()).collect();
+            let data: Vec<u8> = (0..=head_size).map(|_| rng.r#random()).collect();
             builder.add_raw(tag, data);
         }
         let font_data = builder.build();
@@ -354,7 +355,7 @@ mod tests {
         let mut builder = FontBuilder::default();
         builder.add_raw(dsig, vec![0]);
         let mut tags = recommended_order.to_vec();
-        tags.shuffle(&mut rand::thread_rng());
+        tags.shuffle(&mut rand::rng());
         for tag in tags {
             builder.add_raw(tag, vec![0]);
         }

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -1492,7 +1492,7 @@ mod tests {
 
     #[test]
     fn we_match_fonttools_stable_order() {
-        use rand::{seq::SliceRandom, thread_rng};
+        use rand::seq::SliceRandom;
 
         let mut builder = VariationStoreBuilder::new(1);
         let r1 = VariationRegion::new(vec![reg_coords(-1.0, -1.0, 0.0)]);
@@ -1524,7 +1524,7 @@ mod tests {
         ];
 
         // Add delta sets in random order and test that the algorithm is stable
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         delta_sets.shuffle(&mut rng);
         for deltas in delta_sets {
             builder.add_deltas(deltas);


### PR DESCRIPTION
Update `rand` dev-dependencies in `read-fonts` (for benchmarks) and `write-fonts` (for tests) from 0.8 to 0.10. This required some source-code changes. I verified that `cargo test` and `cargo bench` still worked with and without `--all-features`.

Update the `rstest` dev-dependency in `write-fonts` from 0.18 to 0.26. This didn’t require any source-code changes; `rstest` rarely has significant API changes despite its frequent SemVer breaks.