### PR TITLE
[traverse] Use existing ArrayOfOffsets instead type

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -386,32 +386,11 @@ fn traversal_arm_for_field(
             }
 
             FieldType::Offset {
-                target: OffsetTarget::Table(target),
+                target: OffsetTarget::Table(_),
                 ..
             } => {
-                let maybe_data = pass_data.is_none().then(|| quote!(let data = self.data;));
-                let args_if_needed = fld.attrs.read_offset_args.as_ref().map(|args| {
-                    let args = args.to_tokens_for_table_getter();
-                    quote!(let args = #args;)
-                });
-                let resolve = match fld.attrs.read_offset_args.as_deref() {
-                    None => quote!(resolve::<#target>(data)),
-                    Some(_) => quote!(resolve_with_args::<#target>(data, &args)),
-                };
-
-                quote! {{
-                    #maybe_data
-                    #args_if_needed
-                    Field::new(#name_str,
-                        FieldType::array_of_offsets(
-                            better_type_name::<#target>(),
-                            self.#name()#maybe_unwrap,
-                            move |off| {
-                                let target = off.get().#resolve;
-                                FieldType::offset(off.get(), target)
-                            }
-                        ))
-                }}
+                let getter = fld.offset_getter_name().unwrap();
+                quote!(Field::new(#name_str, FieldType::from(self.#getter(#pass_data)#maybe_unwrap)))
             }
             FieldType::Offset {
                 target: OffsetTarget::Array(_),

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -790,20 +790,10 @@ impl<'a> SomeTable<'a> for BaseValues<'a> {
                 self.default_baseline_index(),
             )),
             1usize => Some(Field::new("base_coord_count", self.base_coord_count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "base_coord_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<BaseCoord>(),
-                        self.base_coord_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<BaseCoord>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "base_coord_offsets",
+                FieldType::from(self.base_coords()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -629,20 +629,7 @@ impl<'a> SomeTable<'a> for LayerList<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("num_layers", self.num_layers())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "paint_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Paint>(),
-                        self.paint_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Paint>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new("paint_offsets", FieldType::from(self.paints()))),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -387,20 +387,10 @@ impl<'a> SomeTable<'a> for AttachList<'a> {
                 FieldType::offset(self.coverage_offset(), self.coverage()),
             )),
             1usize => Some(Field::new("glyph_count", self.glyph_count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "attach_point_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<AttachPoint>(),
-                        self.attach_point_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<AttachPoint>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "attach_point_offsets",
+                FieldType::from(self.attach_points()),
+            )),
             _ => None,
         }
     }
@@ -603,20 +593,10 @@ impl<'a> SomeTable<'a> for LigCaretList<'a> {
                 FieldType::offset(self.coverage_offset(), self.coverage()),
             )),
             1usize => Some(Field::new("lig_glyph_count", self.lig_glyph_count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "lig_glyph_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<LigGlyph>(),
-                        self.lig_glyph_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<LigGlyph>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "lig_glyph_offsets",
+                FieldType::from(self.lig_glyphs()),
+            )),
             _ => None,
         }
     }
@@ -711,20 +691,10 @@ impl<'a> SomeTable<'a> for LigGlyph<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("caret_count", self.caret_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "caret_value_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CaretValue>(),
-                        self.caret_value_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CaretValue>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "caret_value_offsets",
+                FieldType::from(self.caret_values()),
+            )),
             _ => None,
         }
     }
@@ -1207,20 +1177,10 @@ impl<'a> SomeTable<'a> for MarkGlyphSets<'a> {
                 "mark_glyph_set_count",
                 self.mark_glyph_set_count(),
             )),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "coverage_offsets",
+                FieldType::from(self.coverages()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1854,21 +1854,10 @@ impl<'a> SomeTable<'a> for PairPosFormat1<'a> {
             2usize => Some(Field::new("value_format1", self.value_format1())),
             3usize => Some(Field::new("value_format2", self.value_format2())),
             4usize => Some(Field::new("pair_set_count", self.pair_set_count())),
-            5usize => Some({
-                let data = self.data;
-                let args = (self.value_format1(), self.value_format2());
-                Field::new(
-                    "pair_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<PairSet>(),
-                        self.pair_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve_with_args::<PairSet>(data, &args);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            5usize => Some(Field::new(
+                "pair_set_offsets",
+                FieldType::from(self.pair_sets()),
+            )),
             _ => None,
         }
     }
@@ -3126,19 +3115,10 @@ impl<'a> SomeRecord<'a> for BaseRecord<'a> {
         RecordResolver {
             name: "BaseRecord",
             get_field: Box::new(move |idx, _data| match idx {
-                0usize => Some({
-                    Field::new(
-                        "base_anchor_offsets",
-                        FieldType::array_of_offsets(
-                            better_type_name::<AnchorTable>(),
-                            self.base_anchor_offsets(),
-                            move |off| {
-                                let target = off.get().resolve::<AnchorTable>(data);
-                                FieldType::offset(off.get(), target)
-                            },
-                        ),
-                    )
-                }),
+                0usize => Some(Field::new(
+                    "base_anchor_offsets",
+                    FieldType::from(self.base_anchors(_data)),
+                )),
                 _ => None,
             }),
             data,
@@ -3441,21 +3421,10 @@ impl<'a> SomeTable<'a> for LigatureArray<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("ligature_count", self.ligature_count())),
-            1usize => Some({
-                let data = self.data;
-                let args = self.mark_class_count();
-                Field::new(
-                    "ligature_attach_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<LigatureAttach>(),
-                        self.ligature_attach_offsets(),
-                        move |off| {
-                            let target = off.get().resolve_with_args::<LigatureAttach>(data, &args);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "ligature_attach_offsets",
+                FieldType::from(self.ligature_attaches()),
+            )),
             _ => None,
         }
     }
@@ -3668,19 +3637,10 @@ impl<'a> SomeRecord<'a> for ComponentRecord<'a> {
         RecordResolver {
             name: "ComponentRecord",
             get_field: Box::new(move |idx, _data| match idx {
-                0usize => Some({
-                    Field::new(
-                        "ligature_anchor_offsets",
-                        FieldType::array_of_offsets(
-                            better_type_name::<AnchorTable>(),
-                            self.ligature_anchor_offsets(),
-                            move |off| {
-                                let target = off.get().resolve::<AnchorTable>(data);
-                                FieldType::offset(off.get(), target)
-                            },
-                        ),
-                    )
-                }),
+                0usize => Some(Field::new(
+                    "ligature_anchor_offsets",
+                    FieldType::from(self.ligature_anchors(_data)),
+                )),
                 _ => None,
             }),
             data,
@@ -4073,19 +4033,10 @@ impl<'a> SomeRecord<'a> for Mark2Record<'a> {
         RecordResolver {
             name: "Mark2Record",
             get_field: Box::new(move |idx, _data| match idx {
-                0usize => Some({
-                    Field::new(
-                        "mark2_anchor_offsets",
-                        FieldType::array_of_offsets(
-                            better_type_name::<AnchorTable>(),
-                            self.mark2_anchor_offsets(),
-                            move |off| {
-                                let target = off.get().resolve::<AnchorTable>(data);
-                                FieldType::offset(off.get(), target)
-                            },
-                        ),
-                    )
-                }),
+                0usize => Some(Field::new(
+                    "mark2_anchor_offsets",
+                    FieldType::from(self.mark2_anchors(_data)),
+                )),
                 _ => None,
             }),
             data,

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -713,20 +713,10 @@ impl<'a> SomeTable<'a> for MultipleSubstFormat1<'a> {
                 FieldType::offset(self.coverage_offset(), self.coverage()),
             )),
             2usize => Some(Field::new("sequence_count", self.sequence_count())),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "sequence_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Sequence>(),
-                        self.sequence_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Sequence>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "sequence_offsets",
+                FieldType::from(self.sequences()),
+            )),
             _ => None,
         }
     }
@@ -955,20 +945,10 @@ impl<'a> SomeTable<'a> for AlternateSubstFormat1<'a> {
                 "alternate_set_count",
                 self.alternate_set_count(),
             )),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "alternate_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<AlternateSet>(),
-                        self.alternate_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<AlternateSet>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "alternate_set_offsets",
+                FieldType::from(self.alternate_sets()),
+            )),
             _ => None,
         }
     }
@@ -1193,20 +1173,10 @@ impl<'a> SomeTable<'a> for LigatureSubstFormat1<'a> {
                 FieldType::offset(self.coverage_offset(), self.coverage()),
             )),
             2usize => Some(Field::new("ligature_set_count", self.ligature_set_count())),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "ligature_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<LigatureSet>(),
-                        self.ligature_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<LigatureSet>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "ligature_set_offsets",
+                FieldType::from(self.ligature_sets()),
+            )),
             _ => None,
         }
     }
@@ -1301,20 +1271,10 @@ impl<'a> SomeTable<'a> for LigatureSet<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("ligature_count", self.ligature_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "ligature_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Ligature>(),
-                        self.ligature_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Ligature>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "ligature_offsets",
+                FieldType::from(self.ligatures()),
+            )),
             _ => None,
         }
     }
@@ -1843,38 +1803,18 @@ impl<'a> SomeTable<'a> for ReverseChainSingleSubstFormat1<'a> {
                 "backtrack_glyph_count",
                 self.backtrack_glyph_count(),
             )),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "backtrack_coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.backtrack_coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "backtrack_coverage_offsets",
+                FieldType::from(self.backtrack_coverages()),
+            )),
             4usize => Some(Field::new(
                 "lookahead_glyph_count",
                 self.lookahead_glyph_count(),
             )),
-            5usize => Some({
-                let data = self.data;
-                Field::new(
-                    "lookahead_coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.lookahead_coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            5usize => Some(Field::new(
+                "lookahead_coverage_offsets",
+                FieldType::from(self.lookahead_coverages()),
+            )),
             6usize => Some(Field::new("glyph_count", self.glyph_count())),
             7usize => Some(Field::new(
                 "substitute_glyph_ids",

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -2327,20 +2327,7 @@ impl<'a> SomeTable<'a> for TableKeyedPatch<'a> {
                 traversal::FieldType::Unknown,
             )),
             2usize => Some(Field::new("patches_count", self.patches_count())),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "patch_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<TablePatch>(),
-                        self.patch_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<TablePatch>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new("patch_offsets", FieldType::from(self.patches()))),
             _ => None,
         }
     }
@@ -3354,20 +3341,10 @@ impl<'a> SomeTable<'a> for GlyphPatches<'a> {
             1usize => Some(Field::new("table_count", self.table_count())),
             2usize => Some(Field::new("glyph_ids", traversal::FieldType::Unknown)),
             3usize => Some(Field::new("tables", self.tables())),
-            4usize => Some({
-                let data = self.data;
-                Field::new(
-                    "glyph_data_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<GlyphData>(),
-                        self.glyph_data_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<GlyphData>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            4usize => Some(Field::new(
+                "glyph_data_offsets",
+                FieldType::from(self.glyph_data()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -820,20 +820,10 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, 
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("lookup_count", self.lookup_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "lookup_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<T>(),
-                        self.lookup_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<T>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "lookup_offsets",
+                FieldType::from(self.lookups()),
+            )),
             _ => None,
         }
     }
@@ -997,20 +987,10 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
             0usize => Some(Field::new("lookup_type", self.lookup_type())),
             1usize => Some(Field::new("lookup_flag", self.traverse_lookup_flag())),
             2usize => Some(Field::new("sub_table_count", self.sub_table_count())),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "subtable_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<T>(),
-                        self.subtable_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<T>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "subtable_offsets",
+                FieldType::from(self.subtables()),
+            )),
             4usize
                 if self
                     .lookup_flag()
@@ -1892,20 +1872,10 @@ impl<'a> SomeTable<'a> for SequenceContextFormat1<'a> {
                 FieldType::offset(self.coverage_offset(), self.coverage()),
             )),
             2usize => Some(Field::new("seq_rule_set_count", self.seq_rule_set_count())),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "seq_rule_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<SequenceRuleSet>(),
-                        self.seq_rule_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<SequenceRuleSet>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "seq_rule_set_offsets",
+                FieldType::from(self.seq_rule_sets()),
+            )),
             _ => None,
         }
     }
@@ -2002,20 +1972,10 @@ impl<'a> SomeTable<'a> for SequenceRuleSet<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("seq_rule_count", self.seq_rule_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "seq_rule_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<SequenceRule>(),
-                        self.seq_rule_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<SequenceRule>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "seq_rule_offsets",
+                FieldType::from(self.seq_rules()),
+            )),
             _ => None,
         }
     }
@@ -2289,20 +2249,10 @@ impl<'a> SomeTable<'a> for SequenceContextFormat2<'a> {
                 "class_seq_rule_set_count",
                 self.class_seq_rule_set_count(),
             )),
-            4usize => Some({
-                let data = self.data;
-                Field::new(
-                    "class_seq_rule_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ClassSequenceRuleSet>(),
-                        self.class_seq_rule_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ClassSequenceRuleSet>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            4usize => Some(Field::new(
+                "class_seq_rule_set_offsets",
+                FieldType::from(self.class_seq_rule_sets()),
+            )),
             _ => None,
         }
     }
@@ -2402,20 +2352,10 @@ impl<'a> SomeTable<'a> for ClassSequenceRuleSet<'a> {
                 "class_seq_rule_count",
                 self.class_seq_rule_count(),
             )),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "class_seq_rule_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ClassSequenceRule>(),
-                        self.class_seq_rule_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ClassSequenceRule>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "class_seq_rule_offsets",
+                FieldType::from(self.class_seq_rules()),
+            )),
             _ => None,
         }
     }
@@ -2665,20 +2605,10 @@ impl<'a> SomeTable<'a> for SequenceContextFormat3<'a> {
             0usize => Some(Field::new("format", self.format())),
             1usize => Some(Field::new("glyph_count", self.glyph_count())),
             2usize => Some(Field::new("seq_lookup_count", self.seq_lookup_count())),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "coverage_offsets",
+                FieldType::from(self.coverages()),
+            )),
             4usize => Some(Field::new(
                 "seq_lookup_records",
                 traversal::FieldType::array_of_records(
@@ -2916,20 +2846,10 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat1<'a> {
                 "chained_seq_rule_set_count",
                 self.chained_seq_rule_set_count(),
             )),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "chained_seq_rule_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ChainedSequenceRuleSet>(),
-                        self.chained_seq_rule_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ChainedSequenceRuleSet>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "chained_seq_rule_set_offsets",
+                FieldType::from(self.chained_seq_rule_sets()),
+            )),
             _ => None,
         }
     }
@@ -3029,20 +2949,10 @@ impl<'a> SomeTable<'a> for ChainedSequenceRuleSet<'a> {
                 "chained_seq_rule_count",
                 self.chained_seq_rule_count(),
             )),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "chained_seq_rule_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ChainedSequenceRule>(),
-                        self.chained_seq_rule_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ChainedSequenceRule>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "chained_seq_rule_offsets",
+                FieldType::from(self.chained_seq_rules()),
+            )),
             _ => None,
         }
     }
@@ -3431,20 +3341,10 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat2<'a> {
                 "chained_class_seq_rule_set_count",
                 self.chained_class_seq_rule_set_count(),
             )),
-            6usize => Some({
-                let data = self.data;
-                Field::new(
-                    "chained_class_seq_rule_set_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ChainedClassSequenceRuleSet>(),
-                        self.chained_class_seq_rule_set_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ChainedClassSequenceRuleSet>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            6usize => Some(Field::new(
+                "chained_class_seq_rule_set_offsets",
+                FieldType::from(self.chained_class_seq_rule_sets()),
+            )),
             _ => None,
         }
     }
@@ -3547,20 +3447,10 @@ impl<'a> SomeTable<'a> for ChainedClassSequenceRuleSet<'a> {
                 "chained_class_seq_rule_count",
                 self.chained_class_seq_rule_count(),
             )),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "chained_class_seq_rule_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ChainedClassSequenceRule>(),
-                        self.chained_class_seq_rule_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ChainedClassSequenceRule>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "chained_class_seq_rule_offsets",
+                FieldType::from(self.chained_class_seq_rules()),
+            )),
             _ => None,
         }
     }
@@ -3934,53 +3824,23 @@ impl<'a> SomeTable<'a> for ChainedSequenceContextFormat3<'a> {
                 "backtrack_glyph_count",
                 self.backtrack_glyph_count(),
             )),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "backtrack_coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.backtrack_coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "backtrack_coverage_offsets",
+                FieldType::from(self.backtrack_coverages()),
+            )),
             3usize => Some(Field::new("input_glyph_count", self.input_glyph_count())),
-            4usize => Some({
-                let data = self.data;
-                Field::new(
-                    "input_coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.input_coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            4usize => Some(Field::new(
+                "input_coverage_offsets",
+                FieldType::from(self.input_coverages()),
+            )),
             5usize => Some(Field::new(
                 "lookahead_glyph_count",
                 self.lookahead_glyph_count(),
             )),
-            6usize => Some({
-                let data = self.data;
-                Field::new(
-                    "lookahead_coverage_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<CoverageTable>(),
-                        self.lookahead_coverage_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<CoverageTable>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            6usize => Some(Field::new(
+                "lookahead_coverage_offsets",
+                FieldType::from(self.lookahead_coverages()),
+            )),
             7usize => Some(Field::new("seq_lookup_count", self.seq_lookup_count())),
             8usize => Some(Field::new(
                 "seq_lookup_records",
@@ -4724,20 +4584,10 @@ impl<'a> SomeTable<'a> for ConditionSet<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("condition_count", self.condition_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "condition_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Condition>(),
-                        self.condition_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Condition>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "condition_offsets",
+                FieldType::from(self.conditions()),
+            )),
             _ => None,
         }
     }
@@ -5163,20 +5013,10 @@ impl<'a> SomeTable<'a> for ConditionFormat3<'a> {
         match idx {
             0usize => Some(Field::new("format", self.format())),
             1usize => Some(Field::new("condition_count", self.condition_count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "condition_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Condition>(),
-                        self.condition_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Condition>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "condition_offsets",
+                FieldType::from(self.conditions()),
+            )),
             _ => None,
         }
     }
@@ -5276,20 +5116,10 @@ impl<'a> SomeTable<'a> for ConditionFormat4<'a> {
         match idx {
             0usize => Some(Field::new("format", self.format())),
             1usize => Some(Field::new("condition_count", self.condition_count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "condition_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Condition>(),
-                        self.condition_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Condition>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "condition_offsets",
+                FieldType::from(self.conditions()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -448,21 +448,10 @@ impl<'a> SomeTable<'a> for Sbix<'a> {
             0usize => Some(Field::new("version", self.version())),
             1usize => Some(Field::new("flags", self.flags())),
             2usize => Some(Field::new("num_strikes", self.num_strikes())),
-            3usize => Some({
-                let data = self.data;
-                let args = self.num_glyphs();
-                Field::new(
-                    "strike_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Strike>(),
-                        self.strike_offsets(),
-                        move |off| {
-                            let target = off.get().resolve_with_args::<Strike>(data, &args);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "strike_offsets",
+                FieldType::from(self.strikes()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -361,20 +361,10 @@ impl<'a> SomeTable<'a> for AxisValueArray<'a> {
     }
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
-            0usize => Some({
-                let data = self.data;
-                Field::new(
-                    "axis_value_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<AxisValue>(),
-                        self.axis_value_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<AxisValue>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            0usize => Some(Field::new(
+                "axis_value_offsets",
+                FieldType::from(self.axis_values()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_test_generic_group.rs
+++ b/read-fonts/generated/generated_test_generic_group.rs
@@ -122,20 +122,10 @@ impl<'a, T: FontRead<'a> + SomeTable<'a> + 'a> SomeTable<'a> for MyLookup<'a, T>
         match idx {
             0usize => Some(Field::new("lookup_type", self.lookup_type())),
             1usize => Some(Field::new("sub_table_count", self.sub_table_count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "subtable_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<T>(),
-                        self.subtable_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<T>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "subtable_offsets",
+                FieldType::from(self.subtables()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -437,62 +437,22 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
         match idx {
             0usize => Some(Field::new("version", self.version())),
             1usize => Some(Field::new("count", self.count())),
-            2usize => Some({
-                let data = self.data;
-                Field::new(
-                    "nonnullable_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Dummy>(),
-                        self.nonnullable_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Dummy>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "nullable_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Dummy>(),
-                        self.nullable_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Dummy>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
-            4usize if self.version().compatible((1u16, 1u16)) => Some({
-                let data = self.data;
-                Field::new(
-                    "versioned_nonnullable_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Dummy>(),
-                        self.versioned_nonnullable_offsets().unwrap(),
-                        move |off| {
-                            let target = off.get().resolve::<Dummy>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
-            5usize if self.version().compatible((1u16, 1u16)) => Some({
-                let data = self.data;
-                Field::new(
-                    "versioned_nullable_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Dummy>(),
-                        self.versioned_nullable_offsets().unwrap(),
-                        move |off| {
-                            let target = off.get().resolve::<Dummy>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            2usize => Some(Field::new(
+                "nonnullable_offsets",
+                FieldType::from(self.nonnullables()),
+            )),
+            3usize => Some(Field::new(
+                "nullable_offsets",
+                FieldType::from(self.nullables()),
+            )),
+            4usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
+                "versioned_nonnullable_offsets",
+                FieldType::from(self.versioned_nonnullables().unwrap()),
+            )),
+            5usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
+                "versioned_nullable_offsets",
+                FieldType::from(self.versioned_nullables().unwrap()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_test_read_args.rs
+++ b/read-fonts/generated/generated_test_read_args.rs
@@ -297,19 +297,10 @@ impl<'a> SomeRecord<'a> for FaceRecord<'a> {
         RecordResolver {
             name: "FaceRecord",
             get_field: Box::new(move |idx, _data| match idx {
-                0usize => Some({
-                    Field::new(
-                        "face_offsets",
-                        FieldType::array_of_offsets(
-                            better_type_name::<Face>(),
-                            self.face_offsets(),
-                            move |off| {
-                                let target = off.get().resolve::<Face>(data);
-                                FieldType::offset(off.get(), target)
-                            },
-                        ),
-                    )
-                }),
+                0usize => Some(Field::new(
+                    "face_offsets",
+                    FieldType::from(self.faces(_data)),
+                )),
                 _ => None,
             }),
             data,

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -313,20 +313,10 @@ impl<'a> SomeTable<'a> for MultiItemVariationStore<'a> {
                 "variation_data_count",
                 self.variation_data_count(),
             )),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "variation_data_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<MultiItemVariationData>(),
-                        self.variation_data_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<MultiItemVariationData>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "variation_data_offsets",
+                FieldType::from(self.variation_data()),
+            )),
             _ => None,
         }
     }
@@ -419,20 +409,10 @@ impl<'a> SomeTable<'a> for SparseVariationRegionList<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("region_count", self.region_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "region_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<SparseVariationRegion>(),
-                        self.region_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<SparseVariationRegion>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "region_offsets",
+                FieldType::from(self.regions()),
+            )),
             _ => None,
         }
     }
@@ -781,20 +761,10 @@ impl<'a> SomeTable<'a> for ConditionList<'a> {
     fn get_field(&self, idx: usize) -> Option<Field<'a>> {
         match idx {
             0usize => Some(Field::new("condition_count", self.condition_count())),
-            1usize => Some({
-                let data = self.data;
-                Field::new(
-                    "condition_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<Condition>(),
-                        self.condition_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<Condition>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            1usize => Some(Field::new(
+                "condition_offsets",
+                FieldType::from(self.conditions()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -1240,20 +1240,10 @@ impl<'a> SomeTable<'a> for ItemVariationStore<'a> {
                 "item_variation_data_count",
                 self.item_variation_data_count(),
             )),
-            3usize => Some({
-                let data = self.data;
-                Field::new(
-                    "item_variation_data_offsets",
-                    FieldType::array_of_offsets(
-                        better_type_name::<ItemVariationData>(),
-                        self.item_variation_data_offsets(),
-                        move |off| {
-                            let target = off.get().resolve::<ItemVariationData>(data);
-                            FieldType::offset(off.get(), target)
-                        },
-                    ),
-                )
-            }),
+            3usize => Some(Field::new(
+                "item_variation_data_offsets",
+                FieldType::from(self.item_variation_data()),
+            )),
             _ => None,
         }
     }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -120,14 +120,6 @@ pub(crate) mod codegen_prelude {
     #[cfg(feature = "experimental_traverse")]
     pub use crate::traversal::{self, Field, FieldType, RecordResolver, SomeRecord, SomeTable};
 
-    // used in generated traversal code to get type names of offset fields, which
-    // may include generics
-    #[cfg(feature = "experimental_traverse")]
-    pub(crate) fn better_type_name<T>() -> &'static str {
-        let raw_name = std::any::type_name::<T>();
-        raw_name.rsplit("::").next().unwrap_or(raw_name)
-    }
-
     /// named transforms used in 'count', e.g
     pub(crate) mod transforms {
         pub fn subtract<T: TryInto<usize>, U: TryInto<usize>>(lhs: T, rhs: U) -> usize {

--- a/read-fonts/src/offset_array.rs
+++ b/read-fonts/src/offset_array.rs
@@ -158,3 +158,51 @@ where
         })
     }
 }
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a, T, O> crate::traversal::SomeArray<'a> for ArrayOfOffsets<'a, T, O>
+where
+    O: Scalar + Offset + Into<crate::traversal::OffsetType>,
+    T: ReadArgs + FontReadWithArgs<'a> + crate::traversal::SomeTable<'a> + 'a,
+    T::Args: Copy + 'static,
+{
+    fn type_name(&self) -> &str {
+        let full_name = std::any::type_name::<T>();
+        full_name.split("::").last().unwrap_or(full_name)
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    fn get(&self, idx: usize) -> Option<crate::traversal::FieldType<'a>> {
+        let off = self.offsets.get(idx)?;
+        let raw = off.get();
+        let result = raw.resolve_with_args::<T>(self.data, &self.args);
+        Some(crate::traversal::FieldType::offset(raw, result))
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a, T, O> crate::traversal::SomeArray<'a> for ArrayOfNullableOffsets<'a, T, O>
+where
+    O: Scalar + Offset + Into<crate::traversal::OffsetType> + Clone,
+    T: ReadArgs + FontReadWithArgs<'a> + crate::traversal::SomeTable<'a> + 'a,
+    T::Args: Copy + 'static,
+{
+    fn type_name(&self) -> &str {
+        let full_name = std::any::type_name::<T>();
+        full_name.split("::").last().unwrap_or(full_name)
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    fn get(&self, idx: usize) -> Option<crate::traversal::FieldType<'a>> {
+        let off = self.offsets.get(idx)?;
+        let raw = off.get();
+        let result = raw.resolve_with_args::<T>(self.data, &self.args);
+        Some(crate::traversal::FieldType::offset(raw, result))
+    }
+}

--- a/read-fonts/src/traversal.rs
+++ b/read-fonts/src/traversal.rs
@@ -100,28 +100,6 @@ pub struct ArrayOffset<'a> {
     pub target: Result<Box<dyn SomeArray<'a> + 'a>, ReadError>,
 }
 
-pub(crate) struct ArrayOfOffsets<'a, O> {
-    type_name: &'static str,
-    offsets: &'a [O],
-    resolver: Box<dyn Fn(&O) -> FieldType<'a> + 'a>,
-}
-
-impl<'a, O> SomeArray<'a> for ArrayOfOffsets<'a, O> {
-    fn type_name(&self) -> &str {
-        self.type_name
-    }
-
-    fn len(&self) -> usize {
-        self.offsets.len()
-    }
-
-    fn get(&self, idx: usize) -> Option<FieldType<'a>> {
-        let off = self.offsets.get(idx)?;
-        let target = (self.resolver)(off);
-        Some(target)
-    }
-}
-
 impl<'a> FieldType<'a> {
     /// makes a field, handling the case where this array may not be present in
     /// all versions
@@ -174,23 +152,6 @@ impl<'a> FieldType<'a> {
             array,
         }
         .into()
-    }
-
-    /// Convenience method for creating a `FieldType` from an array of offsets.
-    ///
-    /// The `resolver` argument is a function that takes an offset and resolves
-    /// it.
-    pub fn array_of_offsets<O>(
-        type_name: &'static str,
-        offsets: &'a [O],
-        resolver: impl Fn(&O) -> FieldType<'a> + 'a,
-    ) -> Self
-where {
-        FieldType::Array(Box::new(ArrayOfOffsets {
-            type_name,
-            offsets,
-            resolver: Box::new(resolver),
-        }))
     }
 
     /// Convenience method for creating a `FieldType` from an offset to an array.


### PR DESCRIPTION
Noticed an easy simplification here while working on the sanitize stuff. This is no functional change, just cleanup.

Traversal predates us having the ArrayOfOffsets types, and so this approach was not available when that code was originally written.

Concretely, this implements SomeArray on the existing ArrayOfOffsets/ ArrayOfNullableOffsets types (behind experimental_traverse feature) and updates codegen to call the typed getter directly, replacing th e closure-based approach. This removes the traversal::ArrayOfOffsets struct, the FieldType::array_of_offsets() method, and the now-unused better_type_name() helper.