### PR TITLE
[codegen] Rework how we handle tables with generic fields

### DIFF
--- a/font-codegen/src/generic_group.rs
+++ b/font-codegen/src/generic_group.rs
@@ -9,7 +9,6 @@ pub(crate) fn generate(item: &GenericGroup) -> syn::Result<TokenStream> {
     let docs = &item.attrs.docs;
     let name = &item.name;
     let inner = &item.inner_type;
-    let type_field = &item.inner_field;
 
     let mut variant_decls = Vec::new();
     let mut read_match_arms = Vec::new();
@@ -21,7 +20,7 @@ pub(crate) fn generate(item: &GenericGroup) -> syn::Result<TokenStream> {
         let typ = &var.typ;
         variant_decls.push(quote! { #var_name ( #inner <'a, #typ<'a>> ) });
         read_match_arms
-            .push(quote! { #type_id => Ok(#name :: #var_name (untyped.into_concrete())) });
+            .push(quote! { #type_id => Ok(#name :: #var_name (FontRead::read(bytes)?)) });
         dyn_inner_arms.push(quote! { #name :: #var_name(table) => table });
         of_unit_arms.push(quote! { #name :: #var_name(inner) => inner.of_unit_type()  });
     }
@@ -40,8 +39,8 @@ pub(crate) fn generate(item: &GenericGroup) -> syn::Result<TokenStream> {
 
         impl<'a> FontRead<'a> for #name <'a> {
             fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
-                let untyped = #inner::read(bytes)?;
-                match untyped.#type_field() {
+                let discriminant = #inner::read_discriminant(bytes)?;
+                match discriminant {
                     #( #read_match_arms, )*
                     other => Err(ReadError::InvalidFormat(other.into())),
                 }

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -89,8 +89,6 @@ pub(crate) struct GenericGroup {
     pub(crate) name: syn::Ident,
     /// the inner type, which must accept a generic parameter
     pub(crate) inner_type: syn::Ident,
-    /// The field on the inner type that determines the type of the generic param
-    pub(crate) inner_field: syn::Ident,
     pub(crate) variants: Vec<GroupVariant>,
 }
 
@@ -375,9 +373,6 @@ impl Parse for GenericGroup {
         let content;
         let _ = parenthesized!(content in input);
         let inner_type = content.parse()?;
-        content.parse::<Token![,]>()?;
-        content.parse::<Token![$]>()?;
-        let inner_field = content.parse()?;
         let content;
         let _ = braced!(content in input);
         let variants = Punctuated::<GroupVariant, Token![,]>::parse_terminated(&content)?
@@ -387,7 +382,6 @@ impl Parse for GenericGroup {
             attrs,
             name,
             inner_type,
-            inner_field,
             variants,
         })
     }

--- a/font-codegen/src/parsing/attrs.rs
+++ b/font-codegen/src/parsing/attrs.rs
@@ -93,6 +93,8 @@ pub(crate) struct FieldAttrs {
     pub(crate) to_owned: Option<Attr<InlineExpr>>,
     /// Custom validation behaviour
     pub(crate) validate: Option<Attr<FieldValidation>>,
+    /// Marks this field as the discriminant for a generic offset type.
+    pub(crate) discriminant: Option<syn::Path>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -276,6 +278,7 @@ static READ_OFFSET_WITH: &str = "read_offset_with";
 static TRAVERSE_WITH: &str = "traverse_with";
 static TO_OWNED: &str = "to_owned";
 static VALIDATE: &str = "validate";
+static DISCRIMINANT: &str = "discriminant";
 
 static MATCH_IF: &str = "match_if";
 static WRITE_FONTS_ONLY: &str = "write_fonts_only";
@@ -344,6 +347,8 @@ impl Parse for FieldAttrs {
                 this.traverse_with = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == FORMAT {
                 this.format = Some(Attr::new(ident.clone(), parse_attr_eq_value(&attr)?))
+            } else if ident == DISCRIMINANT {
+                this.discriminant = Some(attr.path().clone());
             } else {
                 return Err(logged_syn_error(
                     ident.span(),

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -31,22 +31,8 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
 
     let of_unit_docs = " Replace the specific generic type on this implementation with `()`";
 
-    // In the presence of a generic param we only impl FontRead for Name<()>,
-    // and then use into() to convert it to the concrete generic type.
-    let impl_into_generic = generic.as_ref().map(|t| {
+    let impl_of_unit_type = generic.as_ref().map(|t| {
         quote! {
-               impl<'a> #raw_name<'a, ()> {
-                   #[allow(dead_code)]
-                   pub(crate) fn into_concrete<T>(self) -> #raw_name<'a, #t> {
-                       #raw_name {
-                           data: self.data,
-                           offset_type: std::marker::PhantomData,
-                       }
-                   }
-               }
-
-               // we also generate a conversion from typed to untyped, which
-               // we use to write convenience methods on the wrapper
                impl<'a, #t> #raw_name<'a, #t> {
                    #[allow(dead_code)]
                    #[doc = #of_unit_docs]
@@ -88,7 +74,7 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
 
         #font_read
 
-        #impl_into_generic
+        #impl_of_unit_type
 
         #( #docs )*
         #[derive(Clone)]

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -2,9 +2,10 @@
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
+use syn::spanned::Spanned;
 
 use crate::{
-    parsing::{Attr, Field, Table, TableReadArg, TableReadArgs},
+    parsing::{logged_syn_error, Attr, Field, Table, TableReadArg, TableReadArgs},
     Phase,
 };
 
@@ -61,6 +62,7 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
 
     let table_ref_getters = item.iter_table_ref_getters();
     let optional_format_trait_impl = item.impl_format_trait();
+    let optional_discriminant_trait_impl = item.impl_discriminant_trait();
     let font_read = generate_font_read(item)?;
     let debug = generate_debug(item)?;
     let top_level = item.attrs.tag.as_ref().map(|tag| {
@@ -77,6 +79,8 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #optional_format_trait_impl
+
+        #optional_discriminant_trait_impl
 
         #optional_min_byte_range_trait_impl
 
@@ -305,6 +309,14 @@ fn generate_to_owned_impl(item: &Table, parse_module: &syn::Path) -> syn::Result
 
 impl Table {
     pub(crate) fn sanity_check(&self, phase: Phase) -> syn::Result<()> {
+        for fld in self.fields.iter() {
+            if fld.attrs.discriminant.is_some() && self.attrs.generic_offset.is_none() {
+                return Err(logged_syn_error(
+                    fld.attrs.discriminant.as_ref().unwrap().span(),
+                    "#[discriminant] is only valid in tables with #[generic_offset]",
+                ));
+            }
+        }
         self.fields.sanity_check(phase)
     }
 
@@ -399,6 +411,40 @@ impl Table {
                 fn min_table_bytes(&self) -> &'a [u8] {
                     let range = self.min_byte_range();
                     self.data.as_bytes().get(range).unwrap_or_default()
+                }
+            }
+        })
+    }
+
+    pub(crate) fn impl_discriminant_trait(&self) -> Option<TokenStream> {
+        let field = self
+            .fields
+            .iter()
+            .find(|fld| fld.attrs.discriminant.is_some())?;
+        let name = self.raw_name();
+
+        // Compute the static byte offset of the discriminant field by summing
+        // the known sizes of all preceding fields.
+        let offset_parts: Vec<_> = self
+            .fields
+            .iter()
+            .take_while(|fld| fld.name != field.name)
+            .map(|fld| {
+                fld.known_min_size_stmt()
+                    .expect("all fields before #[discriminant] must have a known size")
+            })
+            .filter(|tokens| !tokens.is_empty())
+            .collect();
+        let offset_expr = match offset_parts.as_slice() {
+            [] => quote!(0),
+            [one] => one.to_owned(),
+            more => quote!( (#(#more)+*) ),
+        };
+
+        Some(quote! {
+            impl Discriminant for #name<'_, ()> {
+                fn read_discriminant(data: FontData<'_>) -> Result<u16, ReadError> {
+                    data.read_at(#offset_expr)
                 }
             }
         })

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -3946,16 +3946,6 @@ impl<'a, T> FontRead<'a> for ExtensionPosFormat1<'a, T> {
     }
 }
 
-impl<'a> ExtensionPosFormat1<'a, ()> {
-    #[allow(dead_code)]
-    pub(crate) fn into_concrete<T>(self) -> ExtensionPosFormat1<'a, T> {
-        ExtensionPosFormat1 {
-            data: self.data,
-            offset_type: std::marker::PhantomData,
-        }
-    }
-}
-
 impl<'a, T> ExtensionPosFormat1<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -184,17 +184,17 @@ pub enum PositionLookup<'a> {
 
 impl<'a> FontRead<'a> for PositionLookup<'a> {
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
-        let untyped = Lookup::read(bytes)?;
-        match untyped.lookup_type() {
-            1 => Ok(PositionLookup::Single(untyped.into_concrete())),
-            2 => Ok(PositionLookup::Pair(untyped.into_concrete())),
-            3 => Ok(PositionLookup::Cursive(untyped.into_concrete())),
-            4 => Ok(PositionLookup::MarkToBase(untyped.into_concrete())),
-            5 => Ok(PositionLookup::MarkToLig(untyped.into_concrete())),
-            6 => Ok(PositionLookup::MarkToMark(untyped.into_concrete())),
-            7 => Ok(PositionLookup::Contextual(untyped.into_concrete())),
-            8 => Ok(PositionLookup::ChainContextual(untyped.into_concrete())),
-            9 => Ok(PositionLookup::Extension(untyped.into_concrete())),
+        let discriminant = Lookup::read_discriminant(bytes)?;
+        match discriminant {
+            1 => Ok(PositionLookup::Single(FontRead::read(bytes)?)),
+            2 => Ok(PositionLookup::Pair(FontRead::read(bytes)?)),
+            3 => Ok(PositionLookup::Cursive(FontRead::read(bytes)?)),
+            4 => Ok(PositionLookup::MarkToBase(FontRead::read(bytes)?)),
+            5 => Ok(PositionLookup::MarkToLig(FontRead::read(bytes)?)),
+            6 => Ok(PositionLookup::MarkToMark(FontRead::read(bytes)?)),
+            7 => Ok(PositionLookup::Contextual(FontRead::read(bytes)?)),
+            8 => Ok(PositionLookup::ChainContextual(FontRead::read(bytes)?)),
+            9 => Ok(PositionLookup::Extension(FontRead::read(bytes)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }
@@ -3917,6 +3917,12 @@ impl Format<u16> for ExtensionPosFormat1<'_> {
     const FORMAT: u16 = 1;
 }
 
+impl Discriminant for ExtensionPosFormat1<'_, ()> {
+    fn read_discriminant(data: FontData<'_>) -> Result<u16, ReadError> {
+        data.read_at(u16::RAW_BYTE_LEN)
+    }
+}
+
 impl<'a, T> MinByteRange<'a> for ExtensionPosFormat1<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.extension_offset_byte_range().end
@@ -4062,16 +4068,16 @@ pub enum ExtensionSubtable<'a> {
 
 impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
-        let untyped = ExtensionPosFormat1::read(bytes)?;
-        match untyped.extension_lookup_type() {
-            1 => Ok(ExtensionSubtable::Single(untyped.into_concrete())),
-            2 => Ok(ExtensionSubtable::Pair(untyped.into_concrete())),
-            3 => Ok(ExtensionSubtable::Cursive(untyped.into_concrete())),
-            4 => Ok(ExtensionSubtable::MarkToBase(untyped.into_concrete())),
-            5 => Ok(ExtensionSubtable::MarkToLig(untyped.into_concrete())),
-            6 => Ok(ExtensionSubtable::MarkToMark(untyped.into_concrete())),
-            7 => Ok(ExtensionSubtable::Contextual(untyped.into_concrete())),
-            8 => Ok(ExtensionSubtable::ChainContextual(untyped.into_concrete())),
+        let discriminant = ExtensionPosFormat1::read_discriminant(bytes)?;
+        match discriminant {
+            1 => Ok(ExtensionSubtable::Single(FontRead::read(bytes)?)),
+            2 => Ok(ExtensionSubtable::Pair(FontRead::read(bytes)?)),
+            3 => Ok(ExtensionSubtable::Cursive(FontRead::read(bytes)?)),
+            4 => Ok(ExtensionSubtable::MarkToBase(FontRead::read(bytes)?)),
+            5 => Ok(ExtensionSubtable::MarkToLig(FontRead::read(bytes)?)),
+            6 => Ok(ExtensionSubtable::MarkToMark(FontRead::read(bytes)?)),
+            7 => Ok(ExtensionSubtable::Contextual(FontRead::read(bytes)?)),
+            8 => Ok(ExtensionSubtable::ChainContextual(FontRead::read(bytes)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -1357,16 +1357,6 @@ impl<'a, T> FontRead<'a> for ExtensionSubstFormat1<'a, T> {
     }
 }
 
-impl<'a> ExtensionSubstFormat1<'a, ()> {
-    #[allow(dead_code)]
-    pub(crate) fn into_concrete<T>(self) -> ExtensionSubstFormat1<'a, T> {
-        ExtensionSubstFormat1 {
-            data: self.data,
-            offset_type: std::marker::PhantomData,
-        }
-    }
-}
-
 impl<'a, T> ExtensionSubstFormat1<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -184,16 +184,16 @@ pub enum SubstitutionLookup<'a> {
 
 impl<'a> FontRead<'a> for SubstitutionLookup<'a> {
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
-        let untyped = Lookup::read(bytes)?;
-        match untyped.lookup_type() {
-            1 => Ok(SubstitutionLookup::Single(untyped.into_concrete())),
-            2 => Ok(SubstitutionLookup::Multiple(untyped.into_concrete())),
-            3 => Ok(SubstitutionLookup::Alternate(untyped.into_concrete())),
-            4 => Ok(SubstitutionLookup::Ligature(untyped.into_concrete())),
-            5 => Ok(SubstitutionLookup::Contextual(untyped.into_concrete())),
-            6 => Ok(SubstitutionLookup::ChainContextual(untyped.into_concrete())),
-            7 => Ok(SubstitutionLookup::Extension(untyped.into_concrete())),
-            8 => Ok(SubstitutionLookup::Reverse(untyped.into_concrete())),
+        let discriminant = Lookup::read_discriminant(bytes)?;
+        match discriminant {
+            1 => Ok(SubstitutionLookup::Single(FontRead::read(bytes)?)),
+            2 => Ok(SubstitutionLookup::Multiple(FontRead::read(bytes)?)),
+            3 => Ok(SubstitutionLookup::Alternate(FontRead::read(bytes)?)),
+            4 => Ok(SubstitutionLookup::Ligature(FontRead::read(bytes)?)),
+            5 => Ok(SubstitutionLookup::Contextual(FontRead::read(bytes)?)),
+            6 => Ok(SubstitutionLookup::ChainContextual(FontRead::read(bytes)?)),
+            7 => Ok(SubstitutionLookup::Extension(FontRead::read(bytes)?)),
+            8 => Ok(SubstitutionLookup::Reverse(FontRead::read(bytes)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }
@@ -1328,6 +1328,12 @@ impl Format<u16> for ExtensionSubstFormat1<'_> {
     const FORMAT: u16 = 1;
 }
 
+impl Discriminant for ExtensionSubstFormat1<'_, ()> {
+    fn read_discriminant(data: FontData<'_>) -> Result<u16, ReadError> {
+        data.read_at(u16::RAW_BYTE_LEN)
+    }
+}
+
 impl<'a, T> MinByteRange<'a> for ExtensionSubstFormat1<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.extension_offset_byte_range().end
@@ -1472,15 +1478,15 @@ pub enum ExtensionSubtable<'a> {
 
 impl<'a> FontRead<'a> for ExtensionSubtable<'a> {
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
-        let untyped = ExtensionSubstFormat1::read(bytes)?;
-        match untyped.extension_lookup_type() {
-            1 => Ok(ExtensionSubtable::Single(untyped.into_concrete())),
-            2 => Ok(ExtensionSubtable::Multiple(untyped.into_concrete())),
-            3 => Ok(ExtensionSubtable::Alternate(untyped.into_concrete())),
-            4 => Ok(ExtensionSubtable::Ligature(untyped.into_concrete())),
-            5 => Ok(ExtensionSubtable::Contextual(untyped.into_concrete())),
-            6 => Ok(ExtensionSubtable::ChainContextual(untyped.into_concrete())),
-            8 => Ok(ExtensionSubtable::Reverse(untyped.into_concrete())),
+        let discriminant = ExtensionSubstFormat1::read_discriminant(bytes)?;
+        match discriminant {
+            1 => Ok(ExtensionSubtable::Single(FontRead::read(bytes)?)),
+            2 => Ok(ExtensionSubtable::Multiple(FontRead::read(bytes)?)),
+            3 => Ok(ExtensionSubtable::Alternate(FontRead::read(bytes)?)),
+            4 => Ok(ExtensionSubtable::Ligature(FontRead::read(bytes)?)),
+            5 => Ok(ExtensionSubtable::Contextual(FontRead::read(bytes)?)),
+            6 => Ok(ExtensionSubtable::ChainContextual(FontRead::read(bytes)?)),
+            8 => Ok(ExtensionSubtable::Reverse(FontRead::read(bytes)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -690,16 +690,6 @@ impl<'a, T> FontRead<'a> for LookupList<'a, T> {
     }
 }
 
-impl<'a> LookupList<'a, ()> {
-    #[allow(dead_code)]
-    pub(crate) fn into_concrete<T>(self) -> LookupList<'a, T> {
-        LookupList {
-            data: self.data,
-            offset_type: std::marker::PhantomData,
-        }
-    }
-}
-
 impl<'a, T> LookupList<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`
@@ -819,16 +809,6 @@ impl<'a, T> FontRead<'a> for Lookup<'a, T> {
             data,
             offset_type: std::marker::PhantomData,
         })
-    }
-}
-
-impl<'a> Lookup<'a, ()> {
-    #[allow(dead_code)]
-    pub(crate) fn into_concrete<T>(self) -> Lookup<'a, T> {
-        Lookup {
-            data: self.data,
-            offset_type: std::marker::PhantomData,
-        }
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -793,6 +793,12 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> std::fmt::Debug for LookupList<'a
     }
 }
 
+impl Discriminant for Lookup<'_, ()> {
+    fn read_discriminant(data: FontData<'_>) -> Result<u16, ReadError> {
+        data.read_at(0)
+    }
+}
+
 impl<'a, T> MinByteRange<'a> for Lookup<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.subtable_offsets_byte_range().end

--- a/read-fonts/generated/generated_test_generic_group.rs
+++ b/read-fonts/generated/generated_test_generic_group.rs
@@ -34,16 +34,6 @@ impl<'a, T> FontRead<'a> for MyLookup<'a, T> {
     }
 }
 
-impl<'a> MyLookup<'a, ()> {
-    #[allow(dead_code)]
-    pub(crate) fn into_concrete<T>(self) -> MyLookup<'a, T> {
-        MyLookup {
-            data: self.data,
-            offset_type: std::marker::PhantomData,
-        }
-    }
-}
-
 impl<'a, T> MyLookup<'a, T> {
     #[allow(dead_code)]
     /// Replace the specific generic type on this implementation with `()`

--- a/read-fonts/generated/generated_test_generic_group.rs
+++ b/read-fonts/generated/generated_test_generic_group.rs
@@ -5,6 +5,12 @@
 #[allow(unused_imports)]
 use crate::codegen_prelude::*;
 
+impl Discriminant for MyLookup<'_, ()> {
+    fn read_discriminant(data: FontData<'_>) -> Result<u16, ReadError> {
+        data.read_at(0)
+    }
+}
+
 impl<'a, T> MinByteRange<'a> for MyLookup<'a, T> {
     fn min_byte_range(&self) -> Range<usize> {
         0..self.subtable_offsets_byte_range().end
@@ -393,10 +399,10 @@ pub enum MyLookupGroup<'a> {
 
 impl<'a> FontRead<'a> for MyLookupGroup<'a> {
     fn read(bytes: FontData<'a>) -> Result<Self, ReadError> {
-        let untyped = MyLookup::read(bytes)?;
-        match untyped.lookup_type() {
-            1 => Ok(MyLookupGroup::TypeOne(untyped.into_concrete())),
-            2 => Ok(MyLookupGroup::TypeTwo(untyped.into_concrete())),
+        let discriminant = MyLookup::read_discriminant(bytes)?;
+        match discriminant {
+            1 => Ok(MyLookupGroup::TypeOne(FontRead::read(bytes)?)),
+            2 => Ok(MyLookupGroup::TypeTwo(FontRead::read(bytes)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -109,7 +109,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
     //pub(crate) use crate::read::sealed;
     pub use crate::read::{
-        ComputeSize, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
+        ComputeSize, Discriminant, FontRead, FontReadWithArgs, Format, ReadArgs, ReadError, VarSize,
     };
     pub use crate::table_provider::TopLevelTable;
     pub use crate::table_ref::MinByteRange;

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -67,6 +67,16 @@ pub trait Format<T> {
     const FORMAT: T;
 }
 
+/// A trait for tables that contain offsets to subtables of heterogeneous types.
+///
+/// The type of the subtable is determiend by an inline discriminant; this trait
+/// reads that discriminant.
+pub trait Discriminant {
+    /// Read the discriminant for this table.
+    // Currently these are always u16, we can switch to an associated type if needed
+    fn read_discriminant(data: FontData<'_>) -> Result<u16, ReadError>;
+}
+
 /// A type that can compute its size at runtime, based on some input.
 ///
 /// For types with a constant size, see [`FixedSize`] and

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -23,7 +23,7 @@ table Gpos {
 }
 
 /// A [GPOS Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#gsubLookupTypeEnum) subtable.
- group PositionLookup(Lookup, $lookup_type) {
+ group PositionLookup(Lookup) {
     1 => Single(SinglePos),
     2 => Pair(PairPos),
     3 => Cursive(CursivePosFormat1),
@@ -486,6 +486,7 @@ table ExtensionPosFormat1 {
     pos_format: u16,
     /// Lookup type of subtable referenced by extensionOffset (i.e. the
     /// extension subtable).
+    #[discriminant]
     extension_lookup_type: u16,
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
@@ -494,7 +495,7 @@ table ExtensionPosFormat1 {
 }
 
 /// A [GPOS Extension Positioning](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning) subtable
- group ExtensionSubtable(ExtensionPosFormat1, $extension_lookup_type) {
+ group ExtensionSubtable(ExtensionPosFormat1) {
     1 => Single(SinglePos),
     2 => Pair(PairPos),
     3 => Cursive(CursivePosFormat1),

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -22,7 +22,7 @@ table Gsub {
 }
 
 /// A [GSUB Lookup](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsubLookupTypeEnum) subtable.
- group SubstitutionLookup(Lookup, $lookup_type) {
+ group SubstitutionLookup(Lookup) {
     1 => Single(SingleSubst),
     2 => Multiple(MultipleSubstFormat1),
     3 => Alternate(AlternateSubstFormat1),
@@ -172,6 +172,7 @@ table ExtensionSubstFormat1 {
     subst_format: u16,
     /// Lookup type of subtable referenced by extensionOffset (that is,
     /// the extension subtable).
+    #[discriminant]
     extension_lookup_type: u16,
     /// Offset to the extension subtable, of lookup type
     /// extensionLookupType, relative to the start of the
@@ -180,7 +181,7 @@ table ExtensionSubstFormat1 {
 }
 
 /// A [GSUB Extension Substitution](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#ES) subtable
- group ExtensionSubtable(ExtensionSubstFormat1, $extension_lookup_type) {
+ group ExtensionSubtable(ExtensionSubstFormat1) {
     1 => Single(SingleSubst),
     2 => Multiple(MultipleSubstFormat1),
     3 => Alternate(AlternateSubstFormat1),

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -116,6 +116,7 @@ table LookupList {
 table Lookup {
     /// Different enumerations for GSUB and GPOS
     #[compile(skip)]
+    #[discriminant]
     lookup_type: u16,
     /// Lookup qualifiers
     #[traverse_with(traverse_lookup_flag)]

--- a/resources/codegen_inputs/test_generic_group.rs
+++ b/resources/codegen_inputs/test_generic_group.rs
@@ -10,6 +10,7 @@
 #[skip_constructor]
 table MyLookup {
     /// Determines the concrete type of T
+    #[discriminant]
     lookup_type: u16,
     /// Number of subtables
     #[compile(array_len($subtable_offsets))]
@@ -43,7 +44,7 @@ table MySubtableFormat2 {
 }
 
 /// The group enum dispatching on lookup_type.
-group MyLookupGroup(MyLookup, $lookup_type) {
+group MyLookupGroup(MyLookup) {
     1 => TypeOne(MySubtable),
     2 => TypeTwo(MySubtableFormat1),
 }


### PR DESCRIPTION
Specifically this adds a 'Discriminant' trait that we implement for
tables that have an inline discriminant that determines the type
of a subtable, such as in GPOS/GSUB lookups.

Previously the 'smarts' for reading the discriminant was declared
outside of the containing table itself, and that was going to be
annoying to get working in the sanitize code.

This new approach feels generally cleaner.