### PR TITLE
fix: address RUSTSEC advisories for unmaintained crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ env_logger = "0.11"
 pretty_assertions = "1.3.0"
 
 core_maths = "0.1"
-criterion = "0.3.0"
+criterion = "0.7"
 kurbo = "0.13.0"
 rayon = "1.12"
 serde_json = "1.0"

--- a/otexplorer/Cargo.toml
+++ b/otexplorer/Cargo.toml
@@ -8,8 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-ansi_term = "0.12.1"
-atty = "0.2"
+owo-colors = "4"
 font-types = { workspace = true }
 read-fonts = { workspace = true, features = ["experimental_traverse"] }
 xflags = "0.3.0"

--- a/otexplorer/src/print.rs
+++ b/otexplorer/src/print.rs
@@ -1,8 +1,8 @@
 //! pretty printing implementation
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 
-use ansi_term::{Color, Style};
+use owo_colors::{Style as OwoStyle, XtermColors};
 use read_fonts::traversal::{
     ArrayOffset, FieldType, OffsetType, ResolvedOffset, SomeArray, SomeString, SomeTable,
     StringOffset,
@@ -49,7 +49,7 @@ impl<'a> PrettyPrinter<'a> {
             depth: 0,
             line_pos: 0,
             cur_array_item: None,
-            is_tty: atty::is(atty::Stream::Stdout),
+            is_tty: std::io::stdout().is_terminal(),
             indent_size: 2,
             writer,
         }
@@ -107,7 +107,7 @@ impl<'a> PrettyPrinter<'a> {
 
     fn print_with_style(
         &mut self,
-        style: Style,
+        style: OwoStyle,
         f: impl FnOnce(&mut PrettyPrinter) -> std::io::Result<()>,
     ) -> std::io::Result<()> {
         if !self.is_tty {
@@ -115,11 +115,11 @@ impl<'a> PrettyPrinter<'a> {
         } else {
             // ansi styles aren't counted for the purpose of width calculations
             let pos = self.line_pos;
-            write!(self, "{}", style.prefix())?;
+            write!(self, "{}", style.prefix_formatter())?;
             self.line_pos = pos;
             f(self)?;
             let pos = self.line_pos;
-            write!(self, "{}", style.suffix())?;
+            write!(self, "{}", style.suffix_formatter())?;
             self.line_pos = pos;
         }
         Ok(())
@@ -131,7 +131,9 @@ impl<'a> PrettyPrinter<'a> {
                 self.print_newline()?;
             }
             self.print_indent()?;
-            self.print_with_style(Color::Cyan.into(), |this| write!(this, "{}", field.name))?;
+            self.print_with_style(OwoStyle::new().cyan(), |this| {
+                write!(this, "{}", field.name)
+            })?;
             write!(self, ": ")?;
             self.print_field(&field.value)?;
         }
@@ -176,12 +178,14 @@ impl<'a> PrettyPrinter<'a> {
             FieldType::F2Dot14(val) => write!(self, "{val}")?,
             FieldType::Fixed(val) => write!(self, "{val}")?,
             FieldType::LongDateTime(val) => write!(self, "{val:?}")?,
-            FieldType::GlyphId16(val) => self.print_with_style(Color::Yellow.into(), |this| {
-                write!(this, "{}", val.to_u16())
-            })?,
-            FieldType::GlyphId24(val) => self.print_with_style(Color::Yellow.into(), |this| {
-                write!(this, "{}", val.to_u32())
-            })?,
+            FieldType::GlyphId16(val) => self
+                .print_with_style(OwoStyle::new().yellow(), |this| {
+                    write!(this, "{}", val.to_u16())
+                })?,
+            FieldType::GlyphId24(val) => self
+                .print_with_style(OwoStyle::new().yellow(), |this| {
+                    write!(this, "{}", val.to_u32())
+                })?,
             FieldType::NameId(val) => write!(self, "{val:?}")?,
             FieldType::ResolvedOffset(ResolvedOffset { offset, target }) => {
                 match target {
@@ -191,7 +195,9 @@ impl<'a> PrettyPrinter<'a> {
                         if self.line_pos == 0 {
                             self.print_indent()?;
                         }
-                        self.print_with_style(Color::Blue.into(), |this| write!(this, "{offset}"))?;
+                        self.print_with_style(OwoStyle::new().blue(), |this| {
+                            write!(this, "{offset}")
+                        })?;
                         self.print_current_array_pos()?;
                         self.print_offset_hex(*offset)?;
                         self.print_newline()?;
@@ -202,7 +208,7 @@ impl<'a> PrettyPrinter<'a> {
             }
             FieldType::StringOffset(StringOffset { offset, target }) => match target {
                 Ok(string) => {
-                    self.print_with_style(Color::Blue.into(), |this| write!(this, "{offset}"))?;
+                    self.print_with_style(OwoStyle::new().blue(), |this| write!(this, "{offset}"))?;
                     self.print_current_array_pos()?;
                     self.print_offset_hex(*offset)?;
                     self.print_newline()?;
@@ -212,7 +218,7 @@ impl<'a> PrettyPrinter<'a> {
             },
             FieldType::ArrayOffset(ArrayOffset { offset, target }) => match target {
                 Ok(array) => {
-                    self.print_with_style(Color::Blue.into(), |this| write!(this, "{offset}"))?;
+                    self.print_with_style(OwoStyle::new().blue(), |this| write!(this, "{offset}"))?;
                     self.print_current_array_pos()?;
                     self.print_offset_hex(*offset)?;
                     self.print_newline()?;
@@ -224,7 +230,7 @@ impl<'a> PrettyPrinter<'a> {
                 if self.line_pos == 0 {
                     self.print_indent()?;
                 }
-                self.print_with_style(Color::Blue.into(), |this| match offset.to_u32() {
+                self.print_with_style(OwoStyle::new().blue(), |this| match offset.to_u32() {
                     0 => write!(this, "Null"),
                     _ => write!(this, "{offset}"),
                 })?;
@@ -285,13 +291,13 @@ impl<'a> PrettyPrinter<'a> {
                     return Ok(());
                 }
                 len if self.line_pos + len < L_COLUMN_WIDTH => {
-                    self.print_with_style(Style::default().italic(), |this| this.write_all(&buf))?;
+                    self.print_with_style(OwoStyle::new().italic(), |this| this.write_all(&buf))?;
                 }
                 _ => {
                     self.print_hex(&[])?;
                     self.print_newline()?;
                     self.print_indent()?;
-                    self.print_with_style(Style::default().italic(), |this| this.write_all(&buf))?;
+                    self.print_with_style(OwoStyle::new().italic(), |this| this.write_all(&buf))?;
                 }
             }
         }
@@ -310,7 +316,10 @@ impl<'a> PrettyPrinter<'a> {
             let padding = ARRAY_POS_WIDTH.saturating_sub(self.line_pos);
             let wspace = &MANY_SPACES[..padding];
             self.write_all(wspace)?;
-            self.print_with_style(Color::Fixed(243).italic(), |this| write!(this, " {idx}"))?;
+            self.print_with_style(
+                OwoStyle::new().color(XtermColors::from(243u8)).italic(),
+                |this| write!(this, " {idx}"),
+            )?;
         }
         Ok(())
     }
@@ -327,7 +336,7 @@ impl<'a> PrettyPrinter<'a> {
         let padding = L_COLUMN_WIDTH.saturating_sub(self.line_pos);
         let wspace = &MANY_SPACES[..padding];
         self.write_all(wspace)?;
-        self.print_with_style(Color::Fixed(250).into(), |this| {
+        self.print_with_style(OwoStyle::new().color(XtermColors::from(250u8)), |this| {
             write!(this, "│")?;
             for b in bytes {
                 write!(this, " {b:02X}")?

--- a/read-fonts/benches/int_set_benchmark.rs
+++ b/read-fonts/benches/int_set_benchmark.rs
@@ -1,7 +1,8 @@
 mod bench_helper;
 use bench_helper::{random_set, random_u32_set};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use read_fonts::collections::{IntSet, U32Set};
+use std::hint::black_box;
 
 struct SetTest {
     set_size: u32,

--- a/read-fonts/benches/sparse_bit_set_benchmark.rs
+++ b/read-fonts/benches/sparse_bit_set_benchmark.rs
@@ -1,8 +1,9 @@
 mod bench_helper;
 
 use bench_helper::random_set;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use read_fonts::collections::int_set::{sparse_bit_set::to_sparse_bit_set_with_bf, IntSet};
+use std::hint::black_box;
 
 struct SparseSetTest {
     set_size: u32,

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -34,4 +34,4 @@ diff = "0.1.13"
 font-test-data = { workspace = true }
 rayon = { workspace = true }
 rstest = "0.26.1"
-tempdir = "0.3.7"
+tempfile = "3"

--- a/skera/tests/integration_test.rs
+++ b/skera/tests/integration_test.rs
@@ -16,7 +16,7 @@ use std::fs;
 use std::iter::Peekable;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use tempdir::TempDir;
+use tempfile::TempDir;
 use write_fonts::{
     read::{
         collections::{int_set::Domain, IntSet},
@@ -312,7 +312,7 @@ impl SubsetTestCase {
     }
 
     fn run(&self) {
-        let output_temp_dir = TempDir::new_in(".", "skera_test").unwrap();
+        let output_temp_dir = TempDir::new_in(".").unwrap();
         let output_dir = output_temp_dir.path();
         self.fonts.par_iter().for_each(|font| {
             self.profiles.par_iter().for_each(|profile| {
@@ -325,7 +325,7 @@ impl SubsetTestCase {
     }
 
     fn gen_expected_output(&self) {
-        let output_temp_dir = TempDir::new_in(".", "skera_test").unwrap();
+        let output_temp_dir = TempDir::new_in(".").unwrap();
         let output_dir = output_temp_dir.path();
         for font in &self.fonts {
             for profile in &self.profiles {

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -40,7 +40,7 @@ read-fonts = { workspace = true, features = [
   "codegen_test", "experimental_traverse"
 ] }
 rstest = "0.18.0"
-bincode = "1.0"
+bincode = { version = "2", features = ["serde"] }
 rand = "0.8.5"
 
 pretty_assertions.workspace = true

--- a/write-fonts/src/tables.rs
+++ b/write-fonts/src/tables.rs
@@ -77,6 +77,7 @@ fn do_we_even_serde() {
         ift: ift::Ift,
     }
     let tables = AllTables::default();
-    let dumped = bincode::serialize(&tables).unwrap();
-    let _loaded: AllTables = bincode::deserialize(&dumped).unwrap();
+    let dumped = bincode::serde::encode_to_vec(&tables, bincode::config::legacy()).unwrap();
+    let (_loaded, _): (AllTables, usize) =
+        bincode::serde::decode_from_slice(&dumped, bincode::config::legacy()).unwrap();
 }


### PR DESCRIPTION
- criterion 0.3 → 0.7: removes `serde_cbor` (RUSTSEC-2021-0127) and `atty` (RUSTSEC-2024-0375, RUSTSEC-2021-0145) from criterion's dependency tree
  - Sticking to 0.7 instead of 0.8 since importing 0.8 is not possible on some hardened setups. https://github.com/criterion-rs/criterion.rs/issues/83
- `bincode` 1.0 → 2.0 in `write-fonts`: v1 is unmaintained (RUSTSEC-2025-0141); the `serde` feature enables the `bincode::serde` module for encode/decode, not `serde` derives (which were already on the struct); note that the advisory covers all versions so it still flags v2, but v2 is the latest available
- `tempdir` → `tempfile` in `skera`: `tempdir` is deprecated and depends on `remove_dir_all` 0.5 which has a TOCTOU race condition (RUSTSEC-2023-0018); `tempfile` is the maintained replacement and doesn't pull in `remove_dir_all` (also resolves RUSTSEC-2018-0017);
  - note `tempfile::TempDir::new_in` takes only a directory arg, not directory+prefix like tempdir did
- `ansi_term/atty` → `owo-colors/std::io::IsTerminal` in `otexplorer`: `ansi_term` is `unmaintained` (RUSTSEC-2021-0139) and `atty` is both unmaintained (RUSTSEC-2024-0375) and has an **unaligned read (RUSTSEC-2021-0145);** owo-colors is actively maintained and IsTerminal is in std

Not addressed: paste (RUSTSEC-2024-0436) is a transitive dep from `safer-bytes` via `woff2-patched` (dev dependency only) with no direct control.

Closes #1922 