### PR TITLE
handle unpaired high surrogate in name table CharIter

### DIFF
--- a/read-fonts/src/tables/name.rs
+++ b/read-fonts/src/tables/name.rs
@@ -166,6 +166,13 @@ impl Iterator for CharIter<'_> {
                     let Some(c2) = self.bump_u16() else {
                         return Some(rep);
                     };
+                    if !(0xDC00..=0xDFFF).contains(&c2) {
+                        // c1 is an unpaired high surrogate; rewind so c2 is
+                        // decoded on its own rather than folded into a bogus
+                        // scalar.
+                        self.pos -= 2;
+                        return Some(rep);
+                    }
                     ((c1 & 0x3FF) << 10) + (c2 as u32 & 0x3FF) + 0x10000
                 } else {
                     c1
@@ -308,5 +315,27 @@ mod tests {
             pos: 0,
         };
         assert!(chars.eq(['ऄ', std::char::REPLACEMENT_CHARACTER].into_iter()))
+    }
+
+    #[test]
+    fn high_surrogate_followed_by_non_low() {
+        let rep = std::char::REPLACEMENT_CHARACTER;
+        // High surrogate (0xD800) followed by a BMP scalar 'A' (U+0041): the
+        // high surrogate is unpaired and 'A' must still be decoded.
+        let chars = CharIter {
+            data: &[0xD8, 0x00, 0x00, 0x41],
+            encoding: Encoding::Utf16Be,
+            pos: 0,
+        };
+        assert!(chars.eq([rep, 'A'].into_iter()));
+
+        // High surrogate (0xD800) followed by a valid pair (U+1F600): the first
+        // unit is unpaired and the following pair must decode intact.
+        let chars = CharIter {
+            data: &[0xD8, 0x00, 0xD8, 0x3D, 0xDE, 0x00],
+            encoding: Encoding::Utf16Be,
+            pos: 0,
+        };
+        assert!(chars.eq([rep, '😀'].into_iter()));
     }
 }


### PR DESCRIPTION
**Unpaired high surrogate folded into a bogus scalar**

A UTF-16BE name string whose high surrogate is not followed by a low surrogate was still combined into a single code point, which both yields the wrong character and consumes the next unit, so a following valid pair is lost. It now only combines genuine low surrogates and otherwise emits the replacement character, leaving the next unit to be decoded normally, which keeps the iterator consistent with the existing lone-surrogate handling.