### PR TITLE
[font-types] Add GlyphId24 scalar

### DIFF
--- a/font-codegen/src/parsing/fields.rs
+++ b/font-codegen/src/parsing/fields.rs
@@ -328,6 +328,7 @@ enum WellKnownScalar {
     Tag,
     Version16Dot16,
     GlyphId16,
+    GlyphId24,
     NameId,
     MajorMinor,
 }
@@ -356,6 +357,7 @@ impl std::str::FromStr for WellKnownScalar {
             "Tag" => Ok(WellKnownScalar::Tag),
             "Version16Dot16" => Ok(WellKnownScalar::Version16Dot16),
             "GlyphId16" => Ok(WellKnownScalar::GlyphId16),
+            "GlyphId24" => Ok(WellKnownScalar::GlyphId24),
             "NameId" => Ok(WellKnownScalar::NameId),
             "MajorMinor" => Ok(WellKnownScalar::MajorMinor),
             _ => Err(()),

--- a/font-types/src/glyph_id.rs
+++ b/font-types/src/glyph_id.rs
@@ -1,7 +1,9 @@
 //! Glyph Identifiers.
 //!
-//! Although these are treated as u16s in the spec, we choose to represent them
-//! as a distinct type.
+//! Although these are treated as integers in the spec, we choose to represent
+//! them as distinct types.
+
+use crate::Uint24;
 
 /// A 16-bit glyph identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -66,6 +68,70 @@ impl From<GlyphId16> for u32 {
 
 crate::newtype_scalar!(GlyphId16, [u8; 2]);
 
+/// A 24-bit glyph identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[repr(transparent)]
+pub struct GlyphId24(Uint24);
+
+impl GlyphId24 {
+    /// The identifier reserved for unknown glyphs
+    pub const NOTDEF: GlyphId24 = GlyphId24(Uint24::MIN);
+
+    /// Construct a new `GlyphId24`, saturating on overflow.
+    pub const fn new(raw: u32) -> Self {
+        GlyphId24(Uint24::new(raw))
+    }
+
+    /// Construct a new `GlyphId24`, returning `None` on overflow.
+    pub const fn checked_new(raw: u32) -> Option<Self> {
+        match Uint24::checked_new(raw) {
+            Some(raw) => Some(GlyphId24(raw)),
+            None => None,
+        }
+    }
+
+    /// The identifier as a u32.
+    pub const fn to_u32(self) -> u32 {
+        self.0.to_u32()
+    }
+
+    pub const fn to_be_bytes(self) -> [u8; 3] {
+        self.0.to_be_bytes()
+    }
+
+    pub const fn from_be_bytes(bytes: [u8; 3]) -> Self {
+        GlyphId24(Uint24::from_be_bytes(bytes))
+    }
+}
+
+impl Default for GlyphId24 {
+    fn default() -> Self {
+        GlyphId24::NOTDEF
+    }
+}
+
+impl From<GlyphId24> for usize {
+    fn from(value: GlyphId24) -> Self {
+        value.to_u32() as usize
+    }
+}
+
+impl std::fmt::Display for GlyphId24 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "GID_{}", self.to_u32())
+    }
+}
+
+impl From<GlyphId24> for u32 {
+    fn from(value: GlyphId24) -> u32 {
+        value.to_u32()
+    }
+}
+
+crate::newtype_scalar!(GlyphId24, [u8; 3]);
+
 /// A 32-bit glyph identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,6 +190,12 @@ impl From<GlyphId16> for GlyphId {
     }
 }
 
+impl From<GlyphId24> for GlyphId {
+    fn from(value: GlyphId24) -> GlyphId {
+        Self(value.to_u32())
+    }
+}
+
 impl PartialEq<GlyphId16> for GlyphId {
     fn eq(&self, other: &GlyphId16) -> bool {
         self.0 == other.0 as u32
@@ -158,6 +230,14 @@ impl TryFrom<GlyphId> for GlyphId16 {
                 .try_into()
                 .map_err(|_| TryFromGlyphIdError(value.0))?,
         ))
+    }
+}
+
+impl TryFrom<GlyphId> for GlyphId24 {
+    type Error = TryFromGlyphIdError;
+
+    fn try_from(value: GlyphId) -> Result<Self, Self::Error> {
+        Self::checked_new(value.0).ok_or(TryFromGlyphIdError(value.0))
     }
 }
 

--- a/font-types/src/lib.rs
+++ b/font-types/src/lib.rs
@@ -36,7 +36,7 @@ mod serde_test;
 pub use bbox::BoundingBox;
 pub use fixed::{F26Dot6, F2Dot14, F4Dot12, F6Dot10, Fixed};
 pub use fword::{FWord, UfWord};
-pub use glyph_id::{GlyphId, GlyphId16, TryFromGlyphIdError};
+pub use glyph_id::{GlyphId, GlyphId16, GlyphId24, TryFromGlyphIdError};
 pub use int24::Int24;
 pub use longdatetime::LongDateTime;
 pub use matrix::{Matrix, MatrixElement};

--- a/read-fonts/src/traversal.rs
+++ b/read-fonts/src/traversal.rs
@@ -16,8 +16,8 @@
 use std::{fmt::Debug, ops::Deref};
 
 use types::{
-    BigEndian, F2Dot14, FWord, Fixed, GlyphId16, Int24, LongDateTime, MajorMinor, NameId, Nullable,
-    Offset16, Offset24, Offset32, Scalar, Tag, UfWord, Uint24, Version16Dot16,
+    BigEndian, F2Dot14, FWord, Fixed, GlyphId16, GlyphId24, Int24, LongDateTime, MajorMinor,
+    NameId, Nullable, Offset16, Offset24, Offset32, Scalar, Tag, UfWord, Uint24, Version16Dot16,
 };
 
 use crate::{
@@ -47,6 +47,7 @@ pub enum FieldType<'a> {
     Fixed(Fixed),
     LongDateTime(LongDateTime),
     GlyphId16(GlyphId16),
+    GlyphId24(GlyphId24),
     NameId(NameId),
     BareOffset(OffsetType),
     ResolvedOffset(ResolvedOffset<'a>),
@@ -540,6 +541,10 @@ impl<'a> Debug for FieldType<'a> {
                 write!(f, "g")?;
                 arg0.to_u16().fmt(f)
             }
+            Self::GlyphId24(arg0) => {
+                write!(f, "g")?;
+                arg0.to_u32().fmt(f)
+            }
             Self::NameId(arg0) => arg0.fmt(f),
             Self::StringOffset(string) => match &string.target {
                 Ok(arg0) => arg0.as_ref().fmt(f),
@@ -721,6 +726,12 @@ impl<'a> From<Version16Dot16> for FieldType<'a> {
 impl<'a> From<GlyphId16> for FieldType<'a> {
     fn from(src: GlyphId16) -> FieldType<'a> {
         FieldType::GlyphId16(src)
+    }
+}
+
+impl<'a> From<GlyphId24> for FieldType<'a> {
+    fn from(src: GlyphId24) -> FieldType<'a> {
+        FieldType::GlyphId24(src)
     }
 }
 


### PR DESCRIPTION
Add a typed 24-bit glyph identifier for beyond-64k table fields. Wire it through codegen scalar parsing and generic table traversal so future generated tables can use GlyphId24 directly.

Testing:
- cargo test -p font-types glyph_id
- cargo check -p read-fonts -p font-codegen

Assisted-by: OpenAI Codex