### PR TITLE
[read] Remove funny reexports from gdef module

### DIFF
--- a/read-fonts/src/tables/gdef.rs
+++ b/read-fonts/src/tables/gdef.rs
@@ -2,10 +2,7 @@
 //!
 //! [GDEF]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef
 
-pub use super::layout::{
-    ChainedSequenceContext, ClassDef, CoverageTable, Device, DeviceOrVariationIndex, FeatureList,
-    FeatureVariations, Lookup, LookupList, ScriptList, SequenceContext,
-};
+pub use super::layout::{ClassDef, CoverageTable, DeviceOrVariationIndex};
 
 use super::variations::ItemVariationStore;
 


### PR DESCRIPTION
We _do_ reexport in this case when the type in question is used in the code generated for the reexporting table, but that is not the case for these items.

Looking at the git history, these have basically always been there; I might've just copied gdef.rs from one of gpos/gsub when I first created it?

This is a breaking change but hopefully doesn't impact anyone, unless their IDE autocomplete decided it liked these locations for these imports (which to be fair is how I noticed that they were there at all)


JMM