### PR TITLE
Skip slow skera integration test by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,10 @@ jobs:
         run: |
           pip install -r resources/scripts/skera_ci_requirements.txt
           cargo test -p skera --all-targets --all-features
+          # The slow tests are disabled by default. We may re-enable if the
+          # tests become faster.
+          # https://github.com/googlefonts/fontations/issues/1910
+          cargo test -p skera --all-targets --all-features -- --ignored
 
       - name: cargo test skera (no cli)
         run: cargo test -p skera --no-default-features

--- a/skera/tests/integration_test.rs
+++ b/skera/tests/integration_test.rs
@@ -676,16 +676,30 @@ fn compare_with_expected(output_dir: &Path, output_file: &Path, expected_file: &
     }
 }
 
+const LAYOUT_NOTONASTALIQURDU_TEST: &str = "tests/layout.notonastaliqurdu.tests";
+
 #[rstest]
 fn test_subset_case(#[files("test-data/tests/*.tests")] path: PathBuf) {
+    // Tested in test_subset_layout_notonastaliqurdu.
+    if path.ends_with(LAYOUT_NOTONASTALIQURDU_TEST) {
+        return;
+    }
     let test = SubsetTestCase::new(&path);
     match std::env::var(GEN_EXPECTED_OUTPUTS_VAR) {
-        Ok(_val) => {
-            test.gen_expected_output();
-        }
-        Err(_e) => {
-            test.run();
-        }
+        Ok(_val) => test.gen_expected_output(),
+        Err(_e) => test.run(),
+    }
+}
+
+#[test]
+#[ignore = r#"Slow integration test, see https://github.com/googlefonts/fontations/issues/1910.
+To run manually: cargo test -p skera -- --ignored"#]
+fn test_subset_layout_notonastaliqurdu() {
+    let path = Path::new(TEST_DATA_DIR).join(LAYOUT_NOTONASTALIQURDU_TEST);
+    let test = SubsetTestCase::new(&path);
+    match std::env::var(GEN_EXPECTED_OUTPUTS_VAR) {
+        Ok(_val) => test.gen_expected_output(),
+        Err(_e) => test.run(),
     }
 }
 


### PR DESCRIPTION
- The tests are still run in the CI
- Developers need to run `cargo test -p skera -- --ignored` to trigger a local manual run