### PR TITLE
chore(release): Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,15 +42,15 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.11.3", path = "font-types" }
-read-fonts = { version = "0.39.2", path = "read-fonts", default-features = false }
+font-types = { version = "0.11.4", path = "font-types" }
+read-fonts = { version = "0.40.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.42.1", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.48.1", path = "write-fonts", default-features = false }
-shared-brotli-patch-decoder = { version = "0.1.3", path = "shared-brotli-patch-decoder", default-features = false }
-incremental-font-transfer = { version = "0.3.1", path = "incremental-font-transfer" }
-skera = { version = "0.2.0", path = "skera" }
+skrifa = { version = "0.43.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.49.0", path = "write-fonts", default-features = false }
+shared-brotli-patch-decoder = { version = "0.1.4", path = "shared-brotli-patch-decoder", default-features = false }
+incremental-font-transfer = { version = "0.4.0", path = "incremental-font-transfer" }
+skera = { version = "0.3.0", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.6.2"
+version = "0.6.3"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.11.3"
+version = "0.11.4"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental-font-transfer"
-version = "0.3.1"
+version = "0.4.0"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.39.2"
+version = "0.40.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-brotli-patch-decoder"
-version = "0.1.3"
+version = "0.1.4"
 description = "Wrapper around brotli-sys which allows for decoding shared brotli (https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/) encoded patch data."
 edition.workspace = true
 license.workspace = true

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.2.0"
+version = "0.3.0"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.42.1"
+version = "0.43.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.48.1"
+version = "0.49.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for font-types from font-types-v0.11.3 to 0.11.4
             786e469 [font-types] Add GlyphId24 scalar (#1904)
             a5e7dbd Fix 26.6 mul/div operators  (#1880)
             87bbadd [types] Add f64 conversion fns for all fixed types
     Changes for font-test-data from font-test-data-v0.6.2 to 0.6.3
             da1aa58 Fill out all license metadata (#1790)
     Changes for incremental-font-transfer from incremental-font-transfer-v0.3.1 to 0.4.0
             07a99a7 [skera] Disable tables from write-fonts (#1889)
             03b3336 [ift] Run clippy in CI
             b3b8ec5 Implement Clone and Debug for PatchGroup and related types

     Changes for read-fonts from read-fonts-v0.39.2 to 0.40.0
             786e469 [font-types] Add GlyphId24 scalar (#1904)
             72b73e5 [traverse] Use existing ArrayOfOffsets instead type
             278f1e1 [read-fonts] avoid panics in post table (#1896)
             e8d9a9f [codegen] impl Default for generic groups
             bb425a8 [codegen] generate default for read_args types
             0cd68e9 fix clippy
             73b134b [subset] refactor is_lookup_done, get rid of unnecessary brackets
             2e8f042 [subset] bug fix in ClassDef
             a764319 [glyph closure] check if should visit lookup before inserting seq idx
             0ce6030 [glyph closure] fix a bug in (chain)Context Format2
             d18eb76 [subset] calculate cost correctly
             163964d [subset] Don't err out if lookup index is invalid
             162f647 [codegen] Generate default impls for tables
             cd374e7 [codegen] Remove into_concrete methods for generic tables
             d86e9c3 [codegen] Rework how we handle tables with generic fields
             ece86e9 [codegen] Add a test input for generic groups (#1883)
             7056ea0 [codegen] Add test input for computed array w/ offsets (#1879)
             c15fb3d [read] Remove funny rexports from gdef module (#1876)
             4f67b2a [subset] remove invalid lookup indices before closure_lookups
             f4b4a38 [subset] fix bug in closure_lookups
             b13be85 [colr closure] add binary search branch in closure
             1eae283 [subset] add null checks so we don't emit ReadError for null offsets
             d91a0b4 [read] Make subtables() helper handle empty extensions
     Changes for write-fonts from write-fonts-v0.48.1 to 0.49.0
             6a8b771 Create "tables" feature for write-fonts (#1882)
             2d91846 [write] Cleanup old dead_code annotations (#1888)
             ece86e9 [codegen] Add a test input for generic groups (#1883)
             7056ea0 [codegen] Add test input for computed array w/ offsets (#1879)
     Changes for skrifa from skrifa-v0.42.1 to 0.43.0
             a5e7dbd Fix 26.6 mul/div operators  (#1880)
             c8bad9d make target configurable for HintPlan
             22eb610 add ctor for GlyphStyle
             92fc312 reify scale flags
             c6c76db fix lints
             a1ec6ad Handle FT/ttfautohint quirks
             2095706 expose Axis, Segment and Edge types
             d7482da checkpoint: make some autohinting types public
             d91a0b4 [read] Make subtables() helper handle empty extensions
             8fc06ae (Optional) TTFAutohint uses a different algorithm than FreeType for edge detection
             941e552 Correctness fixes found by diffing against ttfautohint
             a4deea2 Export all the things (if you’re an autohinter)
             74302ef Introduce a Recorder to record hinting decisions
             1ef7790 Keep track of where blues came from
             3872556 Allow auto hinters access to style information
             9f7f21c Allow auto hinters access to full points
             68620bd Make a few more structures exportable (not exported yet)
             aa21d07 Create an autohinter feature to hide new structs behind
             68a30e5 Make script classes and style classes public
     Changes for skera from skera-v0.2.0 to 0.3.0
             3088a1e Merge pull request #1902 from terkel/subset-add-palt-default-feature
             7bd089a [subset] add more tests
             858e08d [subset] fix bug in cmap
             965611d [subset] fix table size estimation
             5c4bbed [subset] bug fix : use word_delta_count to check if delta values are using long types
             93e9f3d [subset] add more tests
             ff0e4b2 [subset] add tests
             8df5593 [subset] remove invalid glyphs after layout closure
             a6255dd Implement hasher directly in Skera (#1877)
             d9562bd [subset] close unicodes over bidi mirror variants
             f720b84 [subset] add more tests
             4f67b2a [subset] remove invalid lookup indices before closure_lookups
             cb3e528 [subset] bug fix for postV2 subset
             e6cd196 [subset] add test
             d213a1d [subset] Don't drop Rule/ChainRule/ConextFormat3 tables with empty lookupRecords
             f4b4a38 [subset] fix bug in closure_lookups
             5f01a6c [Not variations] typo was breaking Khmer
             ef05813 [Not variations] Fix for OS/2 codepage ranges: high codepoints fell through the cracks
             1eae283 [subset] add null checks so we don't emit ReadError for null offsets
             d91a0b4 [read] Make subtables() helper handle empty extensions
     Changes for shared-brotli-patch-decoder from shared-brotli-patch-decoder-v0.1.3 to 0.1.4
             7c9d875 Update brotlic (#1865)
             138903f Treat an empty dictionary the same as a `None` (#1864)
