### PR TITLE
Towards implementing beyond-64k glyphs in the font

### DIFF
--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -258,6 +258,7 @@ impl<'a> PrettyPrinter<'a> {
             FieldType::Fixed(val) => self.print_hex(&val.to_be_bytes())?,
             FieldType::LongDateTime(val) => self.print_hex(&val.to_be_bytes())?,
             FieldType::GlyphId16(val) => self.print_hex(&val.to_be_bytes())?,
+            FieldType::GlyphId24(val) => self.print_hex(&val.to_be_bytes())?,
             FieldType::BareOffset(offset) => self.print_offset_hex(*offset)?,
             _ => (),
         }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1924,10 +1924,7 @@ impl<'a> ClassDefFormat3<'a> {
     pub fn class_value_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start
-            ..start
-                + (usize::try_from(glyph_count).unwrap_or_default())
-                    .saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -2023,7 +2020,7 @@ impl<'a> ClassDefFormat4<'a> {
         let start = self.class_range_count_byte_range().end;
         start
             ..start
-                + (usize::try_from(class_range_count).unwrap_or_default())
+                + (transforms::to_usize(class_range_count))
                     .saturating_mul(ClassRangeRecord2::RAW_BYTE_LEN)
     }
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1846,6 +1846,218 @@ impl<'a> std::fmt::Debug for ClassDefFormat2<'a> {
     }
 }
 
+impl Format<u16> for ClassDefFormat3<'_> {
+    const FORMAT: u16 = 3;
+}
+
+impl<'a> MinByteRange<'a> for ClassDefFormat3<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.class_value_array_byte_range().end
+    }
+    fn min_table_bytes(&self) -> &'a [u8] {
+        let range = self.min_byte_range();
+        self.data.as_bytes().get(range).unwrap_or_default()
+    }
+}
+
+impl<'a> FontRead<'a> for ClassDefFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if data.len() < Self::MIN_SIZE {
+            return Err(ReadError::OutOfBounds);
+        }
+        Ok(Self { data })
+    }
+}
+
+/// [Class Definition Table Format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-3)
+#[derive(Clone)]
+pub struct ClassDefFormat3<'a> {
+    data: FontData<'a>,
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ClassDefFormat3<'a> {
+    pub const MIN_SIZE: usize =
+        (u16::RAW_BYTE_LEN + GlyphId24::RAW_BYTE_LEN + Uint24::RAW_BYTE_LEN);
+    basic_table_impls!(impl_the_methods);
+
+    /// Format identifier — format = 3
+    pub fn class_format(&self) -> u16 {
+        let range = self.class_format_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// First glyph ID of the classValueArray
+    pub fn start_glyph_id(&self) -> GlyphId24 {
+        let range = self.start_glyph_id_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Size of the classValueArray
+    pub fn glyph_count(&self) -> Uint24 {
+        let range = self.glyph_count_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Array of Class Values — one per glyph ID
+    pub fn class_value_array(&self) -> &'a [BigEndian<u16>] {
+        let range = self.class_value_array_byte_range();
+        self.data.read_array(range).ok().unwrap_or_default()
+    }
+
+    pub fn class_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn start_glyph_id_byte_range(&self) -> Range<usize> {
+        let start = self.class_format_byte_range().end;
+        start..start + GlyphId24::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.start_glyph_id_byte_range().end;
+        start..start + Uint24::RAW_BYTE_LEN
+    }
+
+    pub fn class_value_array_byte_range(&self) -> Range<usize> {
+        let glyph_count = self.glyph_count();
+        let start = self.glyph_count_byte_range().end;
+        start
+            ..start
+                + (usize::try_from(glyph_count).unwrap_or_default())
+                    .saturating_mul(u16::RAW_BYTE_LEN)
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a> SomeTable<'a> for ClassDefFormat3<'a> {
+    fn type_name(&self) -> &str {
+        "ClassDefFormat3"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("class_format", self.class_format())),
+            1usize => Some(Field::new("start_glyph_id", self.start_glyph_id())),
+            2usize => Some(Field::new("glyph_count", self.glyph_count())),
+            3usize => Some(Field::new("class_value_array", self.class_value_array())),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+#[allow(clippy::needless_lifetimes)]
+impl<'a> std::fmt::Debug for ClassDefFormat3<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl Format<u16> for ClassDefFormat4<'_> {
+    const FORMAT: u16 = 4;
+}
+
+impl<'a> MinByteRange<'a> for ClassDefFormat4<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.class_range_records_byte_range().end
+    }
+    fn min_table_bytes(&self) -> &'a [u8] {
+        let range = self.min_byte_range();
+        self.data.as_bytes().get(range).unwrap_or_default()
+    }
+}
+
+impl<'a> FontRead<'a> for ClassDefFormat4<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if data.len() < Self::MIN_SIZE {
+            return Err(ReadError::OutOfBounds);
+        }
+        Ok(Self { data })
+    }
+}
+
+/// [Class Definition Table Format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-4)
+#[derive(Clone)]
+pub struct ClassDefFormat4<'a> {
+    data: FontData<'a>,
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> ClassDefFormat4<'a> {
+    pub const MIN_SIZE: usize = (u16::RAW_BYTE_LEN + Uint24::RAW_BYTE_LEN);
+    basic_table_impls!(impl_the_methods);
+
+    /// Format identifier — format = 4
+    pub fn class_format(&self) -> u16 {
+        let range = self.class_format_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Number of ClassRangeRecord2s
+    pub fn class_range_count(&self) -> Uint24 {
+        let range = self.class_range_count_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Array of ClassRangeRecord2s — ordered by startGlyphID
+    pub fn class_range_records(&self) -> &'a [ClassRangeRecord2] {
+        let range = self.class_range_records_byte_range();
+        self.data.read_array(range).ok().unwrap_or_default()
+    }
+
+    pub fn class_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn class_range_count_byte_range(&self) -> Range<usize> {
+        let start = self.class_format_byte_range().end;
+        start..start + Uint24::RAW_BYTE_LEN
+    }
+
+    pub fn class_range_records_byte_range(&self) -> Range<usize> {
+        let class_range_count = self.class_range_count();
+        let start = self.class_range_count_byte_range().end;
+        start
+            ..start
+                + (usize::try_from(class_range_count).unwrap_or_default())
+                    .saturating_mul(ClassRangeRecord2::RAW_BYTE_LEN)
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a> SomeTable<'a> for ClassDefFormat4<'a> {
+    fn type_name(&self) -> &str {
+        "ClassDefFormat4"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("class_format", self.class_format())),
+            1usize => Some(Field::new("class_range_count", self.class_range_count())),
+            2usize => Some(Field::new(
+                "class_range_records",
+                traversal::FieldType::array_of_records(
+                    stringify!(ClassRangeRecord2),
+                    self.class_range_records(),
+                    self.offset_data(),
+                ),
+            )),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+#[allow(clippy::needless_lifetimes)]
+impl<'a> std::fmt::Debug for ClassDefFormat4<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
 /// Used in [ClassDefFormat2]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -1897,11 +2109,64 @@ impl<'a> SomeRecord<'a> for ClassRangeRecord {
     }
 }
 
+/// Used in [ClassDefFormat4]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct ClassRangeRecord2 {
+    /// First glyph ID in the range
+    pub start_glyph_id: BigEndian<GlyphId24>,
+    /// Last glyph ID in the range
+    pub end_glyph_id: BigEndian<GlyphId24>,
+    /// Applied to all glyphs in the range
+    pub class: BigEndian<u16>,
+}
+
+impl ClassRangeRecord2 {
+    /// First glyph ID in the range
+    pub fn start_glyph_id(&self) -> GlyphId24 {
+        self.start_glyph_id.get()
+    }
+
+    /// Last glyph ID in the range
+    pub fn end_glyph_id(&self) -> GlyphId24 {
+        self.end_glyph_id.get()
+    }
+
+    /// Applied to all glyphs in the range
+    pub fn class(&self) -> u16 {
+        self.class.get()
+    }
+}
+
+impl FixedSize for ClassRangeRecord2 {
+    const RAW_BYTE_LEN: usize =
+        GlyphId24::RAW_BYTE_LEN + GlyphId24::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a> SomeRecord<'a> for ClassRangeRecord2 {
+    fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
+        RecordResolver {
+            name: "ClassRangeRecord2",
+            get_field: Box::new(move |idx, _data| match idx {
+                0usize => Some(Field::new("start_glyph_id", self.start_glyph_id())),
+                1usize => Some(Field::new("end_glyph_id", self.end_glyph_id())),
+                2usize => Some(Field::new("class", self.class())),
+                _ => None,
+            }),
+            data,
+        }
+    }
+}
+
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
 #[derive(Clone)]
 pub enum ClassDef<'a> {
     Format1(ClassDefFormat1<'a>),
     Format2(ClassDefFormat2<'a>),
+    Format3(ClassDefFormat3<'a>),
+    Format4(ClassDefFormat4<'a>),
 }
 
 impl Default for ClassDef<'_> {
@@ -1916,6 +2181,8 @@ impl<'a> ClassDef<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
             Self::Format2(item) => item.offset_data(),
+            Self::Format3(item) => item.offset_data(),
+            Self::Format4(item) => item.offset_data(),
         }
     }
 
@@ -1924,6 +2191,8 @@ impl<'a> ClassDef<'a> {
         match self {
             Self::Format1(item) => item.class_format(),
             Self::Format2(item) => item.class_format(),
+            Self::Format3(item) => item.class_format(),
+            Self::Format4(item) => item.class_format(),
         }
     }
 }
@@ -1934,6 +2203,8 @@ impl<'a> FontRead<'a> for ClassDef<'a> {
         match format {
             ClassDefFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             ClassDefFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
+            ClassDefFormat3::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),
+            ClassDefFormat4::FORMAT => Ok(Self::Format4(FontRead::read(data)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }
@@ -1944,12 +2215,16 @@ impl<'a> MinByteRange<'a> for ClassDef<'a> {
         match self {
             Self::Format1(item) => item.min_byte_range(),
             Self::Format2(item) => item.min_byte_range(),
+            Self::Format3(item) => item.min_byte_range(),
+            Self::Format4(item) => item.min_byte_range(),
         }
     }
     fn min_table_bytes(&self) -> &'a [u8] {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+            Self::Format3(item) => item.min_table_bytes(),
+            Self::Format4(item) => item.min_table_bytes(),
         }
     }
 }
@@ -1960,6 +2235,8 @@ impl<'a> ClassDef<'a> {
         match self {
             Self::Format1(table) => table,
             Self::Format2(table) => table,
+            Self::Format3(table) => table,
+            Self::Format4(table) => table,
         }
     }
 }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1226,6 +1226,200 @@ impl<'a> std::fmt::Debug for CoverageFormat2<'a> {
     }
 }
 
+impl Format<u16> for CoverageFormat3<'_> {
+    const FORMAT: u16 = 3;
+}
+
+impl<'a> MinByteRange<'a> for CoverageFormat3<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.glyph_array_byte_range().end
+    }
+    fn min_table_bytes(&self) -> &'a [u8] {
+        let range = self.min_byte_range();
+        self.data.as_bytes().get(range).unwrap_or_default()
+    }
+}
+
+impl<'a> FontRead<'a> for CoverageFormat3<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if data.len() < Self::MIN_SIZE {
+            return Err(ReadError::OutOfBounds);
+        }
+        Ok(Self { data })
+    }
+}
+
+/// [Coverage Format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-3)
+#[derive(Clone)]
+pub struct CoverageFormat3<'a> {
+    data: FontData<'a>,
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> CoverageFormat3<'a> {
+    pub const MIN_SIZE: usize = (u16::RAW_BYTE_LEN + Uint24::RAW_BYTE_LEN);
+    basic_table_impls!(impl_the_methods);
+
+    /// Format identifier — format = 3
+    pub fn coverage_format(&self) -> u16 {
+        let range = self.coverage_format_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Number of glyphs in the glyph array
+    pub fn glyph_count(&self) -> Uint24 {
+        let range = self.glyph_count_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Array of glyph IDs — in numerical order
+    pub fn glyph_array(&self) -> &'a [BigEndian<GlyphId24>] {
+        let range = self.glyph_array_byte_range();
+        self.data.read_array(range).ok().unwrap_or_default()
+    }
+
+    pub fn coverage_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_count_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_format_byte_range().end;
+        start..start + Uint24::RAW_BYTE_LEN
+    }
+
+    pub fn glyph_array_byte_range(&self) -> Range<usize> {
+        let glyph_count = self.glyph_count();
+        let start = self.glyph_count_byte_range().end;
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId24::RAW_BYTE_LEN)
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a> SomeTable<'a> for CoverageFormat3<'a> {
+    fn type_name(&self) -> &str {
+        "CoverageFormat3"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("coverage_format", self.coverage_format())),
+            1usize => Some(Field::new("glyph_count", self.glyph_count())),
+            2usize => Some(Field::new("glyph_array", self.glyph_array())),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+#[allow(clippy::needless_lifetimes)]
+impl<'a> std::fmt::Debug for CoverageFormat3<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
+impl Format<u16> for CoverageFormat4<'_> {
+    const FORMAT: u16 = 4;
+}
+
+impl<'a> MinByteRange<'a> for CoverageFormat4<'a> {
+    fn min_byte_range(&self) -> Range<usize> {
+        0..self.range_records_byte_range().end
+    }
+    fn min_table_bytes(&self) -> &'a [u8] {
+        let range = self.min_byte_range();
+        self.data.as_bytes().get(range).unwrap_or_default()
+    }
+}
+
+impl<'a> FontRead<'a> for CoverageFormat4<'a> {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        #[allow(clippy::absurd_extreme_comparisons)]
+        if data.len() < Self::MIN_SIZE {
+            return Err(ReadError::OutOfBounds);
+        }
+        Ok(Self { data })
+    }
+}
+
+/// [Coverage Format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-4)
+#[derive(Clone)]
+pub struct CoverageFormat4<'a> {
+    data: FontData<'a>,
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> CoverageFormat4<'a> {
+    pub const MIN_SIZE: usize = (u16::RAW_BYTE_LEN + Uint24::RAW_BYTE_LEN);
+    basic_table_impls!(impl_the_methods);
+
+    /// Format identifier — format = 4
+    pub fn coverage_format(&self) -> u16 {
+        let range = self.coverage_format_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Number of RangeRecord2s
+    pub fn range_count(&self) -> Uint24 {
+        let range = self.range_count_byte_range();
+        self.data.read_at(range.start).ok().unwrap()
+    }
+
+    /// Array of glyph ranges — ordered by startGlyphID.
+    pub fn range_records(&self) -> &'a [RangeRecord2] {
+        let range = self.range_records_byte_range();
+        self.data.read_array(range).ok().unwrap_or_default()
+    }
+
+    pub fn coverage_format_byte_range(&self) -> Range<usize> {
+        let start = 0;
+        start..start + u16::RAW_BYTE_LEN
+    }
+
+    pub fn range_count_byte_range(&self) -> Range<usize> {
+        let start = self.coverage_format_byte_range().end;
+        start..start + Uint24::RAW_BYTE_LEN
+    }
+
+    pub fn range_records_byte_range(&self) -> Range<usize> {
+        let range_count = self.range_count();
+        let start = self.range_count_byte_range().end;
+        start
+            ..start + (transforms::to_usize(range_count)).saturating_mul(RangeRecord2::RAW_BYTE_LEN)
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a> SomeTable<'a> for CoverageFormat4<'a> {
+    fn type_name(&self) -> &str {
+        "CoverageFormat4"
+    }
+    fn get_field(&self, idx: usize) -> Option<Field<'a>> {
+        match idx {
+            0usize => Some(Field::new("coverage_format", self.coverage_format())),
+            1usize => Some(Field::new("range_count", self.range_count())),
+            2usize => Some(Field::new(
+                "range_records",
+                traversal::FieldType::array_of_records(
+                    stringify!(RangeRecord2),
+                    self.range_records(),
+                    self.offset_data(),
+                ),
+            )),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "experimental_traverse")]
+#[allow(clippy::needless_lifetimes)]
+impl<'a> std::fmt::Debug for CoverageFormat4<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn SomeTable<'a>).fmt(f)
+    }
+}
+
 /// Used in [CoverageFormat2]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
 #[repr(C)]
@@ -1280,11 +1474,67 @@ impl<'a> SomeRecord<'a> for RangeRecord {
     }
 }
 
+/// Used in [CoverageFormat4]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, bytemuck :: AnyBitPattern)]
+#[repr(C)]
+#[repr(packed)]
+pub struct RangeRecord2 {
+    /// First glyph ID in the range
+    pub start_glyph_id: BigEndian<GlyphId24>,
+    /// Last glyph ID in the range
+    pub end_glyph_id: BigEndian<GlyphId24>,
+    /// Coverage Index of first glyph ID in range
+    pub start_coverage_index: BigEndian<Uint24>,
+}
+
+impl RangeRecord2 {
+    /// First glyph ID in the range
+    pub fn start_glyph_id(&self) -> GlyphId24 {
+        self.start_glyph_id.get()
+    }
+
+    /// Last glyph ID in the range
+    pub fn end_glyph_id(&self) -> GlyphId24 {
+        self.end_glyph_id.get()
+    }
+
+    /// Coverage Index of first glyph ID in range
+    pub fn start_coverage_index(&self) -> Uint24 {
+        self.start_coverage_index.get()
+    }
+}
+
+impl FixedSize for RangeRecord2 {
+    const RAW_BYTE_LEN: usize =
+        GlyphId24::RAW_BYTE_LEN + GlyphId24::RAW_BYTE_LEN + Uint24::RAW_BYTE_LEN;
+}
+
+#[cfg(feature = "experimental_traverse")]
+impl<'a> SomeRecord<'a> for RangeRecord2 {
+    fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
+        RecordResolver {
+            name: "RangeRecord2",
+            get_field: Box::new(move |idx, _data| match idx {
+                0usize => Some(Field::new("start_glyph_id", self.start_glyph_id())),
+                1usize => Some(Field::new("end_glyph_id", self.end_glyph_id())),
+                2usize => Some(Field::new(
+                    "start_coverage_index",
+                    self.start_coverage_index(),
+                )),
+                _ => None,
+            }),
+            data,
+        }
+    }
+}
+
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
 #[derive(Clone)]
 pub enum CoverageTable<'a> {
     Format1(CoverageFormat1<'a>),
     Format2(CoverageFormat2<'a>),
+    Format3(CoverageFormat3<'a>),
+    Format4(CoverageFormat4<'a>),
 }
 
 impl Default for CoverageTable<'_> {
@@ -1299,6 +1549,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             Self::Format1(item) => item.offset_data(),
             Self::Format2(item) => item.offset_data(),
+            Self::Format3(item) => item.offset_data(),
+            Self::Format4(item) => item.offset_data(),
         }
     }
 
@@ -1307,6 +1559,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             Self::Format1(item) => item.coverage_format(),
             Self::Format2(item) => item.coverage_format(),
+            Self::Format3(item) => item.coverage_format(),
+            Self::Format4(item) => item.coverage_format(),
         }
     }
 }
@@ -1317,6 +1571,8 @@ impl<'a> FontRead<'a> for CoverageTable<'a> {
         match format {
             CoverageFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
             CoverageFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
+            CoverageFormat3::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),
+            CoverageFormat4::FORMAT => Ok(Self::Format4(FontRead::read(data)?)),
             other => Err(ReadError::InvalidFormat(other.into())),
         }
     }
@@ -1327,12 +1583,16 @@ impl<'a> MinByteRange<'a> for CoverageTable<'a> {
         match self {
             Self::Format1(item) => item.min_byte_range(),
             Self::Format2(item) => item.min_byte_range(),
+            Self::Format3(item) => item.min_byte_range(),
+            Self::Format4(item) => item.min_byte_range(),
         }
     }
     fn min_table_bytes(&self) -> &'a [u8] {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+            Self::Format3(item) => item.min_table_bytes(),
+            Self::Format4(item) => item.min_table_bytes(),
         }
     }
 }
@@ -1343,6 +1603,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             Self::Format1(table) => table,
             Self::Format2(table) => table,
+            Self::Format3(table) => table,
+            Self::Format4(table) => table,
         }
     }
 }

--- a/read-fonts/src/tables/gpos/closure.rs
+++ b/read-fonts/src/tables/gpos/closure.rs
@@ -198,7 +198,7 @@ impl Intersect for PairPosFormat1<'_> {
             }
         } else {
             for (g, pair_set) in coverage.iter().zip(pair_sets.iter_as_nullable()) {
-                if !glyph_set.contains(GlyphId::from(g)) {
+                if !glyph_set.contains(g) {
                     continue;
                 }
                 let Some(pair_set) = pair_set.transpose()? else {

--- a/read-fonts/src/tables/gsub/closure.rs
+++ b/read-fonts/src/tables/gsub/closure.rs
@@ -471,7 +471,7 @@ impl GlyphClosure for SingleSubstFormat2<'_> {
                 coverage
                     .iter()
                     .zip(subs_glyphs)
-                    .filter(|&(g, _)| glyph_set.contains(GlyphId::from(g)))
+                    .filter(|&(g, _)| glyph_set.contains(g))
                     .map(|(_, &new_g)| GlyphId::from(new_g.get()))
                     .collect()
             };
@@ -512,7 +512,7 @@ impl GlyphClosure for MultipleSubstFormat1<'_> {
                     .zip(sequences.iter_as_nullable())
                     .filter_map(|(g, seq)| {
                         glyph_set
-                            .contains(GlyphId::from(g))
+                            .contains(g)
                             .then(|| seq.transpose().ok().flatten())
                             .flatten()
                     })
@@ -562,7 +562,7 @@ impl GlyphClosure for AlternateSubstFormat1<'_> {
                     .zip(alts.iter_as_nullable())
                     .filter_map(|(g, alt_set)| {
                         glyph_set
-                            .contains(GlyphId::from(g))
+                            .contains(g)
                             .then(|| alt_set.transpose().ok().flatten())
                             .flatten()
                     })
@@ -603,7 +603,7 @@ impl GlyphClosure for LigatureSubstFormat1<'_> {
                 coverage
                     .iter()
                     .enumerate()
-                    .filter(|&(_idx, g)| ctx.parent_active_glyphs().contains(GlyphId::from(g)))
+                    .filter(|&(_idx, g)| ctx.parent_active_glyphs().contains(g))
                     .map(|(idx, _)| idx)
                     .collect()
             };
@@ -649,7 +649,7 @@ impl GlyphClosure for ReverseChainSingleSubstFormat1<'_> {
             coverage
                 .iter()
                 .enumerate()
-                .filter(|&(_idx, g)| glyph_set.contains(GlyphId::from(g)))
+                .filter(|&(_idx, g)| glyph_set.contains(g))
                 .map(|(idx, _)| idx)
                 .collect()
         };
@@ -730,7 +730,7 @@ impl GlyphClosure for ContextFormat1<'_> {
             .zip(self.rule_sets())
             .filter_map(|(g, rule_set)| {
                 rule_set
-                    .filter(|_| cov_active_glyphs.contains(GlyphId::from(g)))
+                    .filter(|_| cov_active_glyphs.contains(g))
                     .map(|rs| (g, rs))
             })
         {
@@ -778,7 +778,7 @@ impl GlyphClosure for ContextFormat1<'_> {
                         // it with the full current glyph set
                         active_glyphs.extend(ctx.glyphs().iter());
                     } else if sequence_idx == 0 {
-                        active_glyphs.insert(GlyphId::from(gid));
+                        active_glyphs.insert(gid);
                     } else {
                         let g = input_seq[sequence_idx as usize - 1].get();
                         active_glyphs.insert(GlyphId::from(g));
@@ -1098,7 +1098,7 @@ impl Intersect for LigatureSubstFormat1<'_> {
         for lig_set in coverage
             .iter()
             .zip(lig_sets.iter_as_nullable())
-            .filter_map(|(g, lig_set)| glyph_set.contains(GlyphId::from(g)).then_some(lig_set))
+            .filter_map(|(g, lig_set)| glyph_set.contains(g).then_some(lig_set))
         {
             let Some(lig_set) = lig_set.transpose()? else {
                 continue;

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -631,14 +631,14 @@ impl<'a> ClassDefFormat1<'a> {
     }
 
     /// Iterate over each glyph and its class.
-    pub fn iter(&self) -> impl Iterator<Item = (GlyphId16, u16)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + 'a {
         let start = self.start_glyph_id();
         self.class_value_array()
             .iter()
             .enumerate()
             .map(move |(i, val)| {
                 let gid = start.to_u16().saturating_add(i as u16);
-                (GlyphId16::new(gid), val.get())
+                (GlyphId::from(gid as u32), val.get())
             })
     }
 
@@ -749,11 +749,11 @@ impl<'a> ClassDefFormat2<'a> {
     }
 
     /// Iterate over each glyph and its class.
-    pub fn iter(&self) -> impl Iterator<Item = (GlyphId16, u16)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + 'a {
         self.class_range_records().iter().flat_map(|range| {
             let start = range.start_glyph_id().to_u16();
             let end = range.end_glyph_id().to_u16();
-            (start..=end).map(|gid| (GlyphId16::new(gid), range.class()))
+            (start..=end).map(|gid| (GlyphId::from(gid as u32), range.class()))
         })
     }
 
@@ -825,7 +825,7 @@ impl<'a> ClassDefFormat2<'a> {
         out
     }
 
-    /// Returns intersected glyphs of this table and input 'glyphs' set that are assgiend to input class value.
+    /// Returns intersected glyphs of this table and input 'glyphs' set that are assigned to input class value.
     #[cfg(feature = "std")]
     fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
         let mut out = IntSet::empty();
@@ -881,7 +881,295 @@ impl<'a> ClassDefFormat2<'a> {
     }
 }
 
+impl<'a> ClassDefFormat3<'a> {
+    /// Get the class for this glyph id
+    #[inline]
+    pub fn get(&self, gid: impl Into<GlyphId>) -> u16 {
+        let Some(idx) = gid
+            .into()
+            .to_u32()
+            .checked_sub(self.start_glyph_id().to_u32())
+        else {
+            return 0;
+        };
+        self.class_value_array()
+            .get(idx as usize)
+            .map(|x| x.get())
+            .unwrap_or(0)
+    }
+
+    /// Iterate over each glyph and its class.
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + 'a {
+        let start = self.start_glyph_id().to_u32();
+        self.class_value_array()
+            .iter()
+            .enumerate()
+            .map(move |(i, val)| (GlyphId::from(start + i as u32), val.get()))
+    }
+
+    /// Return the number of glyphs explicitly assigned to a class in this table
+    pub fn population(&self) -> usize {
+        usize::from(self.glyph_count())
+    }
+
+    /// Return the cost of looking up a glyph in this table
+    pub fn cost(&self) -> u32 {
+        1
+    }
+
+    /// Returns class values for the intersected glyphs of this table and input 'glyphs' set.
+    #[cfg(feature = "std")]
+    fn intersect_classes(&self, glyphs: &IntSet<GlyphId>) -> IntSet<u16> {
+        let mut out = IntSet::empty();
+        if glyphs.is_empty() {
+            return out;
+        }
+
+        let start_glyph = self.start_glyph_id().to_u32();
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count == 0 {
+            out.insert(0);
+            return out;
+        }
+        let end_glyph = start_glyph + glyph_count - 1;
+        if glyphs.first().unwrap().to_u32() < start_glyph
+            || glyphs.last().unwrap().to_u32() > end_glyph
+        {
+            out.insert(0);
+        }
+
+        let class_values = self.class_value_array();
+        if glyphs.contains(GlyphId::from(start_glyph)) {
+            let Some(start_glyph_class) = class_values.first() else {
+                return out;
+            };
+            out.insert(start_glyph_class.get());
+        }
+
+        for g in glyphs.iter_after(GlyphId::from(start_glyph)) {
+            let g = g.to_u32();
+            if g > end_glyph {
+                break;
+            }
+
+            let idx = g - start_glyph;
+            let Some(class) = class_values.get(idx as usize) else {
+                break;
+            };
+            out.insert(class.get());
+        }
+        out
+    }
+
+    /// Returns intersected glyphs of this table and input 'glyphs' set that are assigned to input class value.
+    #[cfg(feature = "std")]
+    fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
+        let mut out = IntSet::empty();
+        if glyphs.is_empty() {
+            return out;
+        }
+
+        let start_glyph = self.start_glyph_id().to_u32();
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count == 0 {
+            if class == 0 {
+                return glyphs.clone();
+            }
+            return out;
+        }
+        let end_glyph = start_glyph + glyph_count - 1;
+        if class == 0 {
+            let first = glyphs.first().unwrap();
+            if first.to_u32() < start_glyph {
+                out.extend(glyphs.range(first..GlyphId::from(start_glyph)));
+            }
+
+            let last = glyphs.last().unwrap();
+            if last.to_u32() > end_glyph {
+                out.extend(glyphs.range(GlyphId::from(end_glyph + 1)..=last));
+            }
+            return out;
+        }
+
+        let class_values = self.class_value_array();
+        for g in glyphs.range(GlyphId::from(start_glyph)..=GlyphId::from(end_glyph)) {
+            let idx = g.to_u32() - start_glyph;
+            let Some(c) = class_values.get(idx as usize) else {
+                break;
+            };
+            if c.get() == class {
+                out.insert(g);
+            }
+        }
+        out
+    }
+}
+
+impl<'a> ClassDefFormat4<'a> {
+    /// Get the class for this glyph id
+    #[inline]
+    pub fn get(&self, gid: impl Into<GlyphId>) -> u16 {
+        let gid = gid.into().to_u32();
+        let records = self.class_range_records();
+        let ix = match records.binary_search_by(|rec| rec.start_glyph_id().to_u32().cmp(&gid)) {
+            Ok(ix) => ix,
+            Err(ix) => ix.saturating_sub(1),
+        };
+        if let Some(record) = records.get(ix) {
+            if (record.start_glyph_id().to_u32()..=record.end_glyph_id().to_u32()).contains(&gid) {
+                return record.class();
+            }
+        }
+        0
+    }
+
+    /// Iterate over each glyph and its class.
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + 'a {
+        self.class_range_records().iter().flat_map(|range| {
+            let start = range.start_glyph_id().to_u32();
+            let end = range.end_glyph_id().to_u32();
+            (start..=end).map(|gid| (GlyphId::from(gid), range.class()))
+        })
+    }
+
+    /// Return the number of glyphs explicitly assigned to a class in this table
+    pub fn population(&self) -> usize {
+        self.class_range_records()
+            .iter()
+            .fold(0, |acc, record| acc + record.population())
+    }
+
+    /// Return the cost of looking up a glyph in this table
+    pub fn cost(&self) -> u32 {
+        bit_storage(self.class_range_count().to_u32())
+    }
+
+    /// Returns class values for the intersected glyphs of this table and input 'glyphs' set.
+    #[cfg(feature = "std")]
+    fn intersect_classes(&self, glyphs: &IntSet<GlyphId>) -> IntSet<u16> {
+        let mut out = IntSet::empty();
+        if glyphs.is_empty() {
+            return out;
+        }
+
+        if self.class_range_count().to_u32() == 0 {
+            out.insert(0);
+            return out;
+        }
+
+        let range_records = self.class_range_records();
+        let first_record = range_records[0];
+
+        if glyphs.first().unwrap().to_u32() < first_record.start_glyph_id().to_u32() {
+            out.insert(0);
+        } else {
+            let mut glyph = GlyphId::from(first_record.end_glyph_id());
+            for record in range_records.iter().skip(1) {
+                let Some(g) = glyphs.iter_after(glyph).next() else {
+                    break;
+                };
+
+                if g.to_u32() < record.start_glyph_id().to_u32() {
+                    out.insert(0);
+                    break;
+                }
+                glyph = GlyphId::from(record.end_glyph_id());
+            }
+            if glyphs.iter_after(glyph).next().is_some() {
+                out.insert(0);
+            }
+        }
+
+        let num_ranges = self.class_range_count().to_u32();
+        if num_ranges as u64 > glyphs.len() * self.cost() as u64 {
+            for g in glyphs.iter() {
+                let class = self.get(g);
+                if class != 0 {
+                    out.insert(class);
+                }
+            }
+        } else {
+            for record in range_records {
+                if glyphs.intersects_range(
+                    GlyphId::from(record.start_glyph_id())..=GlyphId::from(record.end_glyph_id()),
+                ) {
+                    out.insert(record.class());
+                }
+            }
+        }
+        out
+    }
+
+    /// Returns intersected glyphs of this table and input 'glyphs' set that are assgiend to input class value.
+    #[cfg(feature = "std")]
+    fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
+        let mut out = IntSet::empty();
+        if glyphs.is_empty() {
+            return out;
+        }
+
+        let first = glyphs.first().unwrap().to_u32();
+        let last = glyphs.last().unwrap().to_u32();
+        if class == 0 {
+            let mut start = first;
+            for range in self.class_range_records() {
+                let range_start = range.start_glyph_id().to_u32();
+                if start < range_start {
+                    out.extend(glyphs.range(GlyphId::from(start)..GlyphId::from(range_start)));
+                }
+
+                let range_end = range.end_glyph_id().to_u32();
+                if range_end >= last {
+                    break;
+                }
+                start = range_end + 1;
+            }
+
+            if start <= last {
+                out.extend(glyphs.range(GlyphId::from(start)..=GlyphId::from(last)));
+            }
+            return out;
+        }
+
+        let num_ranges = self.class_range_count().to_u32();
+        if num_ranges as u64 > glyphs.len() * self.cost() as u64 {
+            for g in glyphs.iter() {
+                let c = self.get(g);
+                if c == class {
+                    out.insert(g);
+                }
+            }
+        } else {
+            for range in self.class_range_records() {
+                let range_start = range.start_glyph_id().to_u32();
+                let range_end = range.end_glyph_id().to_u32();
+                if range_start > last {
+                    break;
+                }
+                if range.class() != class || range.end_glyph_id().to_u32() < first {
+                    continue;
+                }
+                out.extend(glyphs.range(GlyphId::from(range_start)..=GlyphId::from(range_end)));
+            }
+        }
+        out
+    }
+}
+
 impl ClassRangeRecord {
+    /// Return the number of glyphs explicitly assigned to a class in this table
+    pub fn population(&self) -> usize {
+        let start = self.start_glyph_id().to_u32() as usize;
+        let end = self.end_glyph_id().to_u32() as usize;
+        if start > end {
+            0
+        } else {
+            end - start + 1
+        }
+    }
+}
+
+impl ClassRangeRecord2 {
     /// Return the number of glyphs explicitly assigned to a class in this table
     pub fn population(&self) -> usize {
         let start = self.start_glyph_id().to_u32() as usize;
@@ -901,18 +1189,36 @@ impl ClassDef<'_> {
         match self {
             ClassDef::Format1(table) => table.get(gid),
             ClassDef::Format2(table) => table.get(gid),
+            ClassDef::Format3(table) => table.get(gid),
+            ClassDef::Format4(table) => table.get(gid),
         }
     }
 
     /// Iterate over each glyph and its class.
     ///
     /// This will not include class 0 unless it has been explicitly assigned.
-    pub fn iter(&self) -> impl Iterator<Item = (GlyphId16, u16)> + '_ {
-        let (one, two) = match self {
-            ClassDef::Format1(inner) => (Some(inner.iter()), None),
-            ClassDef::Format2(inner) => (None, Some(inner.iter())),
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + '_ {
+        let one = match self {
+            ClassDef::Format1(inner) => Some(inner.iter()),
+            _ => None,
         };
-        one.into_iter().flatten().chain(two.into_iter().flatten())
+        let two = match self {
+            ClassDef::Format2(inner) => Some(inner.iter()),
+            _ => None,
+        };
+        let three = match self {
+            ClassDef::Format3(inner) => Some(inner.iter()),
+            _ => None,
+        };
+        let four = match self {
+            ClassDef::Format4(inner) => Some(inner.iter()),
+            _ => None,
+        };
+        one.into_iter()
+            .flatten()
+            .chain(two.into_iter().flatten())
+            .chain(three.into_iter().flatten())
+            .chain(four.into_iter().flatten())
     }
 
     /// Return the number of glyphs explicitly assigned to a class in this table
@@ -920,6 +1226,8 @@ impl ClassDef<'_> {
         match self {
             ClassDef::Format1(table) => table.population(),
             ClassDef::Format2(table) => table.population(),
+            ClassDef::Format3(table) => table.population(),
+            ClassDef::Format4(table) => table.population(),
         }
     }
 
@@ -928,6 +1236,8 @@ impl ClassDef<'_> {
         match self {
             ClassDef::Format1(sub) => sub.cost(),
             ClassDef::Format2(sub) => sub.cost(),
+            ClassDef::Format3(sub) => sub.cost(),
+            ClassDef::Format4(sub) => sub.cost(),
         }
     }
 
@@ -937,6 +1247,8 @@ impl ClassDef<'_> {
         match self {
             ClassDef::Format1(table) => table.intersect_classes(glyphs),
             ClassDef::Format2(table) => table.intersect_classes(glyphs),
+            ClassDef::Format3(table) => table.intersect_classes(glyphs),
+            ClassDef::Format4(table) => table.intersect_classes(glyphs),
         }
     }
 
@@ -950,6 +1262,8 @@ impl ClassDef<'_> {
         match self {
             ClassDef::Format1(table) => table.intersected_class_glyphs(glyphs, class),
             ClassDef::Format2(table) => table.intersected_class_glyphs(glyphs, class),
+            ClassDef::Format3(table) => table.intersected_class_glyphs(glyphs, class),
+            ClassDef::Format4(table) => table.intersected_class_glyphs(glyphs, class),
         }
     }
 }
@@ -1123,6 +1437,36 @@ mod tests {
         for (gid, class) in classdef.iter() {
             assert_eq!(classdef.get(gid), class);
         }
+    }
+
+    #[test]
+    fn classdef_get_format3() {
+        const CLASSDEF3_DATA: FontData = FontData::new(&[0, 3, 1, 0, 0, 0, 0, 3, 0, 5, 0, 0, 0, 7]);
+
+        let classdef = ClassDef::read(CLASSDEF3_DATA).unwrap();
+        assert!(matches!(classdef, ClassDef::Format3(..)));
+        assert_eq!(classdef.get(GlyphId::new(0xffff)), 0);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0000)), 5);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0001)), 0);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0002)), 7);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0003)), 0);
+    }
+
+    #[test]
+    fn classdef_get_format4() {
+        const CLASSDEF4_DATA: FontData = FontData::new(&[
+            0, 4, 0, 0, 2, 1, 0, 0, 1, 0, 2, 0, 4, 2, 0, 0, 2, 0, 1, 0, 7,
+        ]);
+
+        let classdef = ClassDef::read(CLASSDEF4_DATA).unwrap();
+        assert!(matches!(classdef, ClassDef::Format4(..)));
+        assert_eq!(classdef.get(GlyphId::new(0xffff)), 0);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0000)), 4);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0002)), 4);
+        assert_eq!(classdef.get(GlyphId::new(0x1_0003)), 0);
+        assert_eq!(classdef.get(GlyphId::new(0x2_0000)), 7);
+        assert_eq!(classdef.get(GlyphId::new(0x2_0001)), 7);
+        assert_eq!(classdef.get(GlyphId::new(0x2_0002)), 0);
     }
 
     #[test]

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -164,6 +164,570 @@ fn bit_storage(v: u32) -> u32 {
     u32::BITS - v.leading_zeros()
 }
 
+trait GlyphIdScalar: Copy + font_types::Scalar {
+    fn to_gid(self) -> GlyphId;
+}
+
+impl GlyphIdScalar for GlyphId16 {
+    fn to_gid(self) -> GlyphId {
+        GlyphId::from(self)
+    }
+}
+
+impl GlyphIdScalar for GlyphId24 {
+    fn to_gid(self) -> GlyphId {
+        GlyphId::from(self)
+    }
+}
+
+trait CoverageArrayFormat<'a> {
+    type RawGlyph: GlyphIdScalar;
+
+    fn glyph_count_u32(&self) -> u32;
+    fn glyph_array(&self) -> &'a [BigEndian<Self::RawGlyph>];
+    fn raw_glyph(gid: GlyphId) -> Option<Self::RawGlyph>;
+}
+
+fn coverage_array_get<'a, T>(table: &T, gid: impl Into<GlyphId>) -> Option<u32>
+where
+    T: CoverageArrayFormat<'a> + 'a,
+    BigEndian<T::RawGlyph>: From<T::RawGlyph> + Ord,
+{
+    let raw = T::raw_glyph(gid.into())?;
+    let be_glyph: BigEndian<T::RawGlyph> = raw.into();
+    table
+        .glyph_array()
+        .binary_search(&be_glyph)
+        .ok()
+        .map(|idx| idx as u32)
+}
+
+#[cfg(feature = "std")]
+fn coverage_array_intersects<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> bool
+where
+    T: CoverageArrayFormat<'a> + 'a,
+    BigEndian<T::RawGlyph>: From<T::RawGlyph> + Ord,
+{
+    if table.glyph_count_u32() as u64 > glyphs.len() * coverage_array_cost(table) as u64 {
+        glyphs
+            .iter()
+            .any(|g| coverage_array_get(table, g).is_some())
+    } else {
+        table
+            .glyph_array()
+            .iter()
+            .any(|g| glyphs.contains(g.get().to_gid()))
+    }
+}
+
+#[cfg(feature = "std")]
+fn coverage_array_intersect_set<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId>
+where
+    T: CoverageArrayFormat<'a> + 'a,
+    BigEndian<T::RawGlyph>: From<T::RawGlyph> + Ord,
+{
+    if table.glyph_count_u32() as u64 > glyphs.len() * coverage_array_cost(table) as u64 {
+        glyphs
+            .iter()
+            .filter_map(|g| coverage_array_get(table, g).map(|_| g))
+            .collect()
+    } else {
+        table
+            .glyph_array()
+            .iter()
+            .filter(|g| glyphs.contains(g.get().to_gid()))
+            .map(|g| g.get().to_gid())
+            .collect()
+    }
+}
+
+fn coverage_array_population<'a, T>(table: &T) -> usize
+where
+    T: CoverageArrayFormat<'a> + 'a,
+{
+    table.glyph_count_u32() as usize
+}
+
+fn coverage_array_cost<'a, T>(table: &T) -> u32
+where
+    T: CoverageArrayFormat<'a> + 'a,
+{
+    bit_storage(table.glyph_count_u32())
+}
+
+trait CoverageRangeRecord {
+    fn start_gid(&self) -> GlyphId;
+    fn end_gid(&self) -> GlyphId;
+    fn start_coverage_index(&self) -> u32;
+    fn population(&self) -> usize;
+}
+
+impl CoverageRangeRecord for RangeRecord {
+    fn start_gid(&self) -> GlyphId {
+        GlyphId::from(self.start_glyph_id())
+    }
+
+    fn end_gid(&self) -> GlyphId {
+        GlyphId::from(self.end_glyph_id())
+    }
+
+    fn start_coverage_index(&self) -> u32 {
+        self.start_coverage_index() as u32
+    }
+
+    fn population(&self) -> usize {
+        RangeRecord::population(self)
+    }
+}
+
+impl CoverageRangeRecord for RangeRecord2 {
+    fn start_gid(&self) -> GlyphId {
+        GlyphId::from(self.start_glyph_id())
+    }
+
+    fn end_gid(&self) -> GlyphId {
+        GlyphId::from(self.end_glyph_id())
+    }
+
+    fn start_coverage_index(&self) -> u32 {
+        self.start_coverage_index().to_u32()
+    }
+
+    fn population(&self) -> usize {
+        RangeRecord2::population(self)
+    }
+}
+
+trait CoverageRangeFormat<'a> {
+    type Record: CoverageRangeRecord;
+
+    fn range_count_u32(&self) -> u32;
+    fn range_records(&self) -> &'a [Self::Record];
+}
+
+fn coverage_range_get<'a, T>(table: &T, gid: impl Into<GlyphId>) -> Option<u32>
+where
+    T: CoverageRangeFormat<'a> + 'a,
+{
+    let gid = gid.into().to_u32();
+    table
+        .range_records()
+        .binary_search_by(|rec| {
+            if rec.end_gid().to_u32() < gid {
+                Ordering::Less
+            } else if rec.start_gid().to_u32() > gid {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        })
+        .ok()
+        .and_then(|idx| {
+            let rec = &table.range_records()[idx];
+            rec.start_coverage_index()
+                .checked_add(gid - rec.start_gid().to_u32())
+        })
+}
+
+#[cfg(feature = "std")]
+fn coverage_range_intersects<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> bool
+where
+    T: CoverageRangeFormat<'a> + 'a,
+{
+    if table.range_count_u32() as u64 > glyphs.len() * coverage_range_cost(table) as u64 {
+        glyphs
+            .iter()
+            .any(|g| coverage_range_get(table, g).is_some())
+    } else {
+        table
+            .range_records()
+            .iter()
+            .any(|record| glyphs.intersects_range(record.start_gid()..=record.end_gid()))
+    }
+}
+
+#[cfg(feature = "std")]
+fn coverage_range_intersect_set<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId>
+where
+    T: CoverageRangeFormat<'a> + 'a,
+{
+    if table.range_count_u32() as u64 > glyphs.len() * coverage_range_cost(table) as u64 {
+        glyphs
+            .iter()
+            .filter_map(|g| coverage_range_get(table, g).map(|_| g))
+            .collect()
+    } else {
+        let mut out = IntSet::empty();
+        let mut last = GlyphId::from(0u32);
+        for record in table.range_records() {
+            // break out of loop for overlapping/broken tables
+            let start = record.start_gid();
+            if start < last {
+                break;
+            }
+            let end = record.end_gid();
+            last = end;
+
+            if glyphs.contains(start) {
+                out.insert(start);
+            }
+
+            for g in glyphs.iter_after(start) {
+                if g > end {
+                    break;
+                }
+                out.insert(g);
+            }
+        }
+        out
+    }
+}
+
+fn coverage_range_population<'a, T>(table: &T) -> usize
+where
+    T: CoverageRangeFormat<'a> + 'a,
+{
+    table
+        .range_records()
+        .iter()
+        .fold(0, |acc, record| acc + record.population())
+}
+
+fn coverage_range_cost<'a, T>(table: &T) -> u32
+where
+    T: CoverageRangeFormat<'a> + 'a,
+{
+    bit_storage(table.range_count_u32())
+}
+
+trait ClassDefArrayFormat<'a> {
+    fn start_gid_u32(&self) -> u32;
+    fn glyph_count_u32(&self) -> u32;
+    fn class_value_array(&self) -> &'a [BigEndian<u16>];
+}
+
+fn classdef_array_get<'a, T>(table: &T, gid: impl Into<GlyphId>) -> u16
+where
+    T: ClassDefArrayFormat<'a> + 'a,
+{
+    let Some(idx) = gid.into().to_u32().checked_sub(table.start_gid_u32()) else {
+        return 0;
+    };
+    table
+        .class_value_array()
+        .get(idx as usize)
+        .map(|x| x.get())
+        .unwrap_or(0)
+}
+
+fn classdef_array_population<'a, T>(table: &T) -> usize
+where
+    T: ClassDefArrayFormat<'a> + 'a,
+{
+    table.glyph_count_u32() as usize
+}
+
+fn classdef_array_cost<'a, T>(_table: &T) -> u32
+where
+    T: ClassDefArrayFormat<'a> + 'a,
+{
+    1
+}
+
+#[cfg(feature = "std")]
+fn classdef_array_intersect_classes<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> IntSet<u16>
+where
+    T: ClassDefArrayFormat<'a> + 'a,
+{
+    let mut out = IntSet::empty();
+    if glyphs.is_empty() {
+        return out;
+    }
+
+    let start_glyph = table.start_gid_u32();
+    let glyph_count = table.glyph_count_u32();
+    if glyph_count == 0 {
+        out.insert(0);
+        return out;
+    }
+    let end_glyph = start_glyph + glyph_count - 1;
+    if glyphs.first().unwrap().to_u32() < start_glyph || glyphs.last().unwrap().to_u32() > end_glyph
+    {
+        out.insert(0);
+    }
+
+    let class_values = table.class_value_array();
+    if glyphs.contains(GlyphId::from(start_glyph)) {
+        let Some(start_glyph_class) = class_values.first() else {
+            return out;
+        };
+        out.insert(start_glyph_class.get());
+    }
+
+    for g in glyphs.iter_after(GlyphId::from(start_glyph)) {
+        let g = g.to_u32();
+        if g > end_glyph {
+            break;
+        }
+
+        let idx = g - start_glyph;
+        let Some(class) = class_values.get(idx as usize) else {
+            break;
+        };
+        out.insert(class.get());
+    }
+    out
+}
+
+#[cfg(feature = "std")]
+fn classdef_array_intersected_class_glyphs<'a, T>(
+    table: &T,
+    glyphs: &IntSet<GlyphId>,
+    class: u16,
+) -> IntSet<GlyphId>
+where
+    T: ClassDefArrayFormat<'a> + 'a,
+{
+    let mut out = IntSet::empty();
+    if glyphs.is_empty() {
+        return out;
+    }
+
+    let start_glyph = table.start_gid_u32();
+    let glyph_count = table.glyph_count_u32();
+    if glyph_count == 0 {
+        if class == 0 {
+            return glyphs.clone();
+        }
+        return out;
+    }
+    let end_glyph = start_glyph + glyph_count - 1;
+    if class == 0 {
+        let first = glyphs.first().unwrap();
+        if first.to_u32() < start_glyph {
+            out.extend(glyphs.range(first..GlyphId::from(start_glyph)));
+        }
+
+        let last = glyphs.last().unwrap();
+        if last.to_u32() > end_glyph {
+            out.extend(glyphs.range(GlyphId::from(end_glyph + 1)..=last));
+        }
+        return out;
+    }
+
+    let class_values = table.class_value_array();
+    for g in glyphs.range(GlyphId::from(start_glyph)..=GlyphId::from(end_glyph)) {
+        let idx = g.to_u32() - start_glyph;
+        let Some(c) = class_values.get(idx as usize) else {
+            break;
+        };
+        if c.get() == class {
+            out.insert(g);
+        }
+    }
+    out
+}
+
+trait ClassRangeRecordLike {
+    fn start_gid(&self) -> GlyphId;
+    fn end_gid(&self) -> GlyphId;
+    fn class(&self) -> u16;
+    fn population(&self) -> usize;
+}
+
+impl ClassRangeRecordLike for ClassRangeRecord {
+    fn start_gid(&self) -> GlyphId {
+        GlyphId::from(self.start_glyph_id())
+    }
+
+    fn end_gid(&self) -> GlyphId {
+        GlyphId::from(self.end_glyph_id())
+    }
+
+    fn class(&self) -> u16 {
+        self.class()
+    }
+
+    fn population(&self) -> usize {
+        self::ClassRangeRecord::population(self)
+    }
+}
+
+impl ClassRangeRecordLike for ClassRangeRecord2 {
+    fn start_gid(&self) -> GlyphId {
+        GlyphId::from(self.start_glyph_id())
+    }
+
+    fn end_gid(&self) -> GlyphId {
+        GlyphId::from(self.end_glyph_id())
+    }
+
+    fn class(&self) -> u16 {
+        self.class()
+    }
+
+    fn population(&self) -> usize {
+        ClassRangeRecord2::population(self)
+    }
+}
+
+trait ClassDefRangeFormat<'a> {
+    type Record: ClassRangeRecordLike;
+
+    fn class_range_count_u32(&self) -> u32;
+    fn class_range_records(&self) -> &'a [Self::Record];
+}
+
+fn classdef_range_get<'a, T>(table: &T, gid: impl Into<GlyphId>) -> u16
+where
+    T: ClassDefRangeFormat<'a> + 'a,
+{
+    let gid = gid.into().to_u32();
+    let records = table.class_range_records();
+    let ix = match records.binary_search_by(|rec| rec.start_gid().to_u32().cmp(&gid)) {
+        Ok(ix) => ix,
+        Err(ix) => ix.saturating_sub(1),
+    };
+    if let Some(record) = records.get(ix) {
+        if (record.start_gid().to_u32()..=record.end_gid().to_u32()).contains(&gid) {
+            return record.class();
+        }
+    }
+    0
+}
+
+fn classdef_range_population<'a, T>(table: &T) -> usize
+where
+    T: ClassDefRangeFormat<'a> + 'a,
+{
+    table
+        .class_range_records()
+        .iter()
+        .fold(0, |acc, record| acc + record.population())
+}
+
+fn classdef_range_cost<'a, T>(table: &T) -> u32
+where
+    T: ClassDefRangeFormat<'a> + 'a,
+{
+    bit_storage(table.class_range_count_u32())
+}
+
+#[cfg(feature = "std")]
+fn classdef_range_intersect_classes<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> IntSet<u16>
+where
+    T: ClassDefRangeFormat<'a> + 'a,
+{
+    let mut out = IntSet::empty();
+    if glyphs.is_empty() {
+        return out;
+    }
+
+    if table.class_range_count_u32() == 0 {
+        out.insert(0);
+        return out;
+    }
+
+    let range_records = table.class_range_records();
+    let first_record = &range_records[0];
+
+    if glyphs.first().unwrap() < first_record.start_gid() {
+        out.insert(0);
+    } else {
+        let mut glyph = first_record.end_gid();
+        for record in range_records.iter().skip(1) {
+            let Some(g) = glyphs.iter_after(glyph).next() else {
+                break;
+            };
+
+            if g < record.start_gid() {
+                out.insert(0);
+                break;
+            }
+            glyph = record.end_gid();
+        }
+        if glyphs.iter_after(glyph).next().is_some() {
+            out.insert(0);
+        }
+    }
+
+    if table.class_range_count_u32() as u64 > glyphs.len() * classdef_range_cost(table) as u64 {
+        for g in glyphs.iter() {
+            let class = classdef_range_get(table, g);
+            if class != 0 {
+                out.insert(class);
+            }
+        }
+    } else {
+        for record in range_records {
+            if glyphs.intersects_range(record.start_gid()..=record.end_gid()) {
+                out.insert(record.class());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(feature = "std")]
+fn classdef_range_intersected_class_glyphs<'a, T>(
+    table: &T,
+    glyphs: &IntSet<GlyphId>,
+    class: u16,
+) -> IntSet<GlyphId>
+where
+    T: ClassDefRangeFormat<'a> + 'a,
+{
+    let mut out = IntSet::empty();
+    if glyphs.is_empty() {
+        return out;
+    }
+
+    let first = glyphs.first().unwrap().to_u32();
+    let last = glyphs.last().unwrap().to_u32();
+    if class == 0 {
+        let mut start = first;
+        for range in table.class_range_records() {
+            let range_start = range.start_gid().to_u32();
+            if start < range_start {
+                out.extend(glyphs.range(GlyphId::from(start)..GlyphId::from(range_start)));
+            }
+
+            let range_end = range.end_gid().to_u32();
+            if range_end >= last {
+                break;
+            }
+            start = range_end + 1;
+        }
+
+        if start <= last {
+            out.extend(glyphs.range(GlyphId::from(start)..=GlyphId::from(last)));
+        }
+        return out;
+    }
+
+    if table.class_range_count_u32() as u64 > glyphs.len() * classdef_range_cost(table) as u64 {
+        for g in glyphs.iter() {
+            let c = classdef_range_get(table, g);
+            if c == class {
+                out.insert(g);
+            }
+        }
+    } else {
+        for range in table.class_range_records() {
+            let range_start = range.start_gid().to_u32();
+            let range_end = range.end_gid().to_u32();
+            if range_start > last {
+                break;
+            }
+            if range.class() != class || range.end_gid().to_u32() < first {
+                continue;
+            }
+            out.extend(glyphs.range(GlyphId::from(range_start)..=GlyphId::from(range_end)));
+        }
+    }
+    out
+}
+
 impl<'a> CoverageTable<'a> {
     pub fn iter(&self) -> impl Iterator<Item = GlyphId> + 'a {
         // all one expression so that we have a single return type
@@ -260,57 +824,61 @@ impl<'a> CoverageTable<'a> {
     }
 }
 
+impl<'a> CoverageArrayFormat<'a> for CoverageFormat1<'a> {
+    type RawGlyph = GlyphId16;
+
+    fn glyph_count_u32(&self) -> u32 {
+        self.glyph_count() as u32
+    }
+
+    fn glyph_array(&self) -> &'a [BigEndian<Self::RawGlyph>] {
+        self.glyph_array()
+    }
+
+    fn raw_glyph(gid: GlyphId) -> Option<Self::RawGlyph> {
+        gid.try_into().ok()
+    }
+}
+
 impl CoverageFormat1<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        let gid16: GlyphId16 = gid.into().try_into().ok()?;
-        let be_glyph: BigEndian<GlyphId16> = gid16.into();
-        self.glyph_array()
-            .binary_search(&be_glyph)
-            .ok()
-            .map(|idx| idx as u32)
+        coverage_array_get(self, gid)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        let glyph_count = self.glyph_count() as u32;
-        if glyph_count > (glyphs.len() as u32) * self.cost() {
-            glyphs.iter().any(|g| self.get(g).is_some())
-        } else {
-            self.glyph_array()
-                .iter()
-                .any(|g| glyphs.contains(GlyphId::from(g.get())))
-        }
+        coverage_array_intersects(self, glyphs)
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        let glyph_count = self.glyph_count() as u32;
-        if glyph_count > (glyphs.len() as u32) * self.cost() {
-            glyphs
-                .iter()
-                .filter_map(|g| self.get(g).map(|_| g))
-                .collect()
-        } else {
-            self.glyph_array()
-                .iter()
-                .filter(|g| glyphs.contains(GlyphId::from(g.get())))
-                .map(|g| GlyphId::from(g.get()))
-                .collect()
-        }
+        coverage_array_intersect_set(self, glyphs)
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        self.glyph_count() as usize
+        coverage_array_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        bit_storage(self.glyph_count() as u32)
+        coverage_array_cost(self)
+    }
+}
+
+impl<'a> CoverageRangeFormat<'a> for CoverageFormat2<'a> {
+    type Record = RangeRecord;
+
+    fn range_count_u32(&self) -> u32 {
+        self.range_count() as u32
+    }
+
+    fn range_records(&self) -> &'a [Self::Record] {
+        self.range_records()
     }
 }
 
@@ -318,84 +886,47 @@ impl CoverageFormat2<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        let gid: GlyphId16 = gid.into().try_into().ok()?;
-        self.range_records()
-            .binary_search_by(|rec| {
-                if rec.end_glyph_id() < gid {
-                    Ordering::Less
-                } else if rec.start_glyph_id() > gid {
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            })
-            .ok()
-            .map(|idx| {
-                let rec = &self.range_records()[idx];
-                (rec.start_coverage_index() + gid.to_u16() - rec.start_glyph_id().to_u16()) as u32
-            })
+        let gid = gid.into();
+        let _: GlyphId16 = gid.try_into().ok()?;
+        coverage_range_get(self, gid)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        let range_count = self.range_count() as u32;
-        if range_count > (glyphs.len() as u32) * self.cost() {
-            glyphs.iter().any(|g| self.get(g).is_some())
-        } else {
-            self.range_records()
-                .iter()
-                .any(|record| record.intersects(glyphs))
-        }
+        coverage_range_intersects(self, glyphs)
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        let range_count = self.range_count() as u32;
-        if range_count > (glyphs.len() as u32) * self.cost() {
-            glyphs
-                .iter()
-                .filter_map(|g| self.get(g).map(|_| g))
-                .collect()
-        } else {
-            let mut out = IntSet::empty();
-            let mut last = GlyphId16::from(0);
-            for record in self.range_records() {
-                // break out of loop for overlapping/broken tables
-                let start_glyph = record.start_glyph_id();
-                if start_glyph < last {
-                    break;
-                }
-                let end = record.end_glyph_id();
-                last = end;
-
-                let start = GlyphId::from(start_glyph);
-                if glyphs.contains(start) {
-                    out.insert(start);
-                }
-
-                for g in glyphs.iter_after(start) {
-                    if g.to_u32() > end.to_u32() {
-                        break;
-                    }
-                    out.insert(g);
-                }
-            }
-            out
-        }
+        coverage_range_intersect_set(self, glyphs)
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        self.range_records()
-            .iter()
-            .fold(0, |acc, record| acc + record.population())
+        coverage_range_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        bit_storage(self.range_count() as u32)
+        coverage_range_cost(self)
+    }
+}
+
+impl<'a> CoverageArrayFormat<'a> for CoverageFormat3<'a> {
+    type RawGlyph = GlyphId24;
+
+    fn glyph_count_u32(&self) -> u32 {
+        self.glyph_count().to_u32()
+    }
+
+    fn glyph_array(&self) -> &'a [BigEndian<Self::RawGlyph>] {
+        self.glyph_array()
+    }
+
+    fn raw_glyph(gid: GlyphId) -> Option<Self::RawGlyph> {
+        gid.try_into().ok()
     }
 }
 
@@ -403,53 +934,41 @@ impl CoverageFormat3<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        let gid24: GlyphId24 = gid.into().try_into().ok()?;
-        let be_glyph: BigEndian<GlyphId24> = gid24.into();
-        self.glyph_array()
-            .binary_search(&be_glyph)
-            .ok()
-            .map(|idx| idx as u32)
+        coverage_array_get(self, gid)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        let glyph_count = self.glyph_count().to_u32();
-        if glyph_count as u64 > glyphs.len() * self.cost() as u64 {
-            glyphs.iter().any(|g| self.get(g).is_some())
-        } else {
-            self.glyph_array()
-                .iter()
-                .any(|g| glyphs.contains(GlyphId::from(g.get())))
-        }
+        coverage_array_intersects(self, glyphs)
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        let glyph_count = self.glyph_count().to_u32();
-        if glyph_count as u64 > glyphs.len() * self.cost() as u64 {
-            glyphs
-                .iter()
-                .filter_map(|g| self.get(g).map(|_| g))
-                .collect()
-        } else {
-            self.glyph_array()
-                .iter()
-                .filter(|g| glyphs.contains(GlyphId::from(g.get())))
-                .map(|g| GlyphId::from(g.get()))
-                .collect()
-        }
+        coverage_array_intersect_set(self, glyphs)
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        usize::from(self.glyph_count())
+        coverage_array_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        bit_storage(self.glyph_count().to_u32())
+        coverage_array_cost(self)
+    }
+}
+
+impl<'a> CoverageRangeFormat<'a> for CoverageFormat4<'a> {
+    type Record = RangeRecord2;
+
+    fn range_count_u32(&self) -> u32 {
+        self.range_count().to_u32()
+    }
+
+    fn range_records(&self) -> &'a [Self::Record] {
+        self.range_records()
     }
 }
 
@@ -457,85 +976,29 @@ impl CoverageFormat4<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        let gid = gid.into().to_u32();
-        self.range_records()
-            .binary_search_by(|rec| {
-                if rec.end_glyph_id().to_u32() < gid {
-                    Ordering::Less
-                } else if rec.start_glyph_id().to_u32() > gid {
-                    Ordering::Greater
-                } else {
-                    Ordering::Equal
-                }
-            })
-            .ok()
-            .and_then(|idx| {
-                let rec = &self.range_records()[idx];
-                rec.start_coverage_index()
-                    .to_u32()
-                    .checked_add(gid - rec.start_glyph_id().to_u32())
-            })
+        coverage_range_get(self, gid)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        let range_count = self.range_count().to_u32();
-        if range_count as u64 > glyphs.len() * self.cost() as u64 {
-            glyphs.iter().any(|g| self.get(g).is_some())
-        } else {
-            self.range_records()
-                .iter()
-                .any(|record| record.intersects(glyphs))
-        }
+        coverage_range_intersects(self, glyphs)
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        let range_count = self.range_count().to_u32();
-        if range_count as u64 > glyphs.len() * self.cost() as u64 {
-            glyphs
-                .iter()
-                .filter_map(|g| self.get(g).map(|_| g))
-                .collect()
-        } else {
-            let mut out = IntSet::empty();
-            let mut last = GlyphId::from(0u32);
-            for record in self.range_records() {
-                // break out of loop for overlapping/broken tables
-                let start_glyph = GlyphId::from(record.start_glyph_id());
-                if start_glyph < last {
-                    break;
-                }
-                let end = GlyphId::from(record.end_glyph_id());
-                last = end;
-
-                if glyphs.contains(start_glyph) {
-                    out.insert(start_glyph);
-                }
-
-                for g in glyphs.iter_after(start_glyph) {
-                    if g > end {
-                        break;
-                    }
-                    out.insert(g);
-                }
-            }
-            out
-        }
+        coverage_range_intersect_set(self, glyphs)
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        self.range_records()
-            .iter()
-            .fold(0, |acc, record| acc + record.population())
+        coverage_range_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        bit_storage(self.range_count().to_u32())
+        coverage_range_cost(self)
     }
 }
 
@@ -613,21 +1076,25 @@ impl From<DeltaFormat> for i64 {
     }
 }
 
+impl<'a> ClassDefArrayFormat<'a> for ClassDefFormat1<'a> {
+    fn start_gid_u32(&self) -> u32 {
+        self.start_glyph_id().to_u32()
+    }
+
+    fn glyph_count_u32(&self) -> u32 {
+        self.glyph_count() as u32
+    }
+
+    fn class_value_array(&self) -> &'a [BigEndian<u16>] {
+        self.class_value_array()
+    }
+}
+
 impl<'a> ClassDefFormat1<'a> {
     /// Get the class for this glyph id
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> u16 {
-        let Some(idx) = gid
-            .into()
-            .to_u32()
-            .checked_sub(self.start_glyph_id().to_u32())
-        else {
-            return 0;
-        };
-        self.class_value_array()
-            .get(idx as usize)
-            .map(|x| x.get())
-            .unwrap_or(0)
+        classdef_array_get(self, gid)
     }
 
     /// Iterate over each glyph and its class.
@@ -644,89 +1111,36 @@ impl<'a> ClassDefFormat1<'a> {
 
     /// Return the number of glyphs explicitly assigned to a class in this table
     pub fn population(&self) -> usize {
-        self.glyph_count() as usize
+        classdef_array_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        1
+        classdef_array_cost(self)
     }
 
     /// Returns class values for the intersected glyphs of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_classes(&self, glyphs: &IntSet<GlyphId>) -> IntSet<u16> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
-
-        let start_glyph = self.start_glyph_id().to_u32();
-        let glyph_count = self.glyph_count();
-        let end_glyph = start_glyph + glyph_count as u32 - 1;
-        if glyphs.first().unwrap().to_u32() < start_glyph
-            || glyphs.last().unwrap().to_u32() > end_glyph
-        {
-            out.insert(0);
-        }
-
-        let class_values = self.class_value_array();
-        if glyphs.contains(GlyphId::from(start_glyph)) {
-            let Some(start_glyph_class) = class_values.first() else {
-                return out;
-            };
-            out.insert(start_glyph_class.get());
-        }
-
-        for g in glyphs.iter_after(GlyphId::from(start_glyph)) {
-            let g = g.to_u32();
-            if g > end_glyph {
-                break;
-            }
-
-            let idx = g - start_glyph;
-            let Some(class) = class_values.get(idx as usize) else {
-                break;
-            };
-            out.insert(class.get());
-        }
-        out
+        classdef_array_intersect_classes(self, glyphs)
     }
 
     /// Returns intersected glyphs of this table and input 'glyphs' set that are assigned to input class value.
     #[cfg(feature = "std")]
     fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
+        classdef_array_intersected_class_glyphs(self, glyphs, class)
+    }
+}
 
-        let start_glyph = self.start_glyph_id().to_u32();
-        let glyph_count = self.glyph_count();
-        let end_glyph = start_glyph + glyph_count as u32 - 1;
-        if class == 0 {
-            let first = glyphs.first().unwrap();
-            if first.to_u32() < start_glyph {
-                out.extend(glyphs.range(first..GlyphId::from(start_glyph)));
-            }
+impl<'a> ClassDefRangeFormat<'a> for ClassDefFormat2<'a> {
+    type Record = ClassRangeRecord;
 
-            let last = glyphs.last().unwrap();
-            if last.to_u32() > end_glyph {
-                out.extend(glyphs.range(GlyphId::from(end_glyph + 1)..=last));
-            }
-            return out;
-        }
+    fn class_range_count_u32(&self) -> u32 {
+        self.class_range_count() as u32
+    }
 
-        let class_values = self.class_value_array();
-        for g in glyphs.range(GlyphId::from(start_glyph)..=GlyphId::from(end_glyph)) {
-            let idx = g.to_u32() - start_glyph;
-            let Some(c) = class_values.get(idx as usize) else {
-                break;
-            };
-            if c.get() == class {
-                out.insert(g);
-            }
-        }
-        out
+    fn class_range_records(&self) -> &'a [Self::Record] {
+        self.class_range_records()
     }
 }
 
@@ -734,18 +1148,7 @@ impl<'a> ClassDefFormat2<'a> {
     /// Get the class for this glyph id
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> u16 {
-        let gid = gid.into().to_u32();
-        let records = self.class_range_records();
-        let ix = match records.binary_search_by(|rec| rec.start_glyph_id().to_u32().cmp(&gid)) {
-            Ok(ix) => ix,
-            Err(ix) => ix.saturating_sub(1),
-        };
-        if let Some(record) = records.get(ix) {
-            if (record.start_glyph_id().to_u32()..=record.end_glyph_id().to_u32()).contains(&gid) {
-                return record.class();
-            }
-        }
-        0
+        classdef_range_get(self, gid)
     }
 
     /// Iterate over each glyph and its class.
@@ -759,125 +1162,38 @@ impl<'a> ClassDefFormat2<'a> {
 
     /// Return the number of glyphs explicitly assigned to a class in this table
     pub fn population(&self) -> usize {
-        self.class_range_records()
-            .iter()
-            .fold(0, |acc, record| acc + record.population())
+        classdef_range_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        bit_storage(self.class_range_count() as u32)
+        classdef_range_cost(self)
     }
 
     /// Returns class values for the intersected glyphs of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_classes(&self, glyphs: &IntSet<GlyphId>) -> IntSet<u16> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
-
-        if self.class_range_count() == 0 {
-            out.insert(0);
-            return out;
-        }
-
-        let range_records = self.class_range_records();
-        let first_record = range_records[0];
-
-        if glyphs.first().unwrap() < first_record.start_glyph_id() {
-            out.insert(0);
-        } else {
-            let mut glyph = GlyphId::from(first_record.end_glyph_id());
-            for record in range_records.iter().skip(1) {
-                let Some(g) = glyphs.iter_after(glyph).next() else {
-                    break;
-                };
-
-                if g < record.start_glyph_id() {
-                    out.insert(0);
-                    break;
-                }
-                glyph = GlyphId::from(record.end_glyph_id());
-            }
-            if glyphs.iter_after(glyph).next().is_some() {
-                out.insert(0);
-            }
-        }
-
-        let num_ranges = self.class_range_count();
-        if num_ranges as u64 > glyphs.len() * self.cost() as u64 {
-            for g in glyphs.iter() {
-                let class = self.get(g);
-                if class != 0 {
-                    out.insert(class);
-                }
-            }
-        } else {
-            for record in range_records {
-                if glyphs.intersects_range(
-                    GlyphId::from(record.start_glyph_id())..=GlyphId::from(record.end_glyph_id()),
-                ) {
-                    out.insert(record.class());
-                }
-            }
-        }
-        out
+        classdef_range_intersect_classes(self, glyphs)
     }
 
     /// Returns intersected glyphs of this table and input 'glyphs' set that are assigned to input class value.
     #[cfg(feature = "std")]
     fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
+        classdef_range_intersected_class_glyphs(self, glyphs, class)
+    }
+}
 
-        let first = glyphs.first().unwrap().to_u32();
-        let last = glyphs.last().unwrap().to_u32();
-        if class == 0 {
-            let mut start = first;
-            for range in self.class_range_records() {
-                let range_start = range.start_glyph_id().to_u32();
-                if start < range_start {
-                    out.extend(glyphs.range(GlyphId::from(start)..GlyphId::from(range_start)));
-                }
+impl<'a> ClassDefArrayFormat<'a> for ClassDefFormat3<'a> {
+    fn start_gid_u32(&self) -> u32 {
+        self.start_glyph_id().to_u32()
+    }
 
-                let range_end = range.end_glyph_id().to_u32();
-                if range_end >= last {
-                    break;
-                }
-                start = range_end + 1;
-            }
+    fn glyph_count_u32(&self) -> u32 {
+        self.glyph_count().to_u32()
+    }
 
-            if start <= last {
-                out.extend(glyphs.range(GlyphId::from(start)..=GlyphId::from(last)));
-            }
-            return out;
-        }
-
-        let num_ranges = self.class_range_count();
-        if num_ranges as u64 > glyphs.len() * self.cost() as u64 {
-            for g in glyphs.iter() {
-                let c = self.get(g);
-                if c == class {
-                    out.insert(g);
-                }
-            }
-        } else {
-            for range in self.class_range_records() {
-                let range_start = range.start_glyph_id().to_u32();
-                let range_end = range.end_glyph_id().to_u32();
-                if range_start > last {
-                    break;
-                }
-                if range.class() != class || range.end_glyph_id().to_u32() < first {
-                    continue;
-                }
-                out.extend(glyphs.range(GlyphId::from(range_start)..=GlyphId::from(range_end)));
-            }
-        }
-        out
+    fn class_value_array(&self) -> &'a [BigEndian<u16>] {
+        self.class_value_array()
     }
 }
 
@@ -885,17 +1201,7 @@ impl<'a> ClassDefFormat3<'a> {
     /// Get the class for this glyph id
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> u16 {
-        let Some(idx) = gid
-            .into()
-            .to_u32()
-            .checked_sub(self.start_glyph_id().to_u32())
-        else {
-            return 0;
-        };
-        self.class_value_array()
-            .get(idx as usize)
-            .map(|x| x.get())
-            .unwrap_or(0)
+        classdef_array_get(self, gid)
     }
 
     /// Iterate over each glyph and its class.
@@ -909,99 +1215,36 @@ impl<'a> ClassDefFormat3<'a> {
 
     /// Return the number of glyphs explicitly assigned to a class in this table
     pub fn population(&self) -> usize {
-        usize::from(self.glyph_count())
+        classdef_array_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        1
+        classdef_array_cost(self)
     }
 
     /// Returns class values for the intersected glyphs of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_classes(&self, glyphs: &IntSet<GlyphId>) -> IntSet<u16> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
-
-        let start_glyph = self.start_glyph_id().to_u32();
-        let glyph_count = self.glyph_count().to_u32();
-        if glyph_count == 0 {
-            out.insert(0);
-            return out;
-        }
-        let end_glyph = start_glyph + glyph_count - 1;
-        if glyphs.first().unwrap().to_u32() < start_glyph
-            || glyphs.last().unwrap().to_u32() > end_glyph
-        {
-            out.insert(0);
-        }
-
-        let class_values = self.class_value_array();
-        if glyphs.contains(GlyphId::from(start_glyph)) {
-            let Some(start_glyph_class) = class_values.first() else {
-                return out;
-            };
-            out.insert(start_glyph_class.get());
-        }
-
-        for g in glyphs.iter_after(GlyphId::from(start_glyph)) {
-            let g = g.to_u32();
-            if g > end_glyph {
-                break;
-            }
-
-            let idx = g - start_glyph;
-            let Some(class) = class_values.get(idx as usize) else {
-                break;
-            };
-            out.insert(class.get());
-        }
-        out
+        classdef_array_intersect_classes(self, glyphs)
     }
 
     /// Returns intersected glyphs of this table and input 'glyphs' set that are assigned to input class value.
     #[cfg(feature = "std")]
     fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
+        classdef_array_intersected_class_glyphs(self, glyphs, class)
+    }
+}
 
-        let start_glyph = self.start_glyph_id().to_u32();
-        let glyph_count = self.glyph_count().to_u32();
-        if glyph_count == 0 {
-            if class == 0 {
-                return glyphs.clone();
-            }
-            return out;
-        }
-        let end_glyph = start_glyph + glyph_count - 1;
-        if class == 0 {
-            let first = glyphs.first().unwrap();
-            if first.to_u32() < start_glyph {
-                out.extend(glyphs.range(first..GlyphId::from(start_glyph)));
-            }
+impl<'a> ClassDefRangeFormat<'a> for ClassDefFormat4<'a> {
+    type Record = ClassRangeRecord2;
 
-            let last = glyphs.last().unwrap();
-            if last.to_u32() > end_glyph {
-                out.extend(glyphs.range(GlyphId::from(end_glyph + 1)..=last));
-            }
-            return out;
-        }
+    fn class_range_count_u32(&self) -> u32 {
+        self.class_range_count().to_u32()
+    }
 
-        let class_values = self.class_value_array();
-        for g in glyphs.range(GlyphId::from(start_glyph)..=GlyphId::from(end_glyph)) {
-            let idx = g.to_u32() - start_glyph;
-            let Some(c) = class_values.get(idx as usize) else {
-                break;
-            };
-            if c.get() == class {
-                out.insert(g);
-            }
-        }
-        out
+    fn class_range_records(&self) -> &'a [Self::Record] {
+        self.class_range_records()
     }
 }
 
@@ -1009,18 +1252,7 @@ impl<'a> ClassDefFormat4<'a> {
     /// Get the class for this glyph id
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> u16 {
-        let gid = gid.into().to_u32();
-        let records = self.class_range_records();
-        let ix = match records.binary_search_by(|rec| rec.start_glyph_id().to_u32().cmp(&gid)) {
-            Ok(ix) => ix,
-            Err(ix) => ix.saturating_sub(1),
-        };
-        if let Some(record) = records.get(ix) {
-            if (record.start_glyph_id().to_u32()..=record.end_glyph_id().to_u32()).contains(&gid) {
-                return record.class();
-            }
-        }
-        0
+        classdef_range_get(self, gid)
     }
 
     /// Iterate over each glyph and its class.
@@ -1034,125 +1266,24 @@ impl<'a> ClassDefFormat4<'a> {
 
     /// Return the number of glyphs explicitly assigned to a class in this table
     pub fn population(&self) -> usize {
-        self.class_range_records()
-            .iter()
-            .fold(0, |acc, record| acc + record.population())
+        classdef_range_population(self)
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        bit_storage(self.class_range_count().to_u32())
+        classdef_range_cost(self)
     }
 
     /// Returns class values for the intersected glyphs of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_classes(&self, glyphs: &IntSet<GlyphId>) -> IntSet<u16> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
-
-        if self.class_range_count().to_u32() == 0 {
-            out.insert(0);
-            return out;
-        }
-
-        let range_records = self.class_range_records();
-        let first_record = range_records[0];
-
-        if glyphs.first().unwrap().to_u32() < first_record.start_glyph_id().to_u32() {
-            out.insert(0);
-        } else {
-            let mut glyph = GlyphId::from(first_record.end_glyph_id());
-            for record in range_records.iter().skip(1) {
-                let Some(g) = glyphs.iter_after(glyph).next() else {
-                    break;
-                };
-
-                if g.to_u32() < record.start_glyph_id().to_u32() {
-                    out.insert(0);
-                    break;
-                }
-                glyph = GlyphId::from(record.end_glyph_id());
-            }
-            if glyphs.iter_after(glyph).next().is_some() {
-                out.insert(0);
-            }
-        }
-
-        let num_ranges = self.class_range_count().to_u32();
-        if num_ranges as u64 > glyphs.len() * self.cost() as u64 {
-            for g in glyphs.iter() {
-                let class = self.get(g);
-                if class != 0 {
-                    out.insert(class);
-                }
-            }
-        } else {
-            for record in range_records {
-                if glyphs.intersects_range(
-                    GlyphId::from(record.start_glyph_id())..=GlyphId::from(record.end_glyph_id()),
-                ) {
-                    out.insert(record.class());
-                }
-            }
-        }
-        out
+        classdef_range_intersect_classes(self, glyphs)
     }
 
     /// Returns intersected glyphs of this table and input 'glyphs' set that are assgiend to input class value.
     #[cfg(feature = "std")]
     fn intersected_class_glyphs(&self, glyphs: &IntSet<GlyphId>, class: u16) -> IntSet<GlyphId> {
-        let mut out = IntSet::empty();
-        if glyphs.is_empty() {
-            return out;
-        }
-
-        let first = glyphs.first().unwrap().to_u32();
-        let last = glyphs.last().unwrap().to_u32();
-        if class == 0 {
-            let mut start = first;
-            for range in self.class_range_records() {
-                let range_start = range.start_glyph_id().to_u32();
-                if start < range_start {
-                    out.extend(glyphs.range(GlyphId::from(start)..GlyphId::from(range_start)));
-                }
-
-                let range_end = range.end_glyph_id().to_u32();
-                if range_end >= last {
-                    break;
-                }
-                start = range_end + 1;
-            }
-
-            if start <= last {
-                out.extend(glyphs.range(GlyphId::from(start)..=GlyphId::from(last)));
-            }
-            return out;
-        }
-
-        let num_ranges = self.class_range_count().to_u32();
-        if num_ranges as u64 > glyphs.len() * self.cost() as u64 {
-            for g in glyphs.iter() {
-                let c = self.get(g);
-                if c == class {
-                    out.insert(g);
-                }
-            }
-        } else {
-            for range in self.class_range_records() {
-                let range_start = range.start_glyph_id().to_u32();
-                let range_end = range.end_glyph_id().to_u32();
-                if range_start > last {
-                    break;
-                }
-                if range.class() != class || range.end_glyph_id().to_u32() < first {
-                    continue;
-                }
-                out.extend(glyphs.range(GlyphId::from(range_start)..=GlyphId::from(range_end)));
-            }
-        }
-        out
+        classdef_range_intersected_class_glyphs(self, glyphs, class)
     }
 }
 

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -164,242 +164,6 @@ fn bit_storage(v: u32) -> u32 {
     u32::BITS - v.leading_zeros()
 }
 
-trait GlyphIdScalar: Copy + font_types::Scalar {
-    fn to_gid(self) -> GlyphId;
-}
-
-impl GlyphIdScalar for GlyphId16 {
-    fn to_gid(self) -> GlyphId {
-        GlyphId::from(self)
-    }
-}
-
-impl GlyphIdScalar for GlyphId24 {
-    fn to_gid(self) -> GlyphId {
-        GlyphId::from(self)
-    }
-}
-
-trait CoverageArrayFormat<'a> {
-    type RawGlyph: GlyphIdScalar;
-
-    fn glyph_count_u32(&self) -> u32;
-    fn glyph_array(&self) -> &'a [BigEndian<Self::RawGlyph>];
-    fn raw_glyph(gid: GlyphId) -> Option<Self::RawGlyph>;
-}
-
-fn coverage_array_get<'a, T>(table: &T, gid: impl Into<GlyphId>) -> Option<u32>
-where
-    T: CoverageArrayFormat<'a> + 'a,
-    BigEndian<T::RawGlyph>: From<T::RawGlyph> + Ord,
-{
-    let raw = T::raw_glyph(gid.into())?;
-    let be_glyph: BigEndian<T::RawGlyph> = raw.into();
-    table
-        .glyph_array()
-        .binary_search(&be_glyph)
-        .ok()
-        .map(|idx| idx as u32)
-}
-
-#[cfg(feature = "std")]
-fn coverage_array_intersects<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> bool
-where
-    T: CoverageArrayFormat<'a> + 'a,
-    BigEndian<T::RawGlyph>: From<T::RawGlyph> + Ord,
-{
-    if table.glyph_count_u32() as u64 > glyphs.len() * coverage_array_cost(table) as u64 {
-        glyphs
-            .iter()
-            .any(|g| coverage_array_get(table, g).is_some())
-    } else {
-        table
-            .glyph_array()
-            .iter()
-            .any(|g| glyphs.contains(g.get().to_gid()))
-    }
-}
-
-#[cfg(feature = "std")]
-fn coverage_array_intersect_set<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId>
-where
-    T: CoverageArrayFormat<'a> + 'a,
-    BigEndian<T::RawGlyph>: From<T::RawGlyph> + Ord,
-{
-    if table.glyph_count_u32() as u64 > glyphs.len() * coverage_array_cost(table) as u64 {
-        glyphs
-            .iter()
-            .filter_map(|g| coverage_array_get(table, g).map(|_| g))
-            .collect()
-    } else {
-        table
-            .glyph_array()
-            .iter()
-            .filter(|g| glyphs.contains(g.get().to_gid()))
-            .map(|g| g.get().to_gid())
-            .collect()
-    }
-}
-
-fn coverage_array_population<'a, T>(table: &T) -> usize
-where
-    T: CoverageArrayFormat<'a> + 'a,
-{
-    table.glyph_count_u32() as usize
-}
-
-fn coverage_array_cost<'a, T>(table: &T) -> u32
-where
-    T: CoverageArrayFormat<'a> + 'a,
-{
-    bit_storage(table.glyph_count_u32())
-}
-
-trait CoverageRangeRecord {
-    fn start_gid(&self) -> GlyphId;
-    fn end_gid(&self) -> GlyphId;
-    fn start_coverage_index(&self) -> u32;
-    fn population(&self) -> usize;
-}
-
-impl CoverageRangeRecord for RangeRecord {
-    fn start_gid(&self) -> GlyphId {
-        GlyphId::from(self.start_glyph_id())
-    }
-
-    fn end_gid(&self) -> GlyphId {
-        GlyphId::from(self.end_glyph_id())
-    }
-
-    fn start_coverage_index(&self) -> u32 {
-        self.start_coverage_index() as u32
-    }
-
-    fn population(&self) -> usize {
-        RangeRecord::population(self)
-    }
-}
-
-impl CoverageRangeRecord for RangeRecord2 {
-    fn start_gid(&self) -> GlyphId {
-        GlyphId::from(self.start_glyph_id())
-    }
-
-    fn end_gid(&self) -> GlyphId {
-        GlyphId::from(self.end_glyph_id())
-    }
-
-    fn start_coverage_index(&self) -> u32 {
-        self.start_coverage_index().to_u32()
-    }
-
-    fn population(&self) -> usize {
-        RangeRecord2::population(self)
-    }
-}
-
-trait CoverageRangeFormat<'a> {
-    type Record: CoverageRangeRecord;
-
-    fn range_count_u32(&self) -> u32;
-    fn range_records(&self) -> &'a [Self::Record];
-}
-
-fn coverage_range_get<'a, T>(table: &T, gid: impl Into<GlyphId>) -> Option<u32>
-where
-    T: CoverageRangeFormat<'a> + 'a,
-{
-    let gid = gid.into().to_u32();
-    table
-        .range_records()
-        .binary_search_by(|rec| {
-            if rec.end_gid().to_u32() < gid {
-                Ordering::Less
-            } else if rec.start_gid().to_u32() > gid {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        })
-        .ok()
-        .and_then(|idx| {
-            let rec = &table.range_records()[idx];
-            rec.start_coverage_index()
-                .checked_add(gid - rec.start_gid().to_u32())
-        })
-}
-
-#[cfg(feature = "std")]
-fn coverage_range_intersects<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> bool
-where
-    T: CoverageRangeFormat<'a> + 'a,
-{
-    if table.range_count_u32() as u64 > glyphs.len() * coverage_range_cost(table) as u64 {
-        glyphs
-            .iter()
-            .any(|g| coverage_range_get(table, g).is_some())
-    } else {
-        table
-            .range_records()
-            .iter()
-            .any(|record| glyphs.intersects_range(record.start_gid()..=record.end_gid()))
-    }
-}
-
-#[cfg(feature = "std")]
-fn coverage_range_intersect_set<'a, T>(table: &T, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId>
-where
-    T: CoverageRangeFormat<'a> + 'a,
-{
-    if table.range_count_u32() as u64 > glyphs.len() * coverage_range_cost(table) as u64 {
-        glyphs
-            .iter()
-            .filter_map(|g| coverage_range_get(table, g).map(|_| g))
-            .collect()
-    } else {
-        let mut out = IntSet::empty();
-        let mut last = GlyphId::from(0u32);
-        for record in table.range_records() {
-            // break out of loop for overlapping/broken tables
-            let start = record.start_gid();
-            if start < last {
-                break;
-            }
-            let end = record.end_gid();
-            last = end;
-
-            if glyphs.contains(start) {
-                out.insert(start);
-            }
-
-            for g in glyphs.iter_after(start) {
-                if g > end {
-                    break;
-                }
-                out.insert(g);
-            }
-        }
-        out
-    }
-}
-
-fn coverage_range_population<'a, T>(table: &T) -> usize
-where
-    T: CoverageRangeFormat<'a> + 'a,
-{
-    table
-        .range_records()
-        .iter()
-        .fold(0, |acc, record| acc + record.population())
-}
-
-fn coverage_range_cost<'a, T>(table: &T) -> u32
-where
-    T: CoverageRangeFormat<'a> + 'a,
-{
-    bit_storage(table.range_count_u32())
-}
-
 trait ClassDefArrayFormat<'a> {
     fn start_gid_u32(&self) -> u32;
     fn glyph_count_u32(&self) -> u32;
@@ -824,61 +588,57 @@ impl<'a> CoverageTable<'a> {
     }
 }
 
-impl<'a> CoverageArrayFormat<'a> for CoverageFormat1<'a> {
-    type RawGlyph = GlyphId16;
-
-    fn glyph_count_u32(&self) -> u32 {
-        self.glyph_count() as u32
-    }
-
-    fn glyph_array(&self) -> &'a [BigEndian<Self::RawGlyph>] {
-        self.glyph_array()
-    }
-
-    fn raw_glyph(gid: GlyphId) -> Option<Self::RawGlyph> {
-        gid.try_into().ok()
-    }
-}
-
 impl CoverageFormat1<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        coverage_array_get(self, gid)
+        let gid16: GlyphId16 = gid.into().try_into().ok()?;
+        let be_glyph: BigEndian<GlyphId16> = gid16.into();
+        self.glyph_array()
+            .binary_search(&be_glyph)
+            .ok()
+            .map(|idx| idx as u32)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        coverage_array_intersects(self, glyphs)
+        let glyph_count = self.glyph_count() as u32;
+        if glyph_count > (glyphs.len() as u32) * self.cost() {
+            glyphs.iter().any(|g| self.get(g).is_some())
+        } else {
+            self.glyph_array()
+                .iter()
+                .any(|g| glyphs.contains(GlyphId::from(g.get())))
+        }
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        coverage_array_intersect_set(self, glyphs)
+        let glyph_count = self.glyph_count() as u32;
+        if glyph_count > (glyphs.len() as u32) * self.cost() {
+            glyphs
+                .iter()
+                .filter_map(|g| self.get(g).map(|_| g))
+                .collect()
+        } else {
+            self.glyph_array()
+                .iter()
+                .filter(|g| glyphs.contains(GlyphId::from(g.get())))
+                .map(|g| GlyphId::from(g.get()))
+                .collect()
+        }
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        coverage_array_population(self)
+        self.glyph_count() as usize
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        coverage_array_cost(self)
-    }
-}
-
-impl<'a> CoverageRangeFormat<'a> for CoverageFormat2<'a> {
-    type Record = RangeRecord;
-
-    fn range_count_u32(&self) -> u32 {
-        self.range_count() as u32
-    }
-
-    fn range_records(&self) -> &'a [Self::Record] {
-        self.range_records()
+        bit_storage(self.glyph_count() as u32)
     }
 }
 
@@ -886,47 +646,84 @@ impl CoverageFormat2<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        let gid = gid.into();
-        let _: GlyphId16 = gid.try_into().ok()?;
-        coverage_range_get(self, gid)
+        let gid: GlyphId16 = gid.into().try_into().ok()?;
+        self.range_records()
+            .binary_search_by(|rec| {
+                if rec.end_glyph_id() < gid {
+                    Ordering::Less
+                } else if rec.start_glyph_id() > gid {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .ok()
+            .map(|idx| {
+                let rec = &self.range_records()[idx];
+                (rec.start_coverage_index() + gid.to_u16() - rec.start_glyph_id().to_u16()) as u32
+            })
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        coverage_range_intersects(self, glyphs)
+        let range_count = self.range_count() as u32;
+        if range_count > (glyphs.len() as u32) * self.cost() {
+            glyphs.iter().any(|g| self.get(g).is_some())
+        } else {
+            self.range_records()
+                .iter()
+                .any(|record| record.intersects(glyphs))
+        }
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        coverage_range_intersect_set(self, glyphs)
+        let range_count = self.range_count() as u32;
+        if range_count > (glyphs.len() as u32) * self.cost() {
+            glyphs
+                .iter()
+                .filter_map(|g| self.get(g).map(|_| g))
+                .collect()
+        } else {
+            let mut out = IntSet::empty();
+            let mut last = GlyphId16::from(0);
+            for record in self.range_records() {
+                // break out of loop for overlapping/broken tables
+                let start_glyph = record.start_glyph_id();
+                if start_glyph < last {
+                    break;
+                }
+                let end = record.end_glyph_id();
+                last = end;
+
+                let start = GlyphId::from(start_glyph);
+                if glyphs.contains(start) {
+                    out.insert(start);
+                }
+
+                for g in glyphs.iter_after(start) {
+                    if g.to_u32() > end.to_u32() {
+                        break;
+                    }
+                    out.insert(g);
+                }
+            }
+            out
+        }
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        coverage_range_population(self)
+        self.range_records()
+            .iter()
+            .fold(0, |acc, record| acc + record.population())
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        coverage_range_cost(self)
-    }
-}
-
-impl<'a> CoverageArrayFormat<'a> for CoverageFormat3<'a> {
-    type RawGlyph = GlyphId24;
-
-    fn glyph_count_u32(&self) -> u32 {
-        self.glyph_count().to_u32()
-    }
-
-    fn glyph_array(&self) -> &'a [BigEndian<Self::RawGlyph>] {
-        self.glyph_array()
-    }
-
-    fn raw_glyph(gid: GlyphId) -> Option<Self::RawGlyph> {
-        gid.try_into().ok()
+        bit_storage(self.range_count() as u32)
     }
 }
 
@@ -934,41 +731,53 @@ impl CoverageFormat3<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        coverage_array_get(self, gid)
+        let gid24: GlyphId24 = gid.into().try_into().ok()?;
+        let be_glyph: BigEndian<GlyphId24> = gid24.into();
+        self.glyph_array()
+            .binary_search(&be_glyph)
+            .ok()
+            .map(|idx| idx as u32)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        coverage_array_intersects(self, glyphs)
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs.iter().any(|g| self.get(g).is_some())
+        } else {
+            self.glyph_array()
+                .iter()
+                .any(|g| glyphs.contains(GlyphId::from(g.get())))
+        }
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        coverage_array_intersect_set(self, glyphs)
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs
+                .iter()
+                .filter_map(|g| self.get(g).map(|_| g))
+                .collect()
+        } else {
+            self.glyph_array()
+                .iter()
+                .filter(|g| glyphs.contains(GlyphId::from(g.get())))
+                .map(|g| GlyphId::from(g.get()))
+                .collect()
+        }
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        coverage_array_population(self)
+        usize::from(self.glyph_count())
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        coverage_array_cost(self)
-    }
-}
-
-impl<'a> CoverageRangeFormat<'a> for CoverageFormat4<'a> {
-    type Record = RangeRecord2;
-
-    fn range_count_u32(&self) -> u32 {
-        self.range_count().to_u32()
-    }
-
-    fn range_records(&self) -> &'a [Self::Record] {
-        self.range_records()
+        bit_storage(self.glyph_count().to_u32())
     }
 }
 
@@ -976,29 +785,85 @@ impl CoverageFormat4<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
     pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
-        coverage_range_get(self, gid)
+        let gid = gid.into().to_u32();
+        self.range_records()
+            .binary_search_by(|rec| {
+                if rec.end_glyph_id().to_u32() < gid {
+                    Ordering::Less
+                } else if rec.start_glyph_id().to_u32() > gid {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .ok()
+            .and_then(|idx| {
+                let rec = &self.range_records()[idx];
+                rec.start_coverage_index()
+                    .to_u32()
+                    .checked_add(gid - rec.start_glyph_id().to_u32())
+            })
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
-        coverage_range_intersects(self, glyphs)
+        let range_count = self.range_count().to_u32();
+        if range_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs.iter().any(|g| self.get(g).is_some())
+        } else {
+            self.range_records()
+                .iter()
+                .any(|record| record.intersects(glyphs))
+        }
     }
 
     /// Returns the intersection of this table and input 'glyphs' set.
     #[cfg(feature = "std")]
     fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
-        coverage_range_intersect_set(self, glyphs)
+        let range_count = self.range_count().to_u32();
+        if range_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs
+                .iter()
+                .filter_map(|g| self.get(g).map(|_| g))
+                .collect()
+        } else {
+            let mut out = IntSet::empty();
+            let mut last = GlyphId::from(0u32);
+            for record in self.range_records() {
+                // break out of loop for overlapping/broken tables
+                let start_glyph = GlyphId::from(record.start_glyph_id());
+                if start_glyph < last {
+                    break;
+                }
+                let end = GlyphId::from(record.end_glyph_id());
+                last = end;
+
+                if glyphs.contains(start_glyph) {
+                    out.insert(start_glyph);
+                }
+
+                for g in glyphs.iter_after(start_glyph) {
+                    if g > end {
+                        break;
+                    }
+                    out.insert(g);
+                }
+            }
+            out
+        }
     }
 
     /// Return the number of glyphs in this table
     pub fn population(&self) -> usize {
-        coverage_range_population(self)
+        self.range_records()
+            .iter()
+            .fold(0, |acc, record| acc + record.population())
     }
 
     /// Return the cost of looking up a glyph in this table
     pub fn cost(&self) -> u32 {
-        coverage_range_cost(self)
+        bit_storage(self.range_count().to_u32())
     }
 }
 

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -165,28 +165,55 @@ fn bit_storage(v: u32) -> u32 {
 }
 
 impl<'a> CoverageTable<'a> {
-    pub fn iter(&self) -> impl Iterator<Item = GlyphId16> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = GlyphId> + 'a {
         // all one expression so that we have a single return type
-        let (iter1, iter2) = match self {
-            CoverageTable::Format1(t) => (Some(t.glyph_array().iter().map(|g| g.get())), None),
-            CoverageTable::Format2(t) => {
-                let iter = t.range_records().iter().flat_map(RangeRecord::iter);
-                (None, Some(iter))
+        let iter1 = match self {
+            CoverageTable::Format1(t) => {
+                Some(t.glyph_array().iter().map(|g| GlyphId::from(g.get())))
             }
+            _ => None,
+        };
+        let iter2 = match self {
+            CoverageTable::Format2(t) => Some(
+                t.range_records()
+                    .iter()
+                    .flat_map(RangeRecord::iter)
+                    .map(GlyphId::from),
+            ),
+            _ => None,
+        };
+        let iter3 = match self {
+            CoverageTable::Format3(t) => {
+                Some(t.glyph_array().iter().map(|g| GlyphId::from(g.get())))
+            }
+            _ => None,
+        };
+        let iter4 = match self {
+            CoverageTable::Format4(t) => Some(
+                t.range_records()
+                    .iter()
+                    .flat_map(RangeRecord2::iter)
+                    .map(GlyphId::from),
+            ),
+            _ => None,
         };
 
         iter1
             .into_iter()
             .flatten()
             .chain(iter2.into_iter().flatten())
+            .chain(iter3.into_iter().flatten())
+            .chain(iter4.into_iter().flatten())
     }
 
     /// If this glyph is in the coverage table, returns its index
     #[inline]
-    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u16> {
+    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
         match self {
             CoverageTable::Format1(sub) => sub.get(gid),
             CoverageTable::Format2(sub) => sub.get(gid),
+            CoverageTable::Format3(sub) => sub.get(gid),
+            CoverageTable::Format4(sub) => sub.get(gid),
         }
     }
 
@@ -196,6 +223,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             CoverageTable::Format1(sub) => sub.intersects(glyphs),
             CoverageTable::Format2(sub) => sub.intersects(glyphs),
+            CoverageTable::Format3(sub) => sub.intersects(glyphs),
+            CoverageTable::Format4(sub) => sub.intersects(glyphs),
         }
     }
 
@@ -205,6 +234,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             CoverageTable::Format1(sub) => sub.intersect_set(glyphs),
             CoverageTable::Format2(sub) => sub.intersect_set(glyphs),
+            CoverageTable::Format3(sub) => sub.intersect_set(glyphs),
+            CoverageTable::Format4(sub) => sub.intersect_set(glyphs),
         }
     }
 
@@ -213,6 +244,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             CoverageTable::Format1(sub) => sub.population(),
             CoverageTable::Format2(sub) => sub.population(),
+            CoverageTable::Format3(sub) => sub.population(),
+            CoverageTable::Format4(sub) => sub.population(),
         }
     }
 
@@ -221,6 +254,8 @@ impl<'a> CoverageTable<'a> {
         match self {
             CoverageTable::Format1(sub) => sub.cost(),
             CoverageTable::Format2(sub) => sub.cost(),
+            CoverageTable::Format3(sub) => sub.cost(),
+            CoverageTable::Format4(sub) => sub.cost(),
         }
     }
 }
@@ -228,13 +263,13 @@ impl<'a> CoverageTable<'a> {
 impl CoverageFormat1<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
-    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u16> {
+    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
         let gid16: GlyphId16 = gid.into().try_into().ok()?;
         let be_glyph: BigEndian<GlyphId16> = gid16.into();
         self.glyph_array()
             .binary_search(&be_glyph)
             .ok()
-            .map(|idx| idx as _)
+            .map(|idx| idx as u32)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
@@ -282,7 +317,7 @@ impl CoverageFormat1<'_> {
 impl CoverageFormat2<'_> {
     /// If this glyph is in the coverage table, returns its index
     #[inline]
-    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u16> {
+    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
         let gid: GlyphId16 = gid.into().try_into().ok()?;
         self.range_records()
             .binary_search_by(|rec| {
@@ -297,7 +332,7 @@ impl CoverageFormat2<'_> {
             .ok()
             .map(|idx| {
                 let rec = &self.range_records()[idx];
-                rec.start_coverage_index() + gid.to_u16() - rec.start_glyph_id().to_u16()
+                (rec.start_coverage_index() + gid.to_u16() - rec.start_glyph_id().to_u16()) as u32
             })
     }
 
@@ -364,9 +399,174 @@ impl CoverageFormat2<'_> {
     }
 }
 
+impl CoverageFormat3<'_> {
+    /// If this glyph is in the coverage table, returns its index
+    #[inline]
+    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
+        let gid24: GlyphId24 = gid.into().try_into().ok()?;
+        let be_glyph: BigEndian<GlyphId24> = gid24.into();
+        self.glyph_array()
+            .binary_search(&be_glyph)
+            .ok()
+            .map(|idx| idx as u32)
+    }
+
+    /// Returns if this table contains at least one glyph in the 'glyphs' set.
+    #[cfg(feature = "std")]
+    fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs.iter().any(|g| self.get(g).is_some())
+        } else {
+            self.glyph_array()
+                .iter()
+                .any(|g| glyphs.contains(GlyphId::from(g.get())))
+        }
+    }
+
+    /// Returns the intersection of this table and input 'glyphs' set.
+    #[cfg(feature = "std")]
+    fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs
+                .iter()
+                .filter_map(|g| self.get(g).map(|_| g))
+                .collect()
+        } else {
+            self.glyph_array()
+                .iter()
+                .filter(|g| glyphs.contains(GlyphId::from(g.get())))
+                .map(|g| GlyphId::from(g.get()))
+                .collect()
+        }
+    }
+
+    /// Return the number of glyphs in this table
+    pub fn population(&self) -> usize {
+        usize::from(self.glyph_count())
+    }
+
+    /// Return the cost of looking up a glyph in this table
+    pub fn cost(&self) -> u32 {
+        bit_storage(self.glyph_count().to_u32())
+    }
+}
+
+impl CoverageFormat4<'_> {
+    /// If this glyph is in the coverage table, returns its index
+    #[inline]
+    pub fn get(&self, gid: impl Into<GlyphId>) -> Option<u32> {
+        let gid = gid.into().to_u32();
+        self.range_records()
+            .binary_search_by(|rec| {
+                if rec.end_glyph_id().to_u32() < gid {
+                    Ordering::Less
+                } else if rec.start_glyph_id().to_u32() > gid {
+                    Ordering::Greater
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .ok()
+            .and_then(|idx| {
+                let rec = &self.range_records()[idx];
+                rec.start_coverage_index()
+                    .to_u32()
+                    .checked_add(gid - rec.start_glyph_id().to_u32())
+            })
+    }
+
+    /// Returns if this table contains at least one glyph in the 'glyphs' set.
+    #[cfg(feature = "std")]
+    fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
+        let range_count = self.range_count().to_u32();
+        if range_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs.iter().any(|g| self.get(g).is_some())
+        } else {
+            self.range_records()
+                .iter()
+                .any(|record| record.intersects(glyphs))
+        }
+    }
+
+    /// Returns the intersection of this table and input 'glyphs' set.
+    #[cfg(feature = "std")]
+    fn intersect_set(&self, glyphs: &IntSet<GlyphId>) -> IntSet<GlyphId> {
+        let range_count = self.range_count().to_u32();
+        if range_count as u64 > glyphs.len() * self.cost() as u64 {
+            glyphs
+                .iter()
+                .filter_map(|g| self.get(g).map(|_| g))
+                .collect()
+        } else {
+            let mut out = IntSet::empty();
+            let mut last = GlyphId::from(0u32);
+            for record in self.range_records() {
+                // break out of loop for overlapping/broken tables
+                let start_glyph = GlyphId::from(record.start_glyph_id());
+                if start_glyph < last {
+                    break;
+                }
+                let end = GlyphId::from(record.end_glyph_id());
+                last = end;
+
+                if glyphs.contains(start_glyph) {
+                    out.insert(start_glyph);
+                }
+
+                for g in glyphs.iter_after(start_glyph) {
+                    if g > end {
+                        break;
+                    }
+                    out.insert(g);
+                }
+            }
+            out
+        }
+    }
+
+    /// Return the number of glyphs in this table
+    pub fn population(&self) -> usize {
+        self.range_records()
+            .iter()
+            .fold(0, |acc, record| acc + record.population())
+    }
+
+    /// Return the cost of looking up a glyph in this table
+    pub fn cost(&self) -> u32 {
+        bit_storage(self.range_count().to_u32())
+    }
+}
+
 impl RangeRecord {
     pub fn iter(&self) -> impl Iterator<Item = GlyphId16> + '_ {
         (self.start_glyph_id().to_u16()..=self.end_glyph_id().to_u16()).map(GlyphId16::new)
+    }
+
+    /// Returns if this table contains at least one glyph in the 'glyphs' set.
+    #[cfg(feature = "std")]
+    pub fn intersects(&self, glyphs: &IntSet<GlyphId>) -> bool {
+        glyphs.intersects_range(
+            GlyphId::from(self.start_glyph_id())..=GlyphId::from(self.end_glyph_id()),
+        )
+    }
+
+    /// Return the number of glyphs in this record
+    pub fn population(&self) -> usize {
+        let start = self.start_glyph_id().to_u32() as usize;
+        let end = self.end_glyph_id().to_u32() as usize;
+        if start > end {
+            0
+        } else {
+            end - start + 1
+        }
+    }
+}
+
+impl RangeRecord2 {
+    pub fn iter(&self) -> impl Iterator<Item = GlyphId24> + '_ {
+        (self.start_glyph_id().to_u32()..=self.end_glyph_id().to_u32()).map(GlyphId24::new)
     }
 
     /// Returns if this table contains at least one glyph in the 'glyphs' set.
@@ -865,6 +1065,36 @@ mod tests {
         assert_eq!(coverage.get(GlyphId::new(32)), Some(7));
         assert_eq!(coverage.get(GlyphId::new(39)), Some(14));
         assert_eq!(coverage.get(GlyphId::new(40)), None);
+    }
+
+    #[test]
+    fn coverage_get_format3() {
+        // manually generated, corresponding to glyphs (1, 65536, 65538).
+        const COV3_DATA: FontData = FontData::new(&[0, 3, 0, 0, 3, 0, 0, 1, 1, 0, 0, 1, 0, 2]);
+
+        let coverage = CoverageFormat3::read(COV3_DATA).unwrap();
+        assert_eq!(coverage.get(GlyphId::new(1)), Some(0));
+        assert_eq!(coverage.get(GlyphId::new(65536)), Some(1));
+        assert_eq!(coverage.get(GlyphId::new(65537)), None);
+        assert_eq!(coverage.get(GlyphId::new(65538)), Some(2));
+    }
+
+    #[test]
+    fn coverage_get_format4() {
+        // manually generated, corresponding to glyphs (65536..65538) and
+        // (131072..131076).
+        const COV4_DATA: FontData = FontData::new(&[
+            0, 4, 0, 0, 2, 1, 0, 0, 1, 0, 2, 0, 0, 0, 2, 0, 0, 2, 0, 4, 0, 0, 3,
+        ]);
+
+        let coverage = CoverageFormat4::read(COV4_DATA).unwrap();
+        assert_eq!(coverage.get(GlyphId::new(65535)), None);
+        assert_eq!(coverage.get(GlyphId::new(65536)), Some(0));
+        assert_eq!(coverage.get(GlyphId::new(65538)), Some(2));
+        assert_eq!(coverage.get(GlyphId::new(65539)), None);
+        assert_eq!(coverage.get(GlyphId::new(131072)), Some(3));
+        assert_eq!(coverage.get(GlyphId::new(131076)), Some(7));
+        assert_eq!(coverage.get(GlyphId::new(131077)), None);
     }
 
     #[test]

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -6,10 +6,10 @@ use super::{
     ArrayOfOffsets, ChainedClassSequenceRule, ChainedClassSequenceRuleSet, ChainedSequenceContext,
     ChainedSequenceContextFormat1, ChainedSequenceContextFormat2, ChainedSequenceContextFormat3,
     ChainedSequenceRule, ChainedSequenceRuleSet, ClassDef, ClassDefFormat1, ClassDefFormat2,
-    ClassSequenceRule, ClassSequenceRuleSet, CoverageTable, ExtensionLookup, Feature, FeatureList,
-    FeatureVariations, FontRead, GlyphId, LangSys, ReadError, Script, ScriptList, SequenceContext,
-    SequenceContextFormat1, SequenceContextFormat2, SequenceContextFormat3, SequenceLookupRecord,
-    SequenceRule, SequenceRuleSet, Subtables, Tag,
+    ClassDefFormat3, ClassDefFormat4, ClassSequenceRule, ClassSequenceRuleSet, CoverageTable,
+    ExtensionLookup, Feature, FeatureList, FeatureVariations, FontRead, GlyphId, LangSys,
+    ReadError, Script, ScriptList, SequenceContext, SequenceContextFormat1, SequenceContextFormat2,
+    SequenceContextFormat3, SequenceLookupRecord, SequenceRule, SequenceRuleSet, Subtables, Tag,
 };
 use crate::{
     collections::IntSet,
@@ -386,6 +386,8 @@ impl Intersect for ClassDef<'_> {
         match self {
             ClassDef::Format1(table) => table.intersects(glyph_set),
             ClassDef::Format2(table) => table.intersects(glyph_set),
+            ClassDef::Format3(table) => table.intersects(glyph_set),
+            ClassDef::Format4(table) => table.intersects(glyph_set),
         }
     }
 }
@@ -429,6 +431,62 @@ impl Intersect for ClassDefFormat2<'_> {
         let num_bits = 16 - num_ranges.leading_zeros();
         if num_ranges as u64 > glyph_set.len() * num_bits as u64 {
             for g in glyph_set.iter().map(|g| GlyphId16::from(g.to_u32() as u16)) {
+                if self.get(g) != 0 {
+                    return Ok(true);
+                }
+            }
+        } else {
+            for record in self.class_range_records() {
+                let first = GlyphId::from(record.start_glyph_id());
+                let last = GlyphId::from(record.end_glyph_id());
+                if glyph_set.intersects_range(first..=last) && record.class() != 0 {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+}
+
+impl Intersect for ClassDefFormat3<'_> {
+    fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count == 0 {
+            return Ok(false);
+        }
+
+        let start = self.start_glyph_id().to_u32();
+        let end = start + glyph_count;
+
+        let mut start_glyph = GlyphId::from(start);
+        let class_values = self.class_value_array();
+        if glyph_set.contains(start_glyph) && class_values[0] != 0 {
+            return Ok(true);
+        }
+
+        while let Some(g) = glyph_set.iter_after(start_glyph).next() {
+            let g = g.to_u32();
+            if g >= end {
+                break;
+            }
+            let Some(class) = class_values.get((g - start) as usize) else {
+                break;
+            };
+            if class.get() != 0 {
+                return Ok(true);
+            }
+            start_glyph = GlyphId::from(g);
+        }
+        Ok(false)
+    }
+}
+
+impl Intersect for ClassDefFormat4<'_> {
+    fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
+        let num_ranges = self.class_range_count().to_u32();
+        let num_bits = 32 - num_ranges.leading_zeros();
+        if num_ranges as u64 > glyph_set.len() * num_bits as u64 {
+            for g in glyph_set.iter() {
                 if self.get(g) != 0 {
                     return Ok(true);
                 }

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -884,7 +884,7 @@ impl Intersect for ContextFormat1<'_> {
         for rule_set in coverage
             .iter()
             .zip(self.rule_sets())
-            .filter_map(|(g, rule_set)| rule_set.filter(|_| glyph_set.contains(GlyphId::from(g))))
+            .filter_map(|(g, rule_set)| rule_set.filter(|_| glyph_set.contains(g)))
         {
             for rule in rule_set?.rules() {
                 let Some(rule) = rule.transpose()? else {
@@ -909,7 +909,7 @@ impl LookupClosure for ContextFormat1<'_> {
         let intersected_idxes: IntSet<u16> = coverage
             .iter()
             .enumerate()
-            .filter(|&(_, g)| glyph_set.contains(GlyphId::from(g)))
+            .filter(|&(_, g)| glyph_set.contains(g))
             .map(|(idx, _)| idx as u16)
             .collect();
 

--- a/read-fonts/src/tests/test_gpos.rs
+++ b/read-fonts/src/tests/test_gpos.rs
@@ -82,6 +82,7 @@ fn pairposformat2() {
                 GlyphId16::new(0x6A)
             );
         }
+        ClassDef::Format3(_) | ClassDef::Format4(_) => panic!("expected format2"),
     }
 }
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -243,6 +243,34 @@ table ClassDefFormat2 {
     class_range_records: [ClassRangeRecord],
 }
 
+/// [Class Definition Table Format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-3)
+table ClassDefFormat3 {
+    /// Format identifier — format = 3
+    #[format = 3]
+    class_format: u16,
+    /// First glyph ID of the classValueArray
+    start_glyph_id: GlyphId24,
+    /// Size of the classValueArray
+    #[compile(array_len($class_value_array))]
+    glyph_count: Uint24,
+    /// Array of Class Values — one per glyph ID
+    #[count($glyph_count)]
+    class_value_array: [u16],
+}
+
+/// [Class Definition Table Format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-4)
+table ClassDefFormat4 {
+    /// Format identifier — format = 4
+    #[format = 4]
+    class_format: u16,
+    /// Number of ClassRangeRecord2s
+    #[compile(array_len($class_range_records))]
+    class_range_count: Uint24,
+    /// Array of ClassRangeRecord2s — ordered by startGlyphID
+    #[count($class_range_count)]
+    class_range_records: [ClassRangeRecord2],
+}
+
 /// Used in [ClassDefFormat2]
 record ClassRangeRecord {
     /// First glyph ID in the range
@@ -254,10 +282,23 @@ record ClassRangeRecord {
     class: u16,
 }
 
+/// Used in [ClassDefFormat4]
+record ClassRangeRecord2 {
+    /// First glyph ID in the range
+    #[validate(validate_glyph_range)]
+    start_glyph_id: GlyphId24,
+    /// Last glyph ID in the range
+    end_glyph_id: GlyphId24,
+    /// Applied to all glyphs in the range
+    class: u16,
+}
+
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
 format u16 ClassDef {
     Format1(ClassDefFormat1),
     Format2(ClassDefFormat2),
+    Format3(ClassDefFormat3),
+    Format4(ClassDefFormat4),
 }
 
 /// [Sequence Lookup Record](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#sequence-lookup-record)

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -161,6 +161,32 @@ table CoverageFormat2 {
     range_records: [RangeRecord],
 }
 
+/// [Coverage Format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-3)
+table CoverageFormat3 {
+    /// Format identifier — format = 3
+    #[format = 3]
+    coverage_format: u16,
+    /// Number of glyphs in the glyph array
+    #[compile(array_len($glyph_array))]
+    glyph_count: Uint24,
+    /// Array of glyph IDs — in numerical order
+    #[count($glyph_count)]
+    glyph_array: [GlyphId24],
+}
+
+/// [Coverage Format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-4)
+table CoverageFormat4 {
+    /// Format identifier — format = 4
+    #[format = 4]
+    coverage_format: u16,
+    /// Number of RangeRecord2s
+    #[compile(array_len($range_records))]
+    range_count: Uint24,
+    /// Array of glyph ranges — ordered by startGlyphID.
+    #[count($range_count)]
+    range_records: [RangeRecord2],
+}
+
 /// Used in [CoverageFormat2]
 record RangeRecord {
     /// First glyph ID in the range
@@ -171,10 +197,22 @@ record RangeRecord {
     start_coverage_index: u16,
 }
 
+/// Used in [CoverageFormat4]
+record RangeRecord2 {
+    /// First glyph ID in the range
+    start_glyph_id: GlyphId24,
+    /// Last glyph ID in the range
+    end_glyph_id: GlyphId24,
+    /// Coverage Index of first glyph ID in range
+    start_coverage_index: Uint24,
+}
+
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
 format u16 CoverageTable {
     Format1(CoverageFormat1),
     Format2(CoverageFormat2),
+    Format3(CoverageFormat3),
+    Format4(CoverageFormat4),
 }
 
 /// [Class Definition Table Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-1)
@@ -791,4 +829,3 @@ table CharacterVariantParams {
     #[count($char_count)]
     character: [Uint24],
 }
-

--- a/skera/src/gdef.rs
+++ b/skera/src/gdef.rs
@@ -17,7 +17,6 @@ use write_fonts::{
             },
             layout::CoverageTable,
         },
-        types::GlyphId,
         FontRef, MinByteRange, ReadError, TopLevelTable,
     },
     types::{FixedSize, Offset16, Offset32},
@@ -288,7 +287,7 @@ impl SubsetTable<'_> for AttachList<'_> {
             .enumerate()
             .take(plan.font_num_glyphs.min(src_glyph_count))
         {
-            let Some(new_gid) = plan.glyph_map_gsub.get(&GlyphId::from(glyph)) else {
+            let Some(new_gid) = plan.glyph_map_gsub.get(&glyph) else {
                 continue;
             };
 
@@ -356,7 +355,7 @@ impl SubsetTable<'_> for LigCaretList<'_> {
             .enumerate()
             .take(plan.font_num_glyphs.min(src_lig_glyph_count))
         {
-            let Some(new_gid) = plan.glyph_map_gsub.get(&GlyphId::from(glyph)) else {
+            let Some(new_gid) = plan.glyph_map_gsub.get(&glyph) else {
                 continue;
             };
 
@@ -561,7 +560,7 @@ impl CollectVariationIndices for LigCaretList<'_> {
             let Ok(lig_glyph) = lig_glyph else {
                 return;
             };
-            if !plan.glyphset_gsub.contains(GlyphId::from(gid)) {
+            if !plan.glyphset_gsub.contains(gid) {
                 continue;
             }
             lig_glyph.collect_variation_indices(plan, varidx_set);

--- a/skera/src/gpos/mark_array.rs
+++ b/skera/src/gpos/mark_array.rs
@@ -37,8 +37,10 @@ pub(crate) fn get_mark_class_map(
     let mark_records = mark_array.mark_records();
 
     let count = match coverage {
-        CoverageTable::Format1(t) => t.glyph_count(),
-        CoverageTable::Format2(t) => t.range_count(),
+        CoverageTable::Format1(t) => t.glyph_count() as u32,
+        CoverageTable::Format2(t) => t.range_count() as u32,
+        CoverageTable::Format3(t) => t.glyph_count().to_u32(),
+        CoverageTable::Format4(t) => t.range_count().to_u32(),
     };
     let num_bits = 32 - count.leading_zeros();
     let coverage_population = coverage.population();
@@ -75,7 +77,7 @@ pub(crate) fn get_mark_class_map(
 }
 
 impl<'a> SubsetTable<'a> for MarkArray<'_> {
-    type ArgsForSubset = (&'a IntSet<u16>, &'a FnvHashMap<u16, u16>);
+    type ArgsForSubset = (&'a IntSet<u32>, &'a FnvHashMap<u16, u16>);
     type Output = ();
     fn subset(
         &self,

--- a/skera/src/gpos/mark_array.rs
+++ b/skera/src/gpos/mark_array.rs
@@ -61,7 +61,7 @@ pub(crate) fn get_mark_class_map(
             coverage
                 .iter()
                 .enumerate()
-                .filter(|&(_, g)| glyph_set.contains(GlyphId::from(g)))
+                .filter(|&(_, g)| glyph_set.contains(g))
                 .filter_map(|(idx, _)| {
                     mark_records
                         .get(idx)

--- a/skera/src/gpos/mark_base_pos.rs
+++ b/skera/src/gpos/mark_base_pos.rs
@@ -153,7 +153,7 @@ impl<'a> SubsetTable<'a> for MarkBasePosFormat1<'_> {
 }
 
 impl<'a> SubsetTable<'a> for BaseArray<'_> {
-    type ArgsForSubset = (&'a [GlyphId], &'a IntSet<u16>, &'a FnvHashMap<u16, u16>);
+    type ArgsForSubset = (&'a [GlyphId], &'a IntSet<u32>, &'a FnvHashMap<u16, u16>);
     type Output = Vec<GlyphId>;
     fn subset(
         &self,

--- a/skera/src/gpos/mark_lig_pos.rs
+++ b/skera/src/gpos/mark_lig_pos.rs
@@ -162,7 +162,7 @@ impl<'a> SubsetTable<'a> for MarkLigPosFormat1<'_> {
 }
 
 impl<'a> SubsetTable<'a> for LigatureArray<'_> {
-    type ArgsForSubset = (&'a [GlyphId], &'a IntSet<u16>, &'a FnvHashMap<u16, u16>);
+    type ArgsForSubset = (&'a [GlyphId], &'a IntSet<u32>, &'a FnvHashMap<u16, u16>);
     type Output = Vec<GlyphId>;
     fn subset(
         &self,

--- a/skera/src/gpos/mark_mark_pos.rs
+++ b/skera/src/gpos/mark_mark_pos.rs
@@ -150,7 +150,7 @@ impl<'a> SubsetTable<'a> for MarkMarkPosFormat1<'_> {
 }
 
 impl<'a> SubsetTable<'a> for Mark2Array<'_> {
-    type ArgsForSubset = (&'a [GlyphId], &'a IntSet<u16>, &'a FnvHashMap<u16, u16>);
+    type ArgsForSubset = (&'a [GlyphId], &'a IntSet<u32>, &'a FnvHashMap<u16, u16>);
     type Output = Vec<GlyphId>;
     fn subset(
         &self,

--- a/skera/src/gpos/single_pos.rs
+++ b/skera/src/gpos/single_pos.rs
@@ -175,7 +175,7 @@ impl<'a> SubsetTable<'a> for SinglePosFormat2<'_> {
         let it = value_records
             .iter()
             .enumerate()
-            .filter(|&(i, ref _rec)| retained_rec_idxes.contains(i as u16))
+            .filter(|&(i, ref _rec)| retained_rec_idxes.contains(i as u32))
             .filter_map(|(_i, rec)| rec.ok());
         let new_format = compute_new_value_format(plan, state.has_gdef_varstore, font, it);
 
@@ -228,7 +228,7 @@ impl<'a> Serialize<'a> for SinglePosFormat2<'_> {
         &'a [GlyphId],
         ValueFormat,
         &'a SinglePosFormat2<'a>,
-        &'a IntSet<u16>,
+        &'a IntSet<u32>,
         &'a Plan,
     );
     fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags> {

--- a/skera/src/graph/coverage_graph.rs
+++ b/skera/src/graph/coverage_graph.rs
@@ -20,7 +20,7 @@ pub(crate) fn coverage_glyphs(graph: &Graph, cov_idx: ObjIdx) -> Result<Vec<Glyp
     let coverage_table = CoverageTable::read(FontData::new(coverage_data))
         .map_err(|_| RepackError::ErrorReadTable)?;
 
-    Ok(coverage_table.iter().map(GlyphId::from).collect())
+    Ok(coverage_table.iter().collect())
 }
 
 // Make a coverage table at the specified coverage vertex

--- a/skera/src/graph/pairpos_graph.rs
+++ b/skera/src/graph/pairpos_graph.rs
@@ -719,7 +719,7 @@ fn get_glyph_classes(
 
     Ok(coverage_table
         .iter()
-        .map(|g| (GlyphId::from(g), class_def.get(g)))
+        .map(|g| (g, class_def.get(g)))
         .collect())
 }
 

--- a/skera/src/graph/pairpos_graph.rs
+++ b/skera/src/graph/pairpos_graph.rs
@@ -848,7 +848,11 @@ fn make_class_def(
     s.start_serialize()
         .map_err(|_| RepackError::ErrorRepackSerialize)?;
 
-    ClassDef::serialize(&mut s, glyph_classes).map_err(|_| RepackError::ErrorRepackSerialize)?;
+    let glyph_classes = glyph_classes
+        .iter()
+        .map(|(gid, class)| (GlyphId::from(*gid as u32), *class))
+        .collect::<Vec<_>>();
+    ClassDef::serialize(&mut s, &glyph_classes).map_err(|_| RepackError::ErrorRepackSerialize)?;
     s.end_serialize();
 
     let classdef_data = s.copy_bytes();
@@ -881,7 +885,11 @@ pub(crate) mod test {
     fn actual_class_def_size(glyph_and_classes: &[(u16, u16)]) -> usize {
         let mut s = Serializer::new(100);
         s.start_serialize().unwrap();
-        ClassDef::serialize(&mut s, glyph_and_classes).unwrap();
+        let glyph_and_classes = glyph_and_classes
+            .iter()
+            .map(|(gid, class)| (GlyphId::from(*gid as u32), *class))
+            .collect::<Vec<_>>();
+        ClassDef::serialize(&mut s, &glyph_and_classes).unwrap();
         s.end_serialize();
         assert!(!s.in_error());
         s.copy_bytes().len()

--- a/skera/src/gsub/reverse_chain_single_subst.rs
+++ b/skera/src/gsub/reverse_chain_single_subst.rs
@@ -48,7 +48,7 @@ impl<'a> SubsetTable<'a> for ReverseChainSingleSubstFormat1<'_> {
             .iter()
             .zip(sub_glyphs)
             .filter_map(|(cov_g, sub_g)| {
-                let new_cov_g = glyph_map.get(&GlyphId::from(cov_g))?;
+                let new_cov_g = glyph_map.get(&cov_g)?;
                 let new_sub_g = glyph_map.get(&GlyphId::from(sub_g.get()))?;
                 Some((*new_cov_g, *new_sub_g))
             })

--- a/skera/src/layout.rs
+++ b/skera/src/layout.rs
@@ -17,15 +17,15 @@ use write_fonts::{
             layout::{
                 CharacterVariantParams, ClassDef, ClassDefFormat1, ClassDefFormat2,
                 ClassRangeRecord, Condition, ConditionFormat1, ConditionSet, CoverageFormat1,
-                CoverageFormat2, CoverageTable, DeltaFormat, Device, DeviceOrVariationIndex,
-                ExtensionLookup, Feature, FeatureList, FeatureParams, FeatureRecord,
-                FeatureTableSubstitution, FeatureTableSubstitutionRecord, FeatureVariationRecord,
-                FeatureVariations, Intersect, LangSys, LangSysRecord, LookupList, RangeRecord,
-                Script, ScriptList, ScriptRecord, SizeParams, StylisticSetParams, Subtables,
-                VariationIndex,
+                CoverageFormat2, CoverageFormat3, CoverageFormat4, CoverageTable, DeltaFormat,
+                Device, DeviceOrVariationIndex, ExtensionLookup, Feature, FeatureList,
+                FeatureParams, FeatureRecord, FeatureTableSubstitution,
+                FeatureTableSubstitutionRecord, FeatureVariationRecord, FeatureVariations,
+                Intersect, LangSys, LangSysRecord, LookupList, RangeRecord, Script, ScriptList,
+                ScriptRecord, SizeParams, StylisticSetParams, Subtables, VariationIndex,
             },
         },
-        types::{GlyphId, GlyphId16, NameId},
+        types::{GlyphId, GlyphId16, GlyphId24, NameId, Uint24},
         FontData, FontRead, FontRef, MinByteRange, ReadError, TopLevelTable,
     },
     types::{FixedSize, Offset16, Offset32, Tag},
@@ -538,6 +538,8 @@ impl<'a> SubsetTable<'a> for CoverageTable<'a> {
         match self {
             CoverageTable::Format1(sub) => sub.subset(plan, s, args),
             CoverageTable::Format2(sub) => sub.subset(plan, s, args),
+            CoverageTable::Format3(sub) => sub.subset(plan, s, args),
+            CoverageTable::Format4(sub) => sub.subset(plan, s, args),
         }
     }
 }
@@ -642,6 +644,52 @@ impl<'a> SubsetTable<'a> for CoverageFormat2<'a> {
     }
 }
 
+impl<'a> SubsetTable<'a> for CoverageFormat3<'a> {
+    type ArgsForSubset = ();
+    type Output = ();
+    fn subset(
+        &self,
+        plan: &Plan,
+        s: &mut Serializer,
+        _args: Self::ArgsForSubset,
+    ) -> Result<Self::Output, SerializeErrorFlags> {
+        let retained_glyphs = CoverageTable::Format3(self.clone())
+            .intersect_set(&plan.glyphset_gsub)
+            .iter()
+            .filter_map(|g| plan.glyph_map_gsub.get(&g))
+            .copied()
+            .collect::<Vec<_>>();
+
+        if retained_glyphs.is_empty() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
+        CoverageTable::serialize(s, &retained_glyphs)
+    }
+}
+
+impl<'a> SubsetTable<'a> for CoverageFormat4<'a> {
+    type ArgsForSubset = ();
+    type Output = ();
+    fn subset(
+        &self,
+        plan: &Plan,
+        s: &mut Serializer,
+        _args: Self::ArgsForSubset,
+    ) -> Result<Self::Output, SerializeErrorFlags> {
+        let retained_glyphs = CoverageTable::Format4(self.clone())
+            .intersect_set(&plan.glyphset_gsub)
+            .iter()
+            .filter_map(|g| plan.glyph_map_gsub.get(&g))
+            .copied()
+            .collect::<Vec<_>>();
+
+        if retained_glyphs.is_empty() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
+        CoverageTable::serialize(s, &retained_glyphs)
+    }
+}
+
 impl<'a> Serialize<'a> for CoverageTable<'a> {
     type Args = &'a [GlyphId];
     fn serialize(s: &mut Serializer, glyphs: &[GlyphId]) -> Result<(), SerializeErrorFlags> {
@@ -650,7 +698,8 @@ impl<'a> Serialize<'a> for CoverageTable<'a> {
         }
 
         let glyph_count = glyphs.len();
-        let mut num_ranges = 1_u16;
+        let use_wide = glyphs.iter().any(|g| GlyphId16::try_from(*g).is_err());
+        let mut num_ranges = 1_u32;
         let mut last = glyphs[0].to_u32();
 
         for g in glyphs.iter().skip(1) {
@@ -664,10 +713,16 @@ impl<'a> Serialize<'a> for CoverageTable<'a> {
 
         // TODO: add support for unsorted glyph list??
         // ref: <https://github.com/harfbuzz/harfbuzz/blob/59001aa9527c056ad08626cfec9a079b65d8aec8/src/OT/Layout/Common/Coverage.hh#L143>
-        if glyph_count <= num_ranges as usize * 3 {
+        if use_wide {
+            if glyph_count <= num_ranges as usize * 3 {
+                CoverageFormat3::serialize(s, glyphs)
+            } else {
+                CoverageFormat4::serialize(s, (glyphs, num_ranges))
+            }
+        } else if glyph_count <= num_ranges as usize * 3 {
             CoverageFormat1::serialize(s, glyphs)
         } else {
-            CoverageFormat2::serialize(s, (glyphs, num_ranges))
+            CoverageFormat2::serialize(s, (glyphs, num_ranges as u16))
         }
     }
 }
@@ -733,17 +788,75 @@ impl<'a> Serialize<'a> for CoverageFormat2<'a> {
     }
 }
 
+impl<'a> Serialize<'a> for CoverageFormat3<'a> {
+    type Args = &'a [GlyphId];
+    fn serialize(s: &mut Serializer, glyphs: &[GlyphId]) -> Result<(), SerializeErrorFlags> {
+        //format
+        s.embed(3_u16)?;
+
+        // count
+        let count = glyphs.len();
+        s.embed(Uint24::new(count as u32))?;
+
+        let pos = s.allocate_size(count * 3, true)?;
+        for (idx, g) in glyphs.iter().enumerate() {
+            s.copy_assign(pos + idx * 3, GlyphId24::new(g.to_u32()));
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Serialize<'a> for CoverageFormat4<'a> {
+    type Args = (&'a [GlyphId], u32);
+    fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags> {
+        let (glyphs, range_count) = args;
+        //format
+        s.embed(4_u16)?;
+
+        //range_count
+        s.embed(Uint24::new(range_count))?;
+
+        // range records
+        let pos = s.allocate_size((range_count as usize) * 9, true)?;
+        let mut last = glyphs[0].to_u32();
+        // copy start glyph of first record
+        s.copy_assign(pos, GlyphId24::new(last));
+        // copy coverage index of first record
+        s.copy_assign(pos + 6, Uint24::new(0));
+
+        let mut range = 0;
+        for (idx, g) in glyphs.iter().enumerate().skip(1) {
+            let g = g.to_u32();
+            let range_pos = pos + range * 9;
+            if last + 1 != g {
+                //end glyph
+                s.copy_assign(range_pos + 3, GlyphId24::new(last));
+                range += 1;
+
+                let new_range_pos = range_pos + 9;
+                // start glyph of next record
+                s.copy_assign(new_range_pos, GlyphId24::new(g));
+                // coverage index of next record
+                s.copy_assign(new_range_pos + 6, Uint24::new(idx as u32));
+            }
+            last = g;
+        }
+
+        let last_range_pos = pos + range * 9;
+        // end glyph
+        s.copy_assign(last_range_pos + 3, GlyphId24::new(last));
+        Ok(())
+    }
+}
+
 /// Return glyphs and their indices in the input Coverage table that intersect with the input glyph set
 /// returned glyphs are mapped into new glyph ids
 pub(crate) fn intersected_glyphs_and_indices(
     coverage: &CoverageTable,
     glyph_set: &IntSet<GlyphId>,
     glyph_map: &FnvHashMap<GlyphId, GlyphId>,
-) -> (Vec<GlyphId>, IntSet<u16>) {
-    let count = match coverage {
-        CoverageTable::Format1(t) => t.glyph_count(),
-        CoverageTable::Format2(t) => t.range_count(),
-    };
+) -> (Vec<GlyphId>, IntSet<u32>) {
+    let count = coverage_count_hint(coverage);
     let num_bits = 32 - count.leading_zeros();
 
     let coverage_population = coverage.population();
@@ -768,7 +881,7 @@ pub(crate) fn intersected_glyphs_and_indices(
             .filter_map(|(i, g)| glyph_map.get(&GlyphId::from(g)).map(|&new_g| (i, new_g)))
         {
             glyphs.push(g);
-            indices.insert(i as u16);
+            indices.insert(i as u32);
         }
     }
     (glyphs, indices)
@@ -778,11 +891,8 @@ pub(crate) fn intersected_glyphs_and_indices(
 pub(crate) fn intersected_coverage_indices(
     coverage: &CoverageTable,
     glyph_set: &IntSet<GlyphId>,
-) -> IntSet<u16> {
-    let count = match coverage {
-        CoverageTable::Format1(t) => t.glyph_count(),
-        CoverageTable::Format2(t) => t.range_count(),
-    };
+) -> IntSet<u32> {
+    let count = coverage_count_hint(coverage);
     let num_bits = 32 - count.leading_zeros();
 
     let coverage_population = coverage.population();
@@ -794,8 +904,17 @@ pub(crate) fn intersected_coverage_indices(
         coverage
             .iter()
             .enumerate()
-            .filter_map(|(i, g)| glyph_set.contains(GlyphId::from(g)).then_some(i as u16))
+            .filter_map(|(i, g)| glyph_set.contains(g).then_some(i as u32))
             .collect()
+    }
+}
+
+fn coverage_count_hint(coverage: &CoverageTable) -> u32 {
+    match coverage {
+        CoverageTable::Format1(t) => t.glyph_count() as u32,
+        CoverageTable::Format2(t) => t.range_count() as u32,
+        CoverageTable::Format3(t) => t.glyph_count().to_u32(),
+        CoverageTable::Format4(t) => t.range_count().to_u32(),
     }
 }
 

--- a/skera/src/layout.rs
+++ b/skera/src/layout.rs
@@ -16,10 +16,10 @@ use write_fonts::{
             gsub::Gsub,
             layout::{
                 CharacterVariantParams, ClassDef, ClassDefFormat1, ClassDefFormat2,
-                ClassRangeRecord, Condition, ConditionFormat1, ConditionSet, CoverageFormat1,
-                CoverageFormat2, CoverageFormat3, CoverageFormat4, CoverageTable, DeltaFormat,
-                Device, DeviceOrVariationIndex, ExtensionLookup, Feature, FeatureList,
-                FeatureParams, FeatureRecord, FeatureTableSubstitution,
+                ClassDefFormat3, ClassDefFormat4, ClassRangeRecord, Condition, ConditionFormat1,
+                ConditionSet, CoverageFormat1, CoverageFormat2, CoverageFormat3, CoverageFormat4,
+                CoverageTable, DeltaFormat, Device, DeviceOrVariationIndex, ExtensionLookup,
+                Feature, FeatureList, FeatureParams, FeatureRecord, FeatureTableSubstitution,
                 FeatureTableSubstitutionRecord, FeatureVariationRecord, FeatureVariations,
                 Intersect, LangSys, LangSysRecord, LookupList, RangeRecord, Script, ScriptList,
                 ScriptRecord, SizeParams, StylisticSetParams, Subtables, VariationIndex,
@@ -173,6 +173,8 @@ impl<'a> SubsetTable<'a> for ClassDef<'a> {
         match self {
             Self::Format1(item) => item.subset(plan, s, args),
             Self::Format2(item) => item.subset(plan, s, args),
+            Self::Format3(item) => item.subset(plan, s, args),
+            Self::Format4(item) => item.subset(plan, s, args),
         }
     }
 }
@@ -221,7 +223,7 @@ impl<'a> SubsetTable<'a> for ClassDefFormat1<'a> {
             }
 
             retained_classes.insert(class);
-            new_gid_classes.push((new_gid.to_u32() as u16, class));
+            new_gid_classes.push((*new_gid, class));
         }
 
         let use_class_zero = if args.use_class_zero {
@@ -292,7 +294,7 @@ impl<'a> SubsetTable<'a> for ClassDefFormat2<'a> {
                 }
 
                 retained_classes.insert(class);
-                new_gid_classes.push((new_gid.to_u32() as u16, class));
+                new_gid_classes.push((*new_gid, class));
             }
         } else {
             for record in self.class_range_records() {
@@ -318,7 +320,172 @@ impl<'a> SubsetTable<'a> for ClassDefFormat2<'a> {
                     }
 
                     retained_classes.insert(class);
-                    new_gid_classes.push((new_gid.to_u32() as u16, class));
+                    new_gid_classes.push((*new_gid, class));
+                }
+            }
+        }
+
+        new_gid_classes.sort_by(|a, b| a.0.cmp(&b.0));
+        let use_class_zero = if args.use_class_zero {
+            let glyph_count = if let Some(glyph_filter) = args.glyph_filter {
+                glyph_map
+                    .keys()
+                    .filter(|&g| glyph_filter.get(*g).is_some())
+                    .count()
+            } else {
+                glyph_map.len()
+            };
+            glyph_count <= new_gid_classes.len()
+        } else {
+            false
+        };
+
+        if !args.keep_empty_table && new_gid_classes.is_empty() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
+
+        classdef_remap_and_serialize(
+            args.remap_class,
+            &retained_classes,
+            use_class_zero,
+            &mut new_gid_classes,
+            s,
+        )
+    }
+}
+
+impl<'a> SubsetTable<'a> for ClassDefFormat3<'a> {
+    type ArgsForSubset = &'a ClassDefSubsetStruct<'a>;
+    // class_map: Option<FnvHashMap<u16, u16>>
+    type Output = Option<FnvHashMap<u16, u16>>;
+    fn subset(
+        &self,
+        plan: &Plan,
+        s: &mut Serializer,
+        args: Self::ArgsForSubset,
+    ) -> Result<Self::Output, SerializeErrorFlags> {
+        let glyph_map = &plan.glyph_map_gsub;
+        let glyph_set = &plan.glyphset_gsub;
+
+        let mut retained_classes = IntSet::empty();
+        let cap = glyph_map.len().min(self.population());
+        let mut new_gid_classes = Vec::with_capacity(cap);
+
+        let start = self.start_glyph_id().to_u32();
+        let glyph_count = self.glyph_count().to_u32();
+        if glyph_count != 0 {
+            let end = start + glyph_count - 1;
+            for gid in glyph_set.range(GlyphId::from(start)..=GlyphId::from(end)) {
+                let Some(new_gid) = glyph_map.get(&gid) else {
+                    continue;
+                };
+                if let Some(glyph_filter) = args.glyph_filter {
+                    if glyph_filter.get(gid).is_none() {
+                        continue;
+                    }
+                }
+
+                let class = self.get(gid);
+                if class == 0 {
+                    continue;
+                }
+
+                retained_classes.insert(class);
+                new_gid_classes.push((*new_gid, class));
+            }
+        }
+
+        let use_class_zero = if args.use_class_zero {
+            let glyph_count = if let Some(glyph_filter) = args.glyph_filter {
+                glyph_map
+                    .keys()
+                    .filter(|&g| glyph_filter.get(*g).is_some())
+                    .count()
+            } else {
+                glyph_map.len()
+            };
+            glyph_count <= new_gid_classes.len()
+        } else {
+            false
+        };
+
+        if !args.keep_empty_table && new_gid_classes.is_empty() {
+            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+        }
+
+        classdef_remap_and_serialize(
+            args.remap_class,
+            &retained_classes,
+            use_class_zero,
+            &mut new_gid_classes,
+            s,
+        )
+    }
+}
+
+impl<'a> SubsetTable<'a> for ClassDefFormat4<'a> {
+    type ArgsForSubset = &'a ClassDefSubsetStruct<'a>;
+    // class_map: Option<FnvHashMap<u16, u16>>
+    type Output = Option<FnvHashMap<u16, u16>>;
+    fn subset(
+        &self,
+        plan: &Plan,
+        s: &mut Serializer,
+        args: Self::ArgsForSubset,
+    ) -> Result<Self::Output, SerializeErrorFlags> {
+        let glyph_map = &plan.glyph_map_gsub;
+        let glyph_set = &plan.glyphset_gsub;
+
+        let mut retained_classes = IntSet::empty();
+
+        let population = self.population();
+        let cap = glyph_map.len().min(population);
+        let mut new_gid_classes = Vec::with_capacity(cap);
+
+        let num_bits = 32 - self.class_range_count().to_u32().leading_zeros() as u64;
+        if population as u64 > glyph_set.len() * num_bits {
+            for g in glyph_set.iter() {
+                let Some(new_gid) = glyph_map.get(&g) else {
+                    continue;
+                };
+                if let Some(glyph_filter) = args.glyph_filter {
+                    if glyph_filter.get(g).is_none() {
+                        continue;
+                    }
+                }
+
+                let class = self.get(g);
+                if class == 0 {
+                    continue;
+                }
+
+                retained_classes.insert(class);
+                new_gid_classes.push((*new_gid, class));
+            }
+        } else {
+            for record in self.class_range_records() {
+                let class = record.class();
+                if class == 0 {
+                    continue;
+                }
+
+                let start = record.start_glyph_id().to_u32();
+                let end = record
+                    .end_glyph_id()
+                    .to_u32()
+                    .min(glyph_set.last().unwrap().to_u32());
+                for gid in glyph_set.range(GlyphId::from(start)..=GlyphId::from(end)) {
+                    let Some(new_gid) = glyph_map.get(&gid) else {
+                        continue;
+                    };
+                    if let Some(glyph_filter) = args.glyph_filter {
+                        if glyph_filter.get(gid).is_none() {
+                            continue;
+                        }
+                    }
+
+                    retained_classes.insert(class);
+                    new_gid_classes.push((*new_gid, class));
                 }
             }
         }
@@ -356,7 +523,7 @@ fn classdef_remap_and_serialize(
     remap_class: bool,
     retained_classes: &IntSet<u16>,
     use_class_zero: bool,
-    new_gid_classes: &mut [(u16, u16)],
+    new_gid_classes: &mut [(GlyphId, u16)],
     s: &mut Serializer,
 ) -> Result<Option<FnvHashMap<u16, u16>>, SerializeErrorFlags> {
     if !remap_class {
@@ -384,50 +551,61 @@ fn classdef_remap_and_serialize(
 }
 
 impl<'a> Serialize<'a> for ClassDef<'a> {
-    type Args = &'a [(u16, u16)];
+    type Args = &'a [(GlyphId, u16)];
     fn serialize(
         s: &mut Serializer,
-        new_gid_classes: &[(u16, u16)],
+        new_gid_classes: &[(GlyphId, u16)],
     ) -> Result<(), SerializeErrorFlags> {
-        let mut glyph_min = 0;
-        let mut glyph_max = 0;
-        let mut prev_g = 0;
+        let mut glyph_min = 0_u32;
+        let mut glyph_max = 0_u32;
+        let mut prev_g = 0_u32;
         let mut prev_class = 0;
 
-        let mut num_glyphs = 0_u16;
-        let mut num_ranges = 1_u16;
+        let mut num_glyphs = 0_u32;
+        let mut num_ranges = 0_u32;
+        let mut use_wide = false;
         for (g, class) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
+            let g = g.to_u32();
             num_glyphs += 1;
+            use_wide |= g > u16::MAX as u32;
             if num_glyphs == 1 {
-                glyph_min = *g;
-                glyph_max = *g;
-                prev_g = *g;
+                glyph_min = g;
+                glyph_max = g;
+                prev_g = g;
                 prev_class = *class;
+                num_ranges = 1;
                 continue;
             }
 
-            glyph_max = glyph_max.max(*g);
-            if *g != prev_g + 1 || *class != prev_class {
+            glyph_max = glyph_max.max(g);
+            if g != prev_g + 1 || *class != prev_class {
                 num_ranges += 1;
             }
 
-            prev_g = *g;
+            prev_g = g;
             prev_class = *class;
         }
 
-        if num_glyphs > 0 && (glyph_max - glyph_min + 1) < num_ranges * 3 {
+        if use_wide {
+            let span = glyph_max - glyph_min + 1;
+            if num_glyphs > 0 && 8 + span as usize * 2 < 5 + num_ranges as usize * 8 {
+                ClassDefFormat3::serialize(s, new_gid_classes)
+            } else {
+                ClassDefFormat4::serialize(s, (new_gid_classes, num_ranges))
+            }
+        } else if num_glyphs > 0 && (glyph_max - glyph_min + 1) < num_ranges * 3 {
             ClassDefFormat1::serialize(s, new_gid_classes)
         } else {
-            ClassDefFormat2::serialize(s, new_gid_classes)
+            ClassDefFormat2::serialize(s, (new_gid_classes, num_ranges as u16))
         }
     }
 }
 
 impl<'a> Serialize<'a> for ClassDefFormat1<'a> {
-    type Args = &'a [(u16, u16)];
+    type Args = &'a [(GlyphId, u16)];
     fn serialize(
         s: &mut Serializer,
-        new_gid_classes: &[(u16, u16)],
+        new_gid_classes: &[(GlyphId, u16)],
     ) -> Result<(), SerializeErrorFlags> {
         // format 1
         s.embed(1_u16)?;
@@ -437,14 +615,15 @@ impl<'a> Serialize<'a> for ClassDefFormat1<'a> {
         let glyph_count_pos = s.embed(0_u16)?;
 
         let mut num = 0;
-        let mut glyph_min = 0;
-        let mut glyph_max = 0;
+        let mut glyph_min = 0_u16;
+        let mut glyph_max = 0_u16;
         for (g, _) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
+            let g = g.to_u32() as u16;
             if num == 0 {
-                glyph_min = *g;
-                glyph_max = *g;
+                glyph_min = g;
+                glyph_max = g;
             } else {
-                glyph_max = *g.max(&glyph_max);
+                glyph_max = g.max(glyph_max);
             }
             num += 1;
         }
@@ -460,7 +639,7 @@ impl<'a> Serialize<'a> for ClassDefFormat1<'a> {
 
         let pos = s.allocate_size((glyph_count as usize) * 2, true)?;
         for (g, class) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
-            let idx = (*g - glyph_min) as usize;
+            let idx = (g.to_u32() as u16 - glyph_min) as usize;
             s.copy_assign(pos + idx * 2, *class);
         }
         Ok(())
@@ -468,26 +647,24 @@ impl<'a> Serialize<'a> for ClassDefFormat1<'a> {
 }
 
 impl<'a> Serialize<'a> for ClassDefFormat2<'a> {
-    type Args = &'a [(u16, u16)];
-    fn serialize(
-        s: &mut Serializer,
-        new_gid_classes: &[(u16, u16)],
-    ) -> Result<(), SerializeErrorFlags> {
+    type Args = (&'a [(GlyphId, u16)], u16);
+    fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags> {
+        let (new_gid_classes, range_count) = args;
         // format 2
         s.embed(2_u16)?;
         //classRange count
-        let range_count_pos = s.embed(0_u16)?;
+        s.embed(range_count)?;
 
         let mut num = 0_u16;
-        let mut prev_g = 0;
+        let mut prev_g = 0_u16;
         let mut prev_class = 0;
 
-        let mut num_ranges = 0_u16;
         let mut pos = 0;
         for (g, class) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
+            let g = g.to_u32() as u16;
             num += 1;
             if num == 1 {
-                prev_g = *g;
+                prev_g = g;
                 prev_class = *class;
 
                 pos = s.allocate_size(ClassRangeRecord::RAW_BYTE_LEN, true)?;
@@ -495,23 +672,21 @@ impl<'a> Serialize<'a> for ClassDefFormat2<'a> {
                 s.copy_assign(pos + 2, prev_g);
                 s.copy_assign(pos + 4, prev_class);
 
-                num_ranges += 1;
                 continue;
             }
 
-            if *g != prev_g + 1 || *class != prev_class {
-                num_ranges += 1;
+            if g != prev_g + 1 || *class != prev_class {
                 // update last_gid of previous record
                 s.copy_assign(pos + 2, prev_g);
 
                 pos = s.allocate_size(ClassRangeRecord::RAW_BYTE_LEN, true)?;
-                s.copy_assign(pos, *g);
-                s.copy_assign(pos + 2, *g);
+                s.copy_assign(pos, g);
+                s.copy_assign(pos + 2, g);
                 s.copy_assign(pos + 4, *class);
             }
 
             prev_class = *class;
-            prev_g = *g;
+            prev_g = g;
         }
 
         if num == 0 {
@@ -520,8 +695,104 @@ impl<'a> Serialize<'a> for ClassDefFormat2<'a> {
 
         // update end glyph of the last record
         s.copy_assign(pos + 2, prev_g);
-        // update range count
-        s.copy_assign(range_count_pos, num_ranges);
+        Ok(())
+    }
+}
+
+impl<'a> Serialize<'a> for ClassDefFormat3<'a> {
+    type Args = &'a [(GlyphId, u16)];
+    fn serialize(
+        s: &mut Serializer,
+        new_gid_classes: &[(GlyphId, u16)],
+    ) -> Result<(), SerializeErrorFlags> {
+        // format 3
+        s.embed(3_u16)?;
+        // start_glyph
+        let start_glyph_pos = s.embed(GlyphId24::NOTDEF)?;
+        // glyph count
+        let glyph_count_pos = s.embed(Uint24::new(0))?;
+
+        let mut num = 0;
+        let mut glyph_min = 0_u32;
+        let mut glyph_max = 0_u32;
+        for (g, _) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
+            let g = g.to_u32();
+            if num == 0 {
+                glyph_min = g;
+                glyph_max = g;
+            } else {
+                glyph_max = g.max(glyph_max);
+            }
+            num += 1;
+        }
+
+        if num == 0 {
+            return Ok(());
+        }
+
+        s.copy_assign(start_glyph_pos, GlyphId24::new(glyph_min));
+
+        let glyph_count = glyph_max - glyph_min + 1;
+        s.copy_assign(glyph_count_pos, Uint24::new(glyph_count));
+
+        let pos = s.allocate_size((glyph_count as usize) * 2, true)?;
+        for (g, class) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
+            let idx = (g.to_u32() - glyph_min) as usize;
+            s.copy_assign(pos + idx * 2, *class);
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Serialize<'a> for ClassDefFormat4<'a> {
+    type Args = (&'a [(GlyphId, u16)], u32);
+    fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags> {
+        let (new_gid_classes, range_count) = args;
+        // format 4
+        s.embed(4_u16)?;
+        // classRange count
+        s.embed(Uint24::new(range_count))?;
+
+        let mut num = 0_u32;
+        let mut prev_g = 0_u32;
+        let mut prev_class = 0;
+
+        let mut pos = 0;
+        for (g, class) in new_gid_classes.iter().filter(|(_, class)| *class != 0) {
+            let g = g.to_u32();
+            num += 1;
+            if num == 1 {
+                prev_g = g;
+                prev_class = *class;
+
+                pos = s.allocate_size(8, true)?;
+                s.copy_assign(pos, GlyphId24::new(prev_g));
+                s.copy_assign(pos + 3, GlyphId24::new(prev_g));
+                s.copy_assign(pos + 6, prev_class);
+
+                continue;
+            }
+
+            if g != prev_g + 1 || *class != prev_class {
+                // update last_gid of previous record
+                s.copy_assign(pos + 3, GlyphId24::new(prev_g));
+
+                pos = s.allocate_size(8, true)?;
+                s.copy_assign(pos, GlyphId24::new(g));
+                s.copy_assign(pos + 3, GlyphId24::new(g));
+                s.copy_assign(pos + 6, *class);
+            }
+
+            prev_class = *class;
+            prev_g = g;
+        }
+
+        if num == 0 {
+            return Ok(());
+        }
+
+        // update end glyph of the last record
+        s.copy_assign(pos + 3, GlyphId24::new(prev_g));
         Ok(())
     }
 }

--- a/skera/src/layout.rs
+++ b/skera/src/layout.rs
@@ -1149,7 +1149,7 @@ pub(crate) fn intersected_glyphs_and_indices(
         for (i, g) in coverage
             .iter()
             .enumerate()
-            .filter_map(|(i, g)| glyph_map.get(&GlyphId::from(g)).map(|&new_g| (i, new_g)))
+            .filter_map(|(i, g)| glyph_map.get(&g).map(|&new_g| (i, new_g)))
         {
             glyphs.push(g);
             indices.insert(i as u32);

--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -125,7 +125,7 @@ pub(crate) struct Outlines<'a> {
 #[derive(Clone, Copy)]
 pub(crate) struct Outline {
     pub(crate) glyph_id: GlyphId,
-    pub(crate) coverage_index: u16,
+    pub(crate) coverage_index: u32,
     max_component_memory: usize,
 }
 
@@ -207,14 +207,14 @@ impl<'a> Outlines<'a> {
     }
 
     /// Lightweight coverage lookup without computing max_component_memory.
-    fn coverage_index(&self, glyph_id: GlyphId) -> Result<Option<u16>, ReadError> {
+    fn coverage_index(&self, glyph_id: GlyphId) -> Result<Option<u32>, ReadError> {
         Ok(self.coverage.get(glyph_id))
     }
 
     fn compute_max_component_memory(
         &self,
         glyph_id: GlyphId,
-        coverage_index: u16,
+        coverage_index: u32,
     ) -> Result<usize, ReadError> {
         let mut stack = GlyphStack::new();
         self.max_component_memory_for_glyph(glyph_id, coverage_index, &mut stack)
@@ -223,7 +223,7 @@ impl<'a> Outlines<'a> {
     fn max_component_memory_for_glyph(
         &self,
         glyph_id: GlyphId,
-        coverage_index: u16,
+        coverage_index: u32,
         stack: &mut GlyphStack,
     ) -> Result<usize, ReadError> {
         if stack.contains(&glyph_id) {
@@ -306,7 +306,7 @@ impl<'a> Outlines<'a> {
     fn draw_glyph(
         &self,
         glyph_id: GlyphId,
-        coverage_index: u16,
+        coverage_index: u32,
         current_coords: &[F2Dot14],
         parent_matrix: Affine,
         ctx: &VarcSharedContext<'a, '_>,

--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -1165,8 +1165,7 @@ mod tests {
         }
 
         let mut tested = 0usize;
-        for gid16 in coverage.iter() {
-            let gid: GlyphId = gid16.into();
+        for gid in coverage.iter() {
             let coverage_index = coverage.get(gid).unwrap() as usize;
             let glyph = outlines.varc.glyph(coverage_index).unwrap();
             for component in glyph.components() {

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -1231,8 +1231,7 @@ impl Validate for ClassDefFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassDefFormat3", |ctx| {
             ctx.in_field("class_value_array", |ctx| {
-                if self.class_value_array.len() > usize::try_from(Uint24::MAX).unwrap_or(usize::MAX)
-                {
+                if self.class_value_array.len() > to_usize(Uint24::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -1293,9 +1292,7 @@ impl Validate for ClassDefFormat4 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassDefFormat4", |ctx| {
             ctx.in_field("class_range_records", |ctx| {
-                if self.class_range_records.len()
-                    > usize::try_from(Uint24::MAX).unwrap_or(usize::MAX)
-                {
+                if self.class_range_records.len() > to_usize(Uint24::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.class_range_records.validate_impl(ctx);

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -1194,6 +1194,135 @@ impl<'a> FontRead<'a> for ClassDefFormat2 {
     }
 }
 
+/// [Class Definition Table Format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-3)
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ClassDefFormat3 {
+    /// First glyph ID of the classValueArray
+    pub start_glyph_id: GlyphId24,
+    /// Array of Class Values — one per glyph ID
+    pub class_value_array: Vec<u16>,
+}
+
+impl ClassDefFormat3 {
+    /// Construct a new `ClassDefFormat3`
+    pub fn new(start_glyph_id: GlyphId24, class_value_array: Vec<u16>) -> Self {
+        Self {
+            start_glyph_id,
+            class_value_array,
+        }
+    }
+}
+
+impl FontWrite for ClassDefFormat3 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (3 as u16).write_into(writer);
+        self.start_glyph_id.write_into(writer);
+        (Uint24::try_from(array_len(&self.class_value_array)).unwrap()).write_into(writer);
+        self.class_value_array.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassDefFormat3")
+    }
+}
+
+impl Validate for ClassDefFormat3 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("ClassDefFormat3", |ctx| {
+            ctx.in_field("class_value_array", |ctx| {
+                if self.class_value_array.len() > usize::try_from(Uint24::MAX).unwrap_or(usize::MAX)
+                {
+                    ctx.report("array exceeds max length");
+                }
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::tables::layout::ClassDefFormat3<'a>> for ClassDefFormat3 {
+    fn from_obj_ref(obj: &read_fonts::tables::layout::ClassDefFormat3<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        ClassDefFormat3 {
+            start_glyph_id: obj.start_glyph_id(),
+            class_value_array: obj.class_value_array().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::layout::ClassDefFormat3<'a>> for ClassDefFormat3 {}
+
+impl<'a> FontRead<'a> for ClassDefFormat3 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::layout::ClassDefFormat3 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
+/// [Class Definition Table Format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table-format-4)
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ClassDefFormat4 {
+    /// Array of ClassRangeRecord2s — ordered by startGlyphID
+    pub class_range_records: Vec<ClassRangeRecord2>,
+}
+
+impl ClassDefFormat4 {
+    /// Construct a new `ClassDefFormat4`
+    pub fn new(class_range_records: Vec<ClassRangeRecord2>) -> Self {
+        Self {
+            class_range_records,
+        }
+    }
+}
+
+impl FontWrite for ClassDefFormat4 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (4 as u16).write_into(writer);
+        (Uint24::try_from(array_len(&self.class_range_records)).unwrap()).write_into(writer);
+        self.class_range_records.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassDefFormat4")
+    }
+}
+
+impl Validate for ClassDefFormat4 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("ClassDefFormat4", |ctx| {
+            ctx.in_field("class_range_records", |ctx| {
+                if self.class_range_records.len()
+                    > usize::try_from(Uint24::MAX).unwrap_or(usize::MAX)
+                {
+                    ctx.report("array exceeds max length");
+                }
+                self.class_range_records.validate_impl(ctx);
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::tables::layout::ClassDefFormat4<'a>> for ClassDefFormat4 {
+    fn from_obj_ref(obj: &read_fonts::tables::layout::ClassDefFormat4<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        ClassDefFormat4 {
+            class_range_records: obj.class_range_records().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::layout::ClassDefFormat4<'a>> for ClassDefFormat4 {}
+
+impl<'a> FontRead<'a> for ClassDefFormat4 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::layout::ClassDefFormat4 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
 /// Used in [ClassDefFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1248,12 +1377,68 @@ impl FromObjRef<read_fonts::tables::layout::ClassRangeRecord> for ClassRangeReco
     }
 }
 
+/// Used in [ClassDefFormat4]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ClassRangeRecord2 {
+    /// First glyph ID in the range
+    pub start_glyph_id: GlyphId24,
+    /// Last glyph ID in the range
+    pub end_glyph_id: GlyphId24,
+    /// Applied to all glyphs in the range
+    pub class: u16,
+}
+
+impl ClassRangeRecord2 {
+    /// Construct a new `ClassRangeRecord2`
+    pub fn new(start_glyph_id: GlyphId24, end_glyph_id: GlyphId24, class: u16) -> Self {
+        Self {
+            start_glyph_id,
+            end_glyph_id,
+            class,
+        }
+    }
+}
+
+impl FontWrite for ClassRangeRecord2 {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.start_glyph_id.write_into(writer);
+        self.end_glyph_id.write_into(writer);
+        self.class.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("ClassRangeRecord2")
+    }
+}
+
+impl Validate for ClassRangeRecord2 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("ClassRangeRecord2", |ctx| {
+            ctx.in_field("start_glyph_id", |ctx| {
+                self.validate_glyph_range(ctx);
+            });
+        })
+    }
+}
+
+impl FromObjRef<read_fonts::tables::layout::ClassRangeRecord2> for ClassRangeRecord2 {
+    fn from_obj_ref(obj: &read_fonts::tables::layout::ClassRangeRecord2, _: FontData) -> Self {
+        ClassRangeRecord2 {
+            start_glyph_id: obj.start_glyph_id(),
+            end_glyph_id: obj.end_glyph_id(),
+            class: obj.class(),
+        }
+    }
+}
+
 /// A [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClassDef {
     Format1(ClassDefFormat1),
     Format2(ClassDefFormat2),
+    Format3(ClassDefFormat3),
+    Format4(ClassDefFormat4),
 }
 
 impl ClassDef {
@@ -1265,6 +1450,16 @@ impl ClassDef {
     /// Construct a new `ClassDefFormat2` subtable
     pub fn format_2(class_range_records: Vec<ClassRangeRecord>) -> Self {
         Self::Format2(ClassDefFormat2::new(class_range_records))
+    }
+
+    /// Construct a new `ClassDefFormat3` subtable
+    pub fn format_3(start_glyph_id: GlyphId24, class_value_array: Vec<u16>) -> Self {
+        Self::Format3(ClassDefFormat3::new(start_glyph_id, class_value_array))
+    }
+
+    /// Construct a new `ClassDefFormat4` subtable
+    pub fn format_4(class_range_records: Vec<ClassRangeRecord2>) -> Self {
+        Self::Format4(ClassDefFormat4::new(class_range_records))
     }
 }
 
@@ -1279,12 +1474,16 @@ impl FontWrite for ClassDef {
         match self {
             Self::Format1(item) => item.write_into(writer),
             Self::Format2(item) => item.write_into(writer),
+            Self::Format3(item) => item.write_into(writer),
+            Self::Format4(item) => item.write_into(writer),
         }
     }
     fn table_type(&self) -> TableType {
         match self {
             Self::Format1(item) => item.table_type(),
             Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
+            Self::Format4(item) => item.table_type(),
         }
     }
 }
@@ -1294,6 +1493,8 @@ impl Validate for ClassDef {
         match self {
             Self::Format1(item) => item.validate_impl(ctx),
             Self::Format2(item) => item.validate_impl(ctx),
+            Self::Format3(item) => item.validate_impl(ctx),
+            Self::Format4(item) => item.validate_impl(ctx),
         }
     }
 }
@@ -1304,6 +1505,8 @@ impl FromObjRef<read_fonts::tables::layout::ClassDef<'_>> for ClassDef {
         match obj {
             ObjRefType::Format1(item) => ClassDef::Format1(item.to_owned_table()),
             ObjRefType::Format2(item) => ClassDef::Format2(item.to_owned_table()),
+            ObjRefType::Format3(item) => ClassDef::Format3(item.to_owned_table()),
+            ObjRefType::Format4(item) => ClassDef::Format4(item.to_owned_table()),
         }
     }
 }
@@ -1325,6 +1528,18 @@ impl From<ClassDefFormat1> for ClassDef {
 impl From<ClassDefFormat2> for ClassDef {
     fn from(src: ClassDefFormat2) -> ClassDef {
         ClassDef::Format2(src)
+    }
+}
+
+impl From<ClassDefFormat3> for ClassDef {
+    fn from(src: ClassDefFormat3) -> ClassDef {
+        ClassDef::Format3(src)
+    }
+}
+
+impl From<ClassDefFormat4> for ClassDef {
+    fn from(src: ClassDefFormat4) -> ClassDef {
+        ClassDef::Format4(src)
     }
 }
 

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -734,6 +734,123 @@ impl<'a> FontRead<'a> for CoverageFormat2 {
     }
 }
 
+/// [Coverage Format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-3)
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CoverageFormat3 {
+    /// Array of glyph IDs — in numerical order
+    pub glyph_array: Vec<GlyphId24>,
+}
+
+impl CoverageFormat3 {
+    /// Construct a new `CoverageFormat3`
+    pub fn new(glyph_array: Vec<GlyphId24>) -> Self {
+        Self { glyph_array }
+    }
+}
+
+impl FontWrite for CoverageFormat3 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (3 as u16).write_into(writer);
+        (Uint24::try_from(array_len(&self.glyph_array)).unwrap()).write_into(writer);
+        self.glyph_array.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CoverageFormat3")
+    }
+}
+
+impl Validate for CoverageFormat3 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("CoverageFormat3", |ctx| {
+            ctx.in_field("glyph_array", |ctx| {
+                if self.glyph_array.len() > to_usize(Uint24::MAX) {
+                    ctx.report("array exceeds max length");
+                }
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::tables::layout::CoverageFormat3<'a>> for CoverageFormat3 {
+    fn from_obj_ref(obj: &read_fonts::tables::layout::CoverageFormat3<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        CoverageFormat3 {
+            glyph_array: obj.glyph_array().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::layout::CoverageFormat3<'a>> for CoverageFormat3 {}
+
+impl<'a> FontRead<'a> for CoverageFormat3 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::layout::CoverageFormat3 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
+/// [Coverage Format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-format-4)
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CoverageFormat4 {
+    /// Array of glyph ranges — ordered by startGlyphID.
+    pub range_records: Vec<RangeRecord2>,
+}
+
+impl CoverageFormat4 {
+    /// Construct a new `CoverageFormat4`
+    pub fn new(range_records: Vec<RangeRecord2>) -> Self {
+        Self { range_records }
+    }
+}
+
+impl FontWrite for CoverageFormat4 {
+    #[allow(clippy::unnecessary_cast)]
+    fn write_into(&self, writer: &mut TableWriter) {
+        (4 as u16).write_into(writer);
+        (Uint24::try_from(array_len(&self.range_records)).unwrap()).write_into(writer);
+        self.range_records.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("CoverageFormat4")
+    }
+}
+
+impl Validate for CoverageFormat4 {
+    fn validate_impl(&self, ctx: &mut ValidationCtx) {
+        ctx.in_table("CoverageFormat4", |ctx| {
+            ctx.in_field("range_records", |ctx| {
+                if self.range_records.len() > to_usize(Uint24::MAX) {
+                    ctx.report("array exceeds max length");
+                }
+                self.range_records.validate_impl(ctx);
+            });
+        })
+    }
+}
+
+impl<'a> FromObjRef<read_fonts::tables::layout::CoverageFormat4<'a>> for CoverageFormat4 {
+    fn from_obj_ref(obj: &read_fonts::tables::layout::CoverageFormat4<'a>, _: FontData) -> Self {
+        let offset_data = obj.offset_data();
+        CoverageFormat4 {
+            range_records: obj.range_records().to_owned_obj(offset_data),
+        }
+    }
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a> FromTableRef<read_fonts::tables::layout::CoverageFormat4<'a>> for CoverageFormat4 {}
+
+impl<'a> FontRead<'a> for CoverageFormat4 {
+    fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <read_fonts::tables::layout::CoverageFormat4 as FontRead>::read(data)
+            .map(|x| x.to_owned_table())
+    }
+}
+
 /// Used in [CoverageFormat2]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -786,12 +903,66 @@ impl FromObjRef<read_fonts::tables::layout::RangeRecord> for RangeRecord {
     }
 }
 
+/// Used in [CoverageFormat4]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RangeRecord2 {
+    /// First glyph ID in the range
+    pub start_glyph_id: GlyphId24,
+    /// Last glyph ID in the range
+    pub end_glyph_id: GlyphId24,
+    /// Coverage Index of first glyph ID in range
+    pub start_coverage_index: Uint24,
+}
+
+impl RangeRecord2 {
+    /// Construct a new `RangeRecord2`
+    pub fn new(
+        start_glyph_id: GlyphId24,
+        end_glyph_id: GlyphId24,
+        start_coverage_index: Uint24,
+    ) -> Self {
+        Self {
+            start_glyph_id,
+            end_glyph_id,
+            start_coverage_index,
+        }
+    }
+}
+
+impl FontWrite for RangeRecord2 {
+    fn write_into(&self, writer: &mut TableWriter) {
+        self.start_glyph_id.write_into(writer);
+        self.end_glyph_id.write_into(writer);
+        self.start_coverage_index.write_into(writer);
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Named("RangeRecord2")
+    }
+}
+
+impl Validate for RangeRecord2 {
+    fn validate_impl(&self, _ctx: &mut ValidationCtx) {}
+}
+
+impl FromObjRef<read_fonts::tables::layout::RangeRecord2> for RangeRecord2 {
+    fn from_obj_ref(obj: &read_fonts::tables::layout::RangeRecord2, _: FontData) -> Self {
+        RangeRecord2 {
+            start_glyph_id: obj.start_glyph_id(),
+            end_glyph_id: obj.end_glyph_id(),
+            start_coverage_index: obj.start_coverage_index(),
+        }
+    }
+}
+
 /// [Coverage Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#coverage-table)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CoverageTable {
     Format1(CoverageFormat1),
     Format2(CoverageFormat2),
+    Format3(CoverageFormat3),
+    Format4(CoverageFormat4),
 }
 
 impl CoverageTable {
@@ -803,6 +974,16 @@ impl CoverageTable {
     /// Construct a new `CoverageFormat2` subtable
     pub fn format_2(range_records: Vec<RangeRecord>) -> Self {
         Self::Format2(CoverageFormat2::new(range_records))
+    }
+
+    /// Construct a new `CoverageFormat3` subtable
+    pub fn format_3(glyph_array: Vec<GlyphId24>) -> Self {
+        Self::Format3(CoverageFormat3::new(glyph_array))
+    }
+
+    /// Construct a new `CoverageFormat4` subtable
+    pub fn format_4(range_records: Vec<RangeRecord2>) -> Self {
+        Self::Format4(CoverageFormat4::new(range_records))
     }
 }
 
@@ -817,12 +998,16 @@ impl FontWrite for CoverageTable {
         match self {
             Self::Format1(item) => item.write_into(writer),
             Self::Format2(item) => item.write_into(writer),
+            Self::Format3(item) => item.write_into(writer),
+            Self::Format4(item) => item.write_into(writer),
         }
     }
     fn table_type(&self) -> TableType {
         match self {
             Self::Format1(item) => item.table_type(),
             Self::Format2(item) => item.table_type(),
+            Self::Format3(item) => item.table_type(),
+            Self::Format4(item) => item.table_type(),
         }
     }
 }
@@ -832,6 +1017,8 @@ impl Validate for CoverageTable {
         match self {
             Self::Format1(item) => item.validate_impl(ctx),
             Self::Format2(item) => item.validate_impl(ctx),
+            Self::Format3(item) => item.validate_impl(ctx),
+            Self::Format4(item) => item.validate_impl(ctx),
         }
     }
 }
@@ -842,6 +1029,8 @@ impl FromObjRef<read_fonts::tables::layout::CoverageTable<'_>> for CoverageTable
         match obj {
             ObjRefType::Format1(item) => CoverageTable::Format1(item.to_owned_table()),
             ObjRefType::Format2(item) => CoverageTable::Format2(item.to_owned_table()),
+            ObjRefType::Format3(item) => CoverageTable::Format3(item.to_owned_table()),
+            ObjRefType::Format4(item) => CoverageTable::Format4(item.to_owned_table()),
         }
     }
 }
@@ -864,6 +1053,18 @@ impl From<CoverageFormat1> for CoverageTable {
 impl From<CoverageFormat2> for CoverageTable {
     fn from(src: CoverageFormat2) -> CoverageTable {
         CoverageTable::Format2(src)
+    }
+}
+
+impl From<CoverageFormat3> for CoverageTable {
+    fn from(src: CoverageFormat3) -> CoverageTable {
+        CoverageTable::Format3(src)
+    }
+}
+
+impl From<CoverageFormat4> for CoverageTable {
+    fn from(src: CoverageFormat4) -> CoverageTable {
+        CoverageTable::Format4(src)
     }
 }
 

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -117,6 +117,14 @@ fn split_coverage(coverage: &rlayout::CoverageTable, start: u16, end: u16) -> Ta
                 data.write(record.start_coverage_index);
             }
         }
+        rlayout::CoverageTable::Format3(_) | rlayout::CoverageTable::Format4(_) => {
+            let coverage = coverage
+                .iter()
+                .skip(start as usize)
+                .take(len as usize)
+                .collect::<wlayout::CoverageTable>();
+            return make_table_data(&coverage);
+        }
     }
     data
 }

--- a/write-fonts/src/graph/splitting/pairpos.rs
+++ b/write-fonts/src/graph/splitting/pairpos.rs
@@ -258,6 +258,7 @@ fn split_off_ppf2(
         .iter()
         .filter_map(|gid| {
             let glyph_class = class_def_1.get(gid);
+            let gid = GlyphId16::try_from(gid).ok()?;
             (start..end)
                 .contains(&(glyph_class as usize))
                 // classes are used as indexes, so adjust them
@@ -396,6 +397,9 @@ impl ClassDefSizeEstimator {
         let mut last_gid = None;
         let mut glyphs_per_class = HashMap::new();
         for (gid, class) in coverage.iter().map(|gid| (gid, classdef.get(gid))) {
+            let Ok(gid) = GlyphId16::try_from(gid) else {
+                continue;
+            };
             if let Some(last) = last_gid.take() {
                 if last + 1 != gid.to_u16() {
                     consecutive_gids = false;
@@ -596,7 +600,7 @@ mod tests {
             .unwrap()
             .iter()
             .chain(sub2.coverage().unwrap().iter())
-            .map(GlyphId16::to_u16)
+            .map(|gid| GlyphId16::try_from(gid).unwrap().to_u16())
             .collect::<Vec<_>>();
         assert_eq!(gids.len(), N_GLYPHS as _);
 

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -1,6 +1,9 @@
 //! OpenType layout.
 
-use std::{collections::HashSet, hash::Hash};
+use std::{
+    collections::{BTreeMap, HashSet},
+    hash::Hash,
+};
 
 pub use read_fonts::tables::layout::LookupFlag;
 use read_fonts::FontRead;
@@ -252,10 +255,12 @@ impl FromObjRef<read_fonts::tables::layout::FeatureParams<'_>> for FeatureParams
 impl FromTableRef<read_fonts::tables::layout::FeatureParams<'_>> for FeatureParams {}
 
 impl ClassDefFormat1 {
-    fn iter(&self) -> impl Iterator<Item = (GlyphId16, u16)> + '_ {
+    fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + '_ {
         self.class_value_array.iter().enumerate().map(|(i, cls)| {
             (
-                GlyphId16::new(self.start_glyph_id.to_u16().saturating_add(i as u16)),
+                GlyphId::from(GlyphId16::new(
+                    self.start_glyph_id.to_u16().saturating_add(i as u16),
+                )),
                 *cls,
             )
         })
@@ -278,40 +283,93 @@ impl ClassRangeRecord {
 }
 
 impl ClassDefFormat2 {
-    fn iter(&self) -> impl Iterator<Item = (GlyphId16, u16)> + '_ {
+    fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + '_ {
         self.class_range_records.iter().flat_map(|rcd| {
             (rcd.start_glyph_id.to_u16()..=rcd.end_glyph_id.to_u16())
-                .map(|gid| (GlyphId16::new(gid), rcd.class))
+                .map(|gid| (GlyphId::from(GlyphId16::new(gid)), rcd.class))
+        })
+    }
+}
+
+impl ClassDefFormat3 {
+    fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + '_ {
+        let start = self.start_glyph_id.to_u32();
+        self.class_value_array
+            .iter()
+            .enumerate()
+            .map(move |(i, cls)| (GlyphId::new(start + i as u32), *cls))
+    }
+}
+
+impl ClassRangeRecord2 {
+    fn validate_glyph_range(&self, ctx: &mut ValidationCtx) {
+        if self.start_glyph_id > self.end_glyph_id {
+            ctx.report(format!(
+                "start_glyph_id {} larger than end_glyph_id {}",
+                self.start_glyph_id, self.end_glyph_id
+            ));
+        }
+    }
+
+    fn contains(&self, gid: GlyphId) -> bool {
+        (self.start_glyph_id.to_u32()..=self.end_glyph_id.to_u32()).contains(&gid.to_u32())
+    }
+}
+
+impl ClassDefFormat4 {
+    fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + '_ {
+        self.class_range_records.iter().flat_map(|rcd| {
+            (rcd.start_glyph_id.to_u32()..=rcd.end_glyph_id.to_u32())
+                .map(|gid| (GlyphId::new(gid), rcd.class))
         })
     }
 }
 
 impl ClassDef {
-    pub fn iter(&self) -> impl Iterator<Item = (GlyphId16, u16)> + '_ {
-        let (one, two) = match self {
-            Self::Format1(table) => (Some(table.iter()), None),
-            Self::Format2(table) => (None, Some(table.iter())),
+    pub fn iter(&self) -> impl Iterator<Item = (GlyphId, u16)> + '_ {
+        let (one, two, three, four) = match self {
+            Self::Format1(table) => (Some(table.iter()), None, None, None),
+            Self::Format2(table) => (None, Some(table.iter()), None, None),
+            Self::Format3(table) => (None, None, Some(table.iter()), None),
+            Self::Format4(table) => (None, None, None, Some(table.iter())),
         };
 
-        one.into_iter().flatten().chain(two.into_iter().flatten())
+        one.into_iter()
+            .flatten()
+            .chain(two.into_iter().flatten())
+            .chain(three.into_iter().flatten())
+            .chain(four.into_iter().flatten())
     }
 
     /// Return the glyph class for the provided glyph.
     ///
     /// Glyphs which have not been assigned a class are given class 0
-    pub fn get(&self, glyph: GlyphId16) -> u16 {
+    pub fn get(&self, glyph: impl Into<GlyphId>) -> u16 {
         self.get_raw(glyph).unwrap_or(0)
     }
 
     // exposed for testing
-    fn get_raw(&self, glyph: GlyphId16) -> Option<u16> {
+    fn get_raw(&self, glyph: impl Into<GlyphId>) -> Option<u16> {
+        let glyph = glyph.into();
         match self {
-            ClassDef::Format1(table) => glyph
-                .to_u16()
-                .checked_sub(table.start_glyph_id.to_u16())
+            ClassDef::Format1(table) => {
+                let glyph = GlyphId16::try_from(glyph).ok()?;
+                glyph
+                    .to_u16()
+                    .checked_sub(table.start_glyph_id.to_u16())
+                    .and_then(|idx| table.class_value_array.get(idx as usize))
+                    .copied()
+            }
+            ClassDef::Format2(table) => table.class_range_records.iter().find_map(|rec| {
+                rec.contains(GlyphId16::try_from(glyph).ok()?)
+                    .then_some(rec.class)
+            }),
+            ClassDef::Format3(table) => glyph
+                .to_u32()
+                .checked_sub(table.start_glyph_id.to_u32())
                 .and_then(|idx| table.class_value_array.get(idx as usize))
                 .copied(),
-            ClassDef::Format2(table) => table
+            ClassDef::Format4(table) => table
                 .class_range_records
                 .iter()
                 .find_map(|rec| rec.contains(glyph).then_some(rec.class)),
@@ -334,6 +392,8 @@ impl ClassDef {
         match self {
             Self::Format1(table) => table.class_value_array.is_empty(),
             Self::Format2(table) => table.class_range_records.is_empty(),
+            Self::Format3(table) => table.class_value_array.is_empty(),
+            Self::Format4(table) => table.class_range_records.is_empty(),
         }
     }
 }
@@ -488,6 +548,42 @@ impl FromIterator<(GlyphId16, u16)> for ClassDef {
     }
 }
 
+impl FromIterator<(GlyphId, u16)> for ClassDef {
+    fn from_iter<T: IntoIterator<Item = (GlyphId, u16)>>(iter: T) -> Self {
+        let items = iter
+            .into_iter()
+            .filter(|(_, cls)| *cls != 0)
+            .collect::<BTreeMap<_, _>>();
+
+        if let Some(items16) = items
+            .iter()
+            .map(|(gid, cls)| GlyphId16::try_from(*gid).ok().map(|gid| (gid, *cls)))
+            .collect::<Option<Vec<_>>>()
+        {
+            builders::ClassDefBuilderImpl::from_iter(items16).build()
+        } else if should_choose_classdef_format_3(&items) {
+            let first = items.keys().next().copied().unwrap_or_default().to_u32();
+            let last = items
+                .keys()
+                .next_back()
+                .copied()
+                .unwrap_or_default()
+                .to_u32();
+            let class_value_array = (first..=last)
+                .map(|gid| items.get(&GlyphId::new(gid)).copied().unwrap_or(0))
+                .collect();
+            ClassDef::Format3(ClassDefFormat3 {
+                start_glyph_id: GlyphId24::new(first),
+                class_value_array,
+            })
+        } else {
+            ClassDef::Format4(ClassDefFormat4 {
+                class_range_records: iter_class_ranges24(&items).collect(),
+            })
+        }
+    }
+}
+
 impl RangeRecord {
     /// An iterator over records for this array of glyphs.
     ///
@@ -588,6 +684,59 @@ fn should_choose_coverage_format_4(glyphs: &[GlyphId24]) -> bool {
     let format4_len = 5 + RangeRecord2::iter_for_glyphs(glyphs).count() * 9;
     let format3_len = 5 + glyphs.len() * 3;
     format4_len < format3_len
+}
+
+fn should_choose_classdef_format_3(values: &BTreeMap<GlyphId, u16>) -> bool {
+    let Some(first) = values.keys().next() else {
+        return false;
+    };
+    let last = values.keys().next_back().unwrap();
+    let span_len = last.to_u32() - first.to_u32() + 1;
+    if span_len > Uint24::MAX.to_u32() {
+        return false;
+    }
+
+    let format3_len = 8 + span_len as usize * 2;
+    let format4_len = 5 + iter_class_ranges24(values).count() * 8;
+    format3_len < format4_len
+}
+
+fn iter_class_ranges24(
+    values: &BTreeMap<GlyphId, u16>,
+) -> impl Iterator<Item = ClassRangeRecord2> + '_ {
+    let mut iter = values.iter();
+    let mut prev = None;
+
+    #[allow(clippy::while_let_on_iterator)]
+    std::iter::from_fn(move || {
+        while let Some((gid, class)) = iter.next() {
+            match prev.take() {
+                None => prev = Some((*gid, *gid, *class)),
+                Some((start, end, pclass))
+                    if gid.to_u32().saturating_sub(end.to_u32()) == 1 && pclass == *class =>
+                {
+                    prev = Some((start, *gid, pclass))
+                }
+                Some((start_glyph_id, end_glyph_id, pclass)) => {
+                    prev = Some((*gid, *gid, *class));
+                    return Some(ClassRangeRecord2 {
+                        start_glyph_id: GlyphId24::try_from(start_glyph_id)
+                            .expect("glyph id exceeds 24 bits"),
+                        end_glyph_id: GlyphId24::try_from(end_glyph_id)
+                            .expect("glyph id exceeds 24 bits"),
+                        class: pclass,
+                    });
+                }
+            }
+        }
+        prev.take()
+            .map(|(start_glyph_id, end_glyph_id, class)| ClassRangeRecord2 {
+                start_glyph_id: GlyphId24::try_from(start_glyph_id)
+                    .expect("glyph id exceeds 24 bits"),
+                end_glyph_id: GlyphId24::try_from(end_glyph_id).expect("glyph id exceeds 24 bits"),
+                class,
+            })
+    })
 }
 
 impl Device {
@@ -724,6 +873,49 @@ mod tests {
                 GlyphId24::new(0x1_0200),
                 GlyphId24::new(0x1_0300),
             ]
+        );
+    }
+
+    #[test]
+    fn classdef_collects_high_dense_glyphs_as_format3() {
+        let classdef = [
+            (GlyphId::new(0x1_0000), 5),
+            (GlyphId::new(0x1_0001), 0),
+            (GlyphId::new(0x1_0002), 7),
+        ]
+        .into_iter()
+        .collect::<ClassDef>();
+
+        let ClassDef::Format3(classdef) = classdef else {
+            panic!("expected ClassDefFormat3");
+        };
+        assert_eq!(classdef.start_glyph_id, GlyphId24::new(0x1_0000));
+        assert_eq!(classdef.class_value_array, vec![5, 0, 7]);
+    }
+
+    #[test]
+    fn classdef_collects_high_sparse_glyphs_as_format4() {
+        let classdef = [
+            (GlyphId::new(0x1_0000), 4),
+            (GlyphId::new(0x1_0001), 4),
+            (GlyphId::new(0x1_0002), 4),
+            (GlyphId::new(0x2_0000), 7),
+            (GlyphId::new(0x2_0001), 7),
+        ]
+        .into_iter()
+        .collect::<ClassDef>();
+
+        let ClassDef::Format4(classdef) = classdef else {
+            panic!("expected ClassDefFormat4");
+        };
+        assert_eq!(classdef.class_range_records.len(), 2);
+        assert_eq!(
+            classdef.class_range_records[0],
+            ClassRangeRecord2::new(GlyphId24::new(0x1_0000), GlyphId24::new(0x1_0002), 4)
+        );
+        assert_eq!(
+            classdef.class_range_records[1],
+            ClassRangeRecord2::new(GlyphId24::new(0x2_0000), GlyphId24::new(0x2_0001), 7)
         );
     }
 

--- a/write-fonts/src/tables/layout.rs
+++ b/write-fonts/src/tables/layout.rs
@@ -349,10 +349,11 @@ impl CoverageFormat1 {
 }
 
 impl CoverageFormat2 {
-    fn iter(&self) -> impl Iterator<Item = GlyphId16> + '_ {
+    fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
         self.range_records
             .iter()
             .flat_map(|rcd| iter_gids(rcd.start_glyph_id, rcd.end_glyph_id))
+            .map(GlyphId::from)
     }
 
     fn len(&self) -> usize {
@@ -369,19 +370,37 @@ impl CoverageFormat2 {
 }
 
 impl CoverageTable {
-    pub fn iter(&self) -> impl Iterator<Item = GlyphId16> + '_ {
-        let (one, two) = match self {
-            Self::Format1(table) => (Some(table.iter()), None),
-            Self::Format2(table) => (None, Some(table.iter())),
+    pub fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+        let one = match self {
+            Self::Format1(table) => Some(table.iter().map(GlyphId::from)),
+            _ => None,
+        };
+        let two = match self {
+            Self::Format2(table) => Some(table.iter()),
+            _ => None,
+        };
+        let three = match self {
+            Self::Format3(table) => Some(table.iter()),
+            _ => None,
+        };
+        let four = match self {
+            Self::Format4(table) => Some(table.iter()),
+            _ => None,
         };
 
-        one.into_iter().flatten().chain(two.into_iter().flatten())
+        one.into_iter()
+            .flatten()
+            .chain(two.into_iter().flatten())
+            .chain(three.into_iter().flatten())
+            .chain(four.into_iter().flatten())
     }
 
     pub fn len(&self) -> usize {
         match self {
             Self::Format1(table) => table.len(),
             Self::Format2(table) => table.len(),
+            Self::Format3(table) => table.len(),
+            Self::Format4(table) => table.len(),
         }
     }
 
@@ -390,10 +409,70 @@ impl CoverageTable {
     }
 }
 
+impl CoverageFormat3 {
+    fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+        self.glyph_array.iter().copied().map(GlyphId::from)
+    }
+
+    fn len(&self) -> usize {
+        self.glyph_array.len()
+    }
+}
+
+impl CoverageFormat4 {
+    fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+        self.range_records
+            .iter()
+            .flat_map(|rcd| iter_gids24(rcd.start_glyph_id, rcd.end_glyph_id).map(GlyphId::from))
+    }
+
+    fn len(&self) -> usize {
+        self.range_records
+            .iter()
+            .map(|rcd| {
+                rcd.end_glyph_id
+                    .to_u32()
+                    .saturating_sub(rcd.start_glyph_id.to_u32()) as usize
+                    + 1
+            })
+            .sum()
+    }
+}
+
 impl FromIterator<GlyphId16> for CoverageTable {
     fn from_iter<T: IntoIterator<Item = GlyphId16>>(iter: T) -> Self {
-        let glyphs = iter.into_iter().collect::<Vec<_>>();
-        builders::CoverageTableBuilder::from_glyphs(glyphs).build()
+        iter.into_iter().map(GlyphId::from).collect()
+    }
+}
+
+impl FromIterator<GlyphId> for CoverageTable {
+    fn from_iter<T: IntoIterator<Item = GlyphId>>(iter: T) -> Self {
+        let mut glyphs = iter.into_iter().collect::<Vec<_>>();
+        glyphs.sort();
+        glyphs.dedup();
+
+        if let Some(glyphs16) = glyphs
+            .iter()
+            .copied()
+            .map(|gid| GlyphId16::try_from(gid).ok())
+            .collect::<Option<Vec<_>>>()
+        {
+            builders::CoverageTableBuilder::from_glyphs(glyphs16).build()
+        } else {
+            let glyphs = glyphs
+                .into_iter()
+                .map(|gid| GlyphId24::try_from(gid).expect("glyph id exceeds 24 bits"))
+                .collect::<Vec<_>>();
+            if should_choose_coverage_format_4(&glyphs) {
+                CoverageTable::Format4(CoverageFormat4 {
+                    range_records: RangeRecord2::iter_for_glyphs(&glyphs).collect(),
+                })
+            } else {
+                CoverageTable::Format3(CoverageFormat3 {
+                    glyph_array: glyphs,
+                })
+            }
+        }
     }
 }
 
@@ -449,12 +528,66 @@ impl RangeRecord {
     }
 }
 
+impl RangeRecord2 {
+    /// An iterator over records for this array of glyphs.
+    ///
+    /// # Note
+    ///
+    /// this function expects that glyphs are already sorted.
+    pub fn iter_for_glyphs(glyphs: &[GlyphId24]) -> impl Iterator<Item = RangeRecord2> + '_ {
+        let mut cur_range = glyphs.first().copied().map(|g| (g, g));
+        let mut len = 0u32;
+        let mut iter = glyphs.iter().skip(1).copied();
+
+        #[allow(clippy::while_let_on_iterator)]
+        std::iter::from_fn(move || {
+            while let Some(glyph) = iter.next() {
+                match cur_range {
+                    None => return None,
+                    Some((a, b)) if are_sequential24(b, glyph) => cur_range = Some((a, glyph)),
+                    Some((a, b)) => {
+                        let result = RangeRecord2 {
+                            start_glyph_id: a,
+                            end_glyph_id: b,
+                            start_coverage_index: Uint24::new(len),
+                        };
+                        cur_range = Some((glyph, glyph));
+                        len += 1 + b.to_u32().saturating_sub(a.to_u32());
+                        return Some(result);
+                    }
+                }
+            }
+            cur_range
+                .take()
+                .map(|(start_glyph_id, end_glyph_id)| RangeRecord2 {
+                    start_glyph_id,
+                    end_glyph_id,
+                    start_coverage_index: Uint24::new(len),
+                })
+        })
+    }
+}
+
 fn iter_gids(gid1: GlyphId16, gid2: GlyphId16) -> impl Iterator<Item = GlyphId16> {
     (gid1.to_u16()..=gid2.to_u16()).map(GlyphId16::new)
 }
 
+fn iter_gids24(gid1: GlyphId24, gid2: GlyphId24) -> impl Iterator<Item = GlyphId24> {
+    (gid1.to_u32()..=gid2.to_u32()).map(GlyphId24::new)
+}
+
 fn are_sequential(gid1: GlyphId16, gid2: GlyphId16) -> bool {
     gid2.to_u16().saturating_sub(gid1.to_u16()) == 1
+}
+
+fn are_sequential24(gid1: GlyphId24, gid2: GlyphId24) -> bool {
+    gid2.to_u32().saturating_sub(gid1.to_u32()) == 1
+}
+
+fn should_choose_coverage_format_4(glyphs: &[GlyphId24]) -> bool {
+    let format4_len = 5 + RangeRecord2::iter_for_glyphs(glyphs).count() * 9;
+    let format3_len = 5 + glyphs.len() * 3;
+    format4_len < format3_len
 }
 
 impl Device {
@@ -531,6 +664,68 @@ impl From<VariationIndex> for u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn gids(values: &[u32]) -> Vec<GlyphId> {
+        values.iter().copied().map(GlyphId::new).collect()
+    }
+
+    #[test]
+    fn coverage_collects_high_sparse_glyphs_as_format4() {
+        let coverage = gids(&[
+            0x1_0000, 0x1_0001, 0x1_0002, 0x1_0003, 0x2_0000, 0x2_0001, 0x2_0002, 0x2_0003,
+        ])
+        .into_iter()
+        .collect::<CoverageTable>();
+
+        let CoverageTable::Format4(coverage) = coverage else {
+            panic!("expected CoverageFormat4");
+        };
+        assert_eq!(coverage.range_records.len(), 2);
+        assert_eq!(
+            coverage.range_records[0].start_glyph_id,
+            GlyphId24::new(0x1_0000)
+        );
+        assert_eq!(
+            coverage.range_records[0].end_glyph_id,
+            GlyphId24::new(0x1_0003)
+        );
+        assert_eq!(
+            coverage.range_records[0].start_coverage_index,
+            Uint24::new(0)
+        );
+        assert_eq!(
+            coverage.range_records[1].start_glyph_id,
+            GlyphId24::new(0x2_0000)
+        );
+        assert_eq!(
+            coverage.range_records[1].end_glyph_id,
+            GlyphId24::new(0x2_0003)
+        );
+        assert_eq!(
+            coverage.range_records[1].start_coverage_index,
+            Uint24::new(4)
+        );
+    }
+
+    #[test]
+    fn coverage_collects_high_dense_glyphs_as_format3() {
+        let coverage = gids(&[0x1_0000, 0x1_0100, 0x1_0200, 0x1_0300])
+            .into_iter()
+            .collect::<CoverageTable>();
+
+        let CoverageTable::Format3(coverage) = coverage else {
+            panic!("expected CoverageFormat3");
+        };
+        assert_eq!(
+            coverage.glyph_array,
+            vec![
+                GlyphId24::new(0x1_0000),
+                GlyphId24::new(0x1_0100),
+                GlyphId24::new(0x1_0200),
+                GlyphId24::new(0x1_0300),
+            ]
+        );
+    }
 
     #[test]
     #[should_panic(expected = "array exceeds max length")]

--- a/write-fonts/src/tables/varc.rs
+++ b/write-fonts/src/tables/varc.rs
@@ -417,7 +417,12 @@ mod tests {
 
         let varc_roundtrip = read_fonts::tables::varc::Varc::read(FontData::new(&bytes))
             .expect("Failed to read varc table");
-        let glyphs: Vec<GlyphId16> = varc_roundtrip.coverage().unwrap().iter().collect();
+        let glyphs: Vec<GlyphId16> = varc_roundtrip
+            .coverage()
+            .unwrap()
+            .iter()
+            .map(|gid| GlyphId16::try_from(gid).unwrap())
+            .collect();
         assert_eq!(glyphs, vec![GlyphId16::new(1)]);
         assert!(varc_roundtrip.multi_var_store().is_none());
         assert!(varc_roundtrip.condition_list().is_none());
@@ -466,7 +471,12 @@ mod tests {
         let bytes = dump_table(&varc).expect("Failed to dump varc table");
         let varc_roundtrip = read_fonts::tables::varc::Varc::read(FontData::new(&bytes))
             .expect("Failed to read varc table");
-        let glyphs: Vec<GlyphId16> = varc_roundtrip.coverage().unwrap().iter().collect();
+        let glyphs: Vec<GlyphId16> = varc_roundtrip
+            .coverage()
+            .unwrap()
+            .iter()
+            .map(|gid| GlyphId16::try_from(gid).unwrap())
+            .collect();
         assert_eq!(glyphs, vec![GlyphId16::new(2)]);
         assert!(varc_roundtrip.multi_var_store().is_none());
         assert!(varc_roundtrip.condition_list().is_none());
@@ -554,7 +564,12 @@ mod tests {
 
         let varc_roundtrip = read_fonts::tables::varc::Varc::read(FontData::new(&bytes))
             .expect("Failed to read varc table");
-        let glyphs: Vec<GlyphId16> = varc_roundtrip.coverage().unwrap().iter().collect();
+        let glyphs: Vec<GlyphId16> = varc_roundtrip
+            .coverage()
+            .unwrap()
+            .iter()
+            .map(|gid| GlyphId16::try_from(gid).unwrap())
+            .collect();
         assert_eq!(glyphs, vec![GlyphId16::new(3)]);
 
         // Verify the multi var store exists and has expected structure

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -328,6 +328,7 @@ write_be_bytes!(types::Tag);
 write_be_bytes!(types::Version16Dot16);
 write_be_bytes!(types::MajorMinor);
 write_be_bytes!(types::GlyphId16);
+write_be_bytes!(types::GlyphId24);
 write_be_bytes!(types::NameId);
 
 impl<T: FontWrite> FontWrite for [T] {


### PR DESCRIPTION
This just adds implementation of 24-bit GlyphIDs and Coverage/ClassDef's format 3 & 4.

First, new formats are done by duplication of the logic. Then a commit to use traits to merge the logic, but the trait commit adds more lines than it deletes. I'm concerned by the size of this change, which is a tiny fraction of what needs to be done for the whole beyond-64k to work, so sharing early to gather feedback.