### PR TITLE
Parallelize skera integration test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ pretty_assertions = "1.3.0"
 core_maths = "0.1"
 criterion = "0.3.0"
 kurbo = "0.13.0"
+rayon = "1.12"
 serde_json = "1.0"
 
 # These allow using the workspace library crates without having to

--- a/fauntlet/Cargo.toml
+++ b/fauntlet/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 skrifa = { workspace = true }
 freetype-rs = { version = "0.38.0", features = ["bundled"] }
 memmap2 = "0.5.10"
-rayon = "1.8.0"
+rayon = { workspace = true }
 clap = { version = "4.4.7", features = ["derive"] }
 wild = "2.2.0"
 similar = "2.3.0"

--- a/font-codegen/Cargo.toml
+++ b/font-codegen/Cargo.toml
@@ -29,7 +29,7 @@ toml = "0.8.19"
 serde = {version = "1.0", features = ["derive"] }
 xflags = "0.3.0"
 log = "0.4"
-rayon = "1.5.3"
+rayon = { workspace = true }
 indexmap = "2.0"
 env_logger.workspace = true
 

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -31,5 +31,7 @@ write-fonts = { workspace = true, features = ["read"] }
 
 [dev-dependencies]
 diff = "0.1.13"
-tempdir = "0.3.7"
 font-test-data = { workspace = true }
+rayon = { workspace = true }
+rstest = "0.26.1"
+tempdir = "0.3.7"

--- a/skera/tests/integration_test.rs
+++ b/skera/tests/integration_test.rs
@@ -6,6 +6,8 @@
 //! To generate the expected output files, pass GEN_EXPECTED_OUTPUTS=1 as an
 //! environment variable.
 
+use rayon::prelude::*;
+use rstest::rstest;
 use skera::{
     parse_unicodes, subset_font, Plan, SubsetFlags, DEFAULT_DROP_TABLES, DEFAULT_LAYOUT_FEATURES,
 };
@@ -312,14 +314,14 @@ impl SubsetTestCase {
     fn run(&self) {
         let output_temp_dir = TempDir::new_in(".", "skera_test").unwrap();
         let output_dir = output_temp_dir.path();
-        for font in &self.fonts {
-            for profile in &self.profiles {
-                for subset in &self.subsets {
+        self.fonts.par_iter().for_each(|font| {
+            self.profiles.par_iter().for_each(|profile| {
+                self.subsets.par_iter().for_each(|subset| {
                     //TODO: add support for instances/iup_options
                     self.run_one_test(font, subset, profile, output_dir);
-                }
-            }
-        }
+                })
+            })
+        })
     }
 
     fn gen_expected_output(&self) {
@@ -674,23 +676,15 @@ fn compare_with_expected(output_dir: &Path, output_file: &Path, expected_file: &
     }
 }
 
-#[test]
-fn run_all_tests() {
-    use std::ffi::OsStr;
-    let tests_path = Path::new(TEST_DATA_DIR).join("tests");
-    for entry in tests_path.read_dir().expect("can't read dir: test-data") {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.extension() == Some(OsStr::new("tests")) {
-            let test = SubsetTestCase::new(&path);
-            match std::env::var(GEN_EXPECTED_OUTPUTS_VAR) {
-                Ok(_val) => {
-                    test.gen_expected_output();
-                }
-                Err(_e) => {
-                    test.run();
-                }
-            }
+#[rstest]
+fn test_subset_case(#[files("test-data/tests/*.tests")] path: PathBuf) {
+    let test = SubsetTestCase::new(&path);
+    match std::env::var(GEN_EXPECTED_OUTPUTS_VAR) {
+        Ok(_val) => {
+            test.gen_expected_output();
+        }
+        Err(_e) => {
+            test.run();
         }
     }
 }


### PR DESCRIPTION
Parallelization, especially in `TestCaseParser::run`, mitigates #1910

# How

- Use `rstest` to make a unit test out of each file
- Use `rayon` to parallelize `run`

# Impact

Pretty good speedup for the `layout.notonastaliqurdu.tests` case. Still a neat improvement if we remove the outlier.

`cargo test -p skera` timings:

Test Scope | Before | After
-- | -- | --
All tests | 33.65s | 8.26s
Excluding layout.notonastaliqurdu.tests | 3.20s | 0.42s
