### PR TITLE
[read-fonts] avoid panics in post table

### DIFF
--- a/read-fonts/src/tables/post.rs
+++ b/read-fonts/src/tables/post.rs
@@ -8,7 +8,7 @@ impl<'a> Post<'a> {
     pub fn num_names(&self) -> usize {
         match self.version() {
             Version16Dot16::VERSION_1_0 => DEFAULT_GLYPH_NAMES.len(),
-            Version16Dot16::VERSION_2_0 => self.num_glyphs().unwrap() as usize,
+            Version16Dot16::VERSION_2_0 => self.num_glyphs().unwrap_or_default() as usize,
             _ => 0,
         }
     }
@@ -23,10 +23,7 @@ impl<'a> Post<'a> {
                     return DEFAULT_GLYPH_NAMES.get(idx).copied();
                 }
                 let idx = idx - DEFAULT_GLYPH_NAMES.len();
-                match self.string_data().unwrap().get(idx) {
-                    Some(Ok(s)) => Some(s.0),
-                    _ => None,
-                }
+                self.string_data()?.get(idx)?.ok().map(|s| s.0)
             }
             _ => None,
         }

--- a/read-fonts/src/tables/post.rs
+++ b/read-fonts/src/tables/post.rs
@@ -182,4 +182,27 @@ mod tests {
         let postv3 = Post::read(buf.data().into()).unwrap();
         assert!(postv3.num_glyphs().is_none());
     }
+
+    #[test]
+    fn num_names_defaults_to_zero_without_num_glyphs() {
+        let buf = make_basic_post(Version16Dot16::VERSION_2_0, false);
+        let post = Post::read(buf.data().into()).unwrap();
+        // Just don't panic
+        assert_eq!(post.num_names(), 0);
+    }
+
+    #[test]
+    fn glyph_name_missing_string_data_returns_none() {
+        let buf = BeBuffer::new()
+            .push(Version16Dot16::VERSION_2_0)
+            .push(Fixed::from_i32(5))
+            .extend([FWord::new(6), FWord::new(7)])
+            .push(0u32)
+            .extend([7u32, 8, 9, 10])
+            .push(1u16)
+            .push(258u16);
+        let post = Post::read(buf.data().into()).unwrap();
+        // Just don't panic
+        assert_eq!(post.glyph_name(GlyphId16::new(0)), None);
+    }
 }


### PR DESCRIPTION
Both `num_names()` and `glyph_name()` can now panic due do unwraps that no longer hold post minimal-validation. Change the former to return `0` and the latter `None` when the necessary data isn't available.

First commit contains failing tests.

Fixes #1885 