### PR TITLE
Bump versions and promote font-types to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.11.4", path = "font-types" }
-read-fonts = { version = "0.40.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.12.0", path = "font-types" }
+read-fonts = { version = "0.40.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.43.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.49.0", path = "write-fonts", default-features = false }
+skrifa = { version = "0.43.1", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.49.1", path = "write-fonts", default-features = false }
 shared-brotli-patch-decoder = { version = "0.1.4", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.4.0", path = "incremental-font-transfer" }
 skera = { version = "0.3.0", path = "skera" }

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.6.3"
+version = "0.7.0"
 description = "Test data for the fontations crates"
 readme = "README.md"
 
@@ -12,4 +12,3 @@ repository.workspace = true
 # do NOT create circular deps, even with dev-dependencies. It messes with google3 import.
 [dependencies]
 font-types = { workspace = true }
-

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.11.4"
+version = "0.12.0"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.40.0"
+version = "0.40.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.43.0"
+version = "0.43.1"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.49.0"
+version = "0.49.1"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
This release bumps several crates, most notably promoting `font-types` to `0.12.0`.

- `font-types` (`0.11.4`) contained breaking changes. That version and its **dependents** have been yanked.
- This update correctly reflects the breaking nature of those changes by incrementing the minor version to `0.12.0`.
- `skera` and `incremental-font-transfer` omitted since I didn't finish their release