### PR TITLE
Disable write-fonts "table" feature from skera and incremental-font-transfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.48.1", path = "write-fonts" }
+write-fonts = { version = "0.48.1", path = "write-fonts", default-features = false }
 shared-brotli-patch-decoder = { version = "0.1.3", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.3.1", path = "incremental-font-transfer" }
 skera = { version = "0.2.0", path = "skera" }

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -22,7 +22,7 @@ c-brotli = ["shared-brotli-patch-decoder/c-brotli"]
 
 [dependencies]
 read-fonts = { workspace = true, features = ["ift"] }
-write-fonts = { workspace = true, features = ["ift"] }
+write-fonts = { workspace = true }
 font-types = { workspace = true }
 skrifa = { workspace = true }
 skera = { workspace = true }
@@ -38,7 +38,7 @@ criterion = { workspace = true }
 font-test-data = { workspace = true }
 read-fonts = { workspace = true }
 woff2-patched = "0.4.0"
-
+write-fonts = { workspace = true, features = ["tables", "ift"] }
 
 [lib]
 name = "incremental_font_transfer"


### PR DESCRIPTION
- This requires setting `--no-default-features` at the workspace level since features are additive. Additive means that crates can not remove any features.
- `incremental-font-transfer` still uses "tables" in test so the feature is added as a dev-dependency
- `fuzz` is fine since it sets `write-fonts.default-features = true`