### PR TITLE
[codegen] generate default for read_args types

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -64,26 +64,27 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
     });
 
     let const_generic = generic.is_some().then(|| quote!(::<()>));
-    // Generate Default for all tables that don't require external args, skipping
-    // tables that have a 'format' field that is not expected to be 0 or 1.
+    // Generate Default for all tables, skipping tables that have a 'format' field
+    // that is not expected to be 0 or 1.
     let table_format = item.format_value_and_width();
 
     // Choose the data constructor based on the table's format value: format=1 needs the
     // first byte set to 1 so that reading back the format field yields the correct value.
-    let data_method = item
-        .attrs
-        .read_args
-        .is_none()
-        .then(|| match table_format {
-            Some((1, 1)) => Some(quote!(default_format_1_u8_table_data)),
-            Some((1, 2)) => Some(quote!(default_format_1_u16_table_data)),
-            None | Some((0, _)) => Some(quote!(default_table_data)),
-            _ => None,
-        })
-        .flatten();
+    let data_method = match table_format {
+        Some((1, 1)) => Some(quote!(default_format_1_u8_table_data)),
+        Some((1, 2)) => Some(quote!(default_format_1_u16_table_data)),
+        None | Some((0, _)) => Some(quote!(default_table_data)),
+        _ => None,
+    };
 
     let impl_default = data_method.map(|data_method| {
         let phantom_init = generic.map(|_| quote!(offset_type: std::marker::PhantomData,));
+        let default_args = item
+            .attrs
+            .read_args
+            .as_ref()
+            .map(|args| args.idents().map(|id| quote!(#id: Default::default(),)).collect::<Vec<_>>())
+            .unwrap_or_default();
 
         let min_size_is_zero = min_valid_size.to_string() == "0";
         // selectively allow this lint so we can assert 0 <= NULL_POOL_SIZE,
@@ -99,6 +100,7 @@ pub(crate) fn generate(item: &Table) -> syn::Result<TokenStream> {
                 fn default() -> Self {
                     Self {
                         data: FontData::#data_method(),
+                        #( #default_args )*
                         #phantom_init
                     }
                 }

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -811,6 +811,20 @@ impl<'a> IndexSubtableList<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(
+    IndexSubtableList::MIN_SIZE
+));
+
+impl Default for IndexSubtableList<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            number_of_index_subtables: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for IndexSubtableList<'a> {
     fn type_name(&self) -> &str {
@@ -1020,6 +1034,18 @@ impl<'a> IndexSubtable1<'a> {
             ..start
                 + (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
                     .saturating_mul(u32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(IndexSubtable1::MIN_SIZE));
+
+impl Default for IndexSubtable1<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_format_1_u16_table_data(),
+            last_glyph_index: Default::default(),
+            first_glyph_index: Default::default(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -281,6 +281,20 @@ impl<'a> SettingNameArray<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(
+    SettingNameArray::MIN_SIZE
+));
+
+impl Default for SettingNameArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            n_settings: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SettingNameArray<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -283,6 +283,22 @@ impl<'a> AxisInstanceArrays<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(
+    AxisInstanceArrays::MIN_SIZE
+));
+
+impl Default for AxisInstanceArrays<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            axis_count: Default::default(),
+            instance_count: Default::default(),
+            instance_size: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AxisInstanceArrays<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1980,6 +1980,18 @@ impl<'a> PairSet<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(PairSet::MIN_SIZE));
+
+impl Default for PairSet<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            value_format1: Default::default(),
+            value_format2: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for PairSet<'a> {
     fn type_name(&self) -> &str {
@@ -2996,6 +3008,17 @@ impl<'a> BaseArray<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BaseArray::MIN_SIZE));
+
+impl Default for BaseArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            mark_class_count: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseArray<'a> {
     fn type_name(&self) -> &str {
@@ -3393,6 +3416,17 @@ impl<'a> LigatureArray<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(LigatureArray::MIN_SIZE));
+
+impl Default for LigatureArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            mark_class_count: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for LigatureArray<'a> {
     fn type_name(&self) -> &str {
@@ -3513,6 +3547,17 @@ impl<'a> LigatureAttach<'a> {
                     <ComponentRecord as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(LigatureAttach::MIN_SIZE));
+
+impl Default for LigatureAttach<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            mark_class_count: Default::default(),
+        }
     }
 }
 
@@ -3907,6 +3952,17 @@ impl<'a> Mark2Array<'a> {
                     <Mark2Record as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Mark2Array::MIN_SIZE));
+
+impl Default for Mark2Array<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            mark_class_count: Default::default(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -591,6 +591,19 @@ impl<'a> SharedTuples<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(SharedTuples::MIN_SIZE));
+
+impl Default for SharedTuples<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            shared_tuple_count: Default::default(),
+            axis_count: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for SharedTuples<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -119,6 +119,17 @@ impl<'a> Hdmx<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Hdmx::MIN_SIZE));
+
+impl Default for Hdmx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            num_glyphs: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hdmx<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -92,6 +92,18 @@ impl<'a> Hmtx<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(Hmtx::MIN_SIZE));
+
+impl Default for Hmtx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            number_of_h_metrics: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Hmtx<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -855,6 +855,18 @@ impl<'a> GlyphMap<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(GlyphMap::MIN_SIZE));
+
+impl Default for GlyphMap<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            glyph_count: Default::default(),
+            max_entry_index: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for GlyphMap<'a> {
     fn type_name(&self) -> &str {
@@ -968,6 +980,17 @@ impl<'a> FeatureMap<'a> {
     pub fn entry_map_data_byte_range(&self) -> Range<usize> {
         let start = self.feature_records_byte_range().end;
         start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(FeatureMap::MIN_SIZE));
+
+impl Default for FeatureMap<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            max_entry_index: Default::default(),
+        }
     }
 }
 
@@ -3306,6 +3329,17 @@ impl<'a> GlyphPatches<'a> {
             ..start
                 + (transforms::multiply_add(glyph_count, table_count, 1_usize))
                     .saturating_mul(Offset32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(GlyphPatches::MIN_SIZE));
+
+impl Default for GlyphPatches<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            flags: Default::default(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -678,6 +678,17 @@ impl<'a> Feature<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Feature::MIN_SIZE));
+
+impl Default for Feature<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            feature_tag: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Feature<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -427,6 +427,17 @@ impl<'a> Sbix<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(Sbix::MIN_SIZE));
+
+impl Default for Sbix<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            num_glyphs: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Sbix<'a> {
     fn type_name(&self) -> &str {
@@ -550,6 +561,17 @@ impl<'a> Strike<'a> {
         let num_glyphs = self.num_glyphs();
         let start = self.ppi_byte_range().end;
         start..start + (transforms::add(num_glyphs, 1_usize)).saturating_mul(u32::RAW_BYTE_LEN)
+    }
+}
+
+const _: () = assert!(FontData::default_data_long_enough(Strike::MIN_SIZE));
+
+impl Default for Strike<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            num_glyphs: Default::default(),
+        }
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -342,6 +342,18 @@ impl<'a> AxisValueArray<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(AxisValueArray::MIN_SIZE));
+
+impl Default for AxisValueArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            axis_value_count: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for AxisValueArray<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_test_read_args.rs
+++ b/read-fonts/generated/generated_test_read_args.rs
@@ -119,6 +119,17 @@ impl<'a> BaseArray<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(BaseArray::MIN_SIZE));
+
+impl Default for BaseArray<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            mark_class_count: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for BaseArray<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -113,6 +113,19 @@ impl<'a> TupleVariationHeader<'a> {
     }
 }
 
+const _: () = assert!(FontData::default_data_long_enough(
+    TupleVariationHeader::MIN_SIZE
+));
+
+impl Default for TupleVariationHeader<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            axis_count: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for TupleVariationHeader<'a> {
     fn type_name(&self) -> &str {

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -92,6 +92,18 @@ impl<'a> Vmtx<'a> {
     }
 }
 
+#[allow(clippy::absurd_extreme_comparisons)]
+const _: () = assert!(FontData::default_data_long_enough(Vmtx::MIN_SIZE));
+
+impl Default for Vmtx<'_> {
+    fn default() -> Self {
+        Self {
+            data: FontData::default_table_data(),
+            number_of_long_ver_metrics: Default::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeTable<'a> for Vmtx<'a> {
     fn type_name(&self) -> &str {


### PR DESCRIPTION
Originally I didn't want to impl Default for types that accept external arguments but I _do_ need this functionality, and after looking through the places where these exist every case can deal with us just using Default::default() to get values for the provided arguments.

If this ever isn't true in the future, we can always add a mechanism for opting out of a Default impl in codegen.