### PR TITLE
[codegen] Cleanup old NeededWhen logic

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -93,6 +93,10 @@ impl Fields {
         self.fields.iter()
     }
 
+    pub(crate) fn find(&self, ident: &syn::Ident) -> Option<&Field> {
+        self.iter().find(|fld| &fld.name == ident)
+    }
+
     pub(crate) fn iter_compile_decls(&self) -> impl Iterator<Item = TokenStream> + '_ {
         self.fields.iter().filter_map(Field::compile_field_decl)
     }
@@ -294,13 +298,6 @@ impl Condition {
             Condition::IfFlag { field, flag } => quote!(self.#field.contains(#flag)),
         }
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum NeededWhen {
-    Parse,
-    Runtime,
-    Both,
 }
 
 /// All the state required to generate a constructor for a table/record
@@ -657,35 +654,17 @@ impl Field {
         self.attrs.skip_getter.is_none()
     }
 
-    /// iterate the names of fields that are required for parsing or instantiating
-    /// this field.
-    pub(crate) fn input_fields(&self) -> Vec<(syn::Ident, NeededWhen)> {
-        let mut result = Vec::new();
-        if let Some(count) = self.attrs.count.as_ref() {
-            result.extend(
-                count
-                    .iter_referenced_fields()
-                    .map(|fld| (fld.clone(), NeededWhen::Parse)),
-            );
-        }
-
-        if let Some(read_with) = self.attrs.read_with_args.as_ref() {
-            result.extend(
-                read_with
-                    .inputs
-                    .iter()
-                    .map(|fld| (fld.clone(), NeededWhen::Both)),
-            );
-        }
-        if let Some(read_offset) = self.attrs.read_offset_args.as_ref() {
-            result.extend(
-                read_offset
-                    .inputs
-                    .iter()
-                    .map(|fld| (fld.clone(), NeededWhen::Runtime)),
-            );
-        }
-        result
+    /// iterate the names of fields that are required for parsing this field
+    ///
+    /// This does not include the version field, since we don't have a reference
+    /// to that.
+    pub(crate) fn count_arg_names(&self) -> impl Iterator<Item = &syn::Ident> + '_ {
+        self.attrs
+            .count
+            .as_ref()
+            .map(|count| count.iter_referenced_fields())
+            .into_iter()
+            .flatten()
     }
 
     /// 'raw' as in this does not include handling offset resolution

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -4,7 +4,6 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 
 use crate::{
-    fields::NeededWhen,
     parsing::{Attr, Field, Table, TableReadArg, TableReadArgs},
     Phase,
 };
@@ -317,16 +316,10 @@ impl Table {
             let field = iter.next()?;
             let fn_name = field.shape_byte_range_fn_name();
             let len_expr = field.field_len_expr();
-            let required_fields = field
-                .input_fields()
-                .into_iter()
-                .filter_map(|(ident, when)| matches!(when, NeededWhen::Parse).then_some(ident));
-            let required_field_decls = required_fields.map(|fld| {
+            let required_field_decls = field.count_arg_names().map(|fld| {
                 let is_opt = self
                     .fields
-                    .fields
-                    .iter()
-                    .find(|x| x.name == fld)
+                    .find(fld)
                     .map(|x| x.is_conditional())
                     .unwrap_or(false);
                 let maybe_unwrap_or_default = (is_opt).then(|| quote!(.unwrap_or_default()));


### PR DESCRIPTION
Before minimal validate, we had some fancier logic around instantiating fields both at parse time and later in their getters. This removes some now unused code related to that.

JMM