### PR TITLE
Update to latest brotlic

### DIFF
--- a/shared-brotli-patch-decoder/build.rs
+++ b/shared-brotli-patch-decoder/build.rs
@@ -36,7 +36,7 @@ mod c_brotli {
             }
 
             let status = Command::new("git")
-                .args(["checkout", "af041f55e7bfa3e1bc502f234538e1d6dd6282bd"])
+                .args(["checkout", "1736fe1d50b205f718281a94035fd66f14d72ef5"])
                 .current_dir(&brotli_dir)
                 .status()
                 .expect("Failed to execute git checkout");

--- a/shared-brotli-patch-decoder/src/lib.rs
+++ b/shared-brotli-patch-decoder/src/lib.rs
@@ -162,17 +162,19 @@ mod tests {
 
     #[test]
     fn brotli_decode_without_shared_dict() {
-        let base = "".as_bytes();
-
         assert_eq!(
             Ok(TARGET.to_vec()),
             BuiltInBrotliDecoder.decode(&NO_DICT_PATCH, None, TARGET.len())
         );
+    }
 
-        // Check that empty base is handled the same as no base.
+    #[test]
+    fn brotli_decode_with_empty_shared_dict() {
+        // An empty shared dictionary used to behave similarly to a `None`, but it is now invalid as
+        // of https://github.com/google/brotli/pull/1479
         assert_eq!(
-            Ok(TARGET.to_vec()),
-            BuiltInBrotliDecoder.decode(&NO_DICT_PATCH, Some(base), TARGET.len())
+            Err(DecodeError::InvalidDictionary),
+            BuiltInBrotliDecoder.decode(&NO_DICT_PATCH, Some(b""), TARGET.len())
         );
     }
 


### PR DESCRIPTION
- Update the commit for brotlic
- Update `brotli_decode_without_shared_dict` to match new behavior
  - See https://github.com/google/brotli/pull/1479