### PR TITLE
Add BSD-3-Clause term to read-fonts license due to AGL

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -7,7 +7,9 @@ categories = ["text-processing", "parsing", "graphics"]
 
 rust-version.workspace = true
 edition.workspace = true
-license.workspace = true
+# The “Adobe Glyph List,” data/glyphlist.txt, is BSD-3-Clause. It is used to
+# produce data/generated/generated_agl.rs.
+license = "(MIT OR Apache-2.0) AND BSD-3-Clause"
 repository.workspace = true
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
While reviewing a proposed `rust-read-fonts` package for Fedora, I observed that the “Adobe Glyph List,” `data/glyphlist.txt`, is `BSD-3-Clause`. It is used to produce `data/generated/generated_agl.rs`. Both files are included in published crates, and the latter contributes to compiled binaries when the `agl` feature is enabled. Therefore, this PR proposes to adjust the license expression for `read-fonts` from `MIT OR Apache-2.0` (from the workspace) to `(MIT OR Apache-2.0) AND BSD-3-Clause`.