### PR TITLE
fix(package): Remove test files from package

### DIFF
--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+exclude = ["/resources/testdata"]
 
 edition.workspace = true
 license.workspace = true

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]
+exclude = ["/test-data"]
 
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
- Skera is over the 10MB cargo package limit ([doc](https://doc.rust-lang.org/cargo/reference/publishing.html#packaging-a-crate)) so we need to exclude the test data
- Added incremental-font-transfer since it has 8MB of testdata as well.