### PR TITLE
skrifa: Support obtaining `LocalizedStrings` from name table without a `FontRef`

### DIFF
--- a/skrifa/src/string.rs
+++ b/skrifa/src/string.rs
@@ -66,6 +66,16 @@ impl<'a> LocalizedStrings<'a> {
         Self { name, records, id }
     }
 
+    /// Creates a new localized string iterator from the given `name` table and string identifier.
+    pub fn new_from_name_table(name: Name<'a>, id: StringId) -> Self {
+        let records = name.name_record().iter();
+        Self {
+            name: Some(name),
+            records,
+            id,
+        }
+    }
+
     /// Returns the informational string identifier for this iterator.
     pub fn id(&self) -> StringId {
         self.id

--- a/skrifa/src/string.rs
+++ b/skrifa/src/string.rs
@@ -67,7 +67,7 @@ impl<'a> LocalizedStrings<'a> {
     }
 
     /// Creates a new localized string iterator from the given `name` table and string identifier.
-    pub fn new_from_name_table(name: Name<'a>, id: StringId) -> Self {
+    pub fn from_name_table(name: Name<'a>, id: StringId) -> Self {
         let records = name.name_record().iter();
         Self {
             name: Some(name),


### PR DESCRIPTION
Currently, the only way to obtain a [`LocalizedStrings`](https://docs.rs/skrifa/latest/skrifa/string/struct.LocalizedStrings.html) object for a font is to use [`LocalizedStrings::new`](), providing a `FontRef`. That's a bit unfortunate because it means it can't be used in situations where one only has the `Name` table, despite it containing all the necessary data. I ran into this problem in [servo](https://github.com/servo/servo/pull/45308).

This change therefore adds `LocalizedStrings::new_from_name_table`.