### PR TITLE
[subset] add palt to default layout features

### DIFF
--- a/skera/src/lib.rs
+++ b/skera/src/lib.rs
@@ -105,7 +105,7 @@ const MAX_NESTING_LEVEL: u8 = 64;
 // See <https://github.com/googlefonts/fontations/issues/997>
 const MAX_GID: GlyphId = GlyphId::new(0xFFFFFFFF);
 
-// ref: <https://github.com/harfbuzz/harfbuzz/blob/021b44388667903d7bc9c92c924ad079f13b90ce/src/hb-subset-input.cc#L82>
+// ref: <https://github.com/harfbuzz/harfbuzz/blob/689383d05b2609a67efa307a9860b85cf40bf8c3/src/hb-subset-input.cc#L82>
 pub static DEFAULT_LAYOUT_FEATURES: &[Tag] = &[
     // default shaper
     // common
@@ -147,6 +147,7 @@ pub static DEFAULT_LAYOUT_FEATURES: &[Tag] = &[
     Tag::new(b"vchw"),
     Tag::new(b"halt"),
     Tag::new(b"vhal"),
+    Tag::new(b"palt"),
     //private
     Tag::new(b"Harf"),
     Tag::new(b"HARF"),

--- a/skera/src/main.rs
+++ b/skera/src/main.rs
@@ -224,7 +224,7 @@ fn main() {
                 std::process::exit(1);
             }
         },
-        // default value: <https://github.com/harfbuzz/harfbuzz/blob/021b44388667903d7bc9c92c924ad079f13b90ce/src/hb-subset-input.cc#L82>
+        // default value: <https://github.com/harfbuzz/harfbuzz/blob/689383d05b2609a67efa307a9860b85cf40bf8c3/src/hb-subset-input.cc#L82>
         None => {
             let mut default_layout_features = IntSet::<Tag>::empty();
             default_layout_features.extend(DEFAULT_LAYOUT_FEATURES.iter().copied());


### PR DESCRIPTION
## Summary

Adds `palt` (Proportional Alternate Widths) to skera's `DEFAULT_LAYOUT_FEATURES`.

`palt` was added to HarfBuzz's default subset layout features (east asian spacing group) in [harfbuzz#6007](https://github.com/harfbuzz/harfbuzz/pull/6007), but skera's list — documented as mirroring `hb-subset-input.cc` — was not updated to match. This adds it in the same position (after `vhal`) and bumps the harfbuzz reference (in `lib.rs` and `main.rs`) to the commit that includes `palt`.

Ref: https://github.com/harfbuzz/harfbuzz/blob/689383d05b2609a67efa307a9860b85cf40bf8c3/src/hb-subset-input.cc#L82

## Testing

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p skera --all-features --all-targets -- -D warnings`: pass
- `cargo test -p skera --all-features`: pass (136 tests)