### PR TITLE
[ift] Run clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,9 @@ jobs:
       - name: cargo clippy fauntlet (1.85)
         run: cargo clippy -p fauntlet --all-features --all-targets -- -D warnings
 
+      - name: cargo clippy incremental-font-transfer (1.85)
+        run: cargo clippy -p incremental-font-transfer --all-features --all-targets -- -D warnings
+
   test-stable:
     name: cargo test stable
     runs-on: ubuntu-latest

--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -950,7 +950,7 @@ impl GlyphDataOffsetArray for Gvar<'_> {
 
             // The spec says that shared tuple data should come before glyph variation data so use a virtual link to
             // ensure the correct ordering.
-            serializer.add_virtual_link(glyph_data_obj);
+            serializer.add_virtual_link(glyph_data_obj)?;
 
             serializer
                 .pop_pack(false)

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -40,7 +40,7 @@ pub struct PatchGroup<'a> {
 
 // We implement Debug manually because FontRef does not implement Debug unconditionally.
 // Additionally, FontRef may be too verbose to be helpful.
-impl<'a> std::fmt::Debug for PatchGroup<'a> {
+impl std::fmt::Debug for PatchGroup<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PatchGroup")
             .field("patches", &self.patches)


### PR DESCRIPTION
This wasn't running previously and there were a few clippy lints, which were causing my pre-push hook to constantly fail.


@garretrieger this also fixes the existing lints; one of these fixes involves ignoring an error. Do we want to be handling it?

JMM