### PR TITLE
[codegen] Use helper for generated count casts

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -226,7 +226,7 @@ impl Fields {
             {
                 let typ = self.get_scalar_field_type(ident);
                 Some(quote! {
-                    if #maybe_check_is_some self.#name #maybe_unwrap.len() > (#typ::MAX as usize) {
+                    if #maybe_check_is_some self.#name #maybe_unwrap.len() > to_usize(#typ::MAX) {
                         ctx.report("array exceeds max length");
                     }
                 })

--- a/font-codegen/src/parsing/attrs.rs
+++ b/font-codegen/src/parsing/attrs.rs
@@ -708,7 +708,7 @@ impl Count {
     pub(crate) fn count_expr(&self) -> TokenStream {
         match self {
             Count::All(_) => unreachable!("'all' count handled separately"),
-            Count::SingleArg(CountArg::Field(arg)) => quote!(#arg as usize),
+            Count::SingleArg(CountArg::Field(arg)) => quote!(transforms::to_usize(#arg)),
             Count::SingleArg(CountArg::Literal(arg)) => quote!(#arg),
             Count::Complicated { args, xform } => match (xform, args.as_slice()) {
                 (CountTransform::Sub, [a, b]) => {
@@ -748,7 +748,7 @@ impl Count {
                     quote!(transforms::subtract_add_two(#a, #b))
                 }
                 (CountTransform::TryInto, [a]) => {
-                    quote!(usize::try_from(#a).unwrap_or_default())
+                    quote!(transforms::to_usize(#a))
                 }
                 _ => unreachable!("validated before now"),
             },

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -101,7 +101,7 @@ impl<'a> TableDirectory<'a> {
     pub fn table_records_byte_range(&self) -> Range<usize> {
         let num_tables = self.num_tables();
         let start = self.range_shift_byte_range().end;
-        start..start + (num_tables as usize).saturating_mul(TableRecord::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_tables)).saturating_mul(TableRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -304,7 +304,7 @@ impl<'a> TTCHeader<'a> {
     pub fn table_directory_offsets_byte_range(&self) -> Range<usize> {
         let num_fonts = self.num_fonts();
         let start = self.num_fonts_byte_range().end;
-        start..start + (num_fonts as usize).saturating_mul(u32::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_fonts)).saturating_mul(u32::RAW_BYTE_LEN)
     }
 
     pub fn dsig_tag_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -478,7 +478,7 @@ impl<'a> Lookup4<'a> {
     pub fn segments_byte_range(&self) -> Range<usize> {
         let n_units = self.n_units();
         let start = self.range_shift_byte_range().end;
-        start..start + (n_units as usize).saturating_mul(LookupSegment4::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_units)).saturating_mul(LookupSegment4::RAW_BYTE_LEN)
     }
 }
 
@@ -797,7 +797,7 @@ impl<'a> Lookup8<'a> {
     pub fn value_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -1155,7 +1155,7 @@ impl<'a> ClassSubtable<'a> {
     pub fn class_array_byte_range(&self) -> Range<usize> {
         let n_glyphs = self.n_glyphs();
         let start = self.n_glyphs_byte_range().end;
-        start..start + (n_glyphs as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_glyphs)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -185,7 +185,7 @@ impl<'a> GlyphDataEntry<'a> {
     pub fn anchor_points_byte_range(&self) -> Range<usize> {
         let num_points = self.num_points();
         let start = self.num_points_byte_range().end;
-        start..start + (num_points as usize).saturating_mul(AnchorPoint::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_points)).saturating_mul(AnchorPoint::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -111,7 +111,8 @@ impl<'a> Avar<'a> {
         let start = self.axis_count_byte_range().end;
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
-            <SegmentMaps as VarSize>::total_len_for_count(data, axis_count as usize).unwrap_or(0)
+            <SegmentMaps as VarSize>::total_len_for_count(data, transforms::to_usize(axis_count))
+                .unwrap_or(0)
         }
     }
 

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -311,7 +311,7 @@ impl<'a> BaseTagList<'a> {
     pub fn baseline_tags_byte_range(&self) -> Range<usize> {
         let base_tag_count = self.base_tag_count();
         let start = self.base_tag_count_byte_range().end;
-        start..start + (base_tag_count as usize).saturating_mul(Tag::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(base_tag_count)).saturating_mul(Tag::RAW_BYTE_LEN)
     }
 }
 
@@ -399,7 +399,10 @@ impl<'a> BaseScriptList<'a> {
     pub fn base_script_records_byte_range(&self) -> Range<usize> {
         let base_script_count = self.base_script_count();
         let start = self.base_script_count_byte_range().end;
-        start..start + (base_script_count as usize).saturating_mul(BaseScriptRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(base_script_count))
+                    .saturating_mul(BaseScriptRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -583,7 +586,9 @@ impl<'a> BaseScript<'a> {
         let base_lang_sys_count = self.base_lang_sys_count();
         let start = self.base_lang_sys_count_byte_range().end;
         start
-            ..start + (base_lang_sys_count as usize).saturating_mul(BaseLangSysRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(base_lang_sys_count))
+                    .saturating_mul(BaseLangSysRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -764,7 +769,9 @@ impl<'a> BaseValues<'a> {
     pub fn base_coord_offsets_byte_range(&self) -> Range<usize> {
         let base_coord_count = self.base_coord_count();
         let start = self.base_coord_count_byte_range().end;
-        start..start + (base_coord_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(base_coord_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -896,7 +903,10 @@ impl<'a> MinMax<'a> {
     pub fn feat_min_max_records_byte_range(&self) -> Range<usize> {
         let feat_min_max_count = self.feat_min_max_count();
         let start = self.feat_min_max_count_byte_range().end;
-        start..start + (feat_min_max_count as usize).saturating_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(feat_min_max_count))
+                    .saturating_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -806,7 +806,7 @@ impl<'a> IndexSubtableList<'a> {
         let start = 0;
         start
             ..start
-                + (number_of_index_subtables as usize)
+                + (transforms::to_usize(number_of_index_subtables))
                     .saturating_mul(IndexSubtableRecord::RAW_BYTE_LEN)
     }
 }
@@ -1627,7 +1627,7 @@ impl<'a> IndexSubtable5<'a> {
     pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let num_glyphs = self.num_glyphs();
         let start = self.num_glyphs_byte_range().end;
-        start..start + (num_glyphs as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_glyphs)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -83,7 +83,7 @@ impl<'a> Cblc<'a> {
     pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
         let num_sizes = self.num_sizes();
         let start = self.num_sizes_byte_range().end;
-        start..start + (num_sizes as usize).saturating_mul(BitmapSize::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_sizes)).saturating_mul(BitmapSize::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -511,7 +511,7 @@ impl<'a> FdSelectFormat3<'a> {
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let n_ranges = self.n_ranges();
         let start = self.n_ranges_byte_range().end;
-        start..start + (n_ranges as usize).saturating_mul(FdSelectRange3::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_ranges)).saturating_mul(FdSelectRange3::RAW_BYTE_LEN)
     }
 
     pub fn sentinel_byte_range(&self) -> Range<usize> {
@@ -665,7 +665,7 @@ impl<'a> FdSelectFormat4<'a> {
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let n_ranges = self.n_ranges();
         let start = self.n_ranges_byte_range().end;
-        start..start + (n_ranges as usize).saturating_mul(FdSelectRange4::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_ranges)).saturating_mul(FdSelectRange4::RAW_BYTE_LEN)
     }
 
     pub fn sentinel_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -108,7 +108,7 @@ impl<'a> Cff2Header<'a> {
     pub fn top_dict_data_byte_range(&self) -> Range<usize> {
         let top_dict_length = self.top_dict_length();
         let start = self._padding_byte_range().end;
-        start..start + (top_dict_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(top_dict_length)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 
     pub fn trailing_data_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -71,7 +71,9 @@ impl<'a> Cmap<'a> {
     pub fn encoding_records_byte_range(&self) -> Range<usize> {
         let num_tables = self.num_tables();
         let start = self.num_tables_byte_range().end;
-        start..start + (num_tables as usize).saturating_mul(EncodingRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_tables)).saturating_mul(EncodingRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -971,7 +973,7 @@ impl<'a> Cmap6<'a> {
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let entry_count = self.entry_count();
         let start = self.entry_count_byte_range().end;
-        start..start + (entry_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(entry_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -1113,7 +1115,10 @@ impl<'a> Cmap8<'a> {
     pub fn groups_byte_range(&self) -> Range<usize> {
         let num_groups = self.num_groups();
         let start = self.num_groups_byte_range().end;
-        start..start + (num_groups as usize).saturating_mul(SequentialMapGroup::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_groups))
+                    .saturating_mul(SequentialMapGroup::RAW_BYTE_LEN)
     }
 }
 
@@ -1318,7 +1323,7 @@ impl<'a> Cmap10<'a> {
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let num_chars = self.num_chars();
         let start = self.num_chars_byte_range().end;
-        start..start + (num_chars as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_chars)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -1446,7 +1451,10 @@ impl<'a> Cmap12<'a> {
     pub fn groups_byte_range(&self) -> Range<usize> {
         let num_groups = self.num_groups();
         let start = self.num_groups_byte_range().end;
-        start..start + (num_groups as usize).saturating_mul(SequentialMapGroup::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_groups))
+                    .saturating_mul(SequentialMapGroup::RAW_BYTE_LEN)
     }
 }
 
@@ -1580,7 +1588,9 @@ impl<'a> Cmap13<'a> {
     pub fn groups_byte_range(&self) -> Range<usize> {
         let num_groups = self.num_groups();
         let start = self.num_groups_byte_range().end;
-        start..start + (num_groups as usize).saturating_mul(ConstantMapGroup::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_groups)).saturating_mul(ConstantMapGroup::RAW_BYTE_LEN)
     }
 }
 
@@ -1747,7 +1757,7 @@ impl<'a> Cmap14<'a> {
         let start = self.num_var_selector_records_byte_range().end;
         start
             ..start
-                + (num_var_selector_records as usize)
+                + (transforms::to_usize(num_var_selector_records))
                     .saturating_mul(VariationSelector::RAW_BYTE_LEN)
     }
 }
@@ -1920,7 +1930,9 @@ impl<'a> DefaultUvs<'a> {
         let num_unicode_value_ranges = self.num_unicode_value_ranges();
         let start = self.num_unicode_value_ranges_byte_range().end;
         start
-            ..start + (num_unicode_value_ranges as usize).saturating_mul(UnicodeRange::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(num_unicode_value_ranges))
+                    .saturating_mul(UnicodeRange::RAW_BYTE_LEN)
     }
 }
 
@@ -2015,7 +2027,9 @@ impl<'a> NonDefaultUvs<'a> {
     pub fn uvs_mapping_byte_range(&self) -> Range<usize> {
         let num_uvs_mappings = self.num_uvs_mappings();
         let start = self.num_uvs_mappings_byte_range().end;
-        start..start + (num_uvs_mappings as usize).saturating_mul(UvsMapping::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_uvs_mappings)).saturating_mul(UvsMapping::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -450,7 +450,7 @@ impl<'a> BaseGlyphList<'a> {
         let start = self.num_base_glyph_paint_records_byte_range().end;
         start
             ..start
-                + (num_base_glyph_paint_records as usize)
+                + (transforms::to_usize(num_base_glyph_paint_records))
                     .saturating_mul(BaseGlyphPaint::RAW_BYTE_LEN)
     }
 }
@@ -607,7 +607,7 @@ impl<'a> LayerList<'a> {
     pub fn paint_offsets_byte_range(&self) -> Range<usize> {
         let num_layers = self.num_layers();
         let start = self.num_layers_byte_range().end;
-        start..start + (num_layers as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_layers)).saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 
@@ -705,7 +705,7 @@ impl<'a> ClipList<'a> {
     pub fn clips_byte_range(&self) -> Range<usize> {
         let num_clips = self.num_clips();
         let start = self.num_clips_byte_range().end;
-        start..start + (num_clips as usize).saturating_mul(Clip::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_clips)).saturating_mul(Clip::RAW_BYTE_LEN)
     }
 }
 
@@ -1452,7 +1452,7 @@ impl<'a> ColorLine<'a> {
     pub fn color_stops_byte_range(&self) -> Range<usize> {
         let num_stops = self.num_stops();
         let start = self.num_stops_byte_range().end;
-        start..start + (num_stops as usize).saturating_mul(ColorStop::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_stops)).saturating_mul(ColorStop::RAW_BYTE_LEN)
     }
 }
 
@@ -1558,7 +1558,7 @@ impl<'a> VarColorLine<'a> {
     pub fn color_stops_byte_range(&self) -> Range<usize> {
         let num_stops = self.num_stops();
         let start = self.num_stops_byte_range().end;
-        start..start + (num_stops as usize).saturating_mul(VarColorStop::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_stops)).saturating_mul(VarColorStop::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -185,7 +185,7 @@ impl<'a> Cpal<'a> {
     pub fn color_record_indices_byte_range(&self) -> Range<usize> {
         let num_palettes = self.num_palettes();
         let start = self.color_records_array_offset_byte_range().end;
-        start..start + (num_palettes as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_palettes)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn palette_types_array_offset_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -84,7 +84,10 @@ impl<'a> Dsig<'a> {
     pub fn signature_records_byte_range(&self) -> Range<usize> {
         let num_signatures = self.num_signatures();
         let start = self.flags_byte_range().end;
-        start..start + (num_signatures as usize).saturating_mul(SignatureRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_signatures))
+                    .saturating_mul(SignatureRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -547,7 +550,7 @@ impl<'a> SignatureBlockFormat1<'a> {
     pub fn signature_byte_range(&self) -> Range<usize> {
         let signature_length = self.signature_length();
         let start = self.signature_length_byte_range().end;
-        start..start + (signature_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(signature_length)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -83,7 +83,7 @@ impl<'a> Eblc<'a> {
     pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
         let num_sizes = self.num_sizes();
         let start = self.num_sizes_byte_range().end;
-        start..start + (num_sizes as usize).saturating_mul(BitmapSize::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_sizes)).saturating_mul(BitmapSize::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -84,7 +84,10 @@ impl<'a> Feat<'a> {
     pub fn names_byte_range(&self) -> Range<usize> {
         let feature_name_count = self.feature_name_count();
         let start = self._reserved2_byte_range().end;
-        start..start + (feature_name_count as usize).saturating_mul(FeatureName::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(feature_name_count))
+                    .saturating_mul(FeatureName::RAW_BYTE_LEN)
     }
 }
 
@@ -277,7 +280,7 @@ impl<'a> SettingNameArray<'a> {
     pub fn settings_byte_range(&self) -> Range<usize> {
         let n_settings = self.n_settings();
         let start = 0;
-        start..start + (n_settings as usize).saturating_mul(SettingName::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_settings)).saturating_mul(SettingName::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -265,7 +265,10 @@ impl<'a> AxisInstanceArrays<'a> {
     pub fn axes_byte_range(&self) -> Range<usize> {
         let axis_count = self.axis_count();
         let start = 0;
-        start..start + (axis_count as usize).saturating_mul(VariationAxisRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(axis_count))
+                    .saturating_mul(VariationAxisRecord::RAW_BYTE_LEN)
     }
 
     pub fn instances_byte_range(&self) -> Range<usize> {
@@ -273,7 +276,7 @@ impl<'a> AxisInstanceArrays<'a> {
         let start = self.axes_byte_range().end;
         start
             ..start
-                + (instance_count as usize).saturating_mul(
+                + (transforms::to_usize(instance_count)).saturating_mul(
                     <InstanceRecord as ComputeSize>::compute_size(&(
                         self.axis_count(),
                         self.instance_size(),

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -72,7 +72,7 @@ impl<'a> Gasp<'a> {
     pub fn gasp_ranges_byte_range(&self) -> Range<usize> {
         let num_ranges = self.num_ranges();
         let start = self.num_ranges_byte_range().end;
-        start..start + (num_ranges as usize).saturating_mul(GaspRange::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_ranges)).saturating_mul(GaspRange::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -361,7 +361,7 @@ impl<'a> AttachList<'a> {
     pub fn attach_point_offsets_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -455,7 +455,7 @@ impl<'a> AttachPoint<'a> {
     pub fn point_indices_byte_range(&self) -> Range<usize> {
         let point_count = self.point_count();
         let start = self.point_count_byte_range().end;
-        start..start + (point_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(point_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -567,7 +567,8 @@ impl<'a> LigCaretList<'a> {
     pub fn lig_glyph_offsets_byte_range(&self) -> Range<usize> {
         let lig_glyph_count = self.lig_glyph_count();
         let start = self.lig_glyph_count_byte_range().end;
-        start..start + (lig_glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(lig_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -669,7 +670,7 @@ impl<'a> LigGlyph<'a> {
     pub fn caret_value_offsets_byte_range(&self) -> Range<usize> {
         let caret_count = self.caret_count();
         let start = self.caret_count_byte_range().end;
-        start..start + (caret_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(caret_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1151,7 +1152,10 @@ impl<'a> MarkGlyphSets<'a> {
     pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
         let mark_glyph_set_count = self.mark_glyph_set_count();
         let start = self.mark_glyph_set_count_byte_range().end;
-        start..start + (mark_glyph_set_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(mark_glyph_set_count))
+                    .saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -189,7 +189,7 @@ impl<'a> SimpleGlyph<'a> {
     pub fn end_pts_of_contours_byte_range(&self) -> Range<usize> {
         let number_of_contours = self.number_of_contours();
         let start = self.y_max_byte_range().end;
-        start..start + (number_of_contours as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(number_of_contours)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn instruction_length_byte_range(&self) -> Range<usize> {
@@ -200,7 +200,7 @@ impl<'a> SimpleGlyph<'a> {
     pub fn instructions_byte_range(&self) -> Range<usize> {
         let instruction_length = self.instruction_length();
         let start = self.instruction_length_byte_range().end;
-        start..start + (instruction_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(instruction_length)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 
     pub fn glyph_data_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -1124,7 +1124,7 @@ impl<'a> MarkArray<'a> {
     pub fn mark_records_byte_range(&self) -> Range<usize> {
         let mark_count = self.mark_count();
         let start = self.mark_count_byte_range().end;
-        start..start + (mark_count as usize).saturating_mul(MarkRecord::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(mark_count)).saturating_mul(MarkRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -1554,7 +1554,7 @@ impl<'a> SinglePosFormat2<'a> {
         let start = self.value_count_byte_range().end;
         start
             ..start
-                + (value_count as usize).saturating_mul(
+                + (transforms::to_usize(value_count)).saturating_mul(
                     <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0),
                 )
     }
@@ -1825,7 +1825,7 @@ impl<'a> PairPosFormat1<'a> {
     pub fn pair_set_offsets_byte_range(&self) -> Range<usize> {
         let pair_set_count = self.pair_set_count();
         let start = self.pair_set_count_byte_range().end;
-        start..start + (pair_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(pair_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1965,7 +1965,7 @@ impl<'a> PairSet<'a> {
         let start = self.pair_value_count_byte_range().end;
         start
             ..start
-                + (pair_value_count as usize).saturating_mul(
+                + (transforms::to_usize(pair_value_count)).saturating_mul(
                     <PairValueRecord as ComputeSize>::compute_size(&(
                         self.value_format1(),
                         self.value_format2(),
@@ -2293,7 +2293,7 @@ impl<'a> PairPosFormat2<'a> {
         let start = self.class2_count_byte_range().end;
         start
             ..start
-                + (class1_count as usize).saturating_mul(
+                + (transforms::to_usize(class1_count)).saturating_mul(
                     <Class1Record as ComputeSize>::compute_size(&(
                         self.class2_count(),
                         self.value_format1(),
@@ -2371,7 +2371,7 @@ impl ComputeSize for Class1Record<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &(u16, ValueFormat, ValueFormat)) -> Result<usize, ReadError> {
         let (class2_count, value_format1, value_format2) = *args;
-        Ok((class2_count as usize).saturating_mul(
+        Ok((transforms::to_usize(class2_count)).saturating_mul(
             <Class2Record as ComputeSize>::compute_size(&(value_format1, value_format2))
                 .unwrap_or(0),
         ))
@@ -2386,8 +2386,10 @@ impl<'a> FontReadWithArgs<'a> for Class1Record<'a> {
         let mut cursor = data.cursor();
         let (class2_count, value_format1, value_format2) = *args;
         Ok(Self {
-            class2_records: cursor
-                .read_computed_array(class2_count as usize, &(value_format1, value_format2))?,
+            class2_records: cursor.read_computed_array(
+                transforms::to_usize(class2_count),
+                &(value_format1, value_format2),
+            )?,
         })
     }
 }
@@ -2604,7 +2606,10 @@ impl<'a> CursivePosFormat1<'a> {
     pub fn entry_exit_record_byte_range(&self) -> Range<usize> {
         let entry_exit_count = self.entry_exit_count();
         let start = self.entry_exit_count_byte_range().end;
-        start..start + (entry_exit_count as usize).saturating_mul(EntryExitRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(entry_exit_count))
+                    .saturating_mul(EntryExitRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -2996,7 +3001,7 @@ impl<'a> BaseArray<'a> {
         let start = self.base_count_byte_range().end;
         start
             ..start
-                + (base_count as usize).saturating_mul(
+                + (transforms::to_usize(base_count)).saturating_mul(
                     <BaseRecord as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
@@ -3083,7 +3088,7 @@ impl ComputeSize for BaseRecord<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok((mark_class_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(mark_class_count)).saturating_mul(Offset16::RAW_BYTE_LEN))
     }
 }
 
@@ -3092,7 +3097,7 @@ impl<'a> FontReadWithArgs<'a> for BaseRecord<'a> {
         let mut cursor = data.cursor();
         let mark_class_count = *args;
         Ok(Self {
-            base_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
+            base_anchor_offsets: cursor.read_array(transforms::to_usize(mark_class_count))?,
         })
     }
 }
@@ -3398,7 +3403,7 @@ impl<'a> LigatureArray<'a> {
     pub fn ligature_attach_offsets_byte_range(&self) -> Range<usize> {
         let ligature_count = self.ligature_count();
         let start = self.ligature_count_byte_range().end;
-        start..start + (ligature_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(ligature_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -3518,7 +3523,7 @@ impl<'a> LigatureAttach<'a> {
         let start = self.component_count_byte_range().end;
         start
             ..start
-                + (component_count as usize).saturating_mul(
+                + (transforms::to_usize(component_count)).saturating_mul(
                     <ComponentRecord as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
@@ -3605,7 +3610,7 @@ impl ComputeSize for ComponentRecord<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok((mark_class_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(mark_class_count)).saturating_mul(Offset16::RAW_BYTE_LEN))
     }
 }
 
@@ -3614,7 +3619,7 @@ impl<'a> FontReadWithArgs<'a> for ComponentRecord<'a> {
         let mut cursor = data.cursor();
         let mark_class_count = *args;
         Ok(Self {
-            ligature_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
+            ligature_anchor_offsets: cursor.read_array(transforms::to_usize(mark_class_count))?,
         })
     }
 }
@@ -3914,7 +3919,7 @@ impl<'a> Mark2Array<'a> {
         let start = self.mark2_count_byte_range().end;
         start
             ..start
-                + (mark2_count as usize).saturating_mul(
+                + (transforms::to_usize(mark2_count)).saturating_mul(
                     <Mark2Record as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
@@ -4001,7 +4006,7 @@ impl ComputeSize for Mark2Record<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok((mark_class_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(mark_class_count)).saturating_mul(Offset16::RAW_BYTE_LEN))
     }
 }
 
@@ -4010,7 +4015,7 @@ impl<'a> FontReadWithArgs<'a> for Mark2Record<'a> {
         let mut cursor = data.cursor();
         let mark_class_count = *args;
         Ok(Self {
-            mark2_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
+            mark2_anchor_offsets: cursor.read_array(transforms::to_usize(mark_class_count))?,
         })
     }
 }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -558,7 +558,7 @@ impl<'a> SingleSubstFormat2<'a> {
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 }
 
@@ -684,7 +684,7 @@ impl<'a> MultipleSubstFormat1<'a> {
     pub fn sequence_offsets_byte_range(&self) -> Range<usize> {
         let sequence_count = self.sequence_count();
         let start = self.sequence_count_byte_range().end;
-        start..start + (sequence_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(sequence_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -782,7 +782,7 @@ impl<'a> Sequence<'a> {
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 }
 
@@ -913,7 +913,9 @@ impl<'a> AlternateSubstFormat1<'a> {
     pub fn alternate_set_offsets_byte_range(&self) -> Range<usize> {
         let alternate_set_count = self.alternate_set_count();
         let start = self.alternate_set_count_byte_range().end;
-        start..start + (alternate_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(alternate_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1013,7 +1015,7 @@ impl<'a> AlternateSet<'a> {
     pub fn alternate_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 }
 
@@ -1144,7 +1146,9 @@ impl<'a> LigatureSubstFormat1<'a> {
     pub fn ligature_set_offsets_byte_range(&self) -> Range<usize> {
         let ligature_set_count = self.ligature_set_count();
         let start = self.ligature_set_count_byte_range().end;
-        start..start + (ligature_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(ligature_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1249,7 +1253,7 @@ impl<'a> LigatureSet<'a> {
     pub fn ligature_offsets_byte_range(&self) -> Range<usize> {
         let ligature_count = self.ligature_count();
         let start = self.ligature_count_byte_range().end;
-        start..start + (ligature_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(ligature_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1749,7 +1753,10 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + (backtrack_glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(backtrack_glyph_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
@@ -1760,7 +1767,10 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + (lookahead_glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(lookahead_glyph_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
@@ -1771,7 +1781,7 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -585,7 +585,7 @@ impl<'a> SharedTuples<'a> {
         let start = 0;
         start
             ..start
-                + (shared_tuple_count as usize).saturating_mul(
+                + (transforms::to_usize(shared_tuple_count)).saturating_mul(
                     <Tuple as ComputeSize>::compute_size(&self.axis_count()).unwrap_or(0),
                 )
     }

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -109,7 +109,7 @@ impl<'a> Hdmx<'a> {
         let start = self.size_device_record_byte_range().end;
         start
             ..start
-                + (num_records as usize).saturating_mul(
+                + (transforms::to_usize(num_records)).saturating_mul(
                     <DeviceRecord as ComputeSize>::compute_size(&(
                         self.num_glyphs(),
                         self.size_device_record(),

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -83,7 +83,10 @@ impl<'a> Hmtx<'a> {
     pub fn h_metrics_byte_range(&self) -> Range<usize> {
         let number_of_h_metrics = self.number_of_h_metrics();
         let start = 0;
-        start..start + (number_of_h_metrics as usize).saturating_mul(LongMetric::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(number_of_h_metrics))
+                    .saturating_mul(LongMetric::RAW_BYTE_LEN)
     }
 
     pub fn left_side_bearings_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -650,7 +650,7 @@ impl<'a> PatchMapFormat1<'a> {
     pub fn url_template_byte_range(&self) -> Range<usize> {
         let url_template_length = self.url_template_length();
         let start = self.url_template_length_byte_range().end;
-        start..start + (url_template_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(url_template_length)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 
     pub fn patch_format_byte_range(&self) -> Range<usize> {
@@ -971,7 +971,7 @@ impl<'a> FeatureMap<'a> {
         let start = self.feature_count_byte_range().end;
         start
             ..start
-                + (feature_count as usize).saturating_mul(
+                + (transforms::to_usize(feature_count)).saturating_mul(
                     <FeatureRecord as ComputeSize>::compute_size(&self.max_entry_index())
                         .unwrap_or(0),
                 )
@@ -1359,7 +1359,7 @@ impl<'a> PatchMapFormat2<'a> {
     pub fn url_template_byte_range(&self) -> Range<usize> {
         let url_template_length = self.url_template_length();
         let start = self.url_template_length_byte_range().end;
-        start..start + (url_template_length as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(url_template_length)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 
     pub fn cff_charstrings_offset_byte_range(&self) -> Range<usize> {
@@ -1622,7 +1622,9 @@ impl<'a> EntryData<'a> {
             ..(self
                 .format_flags()
                 .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE))
-            .then(|| start + (feature_count as usize).saturating_mul(Tag::RAW_BYTE_LEN))
+            .then(|| {
+                start + (transforms::to_usize(feature_count)).saturating_mul(Tag::RAW_BYTE_LEN)
+            })
             .unwrap_or(start)
     }
 
@@ -1645,7 +1647,8 @@ impl<'a> EntryData<'a> {
                 .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE))
             .then(|| {
                 start
-                    + (design_space_count as usize).saturating_mul(DesignSpaceSegment::RAW_BYTE_LEN)
+                    + (transforms::to_usize(design_space_count))
+                        .saturating_mul(DesignSpaceSegment::RAW_BYTE_LEN)
             })
             .unwrap_or(start)
     }
@@ -1669,7 +1672,7 @@ impl<'a> EntryData<'a> {
                 .contains(EntryFormatFlags::CHILD_INDICES))
             .then(|| {
                 start
-                    + (usize::try_from(match_mode_and_count).unwrap_or_default())
+                    + (transforms::to_usize(match_mode_and_count))
                         .saturating_mul(Uint24::RAW_BYTE_LEN)
             })
             .unwrap_or(start)
@@ -3297,7 +3300,7 @@ impl<'a> GlyphPatches<'a> {
         let start = self.table_count_byte_range().end;
         start
             ..start
-                + (glyph_count as usize).saturating_mul(
+                + (transforms::to_usize(glyph_count)).saturating_mul(
                     <U16Or24 as ComputeSize>::compute_size(&self.flags()).unwrap_or(0),
                 )
     }
@@ -3305,7 +3308,7 @@ impl<'a> GlyphPatches<'a> {
     pub fn tables_byte_range(&self) -> Range<usize> {
         let table_count = self.table_count();
         let start = self.glyph_ids_byte_range().end;
-        start..start + (table_count as usize).saturating_mul(Tag::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(table_count)).saturating_mul(Tag::RAW_BYTE_LEN)
     }
 
     pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -506,7 +506,7 @@ impl<'a> Subtable0<'a> {
     pub fn pairs_byte_range(&self) -> Range<usize> {
         let n_pairs = self.n_pairs();
         let start = self.range_shift_byte_range().end;
-        start..start + (n_pairs as usize).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_pairs)).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
     }
 }
 
@@ -614,7 +614,7 @@ impl<'a> Subtable2ClassTable<'a> {
     pub fn offsets_byte_range(&self) -> Range<usize> {
         let n_glyphs = self.n_glyphs();
         let start = self.n_glyphs_byte_range().end;
-        start..start + (n_glyphs as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_glyphs)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -770,19 +770,19 @@ impl<'a> Subtable3<'a> {
     pub fn kern_value_byte_range(&self) -> Range<usize> {
         let kern_value_count = self.kern_value_count();
         let start = self.flags_byte_range().end;
-        start..start + (kern_value_count as usize).saturating_mul(i16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(kern_value_count)).saturating_mul(i16::RAW_BYTE_LEN)
     }
 
     pub fn left_class_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.kern_value_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 
     pub fn right_class_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.left_class_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(u8::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u8::RAW_BYTE_LEN)
     }
 
     pub fn kern_index_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -81,7 +81,8 @@ impl<'a> Kerx<'a> {
         let start = self.n_tables_byte_range().end;
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
-            <Subtable as VarSize>::total_len_for_count(data, n_tables as usize).unwrap_or(0)
+            <Subtable as VarSize>::total_len_for_count(data, transforms::to_usize(n_tables))
+                .unwrap_or(0)
         }
     }
 }
@@ -317,7 +318,7 @@ impl<'a> Subtable0<'a> {
     pub fn pairs_byte_range(&self) -> Range<usize> {
         let n_pairs = self.n_pairs();
         let start = self.range_shift_byte_range().end;
-        start..start + (n_pairs as usize).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(n_pairs)).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -56,7 +56,9 @@ impl<'a> ScriptList<'a> {
     pub fn script_records_byte_range(&self) -> Range<usize> {
         let script_count = self.script_count();
         let start = self.script_count_byte_range().end;
-        start..start + (script_count as usize).saturating_mul(ScriptRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(script_count)).saturating_mul(ScriptRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -222,7 +224,9 @@ impl<'a> Script<'a> {
     pub fn lang_sys_records_byte_range(&self) -> Range<usize> {
         let lang_sys_count = self.lang_sys_count();
         let start = self.lang_sys_count_byte_range().end;
-        start..start + (lang_sys_count as usize).saturating_mul(LangSysRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(lang_sys_count)).saturating_mul(LangSysRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -390,7 +394,7 @@ impl<'a> LangSys<'a> {
     pub fn feature_indices_byte_range(&self) -> Range<usize> {
         let feature_index_count = self.feature_index_count();
         let start = self.feature_index_count_byte_range().end;
-        start..start + (feature_index_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(feature_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -485,7 +489,9 @@ impl<'a> FeatureList<'a> {
     pub fn feature_records_byte_range(&self) -> Range<usize> {
         let feature_count = self.feature_count();
         let start = self.feature_count_byte_range().end;
-        start..start + (feature_count as usize).saturating_mul(FeatureRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(feature_count)).saturating_mul(FeatureRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -674,7 +680,7 @@ impl<'a> Feature<'a> {
     pub fn lookup_list_indices_byte_range(&self) -> Range<usize> {
         let lookup_index_count = self.lookup_index_count();
         let start = self.lookup_index_count_byte_range().end;
-        start..start + (lookup_index_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(lookup_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -795,7 +801,7 @@ impl<'a, T> LookupList<'a, T> {
     pub fn lookup_offsets_byte_range(&self) -> Range<usize> {
         let lookup_count = self.lookup_count();
         let start = self.lookup_count_byte_range().end;
-        start..start + (lookup_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(lookup_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -952,7 +958,8 @@ impl<'a, T> Lookup<'a, T> {
     pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
         let sub_table_count = self.sub_table_count();
         let start = self.sub_table_count_byte_range().end;
-        start..start + (sub_table_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(sub_table_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn mark_filtering_set_byte_range(&self) -> Range<usize> {
@@ -1080,7 +1087,7 @@ impl<'a> CoverageFormat1<'a> {
     pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 }
 
@@ -1185,7 +1192,7 @@ impl<'a> CoverageFormat2<'a> {
     pub fn range_records_byte_range(&self) -> Range<usize> {
         let range_count = self.range_count();
         let start = self.range_count_byte_range().end;
-        start..start + (range_count as usize).saturating_mul(RangeRecord::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(range_count)).saturating_mul(RangeRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -1434,7 +1441,7 @@ impl<'a> ClassDefFormat1<'a> {
     pub fn class_value_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 
@@ -1540,7 +1547,10 @@ impl<'a> ClassDefFormat2<'a> {
     pub fn class_range_records_byte_range(&self) -> Range<usize> {
         let class_range_count = self.class_range_count();
         let start = self.class_range_count_byte_range().end;
-        start..start + (class_range_count as usize).saturating_mul(ClassRangeRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(class_range_count))
+                    .saturating_mul(ClassRangeRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -1843,7 +1853,9 @@ impl<'a> SequenceContextFormat1<'a> {
     pub fn seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let seq_rule_set_count = self.seq_rule_set_count();
         let start = self.seq_rule_set_count_byte_range().end;
-        start..start + (seq_rule_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(seq_rule_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1948,7 +1960,7 @@ impl<'a> SequenceRuleSet<'a> {
     pub fn seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let seq_rule_count = self.seq_rule_count();
         let start = self.seq_rule_count_byte_range().end;
-        start..start + (seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(seq_rule_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -2067,7 +2079,9 @@ impl<'a> SequenceRule<'a> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.input_sequence_byte_range().end;
         start
-            ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(seq_lookup_count))
+                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -2225,7 +2239,10 @@ impl<'a> SequenceContextFormat2<'a> {
     pub fn class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let class_seq_rule_set_count = self.class_seq_rule_set_count();
         let start = self.class_seq_rule_set_count_byte_range().end;
-        start..start + (class_seq_rule_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(class_seq_rule_set_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -2325,7 +2342,10 @@ impl<'a> ClassSequenceRuleSet<'a> {
     pub fn class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let class_seq_rule_count = self.class_seq_rule_count();
         let start = self.class_seq_rule_count_byte_range().end;
-        start..start + (class_seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(class_seq_rule_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -2446,7 +2466,9 @@ impl<'a> ClassSequenceRule<'a> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.input_sequence_byte_range().end;
         start
-            ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(seq_lookup_count))
+                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -2584,14 +2606,16 @@ impl<'a> SequenceContextFormat3<'a> {
     pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start..start + (glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.coverage_offsets_byte_range().end;
         start
-            ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(seq_lookup_count))
+                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -2814,7 +2838,10 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     pub fn chained_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let chained_seq_rule_set_count = self.chained_seq_rule_set_count();
         let start = self.chained_seq_rule_set_count_byte_range().end;
-        start..start + (chained_seq_rule_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(chained_seq_rule_set_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -2922,7 +2949,10 @@ impl<'a> ChainedSequenceRuleSet<'a> {
     pub fn chained_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let chained_seq_rule_count = self.chained_seq_rule_count();
         let start = self.chained_seq_rule_count_byte_range().end;
-        start..start + (chained_seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(chained_seq_rule_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -3054,7 +3084,10 @@ impl<'a> ChainedSequenceRule<'a> {
     pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + (backtrack_glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(backtrack_glyph_count))
+                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 
     pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
@@ -3079,7 +3112,10 @@ impl<'a> ChainedSequenceRule<'a> {
     pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + (lookahead_glyph_count as usize).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(lookahead_glyph_count))
+                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
@@ -3091,7 +3127,9 @@ impl<'a> ChainedSequenceRule<'a> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.seq_lookup_count_byte_range().end;
         start
-            ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(seq_lookup_count))
+                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -3303,7 +3341,8 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
         let start = self.chained_class_seq_rule_set_count_byte_range().end;
         start
             ..start
-                + (chained_class_seq_rule_set_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+                + (transforms::to_usize(chained_class_seq_rule_set_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -3420,7 +3459,9 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
         let chained_class_seq_rule_count = self.chained_class_seq_rule_count();
         let start = self.chained_class_seq_rule_count_byte_range().end;
         start
-            ..start + (chained_class_seq_rule_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(chained_class_seq_rule_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -3553,7 +3594,9 @@ impl<'a> ChainedClassSequenceRule<'a> {
     pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + (backtrack_glyph_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(backtrack_glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
@@ -3578,7 +3621,9 @@ impl<'a> ChainedClassSequenceRule<'a> {
     pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + (lookahead_glyph_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(lookahead_glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
@@ -3590,7 +3635,9 @@ impl<'a> ChainedClassSequenceRule<'a> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.seq_lookup_count_byte_range().end;
         start
-            ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(seq_lookup_count))
+                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -3774,7 +3821,10 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start..start + (backtrack_glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(backtrack_glyph_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
@@ -3785,7 +3835,9 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     pub fn input_coverage_offsets_byte_range(&self) -> Range<usize> {
         let input_glyph_count = self.input_glyph_count();
         let start = self.input_glyph_count_byte_range().end;
-        start..start + (input_glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(input_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
@@ -3796,7 +3848,10 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start..start + (lookahead_glyph_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(lookahead_glyph_count))
+                    .saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
@@ -3808,7 +3863,9 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.seq_lookup_count_byte_range().end;
         start
-            ..start + (seq_lookup_count as usize).saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(seq_lookup_count))
+                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
     }
 }
 
@@ -4374,7 +4431,7 @@ impl<'a> FeatureVariations<'a> {
         let start = self.feature_variation_record_count_byte_range().end;
         start
             ..start
-                + (feature_variation_record_count as usize)
+                + (transforms::to_usize(feature_variation_record_count))
                     .saturating_mul(FeatureVariationRecord::RAW_BYTE_LEN)
     }
 }
@@ -4562,7 +4619,8 @@ impl<'a> ConditionSet<'a> {
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start..start + (condition_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 
@@ -5000,7 +5058,8 @@ impl<'a> ConditionFormat3<'a> {
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start..start + (condition_count as usize).saturating_mul(Offset24::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset24::RAW_BYTE_LEN)
     }
 }
 
@@ -5103,7 +5162,8 @@ impl<'a> ConditionFormat4<'a> {
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start..start + (condition_count as usize).saturating_mul(Offset24::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset24::RAW_BYTE_LEN)
     }
 }
 
@@ -5286,7 +5346,7 @@ impl<'a> FeatureTableSubstitution<'a> {
         let start = self.substitution_count_byte_range().end;
         start
             ..start
-                + (substitution_count as usize)
+                + (transforms::to_usize(substitution_count))
                     .saturating_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN)
     }
 }
@@ -5758,7 +5818,7 @@ impl<'a> CharacterVariantParams<'a> {
     pub fn character_byte_range(&self) -> Range<usize> {
         let char_count = self.char_count();
         let start = self.char_count_byte_range().end;
-        start..start + (char_count as usize).saturating_mul(Uint24::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(char_count)).saturating_mul(Uint24::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -83,7 +83,7 @@ impl<'a> Ltag<'a> {
     pub fn tag_ranges_byte_range(&self) -> Range<usize> {
         let num_tags = self.num_tags();
         let start = self.num_tags_byte_range().end;
-        start..start + (num_tags as usize).saturating_mul(FTStringRange::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_tags)).saturating_mul(FTStringRange::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -89,7 +89,10 @@ impl<'a> Meta<'a> {
     pub fn data_maps_byte_range(&self) -> Range<usize> {
         let data_maps_count = self.data_maps_count();
         let start = self.data_maps_count_byte_range().end;
-        start..start + (data_maps_count as usize).saturating_mul(DataMapRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(data_maps_count))
+                    .saturating_mul(DataMapRecord::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -81,7 +81,8 @@ impl<'a> Morx<'a> {
         let start = self.n_chains_byte_range().end;
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
-            <Chain as VarSize>::total_len_for_count(data, n_chains as usize).unwrap_or(0)
+            <Chain as VarSize>::total_len_for_count(data, transforms::to_usize(n_chains))
+                .unwrap_or(0)
         }
     }
 }
@@ -216,7 +217,9 @@ impl<'a> Chain<'a> {
     pub fn features_byte_range(&self) -> Range<usize> {
         let n_feature_entries = self.n_feature_entries();
         let start = self.n_subtables_byte_range().end;
-        start..start + (n_feature_entries as usize).saturating_mul(Feature::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(n_feature_entries)).saturating_mul(Feature::RAW_BYTE_LEN)
     }
 
     pub fn subtables_byte_range(&self) -> Range<usize> {
@@ -224,7 +227,8 @@ impl<'a> Chain<'a> {
         let start = self.features_byte_range().end;
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
-            <Subtable as VarSize>::total_len_for_count(data, n_subtables as usize).unwrap_or(0)
+            <Subtable as VarSize>::total_len_for_count(data, transforms::to_usize(n_subtables))
+                .unwrap_or(0)
         }
     }
 }

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -110,7 +110,10 @@ impl<'a> Mvar<'a> {
     pub fn value_records_byte_range(&self) -> Range<usize> {
         let value_record_count = self.value_record_count();
         let start = self.item_variation_store_offset_byte_range().end;
-        start..start + (value_record_count as usize).saturating_mul(ValueRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(value_record_count))
+                    .saturating_mul(ValueRecord::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -99,7 +99,7 @@ impl<'a> Name<'a> {
     pub fn name_record_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.storage_offset_byte_range().end;
-        start..start + (count as usize).saturating_mul(NameRecord::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(count)).saturating_mul(NameRecord::RAW_BYTE_LEN)
     }
 
     pub fn lang_tag_count_byte_range(&self) -> Range<usize> {
@@ -116,7 +116,9 @@ impl<'a> Name<'a> {
         start
             ..(self.version().compatible(1u16))
                 .then(|| {
-                    start + (lang_tag_count as usize).saturating_mul(LangTagRecord::RAW_BYTE_LEN)
+                    start
+                        + (transforms::to_usize(lang_tag_count))
+                            .saturating_mul(LangTagRecord::RAW_BYTE_LEN)
                 })
                 .unwrap_or(start)
     }

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -206,7 +206,9 @@ impl<'a> Post<'a> {
         let start = self.num_glyphs_byte_range().end;
         start
             ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + (num_glyphs as usize).saturating_mul(u16::RAW_BYTE_LEN))
+                .then(|| {
+                    start + (transforms::to_usize(num_glyphs)).saturating_mul(u16::RAW_BYTE_LEN)
+                })
                 .unwrap_or(start)
     }
 

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -423,7 +423,7 @@ impl<'a> Sbix<'a> {
     pub fn strike_offsets_byte_range(&self) -> Range<usize> {
         let num_strikes = self.num_strikes();
         let start = self.num_strikes_byte_range().end;
-        start..start + (num_strikes as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(num_strikes)).saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -338,7 +338,9 @@ impl<'a> AxisValueArray<'a> {
     pub fn axis_value_offsets_byte_range(&self) -> Range<usize> {
         let axis_value_count = self.axis_value_count();
         let start = 0;
-        start..start + (axis_value_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(axis_value_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -1013,7 +1015,9 @@ impl<'a> AxisValueFormat4<'a> {
     pub fn axis_values_byte_range(&self) -> Range<usize> {
         let axis_count = self.axis_count();
         let start = self.value_name_id_byte_range().end;
-        start..start + (axis_count as usize).saturating_mul(AxisValueRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(axis_count)).saturating_mul(AxisValueRecord::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -162,7 +162,10 @@ impl<'a> SVGDocumentList<'a> {
     pub fn document_records_byte_range(&self) -> Range<usize> {
         let num_entries = self.num_entries();
         let start = self.num_entries_byte_range().end;
-        start..start + (num_entries as usize).saturating_mul(SVGDocumentRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(num_entries))
+                    .saturating_mul(SVGDocumentRecord::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -165,7 +165,7 @@ impl<'a> Table2<'a> {
     pub fn values_byte_range(&self) -> Range<usize> {
         let value_count = self.value_count();
         let start = self.value_count_byte_range().end;
-        start..start + (value_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(value_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_test_generic_group.rs
+++ b/read-fonts/generated/generated_test_generic_group.rs
@@ -98,7 +98,8 @@ impl<'a, T> MyLookup<'a, T> {
     pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
         let sub_table_count = self.sub_table_count();
         let start = self.sub_table_count_byte_range().end;
-        start..start + (sub_table_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(sub_table_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 }
 
@@ -373,7 +374,7 @@ impl<'a> MySubtableFormat2<'a> {
     pub fn values_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + (count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -388,13 +388,13 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
     pub fn nonnullable_offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + (count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn nullable_offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.nonnullable_offsets_byte_range().end;
-        start..start + (count as usize).saturating_mul(Offset16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
     }
 
     pub fn versioned_nonnullable_offsets_byte_range(&self) -> Range<usize> {
@@ -402,7 +402,9 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
         let start = self.nullable_offsets_byte_range().end;
         start
             ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + (count as usize).saturating_mul(Offset16::RAW_BYTE_LEN))
+                .then(|| {
+                    start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+                })
                 .unwrap_or(start)
     }
 
@@ -411,7 +413,9 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
         let start = self.versioned_nonnullable_offsets_byte_range().end;
         start
             ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + (count as usize).saturating_mul(Offset16::RAW_BYTE_LEN))
+                .then(|| {
+                    start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+                })
                 .unwrap_or(start)
     }
 }
@@ -548,13 +552,13 @@ impl<'a> KindsOfArrays<'a> {
     pub fn scalars_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + (count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn records_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.scalars_byte_range().end;
-        start..start + (count as usize).saturating_mul(Shmecord::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(count)).saturating_mul(Shmecord::RAW_BYTE_LEN)
     }
 
     pub fn versioned_scalars_byte_range(&self) -> Range<usize> {
@@ -562,7 +566,7 @@ impl<'a> KindsOfArrays<'a> {
         let start = self.records_byte_range().end;
         start
             ..(self.version().compatible(1u16))
-                .then(|| start + (count as usize).saturating_mul(u16::RAW_BYTE_LEN))
+                .then(|| start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN))
                 .unwrap_or(start)
     }
 
@@ -571,7 +575,9 @@ impl<'a> KindsOfArrays<'a> {
         let start = self.versioned_scalars_byte_range().end;
         start
             ..(self.version().compatible(1u16))
-                .then(|| start + (count as usize).saturating_mul(Shmecord::RAW_BYTE_LEN))
+                .then(|| {
+                    start + (transforms::to_usize(count)).saturating_mul(Shmecord::RAW_BYTE_LEN)
+                })
                 .unwrap_or(start)
     }
 }
@@ -687,7 +693,8 @@ impl<'a> VarLenHaver<'a> {
         let start = self.count_byte_range().end;
         start..start + {
             let data = self.data.split_off(start).unwrap_or_default();
-            <VarSizeDummy as VarSize>::total_len_for_count(data, count as usize).unwrap_or(0)
+            <VarSizeDummy as VarSize>::total_len_for_count(data, transforms::to_usize(count))
+                .unwrap_or(0)
         }
     }
 

--- a/read-fonts/generated/generated_test_read_args.rs
+++ b/read-fonts/generated/generated_test_read_args.rs
@@ -96,7 +96,7 @@ impl<'a> BaseArray<'a> {
         let start = self.base_count_byte_range().end;
         start
             ..start
-                + (base_count as usize).saturating_mul(
+                + (transforms::to_usize(base_count)).saturating_mul(
                     <BaseRecord as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
@@ -112,7 +112,7 @@ impl<'a> BaseArray<'a> {
         let start = self.face_count_byte_range().end;
         start
             ..start
-                + (base_count as usize).saturating_mul(
+                + (transforms::to_usize(base_count)).saturating_mul(
                     <FaceRecord as ComputeSize>::compute_size(&self.mark_class_count())
                         .unwrap_or(0),
                 )
@@ -194,7 +194,7 @@ impl ComputeSize for BaseRecord<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok((mark_class_count as usize).saturating_mul(u16::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(mark_class_count)).saturating_mul(u16::RAW_BYTE_LEN))
     }
 }
 
@@ -203,7 +203,7 @@ impl<'a> FontReadWithArgs<'a> for BaseRecord<'a> {
         let mut cursor = data.cursor();
         let mark_class_count = *args;
         Ok(Self {
-            base_anchor_offsets: cursor.read_array(mark_class_count as usize)?,
+            base_anchor_offsets: cursor.read_array(transforms::to_usize(mark_class_count))?,
         })
     }
 }
@@ -265,7 +265,7 @@ impl ComputeSize for FaceRecord<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let mark_class_count = *args;
-        Ok((mark_class_count as usize).saturating_mul(Offset16::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(mark_class_count)).saturating_mul(Offset16::RAW_BYTE_LEN))
     }
 }
 
@@ -274,7 +274,7 @@ impl<'a> FontReadWithArgs<'a> for FaceRecord<'a> {
         let mut cursor = data.cursor();
         let mark_class_count = *args;
         Ok(Self {
-            face_offsets: cursor.read_array(mark_class_count as usize)?,
+            face_offsets: cursor.read_array(transforms::to_usize(mark_class_count))?,
         })
     }
 }

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -70,7 +70,9 @@ impl<'a> BasicTable<'a> {
     pub fn simple_records_byte_range(&self) -> Range<usize> {
         let simple_count = self.simple_count();
         let start = self.simple_count_byte_range().end;
-        start..start + (simple_count as usize).saturating_mul(SimpleRecord::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(simple_count)).saturating_mul(SimpleRecord::RAW_BYTE_LEN)
     }
 
     pub fn arrays_inner_count_byte_range(&self) -> Range<usize> {
@@ -88,7 +90,7 @@ impl<'a> BasicTable<'a> {
         let start = self.array_records_count_byte_range().end;
         start
             ..start
-                + (array_records_count as usize).saturating_mul(
+                + (transforms::to_usize(array_records_count)).saturating_mul(
                     <ContainsArrays as ComputeSize>::compute_size(&self.arrays_inner_count())
                         .unwrap_or(0),
                 )
@@ -210,10 +212,12 @@ impl ComputeSize for ContainsArrays<'_> {
         let array_len = *args;
         let mut result = 0usize;
         result = result
-            .checked_add((array_len as usize).saturating_mul(u16::RAW_BYTE_LEN))
+            .checked_add((transforms::to_usize(array_len)).saturating_mul(u16::RAW_BYTE_LEN))
             .ok_or(ReadError::OutOfBounds)?;
         result = result
-            .checked_add((array_len as usize).saturating_mul(SimpleRecord::RAW_BYTE_LEN))
+            .checked_add(
+                (transforms::to_usize(array_len)).saturating_mul(SimpleRecord::RAW_BYTE_LEN),
+            )
             .ok_or(ReadError::OutOfBounds)?;
         Ok(result)
     }
@@ -224,8 +228,8 @@ impl<'a> FontReadWithArgs<'a> for ContainsArrays<'a> {
         let mut cursor = data.cursor();
         let array_len = *args;
         Ok(Self {
-            scalars: cursor.read_array(array_len as usize)?,
-            records: cursor.read_array(array_len as usize)?,
+            scalars: cursor.read_array(transforms::to_usize(array_len))?,
+            records: cursor.read_array(transforms::to_usize(array_len))?,
         })
     }
 }

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -220,7 +220,8 @@ impl<'a> TrackData<'a> {
     pub fn track_table_byte_range(&self) -> Range<usize> {
         let n_tracks = self.n_tracks();
         let start = self.size_table_offset_byte_range().end;
-        start..start + (n_tracks as usize).saturating_mul(TrackTableEntry::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(n_tracks)).saturating_mul(TrackTableEntry::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -281,7 +281,10 @@ impl<'a> MultiItemVariationStore<'a> {
     pub fn variation_data_offsets_byte_range(&self) -> Range<usize> {
         let variation_data_count = self.variation_data_count();
         let start = self.variation_data_count_byte_range().end;
-        start..start + (variation_data_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(variation_data_count))
+                    .saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 
@@ -385,7 +388,7 @@ impl<'a> SparseVariationRegionList<'a> {
     pub fn region_offsets_byte_range(&self) -> Range<usize> {
         let region_count = self.region_count();
         let start = self.region_count_byte_range().end;
-        start..start + (region_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(region_count)).saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 
@@ -476,7 +479,7 @@ impl<'a> SparseVariationRegion<'a> {
         let start = self.region_axis_count_byte_range().end;
         start
             ..start
-                + (region_axis_count as usize)
+                + (transforms::to_usize(region_axis_count))
                     .saturating_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN)
     }
 }
@@ -639,7 +642,7 @@ impl<'a> MultiItemVariationData<'a> {
     pub fn region_indices_byte_range(&self) -> Range<usize> {
         let region_index_count = self.region_index_count();
         let start = self.region_index_count_byte_range().end;
-        start..start + (region_index_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(region_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn raw_delta_sets_byte_range(&self) -> Range<usize> {
@@ -739,7 +742,8 @@ impl<'a> ConditionList<'a> {
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start..start + (condition_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start
+            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -183,7 +183,7 @@ impl ComputeSize for Tuple<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let axis_count = *args;
-        Ok((axis_count as usize).saturating_mul(F2Dot14::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(axis_count)).saturating_mul(F2Dot14::RAW_BYTE_LEN))
     }
 }
 
@@ -192,7 +192,7 @@ impl<'a> FontReadWithArgs<'a> for Tuple<'a> {
         let mut cursor = data.cursor();
         let axis_count = *args;
         Ok(Self {
-            values: cursor.read_array(axis_count as usize)?,
+            values: cursor.read_array(transforms::to_usize(axis_count))?,
         })
     }
 }
@@ -945,7 +945,7 @@ impl<'a> VariationRegionList<'a> {
         let start = self.region_count_byte_range().end;
         start
             ..start
-                + (region_count as usize).saturating_mul(
+                + (transforms::to_usize(region_count)).saturating_mul(
                     <VariationRegion as ComputeSize>::compute_size(&self.axis_count()).unwrap_or(0),
                 )
     }
@@ -1017,7 +1017,7 @@ impl ComputeSize for VariationRegion<'_> {
     #[allow(clippy::needless_question_mark)]
     fn compute_size(args: &u16) -> Result<usize, ReadError> {
         let axis_count = *args;
-        Ok((axis_count as usize).saturating_mul(RegionAxisCoordinates::RAW_BYTE_LEN))
+        Ok((transforms::to_usize(axis_count)).saturating_mul(RegionAxisCoordinates::RAW_BYTE_LEN))
     }
 }
 
@@ -1026,7 +1026,7 @@ impl<'a> FontReadWithArgs<'a> for VariationRegion<'a> {
         let mut cursor = data.cursor();
         let axis_count = *args;
         Ok(Self {
-            region_axes: cursor.read_array(axis_count as usize)?,
+            region_axes: cursor.read_array(transforms::to_usize(axis_count))?,
         })
     }
 }
@@ -1205,7 +1205,10 @@ impl<'a> ItemVariationStore<'a> {
     pub fn item_variation_data_offsets_byte_range(&self) -> Range<usize> {
         let item_variation_data_count = self.item_variation_data_count();
         let start = self.item_variation_data_count_byte_range().end;
-        start..start + (item_variation_data_count as usize).saturating_mul(Offset32::RAW_BYTE_LEN)
+        start
+            ..start
+                + (transforms::to_usize(item_variation_data_count))
+                    .saturating_mul(Offset32::RAW_BYTE_LEN)
     }
 }
 
@@ -1337,7 +1340,7 @@ impl<'a> ItemVariationData<'a> {
     pub fn region_indexes_byte_range(&self) -> Range<usize> {
         let region_index_count = self.region_index_count();
         let start = self.region_index_count_byte_range().end;
-        start..start + (region_index_count as usize).saturating_mul(u16::RAW_BYTE_LEN)
+        start..start + (transforms::to_usize(region_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
     }
 
     pub fn delta_sets_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -83,7 +83,9 @@ impl<'a> Vmtx<'a> {
         let number_of_long_ver_metrics = self.number_of_long_ver_metrics();
         let start = 0;
         start
-            ..start + (number_of_long_ver_metrics as usize).saturating_mul(LongMetric::RAW_BYTE_LEN)
+            ..start
+                + (transforms::to_usize(number_of_long_ver_metrics))
+                    .saturating_mul(LongMetric::RAW_BYTE_LEN)
     }
 
     pub fn top_side_bearings_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -87,7 +87,7 @@ impl<'a> Vorg<'a> {
         let start = self.num_vert_origin_y_metrics_byte_range().end;
         start
             ..start
-                + (num_vert_origin_y_metrics as usize)
+                + (transforms::to_usize(num_vert_origin_y_metrics))
                     .saturating_mul(VertOriginYMetrics::RAW_BYTE_LEN)
     }
 }

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -122,6 +122,10 @@ pub(crate) mod codegen_prelude {
 
     /// named transforms used in 'count', e.g
     pub(crate) mod transforms {
+        pub fn to_usize<T: TryInto<usize>>(value: T) -> usize {
+            value.try_into().unwrap_or_default()
+        }
+
         pub fn subtract<T: TryInto<usize>, U: TryInto<usize>>(lhs: T, rhs: U) -> usize {
             lhs.try_into()
                 .unwrap_or_default()

--- a/write-fonts/generated/generated_avar.rs
+++ b/write-fonts/generated/generated_avar.rs
@@ -51,7 +51,7 @@ impl Validate for Avar {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Avar", |ctx| {
             ctx.in_field("axis_segment_maps", |ctx| {
-                if self.axis_segment_maps.len() > (u16::MAX as usize) {
+                if self.axis_segment_maps.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.axis_segment_maps.validate_impl(ctx);
@@ -124,7 +124,7 @@ impl Validate for SegmentMaps {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SegmentMaps", |ctx| {
             ctx.in_field("axis_value_maps", |ctx| {
-                if self.axis_value_maps.len() > (u16::MAX as usize) {
+                if self.axis_value_maps.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.axis_value_maps.validate_impl(ctx);

--- a/write-fonts/generated/generated_base.rs
+++ b/write-fonts/generated/generated_base.rs
@@ -176,7 +176,7 @@ impl Validate for BaseTagList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseTagList", |ctx| {
             ctx.in_field("baseline_tags", |ctx| {
-                if self.baseline_tags.len() > (u16::MAX as usize) {
+                if self.baseline_tags.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -235,7 +235,7 @@ impl Validate for BaseScriptList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseScriptList", |ctx| {
             ctx.in_field("base_script_records", |ctx| {
-                if self.base_script_records.len() > (u16::MAX as usize) {
+                if self.base_script_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_script_records.validate_impl(ctx);
@@ -366,7 +366,7 @@ impl Validate for BaseScript {
                 self.default_min_max.validate_impl(ctx);
             });
             ctx.in_field("base_lang_sys_records", |ctx| {
-                if self.base_lang_sys_records.len() > (u16::MAX as usize) {
+                if self.base_lang_sys_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_lang_sys_records.validate_impl(ctx);
@@ -487,7 +487,7 @@ impl Validate for BaseValues {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseValues", |ctx| {
             ctx.in_field("base_coords", |ctx| {
-                if self.base_coords.len() > (u16::MAX as usize) {
+                if self.base_coords.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_coords.validate_impl(ctx);
@@ -567,7 +567,7 @@ impl Validate for MinMax {
                 self.max_coord.validate_impl(ctx);
             });
             ctx.in_field("feat_min_max_records", |ctx| {
-                if self.feat_min_max_records.len() > (u16::MAX as usize) {
+                if self.feat_min_max_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.feat_min_max_records.validate_impl(ctx);

--- a/write-fonts/generated/generated_cff.rs
+++ b/write-fonts/generated/generated_cff.rs
@@ -313,7 +313,7 @@ impl Validate for FdSelectFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FdSelectFormat3", |ctx| {
             ctx.in_field("ranges", |ctx| {
-                if self.ranges.len() > (u16::MAX as usize) {
+                if self.ranges.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ranges.validate_impl(ctx);
@@ -416,7 +416,7 @@ impl Validate for FdSelectFormat4 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FdSelectFormat4", |ctx| {
             ctx.in_field("ranges", |ctx| {
-                if self.ranges.len() > (u32::MAX as usize) {
+                if self.ranges.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ranges.validate_impl(ctx);

--- a/write-fonts/generated/generated_cff2.rs
+++ b/write-fonts/generated/generated_cff2.rs
@@ -60,7 +60,7 @@ impl Validate for Cff2Header {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cff2Header", |ctx| {
             ctx.in_field("top_dict_data", |ctx| {
-                if self.top_dict_data.len() > (u16::MAX as usize) {
+                if self.top_dict_data.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_cmap.rs
+++ b/write-fonts/generated/generated_cmap.rs
@@ -37,7 +37,7 @@ impl Validate for Cmap {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap", |ctx| {
             ctx.in_field("encoding_records", |ctx| {
-                if self.encoding_records.len() > (u16::MAX as usize) {
+                if self.encoding_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.encoding_records.validate_impl(ctx);
@@ -689,7 +689,7 @@ impl Validate for Cmap6 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap6", |ctx| {
             ctx.in_field("glyph_id_array", |ctx| {
-                if self.glyph_id_array.len() > (u16::MAX as usize) {
+                if self.glyph_id_array.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -777,7 +777,7 @@ impl Validate for Cmap8 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap8", |ctx| {
             ctx.in_field("groups", |ctx| {
-                if self.groups.len() > (u32::MAX as usize) {
+                if self.groups.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.groups.validate_impl(ctx);
@@ -907,7 +907,7 @@ impl Validate for Cmap10 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap10", |ctx| {
             ctx.in_field("glyph_id_array", |ctx| {
-                if self.glyph_id_array.len() > (u32::MAX as usize) {
+                if self.glyph_id_array.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -973,7 +973,7 @@ impl Validate for Cmap12 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap12", |ctx| {
             ctx.in_field("groups", |ctx| {
-                if self.groups.len() > (u32::MAX as usize) {
+                if self.groups.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.groups.validate_impl(ctx);
@@ -1047,7 +1047,7 @@ impl Validate for Cmap13 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap13", |ctx| {
             ctx.in_field("groups", |ctx| {
-                if self.groups.len() > (u32::MAX as usize) {
+                if self.groups.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.groups.validate_impl(ctx);
@@ -1170,7 +1170,7 @@ impl Validate for Cmap14 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Cmap14", |ctx| {
             ctx.in_field("var_selector", |ctx| {
-                if self.var_selector.len() > (u32::MAX as usize) {
+                if self.var_selector.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.var_selector.validate_impl(ctx);
@@ -1299,7 +1299,7 @@ impl Validate for DefaultUvs {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("DefaultUvs", |ctx| {
             ctx.in_field("ranges", |ctx| {
-                if self.ranges.len() > (u32::MAX as usize) {
+                if self.ranges.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ranges.validate_impl(ctx);
@@ -1359,7 +1359,7 @@ impl Validate for NonDefaultUvs {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("NonDefaultUvs", |ctx| {
             ctx.in_field("uvs_mapping", |ctx| {
-                if self.uvs_mapping.len() > (u32::MAX as usize) {
+                if self.uvs_mapping.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.uvs_mapping.validate_impl(ctx);

--- a/write-fonts/generated/generated_colr.rs
+++ b/write-fonts/generated/generated_colr.rs
@@ -263,7 +263,7 @@ impl Validate for BaseGlyphList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseGlyphList", |ctx| {
             ctx.in_field("base_glyph_paint_records", |ctx| {
-                if self.base_glyph_paint_records.len() > (u32::MAX as usize) {
+                if self.base_glyph_paint_records.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_glyph_paint_records.validate_impl(ctx);
@@ -374,7 +374,7 @@ impl Validate for LayerList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LayerList", |ctx| {
             ctx.in_field("paints", |ctx| {
-                if self.paints.len() > (u32::MAX as usize) {
+                if self.paints.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.paints.validate_impl(ctx);
@@ -439,7 +439,7 @@ impl Validate for ClipList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClipList", |ctx| {
             ctx.in_field("clips", |ctx| {
-                if self.clips.len() > (u32::MAX as usize) {
+                if self.clips.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.clips.validate_impl(ctx);
@@ -989,7 +989,7 @@ impl Validate for ColorLine {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ColorLine", |ctx| {
             ctx.in_field("color_stops", |ctx| {
-                if self.color_stops.len() > (u16::MAX as usize) {
+                if self.color_stops.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.color_stops.validate_impl(ctx);
@@ -1056,7 +1056,7 @@ impl Validate for VarColorLine {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("VarColorLine", |ctx| {
             ctx.in_field("color_stops", |ctx| {
-                if self.color_stops.len() > (u16::MAX as usize) {
+                if self.color_stops.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.color_stops.validate_impl(ctx);

--- a/write-fonts/generated/generated_cpal.rs
+++ b/write-fonts/generated/generated_cpal.rs
@@ -101,7 +101,7 @@ impl Validate for Cpal {
                 self.color_records_array.validate_impl(ctx);
             });
             ctx.in_field("color_record_indices", |ctx| {
-                if self.color_record_indices.len() > (u16::MAX as usize) {
+                if self.color_record_indices.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_dsig.rs
+++ b/write-fonts/generated/generated_dsig.rs
@@ -44,7 +44,7 @@ impl Validate for Dsig {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Dsig", |ctx| {
             ctx.in_field("signature_records", |ctx| {
-                if self.signature_records.len() > (u16::MAX as usize) {
+                if self.signature_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.signature_records.validate_impl(ctx);
@@ -164,7 +164,7 @@ impl Validate for SignatureBlockFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SignatureBlockFormat1", |ctx| {
             ctx.in_field("signature", |ctx| {
-                if self.signature.len() > (u32::MAX as usize) {
+                if self.signature.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_font.rs
+++ b/write-fonts/generated/generated_font.rs
@@ -56,7 +56,7 @@ impl Validate for TableDirectory {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("TableDirectory", |ctx| {
             ctx.in_field("table_records", |ctx| {
-                if self.table_records.len() > (u16::MAX as usize) {
+                if self.table_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.table_records.validate_impl(ctx);
@@ -130,7 +130,7 @@ impl Validate for TTCHeader {
         ctx.in_table("TTCHeader", |ctx| {
             let version: MajorMinor = self.compute_version();
             ctx.in_field("table_directory_offsets", |ctx| {
-                if self.table_directory_offsets.len() > (u32::MAX as usize) {
+                if self.table_directory_offsets.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_fvar.rs
+++ b/write-fonts/generated/generated_fvar.rs
@@ -102,13 +102,13 @@ impl Validate for AxisInstanceArrays {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AxisInstanceArrays", |ctx| {
             ctx.in_field("axes", |ctx| {
-                if self.axes.len() > (u16::MAX as usize) {
+                if self.axes.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.axes.validate_impl(ctx);
             });
             ctx.in_field("instances", |ctx| {
-                if self.instances.len() > (u16::MAX as usize) {
+                if self.instances.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.instances.validate_impl(ctx);

--- a/write-fonts/generated/generated_gasp.rs
+++ b/write-fonts/generated/generated_gasp.rs
@@ -45,7 +45,7 @@ impl Validate for Gasp {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Gasp", |ctx| {
             ctx.in_field("gasp_ranges", |ctx| {
-                if self.gasp_ranges.len() > (u16::MAX as usize) {
+                if self.gasp_ranges.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.gasp_ranges.validate_impl(ctx);

--- a/write-fonts/generated/generated_gdef.rs
+++ b/write-fonts/generated/generated_gdef.rs
@@ -168,7 +168,7 @@ impl Validate for AttachList {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("attach_points", |ctx| {
-                if self.attach_points.len() > (u16::MAX as usize) {
+                if self.attach_points.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.attach_points.validate_impl(ctx);
@@ -225,7 +225,7 @@ impl Validate for AttachPoint {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AttachPoint", |ctx| {
             ctx.in_field("point_indices", |ctx| {
-                if self.point_indices.len() > (u16::MAX as usize) {
+                if self.point_indices.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -291,7 +291,7 @@ impl Validate for LigCaretList {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("lig_glyphs", |ctx| {
-                if self.lig_glyphs.len() > (u16::MAX as usize) {
+                if self.lig_glyphs.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.lig_glyphs.validate_impl(ctx);
@@ -351,7 +351,7 @@ impl Validate for LigGlyph {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigGlyph", |ctx| {
             ctx.in_field("caret_values", |ctx| {
-                if self.caret_values.len() > (u16::MAX as usize) {
+                if self.caret_values.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.caret_values.validate_impl(ctx);
@@ -668,7 +668,7 @@ impl Validate for MarkGlyphSets {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkGlyphSets", |ctx| {
             ctx.in_field("coverages", |ctx| {
-                if self.coverages.len() > (u16::MAX as usize) {
+                if self.coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.coverages.validate_impl(ctx);

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -595,7 +595,7 @@ impl Validate for MarkArray {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MarkArray", |ctx| {
             ctx.in_field("mark_records", |ctx| {
-                if self.mark_records.len() > (u16::MAX as usize) {
+                if self.mark_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.mark_records.validate_impl(ctx);
@@ -856,7 +856,7 @@ impl Validate for SinglePosFormat2 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("value_records", |ctx| {
-                if self.value_records.len() > (u16::MAX as usize) {
+                if self.value_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.value_records.validate_impl(ctx);
@@ -1022,7 +1022,7 @@ impl Validate for PairPosFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("pair_sets", |ctx| {
-                if self.pair_sets.len() > (u16::MAX as usize) {
+                if self.pair_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.check_format_consistency(ctx);
@@ -1081,7 +1081,7 @@ impl Validate for PairSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("PairSet", |ctx| {
             ctx.in_field("pair_value_records", |ctx| {
-                if self.pair_value_records.len() > (u16::MAX as usize) {
+                if self.pair_value_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.pair_value_records.validate_impl(ctx);
@@ -1226,7 +1226,7 @@ impl Validate for PairPosFormat2 {
                 self.class_def2.validate_impl(ctx);
             });
             ctx.in_field("class1_records", |ctx| {
-                if self.class1_records.len() > (u16::MAX as usize) {
+                if self.class1_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.class1_records.validate_impl(ctx);
@@ -1290,7 +1290,7 @@ impl Validate for Class1Record {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Class1Record", |ctx| {
             ctx.in_field("class2_records", |ctx| {
-                if self.class2_records.len() > (u16::MAX as usize) {
+                if self.class2_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.class2_records.validate_impl(ctx);
@@ -1394,7 +1394,7 @@ impl Validate for CursivePosFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("entry_exit_record", |ctx| {
-                if self.entry_exit_record.len() > (u16::MAX as usize) {
+                if self.entry_exit_record.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.entry_exit_record.validate_impl(ctx);
@@ -1600,7 +1600,7 @@ impl Validate for BaseArray {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseArray", |ctx| {
             ctx.in_field("base_records", |ctx| {
-                if self.base_records.len() > (u16::MAX as usize) {
+                if self.base_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_records.validate_impl(ctx);
@@ -1657,7 +1657,7 @@ impl Validate for BaseRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseRecord", |ctx| {
             ctx.in_field("base_anchors", |ctx| {
-                if self.base_anchors.len() > (u16::MAX as usize) {
+                if self.base_anchors.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_anchors.validate_impl(ctx);
@@ -1798,7 +1798,7 @@ impl Validate for LigatureArray {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigatureArray", |ctx| {
             ctx.in_field("ligature_attaches", |ctx| {
-                if self.ligature_attaches.len() > (u16::MAX as usize) {
+                if self.ligature_attaches.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ligature_attaches.validate_impl(ctx);
@@ -1848,7 +1848,7 @@ impl Validate for LigatureAttach {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigatureAttach", |ctx| {
             ctx.in_field("component_records", |ctx| {
-                if self.component_records.len() > (u16::MAX as usize) {
+                if self.component_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.component_records.validate_impl(ctx);
@@ -1905,7 +1905,7 @@ impl Validate for ComponentRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ComponentRecord", |ctx| {
             ctx.in_field("ligature_anchors", |ctx| {
-                if self.ligature_anchors.len() > (u16::MAX as usize) {
+                if self.ligature_anchors.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ligature_anchors.validate_impl(ctx);
@@ -2045,7 +2045,7 @@ impl Validate for Mark2Array {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Mark2Array", |ctx| {
             ctx.in_field("mark2_records", |ctx| {
-                if self.mark2_records.len() > (u16::MAX as usize) {
+                if self.mark2_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.mark2_records.validate_impl(ctx);
@@ -2102,7 +2102,7 @@ impl Validate for Mark2Record {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Mark2Record", |ctx| {
             ctx.in_field("mark2_anchors", |ctx| {
-                if self.mark2_anchors.len() > (u16::MAX as usize) {
+                if self.mark2_anchors.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.mark2_anchors.validate_impl(ctx);

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -425,7 +425,7 @@ impl Validate for SingleSubstFormat2 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("substitute_glyph_ids", |ctx| {
-                if self.substitute_glyph_ids.len() > (u16::MAX as usize) {
+                if self.substitute_glyph_ids.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -495,7 +495,7 @@ impl Validate for MultipleSubstFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("sequences", |ctx| {
-                if self.sequences.len() > (u16::MAX as usize) {
+                if self.sequences.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.sequences.validate_impl(ctx);
@@ -555,7 +555,7 @@ impl Validate for Sequence {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Sequence", |ctx| {
             ctx.in_field("substitute_glyph_ids", |ctx| {
-                if self.substitute_glyph_ids.len() > (u16::MAX as usize) {
+                if self.substitute_glyph_ids.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -623,7 +623,7 @@ impl Validate for AlternateSubstFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("alternate_sets", |ctx| {
-                if self.alternate_sets.len() > (u16::MAX as usize) {
+                if self.alternate_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.alternate_sets.validate_impl(ctx);
@@ -689,7 +689,7 @@ impl Validate for AlternateSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AlternateSet", |ctx| {
             ctx.in_field("alternate_glyph_ids", |ctx| {
-                if self.alternate_glyph_ids.len() > (u16::MAX as usize) {
+                if self.alternate_glyph_ids.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -757,7 +757,7 @@ impl Validate for LigatureSubstFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("ligature_sets", |ctx| {
-                if self.ligature_sets.len() > (u16::MAX as usize) {
+                if self.ligature_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ligature_sets.validate_impl(ctx);
@@ -818,7 +818,7 @@ impl Validate for LigatureSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LigatureSet", |ctx| {
             ctx.in_field("ligatures", |ctx| {
-                if self.ligatures.len() > (u16::MAX as usize) {
+                if self.ligatures.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.ligatures.validate_impl(ctx);
@@ -1150,19 +1150,19 @@ impl Validate for ReverseChainSingleSubstFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("backtrack_coverages", |ctx| {
-                if self.backtrack_coverages.len() > (u16::MAX as usize) {
+                if self.backtrack_coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.backtrack_coverages.validate_impl(ctx);
             });
             ctx.in_field("lookahead_coverages", |ctx| {
-                if self.lookahead_coverages.len() > (u16::MAX as usize) {
+                if self.lookahead_coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.lookahead_coverages.validate_impl(ctx);
             });
             ctx.in_field("substitute_glyph_ids", |ctx| {
-                if self.substitute_glyph_ids.len() > (u16::MAX as usize) {
+                if self.substitute_glyph_ids.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_gvar.rs
+++ b/write-fonts/generated/generated_gvar.rs
@@ -88,7 +88,7 @@ impl Validate for SharedTuples {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SharedTuples", |ctx| {
             ctx.in_field("tuples", |ctx| {
-                if self.tuples.len() > (u16::MAX as usize) {
+                if self.tuples.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.tuples.validate_impl(ctx);

--- a/write-fonts/generated/generated_hdmx.rs
+++ b/write-fonts/generated/generated_hdmx.rs
@@ -52,7 +52,7 @@ impl Validate for Hdmx {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Hdmx", |ctx| {
             ctx.in_field("records", |ctx| {
-                if self.records.len() > (u16::MAX as usize) {
+                if self.records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.records.validate_impl(ctx);

--- a/write-fonts/generated/generated_hmtx.rs
+++ b/write-fonts/generated/generated_hmtx.rs
@@ -41,7 +41,7 @@ impl Validate for Hmtx {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Hmtx", |ctx| {
             ctx.in_field("h_metrics", |ctx| {
-                if self.h_metrics.len() > (u16::MAX as usize) {
+                if self.h_metrics.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.h_metrics.validate_impl(ctx);

--- a/write-fonts/generated/generated_ift.rs
+++ b/write-fonts/generated/generated_ift.rs
@@ -246,7 +246,7 @@ impl Validate for PatchMapFormat1 {
                 self.feature_map.validate_impl(ctx);
             });
             ctx.in_field("url_template", |ctx| {
-                if self.url_template.len() > (u16::MAX as usize) {
+                if self.url_template.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -563,7 +563,7 @@ impl Validate for PatchMapFormat2 {
                 self.entry_id_string_data.validate_impl(ctx);
             });
             ctx.in_field("url_template", |ctx| {
-                if self.url_template.len() > (u16::MAX as usize) {
+                if self.url_template.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -791,7 +791,7 @@ impl Validate for EntryData {
                     ctx.report("FEATURES_AND_DESIGN_SPACE is set but 'feature_tags' is None")
                 }
                 if self.feature_tags.is_some()
-                    && self.feature_tags.as_ref().unwrap().len() > (u8::MAX as usize)
+                    && self.feature_tags.as_ref().unwrap().len() > to_usize(u8::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }
@@ -834,7 +834,7 @@ impl Validate for EntryData {
                     )
                 }
                 if self.design_space_segments.is_some()
-                    && self.design_space_segments.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.design_space_segments.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }
@@ -1239,7 +1239,7 @@ impl Validate for GlyphPatches {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("GlyphPatches", |ctx| {
             ctx.in_field("tables", |ctx| {
-                if self.tables.len() > (u8::MAX as usize) {
+                if self.tables.len() > to_usize(u8::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -37,7 +37,7 @@ impl Validate for ScriptList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ScriptList", |ctx| {
             ctx.in_field("script_records", |ctx| {
-                if self.script_records.len() > (u16::MAX as usize) {
+                if self.script_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.script_records.validate_impl(ctx);
@@ -153,7 +153,7 @@ impl Validate for Script {
                 self.default_lang_sys.validate_impl(ctx);
             });
             ctx.in_field("lang_sys_records", |ctx| {
-                if self.lang_sys_records.len() > (u16::MAX as usize) {
+                if self.lang_sys_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.lang_sys_records.validate_impl(ctx);
@@ -279,7 +279,7 @@ impl Validate for LangSys {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LangSys", |ctx| {
             ctx.in_field("feature_indices", |ctx| {
-                if self.feature_indices.len() > (u16::MAX as usize) {
+                if self.feature_indices.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -337,7 +337,7 @@ impl Validate for FeatureList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FeatureList", |ctx| {
             ctx.in_field("feature_records", |ctx| {
-                if self.feature_records.len() > (u16::MAX as usize) {
+                if self.feature_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.feature_records.validate_impl(ctx);
@@ -457,7 +457,7 @@ impl Validate for Feature {
                 self.feature_params.validate_impl(ctx);
             });
             ctx.in_field("lookup_list_indices", |ctx| {
-                if self.lookup_list_indices.len() > (u16::MAX as usize) {
+                if self.lookup_list_indices.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -511,7 +511,7 @@ impl<T: Validate> Validate for LookupList<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("LookupList", |ctx| {
             ctx.in_field("lookups", |ctx| {
-                if self.lookups.len() > (u16::MAX as usize) {
+                if self.lookups.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.lookups.validate_impl(ctx);
@@ -570,7 +570,7 @@ impl<T: Validate> Validate for Lookup<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Lookup", |ctx| {
             ctx.in_field("subtables", |ctx| {
-                if self.subtables.len() > (u16::MAX as usize) {
+                if self.subtables.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.subtables.validate_impl(ctx);
@@ -648,7 +648,7 @@ impl Validate for CoverageFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("CoverageFormat1", |ctx| {
             ctx.in_field("glyph_array", |ctx| {
-                if self.glyph_array.len() > (u16::MAX as usize) {
+                if self.glyph_array.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -706,7 +706,7 @@ impl Validate for CoverageFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("CoverageFormat2", |ctx| {
             ctx.in_field("range_records", |ctx| {
-                if self.range_records.len() > (u16::MAX as usize) {
+                if self.range_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.range_records.validate_impl(ctx);
@@ -904,7 +904,7 @@ impl Validate for ClassDefFormat1 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassDefFormat1", |ctx| {
             ctx.in_field("class_value_array", |ctx| {
-                if self.class_value_array.len() > (u16::MAX as usize) {
+                if self.class_value_array.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -965,7 +965,7 @@ impl Validate for ClassDefFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassDefFormat2", |ctx| {
             ctx.in_field("class_range_records", |ctx| {
-                if self.class_range_records.len() > (u16::MAX as usize) {
+                if self.class_range_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.class_range_records.validate_impl(ctx);
@@ -1212,7 +1212,7 @@ impl Validate for SequenceContextFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("seq_rule_sets", |ctx| {
-                if self.seq_rule_sets.len() > (u16::MAX as usize) {
+                if self.seq_rule_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_rule_sets.validate_impl(ctx);
@@ -1281,7 +1281,7 @@ impl Validate for SequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceRuleSet", |ctx| {
             ctx.in_field("seq_rules", |ctx| {
-                if self.seq_rules.len() > (u16::MAX as usize) {
+                if self.seq_rules.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_rules.validate_impl(ctx);
@@ -1348,7 +1348,7 @@ impl Validate for SequenceRule {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceRule", |ctx| {
             ctx.in_field("seq_lookup_records", |ctx| {
-                if self.seq_lookup_records.len() > (u16::MAX as usize) {
+                if self.seq_lookup_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_lookup_records.validate_impl(ctx);
@@ -1431,7 +1431,7 @@ impl Validate for SequenceContextFormat2 {
                 self.class_def.validate_impl(ctx);
             });
             ctx.in_field("class_seq_rule_sets", |ctx| {
-                if self.class_seq_rule_sets.len() > (u16::MAX as usize) {
+                if self.class_seq_rule_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.class_seq_rule_sets.validate_impl(ctx);
@@ -1501,7 +1501,7 @@ impl Validate for ClassSequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassSequenceRuleSet", |ctx| {
             ctx.in_field("class_seq_rules", |ctx| {
-                if self.class_seq_rules.len() > (u16::MAX as usize) {
+                if self.class_seq_rules.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.class_seq_rules.validate_impl(ctx);
@@ -1572,7 +1572,7 @@ impl Validate for ClassSequenceRule {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ClassSequenceRule", |ctx| {
             ctx.in_field("seq_lookup_records", |ctx| {
-                if self.seq_lookup_records.len() > (u16::MAX as usize) {
+                if self.seq_lookup_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_lookup_records.validate_impl(ctx);
@@ -1643,13 +1643,13 @@ impl Validate for SequenceContextFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SequenceContextFormat3", |ctx| {
             ctx.in_field("coverages", |ctx| {
-                if self.coverages.len() > (u16::MAX as usize) {
+                if self.coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.coverages.validate_impl(ctx);
             });
             ctx.in_field("seq_lookup_records", |ctx| {
-                if self.seq_lookup_records.len() > (u16::MAX as usize) {
+                if self.seq_lookup_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_lookup_records.validate_impl(ctx);
@@ -1838,7 +1838,7 @@ impl Validate for ChainedSequenceContextFormat1 {
                 self.coverage.validate_impl(ctx);
             });
             ctx.in_field("chained_seq_rule_sets", |ctx| {
-                if self.chained_seq_rule_sets.len() > (u16::MAX as usize) {
+                if self.chained_seq_rule_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.chained_seq_rule_sets.validate_impl(ctx);
@@ -1907,7 +1907,7 @@ impl Validate for ChainedSequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceRuleSet", |ctx| {
             ctx.in_field("chained_seq_rules", |ctx| {
-                if self.chained_seq_rules.len() > (u16::MAX as usize) {
+                if self.chained_seq_rules.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.chained_seq_rules.validate_impl(ctx);
@@ -1994,17 +1994,17 @@ impl Validate for ChainedSequenceRule {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceRule", |ctx| {
             ctx.in_field("backtrack_sequence", |ctx| {
-                if self.backtrack_sequence.len() > (u16::MAX as usize) {
+                if self.backtrack_sequence.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
             ctx.in_field("lookahead_sequence", |ctx| {
-                if self.lookahead_sequence.len() > (u16::MAX as usize) {
+                if self.lookahead_sequence.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
             ctx.in_field("seq_lookup_records", |ctx| {
-                if self.seq_lookup_records.len() > (u16::MAX as usize) {
+                if self.seq_lookup_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_lookup_records.validate_impl(ctx);
@@ -2113,7 +2113,7 @@ impl Validate for ChainedSequenceContextFormat2 {
                 self.lookahead_class_def.validate_impl(ctx);
             });
             ctx.in_field("chained_class_seq_rule_sets", |ctx| {
-                if self.chained_class_seq_rule_sets.len() > (u16::MAX as usize) {
+                if self.chained_class_seq_rule_sets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.chained_class_seq_rule_sets.validate_impl(ctx);
@@ -2188,7 +2188,7 @@ impl Validate for ChainedClassSequenceRuleSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedClassSequenceRuleSet", |ctx| {
             ctx.in_field("chained_class_seq_rules", |ctx| {
-                if self.chained_class_seq_rules.len() > (u16::MAX as usize) {
+                if self.chained_class_seq_rules.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.chained_class_seq_rules.validate_impl(ctx);
@@ -2276,17 +2276,17 @@ impl Validate for ChainedClassSequenceRule {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedClassSequenceRule", |ctx| {
             ctx.in_field("backtrack_sequence", |ctx| {
-                if self.backtrack_sequence.len() > (u16::MAX as usize) {
+                if self.backtrack_sequence.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
             ctx.in_field("lookahead_sequence", |ctx| {
-                if self.lookahead_sequence.len() > (u16::MAX as usize) {
+                if self.lookahead_sequence.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
             ctx.in_field("seq_lookup_records", |ctx| {
-                if self.seq_lookup_records.len() > (u16::MAX as usize) {
+                if self.seq_lookup_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_lookup_records.validate_impl(ctx);
@@ -2378,25 +2378,25 @@ impl Validate for ChainedSequenceContextFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ChainedSequenceContextFormat3", |ctx| {
             ctx.in_field("backtrack_coverages", |ctx| {
-                if self.backtrack_coverages.len() > (u16::MAX as usize) {
+                if self.backtrack_coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.backtrack_coverages.validate_impl(ctx);
             });
             ctx.in_field("input_coverages", |ctx| {
-                if self.input_coverages.len() > (u16::MAX as usize) {
+                if self.input_coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.input_coverages.validate_impl(ctx);
             });
             ctx.in_field("lookahead_coverages", |ctx| {
-                if self.lookahead_coverages.len() > (u16::MAX as usize) {
+                if self.lookahead_coverages.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.lookahead_coverages.validate_impl(ctx);
             });
             ctx.in_field("seq_lookup_records", |ctx| {
-                if self.seq_lookup_records.len() > (u16::MAX as usize) {
+                if self.seq_lookup_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.seq_lookup_records.validate_impl(ctx);
@@ -2837,7 +2837,7 @@ impl Validate for FeatureVariations {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FeatureVariations", |ctx| {
             ctx.in_field("feature_variation_records", |ctx| {
-                if self.feature_variation_records.len() > (u32::MAX as usize) {
+                if self.feature_variation_records.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.feature_variation_records.validate_impl(ctx);
@@ -2960,7 +2960,7 @@ impl Validate for ConditionSet {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ConditionSet", |ctx| {
             ctx.in_field("conditions", |ctx| {
-                if self.conditions.len() > (u16::MAX as usize) {
+                if self.conditions.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.conditions.validate_impl(ctx);
@@ -3288,7 +3288,7 @@ impl Validate for ConditionFormat3 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ConditionFormat3", |ctx| {
             ctx.in_field("conditions", |ctx| {
-                if self.conditions.len() > (u8::MAX as usize) {
+                if self.conditions.len() > to_usize(u8::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.conditions.validate_impl(ctx);
@@ -3352,7 +3352,7 @@ impl Validate for ConditionFormat4 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ConditionFormat4", |ctx| {
             ctx.in_field("conditions", |ctx| {
-                if self.conditions.len() > (u8::MAX as usize) {
+                if self.conditions.len() > to_usize(u8::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.conditions.validate_impl(ctx);
@@ -3467,7 +3467,7 @@ impl Validate for FeatureTableSubstitution {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FeatureTableSubstitution", |ctx| {
             ctx.in_field("substitutions", |ctx| {
-                if self.substitutions.len() > (u16::MAX as usize) {
+                if self.substitutions.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.substitutions.validate_impl(ctx);
@@ -3773,7 +3773,7 @@ impl Validate for CharacterVariantParams {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("CharacterVariantParams", |ctx| {
             ctx.in_field("character", |ctx| {
-                if self.character.len() > (u16::MAX as usize) {
+                if self.character.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_meta.rs
+++ b/write-fonts/generated/generated_meta.rs
@@ -38,7 +38,7 @@ impl Validate for Meta {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Meta", |ctx| {
             ctx.in_field("data_maps", |ctx| {
-                if self.data_maps.len() > (u32::MAX as usize) {
+                if self.data_maps.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.data_maps.validate_impl(ctx);

--- a/write-fonts/generated/generated_mvar.rs
+++ b/write-fonts/generated/generated_mvar.rs
@@ -44,7 +44,7 @@ impl Validate for Mvar {
                 self.item_variation_store.validate_impl(ctx);
             });
             ctx.in_field("value_records", |ctx| {
-                if self.value_records.len() > (u16::MAX as usize) {
+                if self.value_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.value_records.validate_impl(ctx);

--- a/write-fonts/generated/generated_name.rs
+++ b/write-fonts/generated/generated_name.rs
@@ -57,7 +57,7 @@ impl Validate for Name {
         ctx.in_table("Name", |ctx| {
             let version: u16 = self.compute_version();
             ctx.in_field("name_record", |ctx| {
-                if self.name_record.len() > (u16::MAX as usize) {
+                if self.name_record.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.check_sorted_and_unique_name_records(ctx);
@@ -67,7 +67,7 @@ impl Validate for Name {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.lang_tag_record.is_some()
-                    && self.lang_tag_record.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.lang_tag_record.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }

--- a/write-fonts/generated/generated_post.rs
+++ b/write-fonts/generated/generated_post.rs
@@ -148,7 +148,7 @@ impl Validate for Post {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.glyph_name_index.is_some()
-                    && self.glyph_name_index.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.glyph_name_index.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }

--- a/write-fonts/generated/generated_sbix.rs
+++ b/write-fonts/generated/generated_sbix.rs
@@ -52,7 +52,7 @@ impl Validate for Sbix {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Sbix", |ctx| {
             ctx.in_field("strikes", |ctx| {
-                if self.strikes.len() > (u32::MAX as usize) {
+                if self.strikes.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.strikes.validate_impl(ctx);

--- a/write-fonts/generated/generated_stat.rs
+++ b/write-fonts/generated/generated_stat.rs
@@ -174,7 +174,7 @@ impl Validate for AxisValueArray {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AxisValueArray", |ctx| {
             ctx.in_field("axis_values", |ctx| {
-                if self.axis_values.len() > (u16::MAX as usize) {
+                if self.axis_values.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.axis_values.validate_impl(ctx);
@@ -632,7 +632,7 @@ impl Validate for AxisValueFormat4 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("AxisValueFormat4", |ctx| {
             ctx.in_field("axis_values", |ctx| {
-                if self.axis_values.len() > (u16::MAX as usize) {
+                if self.axis_values.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.axis_values.validate_impl(ctx);

--- a/write-fonts/generated/generated_test_formats.rs
+++ b/write-fonts/generated/generated_test_formats.rs
@@ -83,7 +83,7 @@ impl Validate for Table2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Table2", |ctx| {
             ctx.in_field("values", |ctx| {
-                if self.values.len() > (u16::MAX as usize) {
+                if self.values.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_test_generic_group.rs
+++ b/write-fonts/generated/generated_test_generic_group.rs
@@ -31,7 +31,7 @@ impl<T: Validate> Validate for MyLookup<T> {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MyLookup", |ctx| {
             ctx.in_field("subtables", |ctx| {
-                if self.subtables.len() > (u16::MAX as usize) {
+                if self.subtables.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.subtables.validate_impl(ctx);
@@ -206,7 +206,7 @@ impl Validate for MySubtableFormat2 {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MySubtableFormat2", |ctx| {
             ctx.in_field("values", |ctx| {
-                if self.values.len() > (u16::MAX as usize) {
+                if self.values.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_test_offsets_arrays.rs
+++ b/write-fonts/generated/generated_test_offsets_arrays.rs
@@ -178,13 +178,13 @@ impl Validate for KindsOfArraysOfOffsets {
         ctx.in_table("KindsOfArraysOfOffsets", |ctx| {
             let version: MajorMinor = MajorMinor::VERSION_1_1;
             ctx.in_field("nonnullables", |ctx| {
-                if self.nonnullables.len() > (u16::MAX as usize) {
+                if self.nonnullables.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.nonnullables.validate_impl(ctx);
             });
             ctx.in_field("nullables", |ctx| {
-                if self.nullables.len() > (u16::MAX as usize) {
+                if self.nullables.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.nullables.validate_impl(ctx);
@@ -194,7 +194,7 @@ impl Validate for KindsOfArraysOfOffsets {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_nonnullables.is_some()
-                    && self.versioned_nonnullables.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.versioned_nonnullables.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }
@@ -205,7 +205,7 @@ impl Validate for KindsOfArraysOfOffsets {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_nullables.is_some()
-                    && self.versioned_nullables.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.versioned_nullables.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }
@@ -301,12 +301,12 @@ impl Validate for KindsOfArrays {
         ctx.in_table("KindsOfArrays", |ctx| {
             let version = self.version;
             ctx.in_field("scalars", |ctx| {
-                if self.scalars.len() > (u16::MAX as usize) {
+                if self.scalars.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
             ctx.in_field("records", |ctx| {
-                if self.records.len() > (u16::MAX as usize) {
+                if self.records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.records.validate_impl(ctx);
@@ -316,7 +316,7 @@ impl Validate for KindsOfArrays {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_scalars.is_some()
-                    && self.versioned_scalars.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.versioned_scalars.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }
@@ -326,7 +326,7 @@ impl Validate for KindsOfArrays {
                     ctx.report(format!("field must be present for version {version}"));
                 }
                 if self.versioned_records.is_some()
-                    && self.versioned_records.as_ref().unwrap().len() > (u16::MAX as usize)
+                    && self.versioned_records.as_ref().unwrap().len() > to_usize(u16::MAX)
                 {
                     ctx.report("array exceeds max length");
                 }
@@ -388,7 +388,7 @@ impl Validate for VarLenHaver {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("VarLenHaver", |ctx| {
             ctx.in_field("var_len", |ctx| {
-                if self.var_len.len() > (u16::MAX as usize) {
+                if self.var_len.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.var_len.validate_impl(ctx);

--- a/write-fonts/generated/generated_test_read_args.rs
+++ b/write-fonts/generated/generated_test_read_args.rs
@@ -30,13 +30,13 @@ impl Validate for BaseArray {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseArray", |ctx| {
             ctx.in_field("base_records", |ctx| {
-                if self.base_records.len() > (u16::MAX as usize) {
+                if self.base_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.base_records.validate_impl(ctx);
             });
             ctx.in_field("face_records", |ctx| {
-                if self.face_records.len() > (u16::MAX as usize) {
+                if self.face_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.face_records.validate_impl(ctx);
@@ -89,7 +89,7 @@ impl Validate for BaseRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BaseRecord", |ctx| {
             ctx.in_field("base_anchor_offsets", |ctx| {
-                if self.base_anchor_offsets.len() > (u16::MAX as usize) {
+                if self.base_anchor_offsets.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -128,7 +128,7 @@ impl Validate for FaceRecord {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("FaceRecord", |ctx| {
             ctx.in_field("faces", |ctx| {
-                if self.faces.len() > (u16::MAX as usize) {
+                if self.faces.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.faces.validate_impl(ctx);

--- a/write-fonts/generated/generated_test_records.rs
+++ b/write-fonts/generated/generated_test_records.rs
@@ -40,13 +40,13 @@ impl Validate for BasicTable {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("BasicTable", |ctx| {
             ctx.in_field("simple_records", |ctx| {
-                if self.simple_records.len() > (u16::MAX as usize) {
+                if self.simple_records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.simple_records.validate_impl(ctx);
             });
             ctx.in_field("array_records", |ctx| {
-                if self.array_records.len() > (u32::MAX as usize) {
+                if self.array_records.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.array_records.validate_impl(ctx);
@@ -145,12 +145,12 @@ impl Validate for ContainsArrays {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ContainsArrays", |ctx| {
             ctx.in_field("scalars", |ctx| {
-                if self.scalars.len() > (u16::MAX as usize) {
+                if self.scalars.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
             ctx.in_field("records", |ctx| {
-                if self.records.len() > (u16::MAX as usize) {
+                if self.records.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.records.validate_impl(ctx);

--- a/write-fonts/generated/generated_varc.rs
+++ b/write-fonts/generated/generated_varc.rs
@@ -146,7 +146,7 @@ impl Validate for MultiItemVariationStore {
                 self.region_list.validate_impl(ctx);
             });
             ctx.in_field("variation_data", |ctx| {
-                if self.variation_data.len() > (u16::MAX as usize) {
+                if self.variation_data.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.variation_data.validate_impl(ctx);
@@ -214,7 +214,7 @@ impl Validate for SparseVariationRegionList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SparseVariationRegionList", |ctx| {
             ctx.in_field("regions", |ctx| {
-                if self.regions.len() > (u16::MAX as usize) {
+                if self.regions.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.regions.validate_impl(ctx);
@@ -281,7 +281,7 @@ impl Validate for SparseVariationRegion {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("SparseVariationRegion", |ctx| {
             ctx.in_field("region_axes", |ctx| {
-                if self.region_axes.len() > (u16::MAX as usize) {
+                if self.region_axes.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.region_axes.validate_impl(ctx);
@@ -405,7 +405,7 @@ impl Validate for MultiItemVariationData {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("MultiItemVariationData", |ctx| {
             ctx.in_field("region_indices", |ctx| {
-                if self.region_indices.len() > (u16::MAX as usize) {
+                if self.region_indices.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -473,7 +473,7 @@ impl Validate for ConditionList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ConditionList", |ctx| {
             ctx.in_field("conditions", |ctx| {
-                if self.conditions.len() > (u32::MAX as usize) {
+                if self.conditions.len() > to_usize(u32::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.conditions.validate_impl(ctx);

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -105,7 +105,7 @@ impl Validate for Tuple {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Tuple", |ctx| {
             ctx.in_field("values", |ctx| {
-                if self.values.len() > (u16::MAX as usize) {
+                if self.values.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });
@@ -393,7 +393,7 @@ impl Validate for VariationRegionList {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("VariationRegionList", |ctx| {
             ctx.in_field("variation_regions", |ctx| {
-                if self.variation_regions.len() > (u16::MAX as usize) {
+                if self.variation_regions.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.variation_regions.validate_impl(ctx);
@@ -463,7 +463,7 @@ impl Validate for VariationRegion {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("VariationRegion", |ctx| {
             ctx.in_field("region_axes", |ctx| {
-                if self.region_axes.len() > (u16::MAX as usize) {
+                if self.region_axes.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.region_axes.validate_impl(ctx);
@@ -579,7 +579,7 @@ impl Validate for ItemVariationStore {
                 self.variation_region_list.validate_impl(ctx);
             });
             ctx.in_field("item_variation_data", |ctx| {
-                if self.item_variation_data.len() > (u16::MAX as usize) {
+                if self.item_variation_data.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.item_variation_data.validate_impl(ctx);
@@ -663,7 +663,7 @@ impl Validate for ItemVariationData {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("ItemVariationData", |ctx| {
             ctx.in_field("region_indexes", |ctx| {
-                if self.region_indexes.len() > (u16::MAX as usize) {
+                if self.region_indexes.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
             });

--- a/write-fonts/generated/generated_vmtx.rs
+++ b/write-fonts/generated/generated_vmtx.rs
@@ -40,7 +40,7 @@ impl Validate for Vmtx {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Vmtx", |ctx| {
             ctx.in_field("v_metrics", |ctx| {
-                if self.v_metrics.len() > (u16::MAX as usize) {
+                if self.v_metrics.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.v_metrics.validate_impl(ctx);

--- a/write-fonts/generated/generated_vorg.rs
+++ b/write-fonts/generated/generated_vorg.rs
@@ -44,7 +44,7 @@ impl Validate for Vorg {
     fn validate_impl(&self, ctx: &mut ValidationCtx) {
         ctx.in_table("Vorg", |ctx| {
             ctx.in_field("vert_origin_y_metrics", |ctx| {
-                if self.vert_origin_y_metrics.len() > (u16::MAX as usize) {
+                if self.vert_origin_y_metrics.len() > to_usize(u16::MAX) {
                     ctx.report("array exceeds max length");
                 }
                 self.vert_origin_y_metrics.validate_impl(ctx);

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -211,6 +211,10 @@ pub(crate) mod codegen_prelude {
         s.len()
     }
 
+    pub fn to_usize<T: TryInto<usize>>(value: T) -> usize {
+        value.try_into().unwrap_or_default()
+    }
+
     #[cfg(feature = "tables")]
     pub fn plus_one(val: &usize) -> usize {
         val.saturating_add(1)


### PR DESCRIPTION
Generated count expressions were casting field counts with `as usize` or emitting fallible conversions directly. Route those conversions through a shared `to_usize` helper in the generated-code preludes so the generated read and write tables avoid clippy noise while preserving the previous fallback behavior for failed conversions.

This isolates the codegen-wide cleanup from the beyond-64k table schema changes in PR #1901.

Assisted-by: OpenAI Codex