### PR TITLE
read-fonts: fix oob panic in fvar.rs user_to_normalized

### DIFF
--- a/read-fonts/src/tables/fvar.rs
+++ b/read-fonts/src/tables/fvar.rs
@@ -143,8 +143,14 @@ impl<'a> Fvar<'a> {
         let var_store = avar.var_store();
         let var_index_map = avar.axis_index_map();
 
-        let mut coords_2dot14 = [F2Dot14::ZERO; MAX_INLINE_AVAR2_AXES];
-        let coords_2dot14 = &mut coords_2dot14[..actual_len];
+        let mut stack_coords_2dot14 = [F2Dot14::ZERO; MAX_INLINE_AVAR2_AXES];
+        let mut heap_coords_2dot14 = Vec::new();
+        let coords_2dot14 = if actual_len > MAX_INLINE_AVAR2_AXES {
+            heap_coords_2dot14.resize(actual_len, F2Dot14::ZERO);
+            heap_coords_2dot14.as_mut_slice()
+        } else {
+            &mut stack_coords_2dot14[..actual_len]
+        };
         for (coord_2dot14, coord) in coords_2dot14.iter_mut().zip(fixed_coords.iter()) {
             *coord_2dot14 = coord.to_f2dot14();
         }


### PR DESCRIPTION
Hi,
I'm experimenting with some fuzzing techniques on the fuzzing harnesses in this repo and ran into a crash:
`thread panicked at read-fonts/src/tables/fvar.rs:147:47: range end index 65 out of range for slice of length 64`

This PR applies the same pattern that's already used with `heap_fixed_coords` a few lines above: Use a heap allocation if the amount of coords exceeds the `MAX_INLINE_AVAR2_AXES` limit.

Let me know if you'd like to see a regression test for this. I've haven't included one since the fix feels fairly uncontroversial :slightly_smiling_face: 
Thanks!