### PR TITLE
Create "tables" feature for write-fonts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,11 @@ jobs:
       - name: cargo test write-fonts (default)
         run: cargo test -p write-fonts
 
+      - name: cargo test write-fonts (no-features)
+        # --tests makes it so we run only the unit tests and skip the doctests.
+        # The doctests assume that "tables" is enabled.
+        run: cargo test -p write-fonts --no-default-features --tests
+
       - name: cargo test write-fonts (all)
         run: cargo test -p write-fonts --all-targets --all-features
 

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -16,7 +16,8 @@ repository.workspace = true
 all-features = true
 
 [features]
-default = []
+default = ["tables"]
+tables = ["dep:indexmap", "dep:kurbo"]
 read = []
 dot2 = ["dep:dot2"]
 serde = ["dep:serde", "font-types/serde", "read-fonts/serde"]
@@ -26,10 +27,10 @@ ift = ["read-fonts/ift"]
 font-types = { workspace = true }
 read-fonts = { workspace = true, default-features = true }
 log = "0.4"
-kurbo.workspace = true
+kurbo = { workspace = true, optional = true }
 dot2 = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-indexmap = "2.0"
+indexmap = { version = "2.0", optional = true }
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/write-fonts/src/collections.rs
+++ b/write-fonts/src/collections.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeSet;
 
+#[cfg(feature = "tables")]
 use crate::{NullableOffsetMarker, OffsetMarker};
 
 /// A helper trait for array-like fields, where we need to know
@@ -37,12 +38,14 @@ impl<T: HasLen> HasLen for Option<T> {
     }
 }
 
+#[cfg(feature = "tables")]
 impl<T: HasLen, const N: usize> HasLen for OffsetMarker<T, N> {
     fn len(&self) -> usize {
         T::len(self)
     }
 }
 
+#[cfg(feature = "tables")]
 impl<T: HasLen, const N: usize> HasLen for NullableOffsetMarker<T, N> {
     fn len(&self) -> usize {
         self.as_ref().map(HasLen::len).unwrap_or(0)

--- a/write-fonts/src/error.rs
+++ b/write-fonts/src/error.rs
@@ -2,7 +2,22 @@
 
 use std::sync::Arc;
 
+use types::Tag;
+
 use crate::{graph::Graph, validate::ValidationReport};
+
+/// An error returned when attempting to add a table to the builder.
+///
+/// This wraps a compilation error, adding the tag of the table where it was
+/// encountered.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct BuilderError {
+    /// The tag of the root table where the error occurred
+    pub tag: Tag,
+    /// The underlying error
+    pub inner: Error,
+}
 
 /// A packing could not be found that satisfied all offsets
 ///
@@ -43,6 +58,18 @@ impl PackingError {
     #[cfg(feature = "dot2")]
     pub fn write_graph_viz(&self, path: impl AsRef<std::path::Path>) -> std::io::Result<()> {
         self.graph.write_graph_viz(path)
+    }
+}
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "failed to build '{}' table: '{}'", self.tag, self.inner)
+    }
+}
+
+impl std::error::Error for BuilderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
     }
 }
 

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -1,12 +1,14 @@
 //!  A builder for top-level font objects
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::{borrow::Cow, fmt::Display};
 
 use read_fonts::{FontRef, TableProvider};
 use types::{Tag, TT_SFNT_VERSION};
 
-use crate::util::SearchRange;
+#[cfg(feature = "tables")]
+use crate::error::BuilderError;
+use crate::search_range::SearchRange;
 
 include!("../generated/generated_font.rs");
 
@@ -18,20 +20,6 @@ const CFF2: Tag = Tag::new(b"CFF2");
 #[derive(Debug, Clone, Default)]
 pub struct FontBuilder<'a> {
     tables: BTreeMap<Tag, Cow<'a, [u8]>>,
-}
-
-/// An error returned when attempting to add a table to the builder.
-///
-/// This wraps a compilation error, adding the tag of the table where it was
-/// encountered.
-#[derive(Clone, Debug)]
-#[cfg(feature = "tables")]
-#[non_exhaustive]
-pub struct BuilderError {
-    /// The tag of the root table where the error occurred
-    pub tag: Tag,
-    /// The underlying error
-    pub inner: crate::error::Error,
 }
 
 impl TableDirectory {
@@ -265,20 +253,6 @@ fn checksum_and_padding(table: &[u8]) -> (u32, u32) {
 impl TTCHeader {
     fn compute_version(&self) -> MajorMinor {
         panic!("TTCHeader writing not supported (yet)")
-    }
-}
-
-#[cfg(feature = "tables")]
-impl Display for BuilderError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "failed to build '{}' table: '{}'", self.tag, self.inner)
-    }
-}
-
-#[cfg(feature = "tables")]
-impl std::error::Error for BuilderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.inner)
     }
 }
 

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -25,6 +25,7 @@ pub struct FontBuilder<'a> {
 /// This wraps a compilation error, adding the tag of the table where it was
 /// encountered.
 #[derive(Clone, Debug)]
+#[cfg(feature = "tables")]
 #[non_exhaustive]
 pub struct BuilderError {
     /// The tag of the root table where the error occurred
@@ -103,6 +104,7 @@ impl<'a> FontBuilder<'a> {
     /// The table can be any top-level table defined in this crate. This function
     /// will attempt to compile the table and then add it to the builder if
     /// successful, returning an error otherwise.
+    #[cfg(feature = "tables")]
     pub fn add_table<T>(&mut self, table: &T) -> Result<&mut Self, BuilderError>
     where
         T: FontWrite + Validate + TopLevelTable,
@@ -266,12 +268,14 @@ impl TTCHeader {
     }
 }
 
+#[cfg(feature = "tables")]
 impl Display for BuilderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "failed to build '{}' table: '{}'", self.tag, self.inner)
     }
 }
 
+#[cfg(feature = "tables")]
 impl std::error::Error for BuilderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.inner)

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -1,16 +1,19 @@
 //! A graph for resolving table offsets
 
+#[cfg(feature = "tables")]
 use font_types::Uint24;
 
-use crate::{table_type::TableType, tables::layout::LookupType, write::TableData};
+use crate::write::TableData;
+#[cfg(feature = "tables")]
+use crate::{table_type::TableType, tables::layout::LookupType};
 
-use std::{
-    collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque},
-    sync::atomic::AtomicU64,
-};
+#[cfg(feature = "tables")]
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet, VecDeque};
+use std::{collections::HashMap, sync::atomic::AtomicU64};
 
 #[cfg(feature = "dot2")]
 mod graphviz;
+#[cfg(feature = "tables")]
 mod splitting;
 
 static OBJECT_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -29,6 +32,7 @@ pub enum OffsetLen {
 
 impl OffsetLen {
     /// The maximum value for an offset of this length.
+    #[cfg(feature = "tables")]
     pub const fn max_value(self) -> u32 {
         match self {
             Self::Offset16 => u16::MAX as u32,
@@ -52,8 +56,10 @@ impl std::fmt::Display for OffsetLen {
 /// Nodes are assigned a space, and nodes in lower spaces are always
 /// packed before nodes in higher spaces.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Hash, PartialEq, Eq)]
+#[cfg(feature = "tables")]
 pub struct Space(u32);
 
+#[cfg(feature = "tables")]
 impl Space {
     /// A generic space for nodes reachable via 16-bit offsets.
     const SHORT_REACHABLE: Space = Space(0);
@@ -89,6 +95,7 @@ impl ObjectStore {
 /// This type is used during compilation, to determine the final write order
 /// for the various subtables.
 //NOTE: we don't derive Debug because it's way too verbose to be useful
+#[cfg(feature = "tables")]
 pub struct Graph {
     /// the actual data for each table
     objects: BTreeMap<ObjectId, TableData>,
@@ -104,6 +111,7 @@ pub struct Graph {
 }
 
 #[derive(Debug)]
+#[cfg(feature = "tables")]
 struct Node {
     size: u32,
     distance: u64,
@@ -116,6 +124,7 @@ struct Node {
 
 /// Scored used when computing shortest distance
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg(feature = "tables")]
 struct Distance {
     // a space ranking; like rankings are packed together,
     // and larger rankings are packed after smaller ones.
@@ -127,10 +136,12 @@ struct Distance {
 
 //TODO: remove me? maybe? not really used right now...
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg(feature = "tables")]
 struct Priority(u8);
 
 /// A record of an overflowing offset
 #[derive(Clone, Debug)]
+#[cfg(feature = "tables")]
 pub(crate) struct Overflow {
     parent: ObjectId,
     child: ObjectId,
@@ -138,6 +149,7 @@ pub(crate) struct Overflow {
     offset_type: OffsetLen,
 }
 
+#[cfg(feature = "tables")]
 impl Priority {
     const ZERO: Priority = Priority(0);
     const ONE: Priority = Priority(1);
@@ -152,6 +164,7 @@ impl Priority {
     }
 }
 
+#[cfg(feature = "tables")]
 impl Distance {
     const ROOT: Distance = Distance {
         space: Space::SHORT_REACHABLE,
@@ -164,6 +177,7 @@ impl Distance {
     }
 }
 
+#[cfg(feature = "tables")]
 impl Node {
     pub fn new(size: u32) -> Self {
         Node {
@@ -201,6 +215,7 @@ impl Node {
     }
 }
 
+#[cfg(feature = "tables")]
 impl Graph {
     pub(crate) fn from_obj_store(store: ObjectStore, root: ObjectId) -> Self {
         let objects = store.objects.into_iter().map(|(k, v)| (v, k)).collect();
@@ -300,6 +315,7 @@ impl Graph {
     /// returns `true` if a solution is found, `false` otherwise
     ///
     /// [repacker docs]: https://github.com/harfbuzz/harfbuzz/blob/main/docs/repacker.md
+    #[cfg(feature = "tables")]
     pub(crate) fn pack_objects(&mut self) -> bool {
         if self.basic_sort() {
             return true;
@@ -870,6 +886,7 @@ impl Graph {
         self.next_space
     }
 
+    #[cfg(feature = "tables")]
     fn try_promoting_subtables(&mut self) {
         let Some((can_promote, parent_id)) = self.get_promotable_subtables() else {
             return;
@@ -883,6 +900,7 @@ impl Graph {
         self.actually_promote_subtables(&to_promote);
     }
 
+    #[cfg(feature = "tables")]
     fn actually_promote_subtables(&mut self, to_promote: &[ObjectId]) {
         fn make_extension(type_: LookupType, subtable_id: ObjectId) -> TableData {
             const EXT_FORMAT: u16 = 1;
@@ -933,6 +951,7 @@ impl Graph {
     }
 
     // get the list of tables that can be promoted, as well as the id of their parent table
+    #[cfg(feature = "tables")]
     fn get_promotable_subtables(&self) -> Option<(Vec<ObjectId>, ObjectId)> {
         let can_promote = self
             .objects
@@ -1062,6 +1081,7 @@ impl Graph {
     /// Based on [`_presplit_subtables_if_needed`][presplit] in hb-repacker
     ///
     /// [presplit]: https://github.com/harfbuzz/harfbuzz/blob/5d543d64222c6ce45332d0c188790f90691ef112/src/hb-repacker.hh#LL72C22-L72C22
+    #[cfg(feature = "tables")]
     fn try_splitting_subtables(&mut self) {
         let splittable = self
             .objects
@@ -1076,6 +1096,7 @@ impl Graph {
         }
     }
 
+    #[cfg(feature = "tables")]
     fn split_subtables_if_needed(&mut self, lookup: ObjectId) {
         // So You Want to Split Subtables:
         // - support PairPos and MarkBase.
@@ -1202,6 +1223,7 @@ impl Graph {
     }
 }
 
+#[cfg(feature = "tables")]
 impl Default for Priority {
     fn default() -> Self {
         Priority::ZERO

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -1,65 +1,29 @@
 //! A graph for resolving table offsets
 
-#[cfg(feature = "tables")]
 use font_types::Uint24;
 
-use crate::write::TableData;
-#[cfg(feature = "tables")]
-use crate::{table_type::TableType, tables::layout::LookupType};
+use crate::{
+    object::{ObjectId, ObjectStore},
+    offsets::OffsetLen,
+    table_type::TableType,
+    tables::layout::LookupType,
+    write::TableData,
+};
 
-#[cfg(feature = "tables")]
+use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet, VecDeque};
-use std::{collections::HashMap, sync::atomic::AtomicU64};
 
 #[cfg(feature = "dot2")]
 mod graphviz;
-#[cfg(feature = "tables")]
 mod splitting;
 
-static OBJECT_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// An identifier for an object in the compilation graph.
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, Hash, PartialEq, Eq)]
-pub struct ObjectId(u64);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u8)]
-pub enum OffsetLen {
-    Offset16 = 2,
-    Offset24 = 3,
-    Offset32 = 4,
-}
-
-impl OffsetLen {
-    /// The maximum value for an offset of this length.
-    #[cfg(feature = "tables")]
-    pub const fn max_value(self) -> u32 {
-        match self {
-            Self::Offset16 => u16::MAX as u32,
-            Self::Offset24 => (1 << 24) - 1,
-            Self::Offset32 => u32::MAX,
-        }
-    }
-}
-
-impl std::fmt::Display for OffsetLen {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Offset16 => write!(f, "Offset16"),
-            Self::Offset24 => write!(f, "Offset24"),
-            Self::Offset32 => write!(f, "Offset32"),
-        }
-    }
-}
 /// A ranking used for sorting the graph.
 ///
 /// Nodes are assigned a space, and nodes in lower spaces are always
 /// packed before nodes in higher spaces.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, Hash, PartialEq, Eq)]
-#[cfg(feature = "tables")]
 pub struct Space(u32);
 
-#[cfg(feature = "tables")]
 impl Space {
     /// A generic space for nodes reachable via 16-bit offsets.
     const SHORT_REACHABLE: Space = Space(0);
@@ -73,29 +37,11 @@ impl Space {
     }
 }
 
-impl ObjectId {
-    pub fn next() -> Self {
-        ObjectId(OBJECT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
-    }
-}
-
-#[derive(Debug, Default)]
-pub(crate) struct ObjectStore {
-    pub(crate) objects: HashMap<TableData, ObjectId>,
-}
-
-impl ObjectStore {
-    pub(crate) fn add(&mut self, data: TableData) -> ObjectId {
-        *self.objects.entry(data).or_insert_with(ObjectId::next)
-    }
-}
-
 /// A graph of subtables, starting at a single root.
 ///
 /// This type is used during compilation, to determine the final write order
 /// for the various subtables.
 //NOTE: we don't derive Debug because it's way too verbose to be useful
-#[cfg(feature = "tables")]
 pub struct Graph {
     /// the actual data for each table
     objects: BTreeMap<ObjectId, TableData>,
@@ -111,7 +57,6 @@ pub struct Graph {
 }
 
 #[derive(Debug)]
-#[cfg(feature = "tables")]
 struct Node {
     size: u32,
     distance: u64,
@@ -124,7 +69,6 @@ struct Node {
 
 /// Scored used when computing shortest distance
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg(feature = "tables")]
 struct Distance {
     // a space ranking; like rankings are packed together,
     // and larger rankings are packed after smaller ones.
@@ -136,12 +80,10 @@ struct Distance {
 
 //TODO: remove me? maybe? not really used right now...
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg(feature = "tables")]
 struct Priority(u8);
 
 /// A record of an overflowing offset
 #[derive(Clone, Debug)]
-#[cfg(feature = "tables")]
 pub(crate) struct Overflow {
     parent: ObjectId,
     child: ObjectId,
@@ -149,7 +91,6 @@ pub(crate) struct Overflow {
     offset_type: OffsetLen,
 }
 
-#[cfg(feature = "tables")]
 impl Priority {
     const ZERO: Priority = Priority(0);
     const ONE: Priority = Priority(1);
@@ -164,7 +105,6 @@ impl Priority {
     }
 }
 
-#[cfg(feature = "tables")]
 impl Distance {
     const ROOT: Distance = Distance {
         space: Space::SHORT_REACHABLE,
@@ -177,7 +117,6 @@ impl Distance {
     }
 }
 
-#[cfg(feature = "tables")]
 impl Node {
     pub fn new(size: u32) -> Self {
         Node {
@@ -215,7 +154,6 @@ impl Node {
     }
 }
 
-#[cfg(feature = "tables")]
 impl Graph {
     pub(crate) fn from_obj_store(store: ObjectStore, root: ObjectId) -> Self {
         let objects = store.objects.into_iter().map(|(k, v)| (v, k)).collect();
@@ -315,7 +253,6 @@ impl Graph {
     /// returns `true` if a solution is found, `false` otherwise
     ///
     /// [repacker docs]: https://github.com/harfbuzz/harfbuzz/blob/main/docs/repacker.md
-    #[cfg(feature = "tables")]
     pub(crate) fn pack_objects(&mut self) -> bool {
         if self.basic_sort() {
             return true;
@@ -886,7 +823,6 @@ impl Graph {
         self.next_space
     }
 
-    #[cfg(feature = "tables")]
     fn try_promoting_subtables(&mut self) {
         let Some((can_promote, parent_id)) = self.get_promotable_subtables() else {
             return;
@@ -900,7 +836,6 @@ impl Graph {
         self.actually_promote_subtables(&to_promote);
     }
 
-    #[cfg(feature = "tables")]
     fn actually_promote_subtables(&mut self, to_promote: &[ObjectId]) {
         fn make_extension(type_: LookupType, subtable_id: ObjectId) -> TableData {
             const EXT_FORMAT: u16 = 1;
@@ -951,7 +886,6 @@ impl Graph {
     }
 
     // get the list of tables that can be promoted, as well as the id of their parent table
-    #[cfg(feature = "tables")]
     fn get_promotable_subtables(&self) -> Option<(Vec<ObjectId>, ObjectId)> {
         let can_promote = self
             .objects
@@ -1081,7 +1015,6 @@ impl Graph {
     /// Based on [`_presplit_subtables_if_needed`][presplit] in hb-repacker
     ///
     /// [presplit]: https://github.com/harfbuzz/harfbuzz/blob/5d543d64222c6ce45332d0c188790f90691ef112/src/hb-repacker.hh#LL72C22-L72C22
-    #[cfg(feature = "tables")]
     fn try_splitting_subtables(&mut self) {
         let splittable = self
             .objects
@@ -1096,7 +1029,6 @@ impl Graph {
         }
     }
 
-    #[cfg(feature = "tables")]
     fn split_subtables_if_needed(&mut self, lookup: ObjectId) {
         // So You Want to Split Subtables:
         // - support PairPos and MarkBase.
@@ -1223,7 +1155,6 @@ impl Graph {
     }
 }
 
-#[cfg(feature = "tables")]
 impl Default for Priority {
     fn default() -> Self {
         Priority::ZERO

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -17,8 +17,10 @@ use read_fonts::tables::{
     layout as rlayout,
 };
 
-use super::{Graph, ObjectId};
-use crate::{tables::layout as wlayout, write::TableData, FontWrite, TableWriter};
+use super::Graph;
+use crate::{
+    object::ObjectId, tables::layout as wlayout, write::TableData, FontWrite, TableWriter,
+};
 
 mod mark2base;
 mod pairpos;

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -142,15 +142,19 @@ pub mod error;
 mod font_builder;
 #[cfg(feature = "tables")]
 pub mod from_obj;
+#[cfg(feature = "tables")]
 mod graph;
+mod object;
 mod offsets;
 #[cfg(feature = "tables")]
 pub mod ps;
 #[cfg(feature = "tables")]
 mod round;
+mod search_range;
 mod table_type;
 #[cfg(feature = "tables")]
 pub mod tables;
+#[cfg(feature = "tables")]
 mod util;
 #[cfg(feature = "tables")]
 pub mod validate;
@@ -164,7 +168,7 @@ mod codegen_test;
 mod hex_diff;
 
 #[cfg(feature = "tables")]
-pub use font_builder::BuilderError;
+pub use error::BuilderError;
 pub use font_builder::FontBuilder;
 #[cfg(feature = "tables")]
 pub use offsets::{NullableOffsetMarker, OffsetMarker};

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -137,17 +137,25 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod collections;
+#[cfg(feature = "tables")]
 pub mod error;
 mod font_builder;
+#[cfg(feature = "tables")]
 pub mod from_obj;
 mod graph;
 mod offsets;
+#[cfg(feature = "tables")]
 pub mod ps;
+#[cfg(feature = "tables")]
 mod round;
 mod table_type;
+#[cfg(feature = "tables")]
 pub mod tables;
 mod util;
+#[cfg(feature = "tables")]
 pub mod validate;
+#[cfg(not(feature = "tables"))]
+mod validate;
 mod write;
 
 #[cfg(test)]
@@ -155,10 +163,19 @@ mod codegen_test;
 #[cfg(test)]
 mod hex_diff;
 
-pub use font_builder::{BuilderError, FontBuilder};
+#[cfg(feature = "tables")]
+pub use font_builder::BuilderError;
+pub use font_builder::FontBuilder;
+#[cfg(feature = "tables")]
 pub use offsets::{NullableOffsetMarker, OffsetMarker};
+#[cfg(feature = "tables")]
 pub use round::OtRound;
-pub use write::{dump_table, FontWrite, TableWriter};
+#[cfg(feature = "tables")]
+pub use write::dump_table;
+#[cfg(feature = "tables")]
+pub use write::FontWrite;
+#[cfg(feature = "tables")]
+pub use write::TableWriter;
 
 /// Rexport of the common font types
 pub extern crate font_types as types;
@@ -171,6 +188,7 @@ pub extern crate read_fonts as read;
 pub(crate) mod codegen_prelude {
     use std::num::TryFromIntError;
 
+    #[cfg(feature = "tables")]
     pub use super::from_obj::{FromObjRef, FromTableRef, ToOwnedObj, ToOwnedTable};
     pub use super::offsets::{NullableOffsetMarker, OffsetMarker, WIDTH_16, WIDTH_24, WIDTH_32};
     pub use super::table_type::TableType;
@@ -188,6 +206,7 @@ pub(crate) mod codegen_prelude {
         s.len()
     }
 
+    #[cfg(feature = "tables")]
     pub fn plus_one(val: &usize) -> usize {
         val.saturating_add(1)
     }

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -162,9 +162,9 @@ pub mod validate;
 mod validate;
 mod write;
 
-#[cfg(test)]
+#[cfg(all(feature = "tables", test))]
 mod codegen_test;
-#[cfg(test)]
+#[cfg(all(feature = "tables", test))]
 mod hex_diff;
 
 #[cfg(feature = "tables")]
@@ -194,6 +194,7 @@ pub(crate) mod codegen_prelude {
 
     #[cfg(feature = "tables")]
     pub use super::from_obj::{FromObjRef, FromTableRef, ToOwnedObj, ToOwnedTable};
+    #[allow(dead_code)]
     pub use super::offsets::{NullableOffsetMarker, OffsetMarker, WIDTH_16, WIDTH_24, WIDTH_32};
     pub use super::table_type::TableType;
     pub use super::validate::{Validate, ValidationCtx};

--- a/write-fonts/src/object.rs
+++ b/write-fonts/src/object.rs
@@ -1,0 +1,26 @@
+use std::{collections::HashMap, sync::atomic::AtomicU64};
+
+use crate::write::TableData;
+
+static OBJECT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// An identifier for an object in the compilation graph.
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, Hash, PartialEq, Eq)]
+pub struct ObjectId(pub(crate) u64);
+
+impl ObjectId {
+    pub fn next() -> Self {
+        ObjectId(OBJECT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ObjectStore {
+    pub(crate) objects: HashMap<TableData, ObjectId>,
+}
+
+impl ObjectStore {
+    pub(crate) fn add(&mut self, data: TableData) -> ObjectId {
+        *self.objects.entry(data).or_insert_with(ObjectId::next)
+    }
+}

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -7,6 +7,7 @@ pub const WIDTH_16: usize = 2;
 /// The width in bytes of an Offset24
 pub const WIDTH_24: usize = 3;
 /// The width in bytes of an Offset32
+#[allow(dead_code)]
 pub const WIDTH_32: usize = 4;
 
 /// An offset subtable.
@@ -67,7 +68,7 @@ impl<T, const N: usize> AsMut<T> for OffsetMarker<T, N> {
 
 // NOTE: we don't impl AsRef/AsMut for NullableOffsetMarker, since it is less
 // useful than the Option::as_ref and Option::as_mut methods available through deref
-
+#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl<const N: usize, T> OffsetMarker<T, N> {
     /// Create a new marker.
     pub fn new(obj: T) -> Self {
@@ -85,6 +86,7 @@ impl<const N: usize, T> OffsetMarker<T, N> {
     }
 }
 
+#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl<const N: usize, T> NullableOffsetMarker<T, N> {
     /// Create a new marker.
     pub fn new(obj: Option<T>) -> Self {

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -10,6 +10,36 @@ pub const WIDTH_24: usize = 3;
 #[allow(dead_code)]
 pub const WIDTH_32: usize = 4;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum OffsetLen {
+    Offset16 = 2,
+    Offset24 = 3,
+    Offset32 = 4,
+}
+
+impl OffsetLen {
+    /// The maximum value for an offset of this length.
+    #[cfg(feature = "tables")]
+    pub const fn max_value(self) -> u32 {
+        match self {
+            Self::Offset16 => u16::MAX as u32,
+            Self::Offset24 => (1 << 24) - 1,
+            Self::Offset32 => u32::MAX,
+        }
+    }
+}
+
+impl std::fmt::Display for OffsetLen {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Offset16 => write!(f, "Offset16"),
+            Self::Offset24 => write!(f, "Offset24"),
+            Self::Offset32 => write!(f, "Offset32"),
+        }
+    }
+}
+
 /// An offset subtable.
 ///
 /// The generic const `N` is the width of the offset, in bytes.

--- a/write-fonts/src/offsets.rs
+++ b/write-fonts/src/offsets.rs
@@ -98,7 +98,6 @@ impl<T, const N: usize> AsMut<T> for OffsetMarker<T, N> {
 
 // NOTE: we don't impl AsRef/AsMut for NullableOffsetMarker, since it is less
 // useful than the Option::as_ref and Option::as_mut methods available through deref
-#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl<const N: usize, T> OffsetMarker<T, N> {
     /// Create a new marker.
     pub fn new(obj: T) -> Self {
@@ -106,17 +105,18 @@ impl<const N: usize, T> OffsetMarker<T, N> {
     }
 
     /// Set the contents of the marker, replacing any existing contents.
+    #[cfg(feature = "tables")]
     pub fn set(&mut self, obj: impl Into<T>) {
         self.obj = Box::new(obj.into());
     }
 
     /// Convert into the inner type
+    #[cfg(feature = "tables")]
     pub fn into_inner(self) -> T {
         *self.obj
     }
 }
 
-#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl<const N: usize, T> NullableOffsetMarker<T, N> {
     /// Create a new marker.
     pub fn new(obj: Option<T>) -> Self {
@@ -131,16 +131,19 @@ impl<const N: usize, T> NullableOffsetMarker<T, N> {
     /// [`clear`] method.
     ///
     /// [`clear`]: Self::clear
+    #[cfg(feature = "tables")]
     pub fn set(&mut self, obj: impl Into<T>) {
         self.obj = Some(Box::new(obj.into()))
     }
 
     /// Clear the contents of the marker.
+    #[cfg(feature = "tables")]
     pub fn clear(&mut self) {
         self.obj = None;
     }
 
     /// Convert into the inner type
+    #[cfg(feature = "tables")]
     pub fn into_inner(self) -> Option<T> {
         self.obj.map(|b| *b)
     }
@@ -152,6 +155,7 @@ impl<const N: usize, T> NullableOffsetMarker<T, N> {
         }
     }
 
+    #[cfg(feature = "tables")]
     pub fn as_mut(&mut self) -> Option<&mut T> {
         match &mut self.obj {
             Some(obj) => Some(&mut *obj),

--- a/write-fonts/src/search_range.rs
+++ b/write-fonts/src/search_range.rs
@@ -1,0 +1,55 @@
+/// Search range values used in various tables
+#[derive(Clone, Copy, Debug)]
+pub struct SearchRange {
+    pub search_range: u16,
+    pub entry_selector: u16,
+    pub range_shift: u16,
+}
+
+impl SearchRange {
+    //https://github.com/fonttools/fonttools/blob/729b3d2960ef/Lib/fontTools/ttLib/ttFont.py#L1147
+    /// calculate searchRange, entrySelector, and rangeShift
+    ///
+    /// these values are used in various places, such as [the base table directory]
+    /// and [cmap format 4].
+    ///
+    /// [the base table directory]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
+    /// [cmap format 4]: https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values
+    pub fn compute(n_items: usize, item_size: usize) -> Self {
+        let entry_selector = (n_items as f64).log2().floor() as usize;
+        let search_range = (2.0_f64.powi(entry_selector as i32) * item_size as f64) as usize;
+        // The result doesn't really make sense with 0 tables but ... let's at least not fail
+        let range_shift = (n_items * item_size).saturating_sub(search_range);
+        SearchRange {
+            search_range: search_range.try_into().unwrap(),
+            entry_selector: entry_selector.try_into().unwrap(),
+            range_shift: range_shift.try_into().unwrap(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// based on example at
+    /// <https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values>
+    #[test]
+    fn simple_search_range() {
+        let SearchRange {
+            search_range,
+            entry_selector,
+            range_shift,
+        } = SearchRange::compute(39, 2);
+        assert_eq!((search_range, entry_selector, range_shift), (64, 5, 14));
+    }
+
+    #[test]
+    fn search_range_no_crashy() {
+        let foo = SearchRange::compute(0, 0);
+        assert_eq!(
+            (foo.search_range, foo.entry_selector, foo.range_shift),
+            (0, 0, 0)
+        )
+    }
+}

--- a/write-fonts/src/table_type.rs
+++ b/write-fonts/src/table_type.rs
@@ -112,7 +112,7 @@ impl Display for TableType {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "tables"))]
 mod tests {
     use crate::tables::{
         gpos, gsub,

--- a/write-fonts/src/table_type.rs
+++ b/write-fonts/src/table_type.rs
@@ -7,6 +7,7 @@ use std::fmt::Display;
 
 use font_types::Tag;
 
+#[cfg(feature = "tables")]
 use crate::tables::layout::LookupType;
 
 /// A marker for identifying the original source of various compiled tables.
@@ -15,6 +16,7 @@ use crate::tables::layout::LookupType;
 /// what the bytes represent; however in certain special cases we do need this
 /// information, in order to try alternate compilation strategies.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 #[non_exhaustive]
 pub enum TableType {
     /// An unknown table
@@ -35,7 +37,10 @@ impl TableType {
     pub(crate) fn is_mock(&self) -> bool {
         *self == TableType::MockTable
     }
+}
 
+#[cfg(feature = "tables")]
+impl TableType {
     pub(crate) fn is_promotable(self) -> bool {
         match self {
             TableType::GposLookup(type_) => type_ != LookupType::GPOS_EXT_TYPE,
@@ -61,6 +66,7 @@ impl TableType {
     }
 }
 
+#[cfg(feature = "tables")]
 impl From<LookupType> for TableType {
     fn from(src: LookupType) -> TableType {
         match src {

--- a/write-fonts/src/tables/cmap.rs
+++ b/write-fonts/src/tables/cmap.rs
@@ -6,7 +6,7 @@ include!("../../generated/generated_cmap.rs");
 
 use std::collections::HashMap;
 
-use crate::util::SearchRange;
+use crate::search_range::SearchRange;
 
 // https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#windows-platform-platform-id--3
 const WINDOWS_BMP_ENCODING: u16 = 1;

--- a/write-fonts/src/util.rs
+++ b/write-fonts/src/util.rs
@@ -3,8 +3,10 @@
 /// Iterator that iterates over a vector of iterators simultaneously.
 ///
 /// Adapted from <https://stackoverflow.com/a/55292215>
+#[cfg(feature = "tables")]
 pub struct MultiZip<I: Iterator>(Vec<I>);
 
+#[cfg(feature = "tables")]
 impl<I: Iterator> MultiZip<I> {
     /// Create a new MultiZip from a vector of iterators
     pub fn new(vec_of_iters: Vec<I>) -> Self {
@@ -12,6 +14,7 @@ impl<I: Iterator> MultiZip<I> {
     }
 }
 
+#[cfg(feature = "tables")]
 impl<I: Iterator> Iterator for MultiZip<I> {
     type Item = Vec<I::Item>;
 
@@ -24,11 +27,13 @@ impl<I: Iterator> Iterator for MultiZip<I> {
 ///
 /// This is particularly useful when porting from Python where reading
 /// idx - 1, with -1 meaning last, is common.
+#[cfg(feature = "tables")]
 pub trait WrappingGet<T> {
     fn wrapping_next(&self, idx: usize) -> &T;
     fn wrapping_prev(&self, idx: usize) -> &T;
 }
 
+#[cfg(feature = "tables")]
 impl<T> WrappingGet<T> for &[T] {
     fn wrapping_next(&self, idx: usize) -> &T {
         &self[match idx {
@@ -53,20 +58,22 @@ impl<T> WrappingGet<T> for &[T] {
 /// - [PEP425](https://peps.python.org/pep-0485/)
 /// - [math.isclose](https://docs.python.org/3/library/math.html#math.isclose)
 #[derive(Clone, Copy, Debug)]
+#[cfg(feature = "tables")]
 pub struct FloatComparator {
     // TODO: Make it generic over T: Float? Need to add num-traits as a dependency
     rel_tol: f64,
     abs_tol: f64,
 }
 
+#[cfg(feature = "tables")]
 impl FloatComparator {
     /// Create a new FloatComparator with the specified relative and absolute tolerances.
     pub fn new(rel_tol: f64, abs_tol: f64) -> Self {
         Self { rel_tol, abs_tol }
     }
 
-    #[inline]
     /// Return true if a and b are close according to the specified tolerances.
+    #[inline]
     pub fn isclose(self, a: f64, b: f64) -> bool {
         if a == b {
             return true;
@@ -85,6 +92,7 @@ impl FloatComparator {
     }
 }
 
+#[cfg(feature = "tables")]
 impl Default for FloatComparator {
     /// Create a new FloatComparator with `rel_to=1e-9` and `abs_tol=0.0`.
     fn default() -> Self {
@@ -97,6 +105,7 @@ impl Default for FloatComparator {
 ///
 /// To use different relative or absolute tolerances, create a FloatComparator
 /// and use its `isclose` method.
+#[cfg(feature = "tables")]
 pub fn isclose(a: f64, b: f64) -> bool {
     FloatComparator::default().isclose(a, b)
 }

--- a/write-fonts/src/util.rs
+++ b/write-fonts/src/util.rs
@@ -3,10 +3,8 @@
 /// Iterator that iterates over a vector of iterators simultaneously.
 ///
 /// Adapted from <https://stackoverflow.com/a/55292215>
-#[cfg(feature = "tables")]
 pub struct MultiZip<I: Iterator>(Vec<I>);
 
-#[cfg(feature = "tables")]
 impl<I: Iterator> MultiZip<I> {
     /// Create a new MultiZip from a vector of iterators
     pub fn new(vec_of_iters: Vec<I>) -> Self {
@@ -14,7 +12,6 @@ impl<I: Iterator> MultiZip<I> {
     }
 }
 
-#[cfg(feature = "tables")]
 impl<I: Iterator> Iterator for MultiZip<I> {
     type Item = Vec<I::Item>;
 
@@ -27,13 +24,11 @@ impl<I: Iterator> Iterator for MultiZip<I> {
 ///
 /// This is particularly useful when porting from Python where reading
 /// idx - 1, with -1 meaning last, is common.
-#[cfg(feature = "tables")]
 pub trait WrappingGet<T> {
     fn wrapping_next(&self, idx: usize) -> &T;
     fn wrapping_prev(&self, idx: usize) -> &T;
 }
 
-#[cfg(feature = "tables")]
 impl<T> WrappingGet<T> for &[T] {
     fn wrapping_next(&self, idx: usize) -> &T {
         &self[match idx {
@@ -58,14 +53,12 @@ impl<T> WrappingGet<T> for &[T] {
 /// - [PEP425](https://peps.python.org/pep-0485/)
 /// - [math.isclose](https://docs.python.org/3/library/math.html#math.isclose)
 #[derive(Clone, Copy, Debug)]
-#[cfg(feature = "tables")]
 pub struct FloatComparator {
     // TODO: Make it generic over T: Float? Need to add num-traits as a dependency
     rel_tol: f64,
     abs_tol: f64,
 }
 
-#[cfg(feature = "tables")]
 impl FloatComparator {
     /// Create a new FloatComparator with the specified relative and absolute tolerances.
     pub fn new(rel_tol: f64, abs_tol: f64) -> Self {
@@ -92,7 +85,6 @@ impl FloatComparator {
     }
 }
 
-#[cfg(feature = "tables")]
 impl Default for FloatComparator {
     /// Create a new FloatComparator with `rel_to=1e-9` and `abs_tol=0.0`.
     fn default() -> Self {
@@ -105,63 +97,6 @@ impl Default for FloatComparator {
 ///
 /// To use different relative or absolute tolerances, create a FloatComparator
 /// and use its `isclose` method.
-#[cfg(feature = "tables")]
 pub fn isclose(a: f64, b: f64) -> bool {
     FloatComparator::default().isclose(a, b)
-}
-
-/// Search range values used in various tables
-#[derive(Clone, Copy, Debug)]
-pub struct SearchRange {
-    pub search_range: u16,
-    pub entry_selector: u16,
-    pub range_shift: u16,
-}
-
-impl SearchRange {
-    //https://github.com/fonttools/fonttools/blob/729b3d2960ef/Lib/fontTools/ttLib/ttFont.py#L1147
-    /// calculate searchRange, entrySelector, and rangeShift
-    ///
-    /// these values are used in various places, such as [the base table directory]
-    /// and [cmap format 4].
-    ///
-    /// [the base table directory]: https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory
-    /// [cmap format 4]: https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values
-    pub fn compute(n_items: usize, item_size: usize) -> Self {
-        let entry_selector = (n_items as f64).log2().floor() as usize;
-        let search_range = (2.0_f64.powi(entry_selector as i32) * item_size as f64) as usize;
-        // The result doesn't really make sense with 0 tables but ... let's at least not fail
-        let range_shift = (n_items * item_size).saturating_sub(search_range);
-        SearchRange {
-            search_range: search_range.try_into().unwrap(),
-            entry_selector: entry_selector.try_into().unwrap(),
-            range_shift: range_shift.try_into().unwrap(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// based on example at
-    /// <https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values>
-    #[test]
-    fn simple_search_range() {
-        let SearchRange {
-            search_range,
-            entry_selector,
-            range_shift,
-        } = SearchRange::compute(39, 2);
-        assert_eq!((search_range, entry_selector, range_shift), (64, 5, 14));
-    }
-
-    #[test]
-    fn search_range_no_crashy() {
-        let foo = SearchRange::compute(0, 0);
-        assert_eq!(
-            (foo.search_range, foo.entry_selector, foo.range_shift),
-            (0, 0, 0)
-        )
-    }
 }

--- a/write-fonts/src/validate.rs
+++ b/write-fonts/src/validate.rs
@@ -14,6 +14,7 @@ use crate::offsets::{NullableOffsetMarker, OffsetMarker};
 /// tables that are awkward to encode in the type system, such as requiring
 /// certain arrays to have equal lengths. These requirements are enforced
 /// via a validation pass.
+#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 pub trait Validate {
     /// Ensure that this table is well-formed, reporting any errors.
     ///

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeSet;
 use crate::error::{Error, PackingError};
 #[cfg(feature = "tables")]
 use crate::graph::Graph;
-use crate::graph::{ObjectId, ObjectStore, OffsetLen};
+use crate::object::{ObjectId, ObjectStore};
+use crate::offsets::OffsetLen;
 use crate::table_type::TableType;
 #[cfg(feature = "tables")]
 use crate::validate::Validate;

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -9,7 +9,9 @@ use crate::offsets::OffsetLen;
 use crate::table_type::TableType;
 #[cfg(feature = "tables")]
 use crate::validate::Validate;
+#[cfg(feature = "tables")]
 use font_types::{FixedSize, Scalar};
+#[cfg(feature = "tables")]
 use read_fonts::{FontData, FontRead, FontReadWithArgs, ReadError};
 
 /// A type that that can be written out as part of a font file.
@@ -68,7 +70,6 @@ pub fn dump_table<T: FontWrite + Validate>(table: &T) -> Result<Vec<u8>, Error> 
     Ok(graph.serialize())
 }
 
-#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl TableWriter {
     /// A convenience method for generating a graph with the provided root object.
     #[cfg(feature = "tables")]
@@ -87,6 +88,7 @@ impl TableWriter {
     }
 
     /// Call the provided closure, adjusting any written offsets by `adjustment`.
+    #[cfg(feature = "tables")]
     pub(crate) fn adjust_offsets(&mut self, adjustment: u32, f: impl FnOnce(&mut TableWriter)) {
         self.offset_adjustment = adjustment;
         f(self);
@@ -121,6 +123,7 @@ impl TableWriter {
     ///
     /// This is necessary for things like the glyph table, which require offsets
     /// to be aligned on 2-byte boundaries.
+    #[cfg(feature = "tables")]
     pub fn pad_to_2byte_aligned(&mut self) {
         if self.stack.last().unwrap().bytes.len() % 2 != 0 {
             self.write_slice(&[0]);
@@ -139,6 +142,7 @@ impl TableWriter {
     ///
     /// This is currently only used to figure out the glyph positions when
     /// compiling the glyf table.
+    #[cfg(feature = "tables")]
     pub(crate) fn current_data(&self) -> &TableData {
         self.stack.last().unwrap() // there is always at least one
     }
@@ -194,8 +198,8 @@ pub(crate) struct OffsetRecord {
     pub(crate) adjustment: u32,
 }
 
-#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl TableData {
+    #[cfg(feature = "tables")]
     pub(crate) fn new(type_: TableType) -> Self {
         TableData {
             type_,
@@ -224,6 +228,7 @@ impl TableData {
         self.write_bytes(placeholder);
     }
 
+    #[cfg(feature = "tables")]
     pub(crate) fn write<T: Scalar>(&mut self, value: T) {
         self.write_bytes(value.to_raw().as_ref())
     }
@@ -232,6 +237,7 @@ impl TableData {
     ///
     /// Only used in very special cases. The caller is responsible for knowing
     /// what they are doing.
+    #[cfg(feature = "tables")]
     pub(crate) fn write_over<T: Scalar>(&mut self, value: T, pos: usize) {
         let raw = value.to_raw();
         let len = raw.as_ref().len();
@@ -246,12 +252,14 @@ impl TableData {
     ///
     /// Used internally when modifying the graph after initial compilation,
     /// such as during table splitting.
+    #[cfg(feature = "tables")]
     pub(crate) fn reparse<'a, T: FontRead<'a>>(&'a self) -> Result<T, ReadError> {
         let data = FontData::new(&self.bytes);
         T::read(data)
     }
 
     // see above
+    #[cfg(feature = "tables")]
     pub(crate) fn reparse_with_args<'a, A, T: FontReadWithArgs<'a, Args = A>>(
         &'a self,
         args: &A,
@@ -261,12 +269,13 @@ impl TableData {
     }
 
     /// A helper function to read a value out of this data.
+    #[cfg(feature = "tables")]
     pub(crate) fn read_at<T: Scalar>(&self, pos: usize) -> Option<T> {
         let len = T::RAW_BYTE_LEN;
         self.bytes.get(pos..pos + len).and_then(T::read)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "tables"))]
     pub fn make_mock(size: usize) -> Self {
         TableData {
             bytes: vec![0xca; size], // has no special meaning
@@ -275,7 +284,7 @@ impl TableData {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "tables"))]
     pub fn add_mock_offset(&mut self, object: ObjectId, len: OffsetLen) {
         let pos = self.offsets.iter().map(|off| off.len as u8 as u32).sum();
         self.offsets.push(OffsetRecord {

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -1,8 +1,12 @@
 use std::collections::BTreeSet;
 
+#[cfg(feature = "tables")]
 use crate::error::{Error, PackingError};
-use crate::graph::{Graph, ObjectId, ObjectStore, OffsetLen};
+#[cfg(feature = "tables")]
+use crate::graph::Graph;
+use crate::graph::{ObjectId, ObjectStore, OffsetLen};
 use crate::table_type::TableType;
+#[cfg(feature = "tables")]
 use crate::validate::Validate;
 use font_types::{FixedSize, Scalar};
 use read_fonts::{FontData, FontRead, FontReadWithArgs, ReadError};
@@ -49,6 +53,7 @@ pub struct TableWriter {
 ///
 /// Returns an error if the table is malformed or cannot otherwise be serialized,
 /// otherwise it will return the bytes encoding the table.
+#[cfg(feature = "tables")]
 pub fn dump_table<T: FontWrite + Validate>(table: &T) -> Result<Vec<u8>, Error> {
     log::trace!("writing table '{}'", table.table_type());
     table.validate()?;
@@ -62,8 +67,10 @@ pub fn dump_table<T: FontWrite + Validate>(table: &T) -> Result<Vec<u8>, Error> 
     Ok(graph.serialize())
 }
 
+#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl TableWriter {
     /// A convenience method for generating a graph with the provided root object.
+    #[cfg(feature = "tables")]
     pub(crate) fn make_graph(root: &impl FontWrite) -> Graph {
         let mut writer = TableWriter::default();
         let root_id = writer.add_table(root);
@@ -186,6 +193,7 @@ pub(crate) struct OffsetRecord {
     pub(crate) adjustment: u32,
 }
 
+#[cfg_attr(not(feature = "tables"), allow(dead_code))]
 impl TableData {
     pub(crate) fn new(type_: TableType) -> Self {
         TableData {


### PR DESCRIPTION
# Motivation

Chromium doesn't want to include `kurbo` and its transitive dependencies, especially since they are not used in skera and incremental-font-transfer. This change removes some of the dependency while also improving compile times for skera only use cases.

# Changes

Without the crates feature:

- Most of the codegen goes away. Skera CLI compile time goes from `~18s` to `~16s`
  - The `write-fonts` portion goes from `~10s` to `~1s`
- Can still use the bytes based API
- Removes kurbo and indexmap dependencies

# Before

<img width="1124" height="1151" alt="image" src="https://github.com/user-attachments/assets/588881d8-f559-4f1b-9c73-511bee9416bf" />


# After

<img width="953" height="980" alt="image" src="https://github.com/user-attachments/assets/2b6f8e67-718e-4f56-8309-448540645eda" />

