### PR TITLE
Reduce SubsetDefinition clones in IFT

### DIFF
--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -123,7 +123,7 @@ fn add_intersecting_format1_patches(
             })?;
         let intersection_info = if PatchFormat::is_invalidating_format(map.patch_format()) {
             IntersectionInfo::from_subset(
-                subset_def,
+                &subset_def,
                 // For format 1 the entry index is the "order",
                 // see: https://w3c.github.io/IFT/Overview.html#font-patch-invalidations
                 index.into(),
@@ -384,17 +384,37 @@ fn merge_intersecting_entries<const RECORD_INTERSECTION: bool>(
     }
 }
 
+#[derive(Clone, Default)]
+struct CacheEntries {
+    intersects: Option<bool>,
+    coverage: Option<SubsetDefinition>,
+}
+
 struct EntryIntersectionCache<'a> {
     entries: &'a [Format2Entry],
     target_subset_definition: &'a SubsetDefinition,
-    cache: HashMap<usize, bool>,
-    coverage_cache: HashMap<usize, SubsetDefinition>,
+    cache: Vec<CacheEntries>,
 }
 
-impl EntryIntersectionCache<'_> {
+impl<'a> EntryIntersectionCache<'a> {
+    fn new(
+        entries: &'a [Format2Entry],
+        target_subset_definition: &'a SubsetDefinition,
+    ) -> EntryIntersectionCache<'a> {
+        EntryIntersectionCache {
+            entries,
+            target_subset_definition,
+            cache: vec![CacheEntries::default(); entries.len()],
+        }
+    }
+
     /// Returns true if the target_subset_definition intersects the entry at index.
     fn intersects(&mut self, index: usize) -> bool {
-        if let Some(result) = self.cache.get(&index) {
+        if let Some(CacheEntries {
+            intersects: Some(result),
+            ..
+        }) = self.cache.get(index)
+        {
             return *result;
         }
 
@@ -403,31 +423,50 @@ impl EntryIntersectionCache<'_> {
         };
 
         let result = self.compute_intersection(entry);
-        self.cache.insert(index, result);
+        if let Some(cache) = self.cache.get_mut(index) {
+            cache.intersects = Some(result);
+        }
         result
     }
 
-    /// Returns the intersection of target_subset_definition and the union of entry and all of it's descendants.
-    fn coverage_intersection(&mut self, index: usize) -> SubsetDefinition {
-        if let Some(result) = self.coverage_cache.get(&index) {
-            return result.clone();
+    /// Returns the intersection of target_subset_definition and the union of entry and all of its descendants.
+    fn coverage_intersection(&mut self, index: usize) -> Result<&SubsetDefinition, ReadError> {
+        Self::coverage_intersection_impl(
+            self.entries,
+            self.target_subset_definition,
+            index,
+            &mut self.cache,
+        )
+        .ok_or(ReadError::OutOfBounds)
+    }
+
+    /// Returns None if `index` is out of range.
+    fn coverage_intersection_impl<'b>(
+        entries: &[Format2Entry],
+        target_subset_definition: &SubsetDefinition,
+        index: usize,
+        cache: &'b mut [CacheEntries],
+    ) -> Option<&'b SubsetDefinition> {
+        if cache.get(index)?.coverage.is_some() {
+            return cache[index].coverage.as_ref();
         }
 
-        let Some(entry) = self.entries.get(index) else {
-            return Default::default();
-        };
+        let entry = entries.get(index)?;
 
         let mut self_intersection = entry
             .subset_definition
-            .intersection(self.target_subset_definition);
+            .intersection(target_subset_definition);
         for child_index in entry.child_indices.iter() {
-            self_intersection.union(&self.coverage_intersection(*child_index));
+            let subset = Self::coverage_intersection_impl(
+                entries,
+                target_subset_definition,
+                *child_index,
+                cache,
+            )?;
+            self_intersection.union(subset);
         }
 
-        self.coverage_cache
-            .entry(index)
-            .or_insert(self_intersection)
-            .clone()
+        Some(cache.get_mut(index)?.coverage.insert(self_intersection))
     }
 
     fn compute_intersection(&mut self, entry: &Format2Entry) -> bool {
@@ -475,12 +514,7 @@ fn add_intersecting_format2_patches(
     let entries = decode_format2_entries(map)?;
 
     // Caches the result of intersection check for an entry index.
-    let mut entry_intersection_cache = EntryIntersectionCache {
-        entries: &entries,
-        cache: Default::default(),
-        coverage_cache: Default::default(),
-        target_subset_definition: subset_definition,
-    };
+    let mut entry_intersection_cache = EntryIntersectionCache::new(&entries, subset_definition);
 
     let mut application_bit_indices: HashMap<PatchUrl, IntSet<u32>> = Default::default();
     let new_patches_first_index = patches.len();
@@ -504,10 +538,8 @@ fn add_intersecting_format2_patches(
         // url in an entry needs to be updated because only the first url is
         // used for selection.
         let intersection_info = if e.format.is_invalidating() {
-            IntersectionInfo::from_subset(
-                entry_intersection_cache.coverage_intersection(order),
-                order,
-            )
+            let subset = entry_intersection_cache.coverage_intersection(order)?;
+            IntersectionInfo::from_subset(subset, order)
         } else {
             // non-invalidating entries still require information on entry order so just record that.
             IntersectionInfo::from_order(order)
@@ -1070,11 +1102,11 @@ impl Ord for IntersectionInfo {
 }
 
 impl IntersectionInfo {
-    fn from_subset(value: SubsetDefinition, order: usize) -> Self {
+    fn from_subset(value: &SubsetDefinition, order: usize) -> Self {
         Self {
             intersecting_codepoints: value.codepoints.len(),
             intersecting_layout_tags: value.feature_tags.len(),
-            intersecting_design_space: Self::design_space_size(value.design_space),
+            intersecting_design_space: Self::design_space_size(&value.design_space),
             entry_order: order,
         }
     }
@@ -1086,18 +1118,18 @@ impl IntersectionInfo {
         }
     }
 
-    fn design_space_size(value: DesignSpace) -> BTreeMap<Tag, Fixed> {
+    fn design_space_size(value: &DesignSpace) -> BTreeMap<Tag, Fixed> {
         match value {
             DesignSpace::All => Default::default(),
             DesignSpace::Ranges(value) => value
-                .into_iter()
+                .iter()
                 .map(|(tag, ranges)| {
                     let total = ranges
                         .iter()
                         .map(|range| *range.end() - *range.start())
                         .fold(Fixed::ZERO, |acc, x| acc + x);
 
-                    (tag, total)
+                    (*tag, total)
                 })
                 .collect(),
         }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -385,15 +385,19 @@ fn merge_intersecting_entries<const RECORD_INTERSECTION: bool>(
 }
 
 #[derive(Clone, Default)]
-struct CacheEntries {
+struct EntryCaches {
+    // If the entry intersects or `None` if it has not been computing.
     intersects: Option<bool>,
+    // The coverage for the intersection or `None` if there is no subset.
     coverage: Option<SubsetDefinition>,
 }
 
 struct EntryIntersectionCache<'a> {
-    entries: &'a [Format2Entry],
     target_subset_definition: &'a SubsetDefinition,
-    cache: Vec<CacheEntries>,
+    // The entries that we are inspecting.
+    entries: &'a [Format2Entry],
+    // Storage for cached values for entries. Initialized to have the same length as `entries`.
+    cache: Vec<EntryCaches>,
 }
 
 impl<'a> EntryIntersectionCache<'a> {
@@ -402,15 +406,20 @@ impl<'a> EntryIntersectionCache<'a> {
         target_subset_definition: &'a SubsetDefinition,
     ) -> EntryIntersectionCache<'a> {
         EntryIntersectionCache {
-            entries,
             target_subset_definition,
-            cache: vec![CacheEntries::default(); entries.len()],
+            entries,
+            cache: vec![EntryCaches::default(); entries.len()],
         }
     }
 
     /// Returns true if the target_subset_definition intersects the entry at index.
+    ///
+    /// # TODO
+    ///
+    /// Determine what to do when `index` is invalid. This should not happen in well-formed fonts,
+    /// but `compute_intersection` may discover a child index that is out of bounds.
     fn intersects(&mut self, index: usize) -> bool {
-        if let Some(CacheEntries {
+        if let Some(EntryCaches {
             intersects: Some(result),
             ..
         }) = self.cache.get(index)
@@ -427,46 +436,6 @@ impl<'a> EntryIntersectionCache<'a> {
             cache.intersects = Some(result);
         }
         result
-    }
-
-    /// Returns the intersection of target_subset_definition and the union of entry and all of its descendants.
-    fn coverage_intersection(&mut self, index: usize) -> Result<&SubsetDefinition, ReadError> {
-        Self::coverage_intersection_impl(
-            self.entries,
-            self.target_subset_definition,
-            index,
-            &mut self.cache,
-        )
-        .ok_or(ReadError::OutOfBounds)
-    }
-
-    /// Returns None if `index` is out of range.
-    fn coverage_intersection_impl<'b>(
-        entries: &[Format2Entry],
-        target_subset_definition: &SubsetDefinition,
-        index: usize,
-        cache: &'b mut [CacheEntries],
-    ) -> Option<&'b SubsetDefinition> {
-        if cache.get(index)?.coverage.is_some() {
-            return cache[index].coverage.as_ref();
-        }
-
-        let entry = entries.get(index)?;
-
-        let mut self_intersection = entry
-            .subset_definition
-            .intersection(target_subset_definition);
-        for child_index in entry.child_indices.iter() {
-            let subset = Self::coverage_intersection_impl(
-                entries,
-                target_subset_definition,
-                *child_index,
-                cache,
-            )?;
-            self_intersection.union(subset);
-        }
-
-        Some(cache.get_mut(index)?.coverage.insert(self_intersection))
     }
 
     fn compute_intersection(&mut self, entry: &Format2Entry) -> bool {
@@ -502,6 +471,46 @@ impl<'a> EntryIntersectionCache<'a> {
             }
         }
         false
+    }
+
+    /// Returns the intersection of target_subset_definition and the union of entry and all of its descendants.
+    fn coverage_intersection(&mut self, index: usize) -> Result<&SubsetDefinition, ReadError> {
+        Self::coverage_intersection_impl(
+            self.entries,
+            self.target_subset_definition,
+            index,
+            &mut self.cache,
+        )
+        .ok_or(ReadError::OutOfBounds)
+    }
+
+    /// Returns None if `index` is out of range.
+    fn coverage_intersection_impl<'b>(
+        entries: &[Format2Entry],
+        target_subset_definition: &SubsetDefinition,
+        index: usize,
+        cache: &'b mut [EntryCaches],
+    ) -> Option<&'b SubsetDefinition> {
+        if cache.get(index)?.coverage.is_some() {
+            return cache[index].coverage.as_ref();
+        }
+
+        let entry = entries.get(index)?;
+
+        let mut self_intersection = entry
+            .subset_definition
+            .intersection(target_subset_definition);
+        for child_index in entry.child_indices.iter() {
+            let subset = Self::coverage_intersection_impl(
+                entries,
+                target_subset_definition,
+                *child_index,
+                cache,
+            )?;
+            self_intersection.union(subset);
+        }
+
+        Some(cache.get_mut(index)?.coverage.insert(self_intersection))
     }
 }
 


### PR DESCRIPTION
# Benchmark Results

| Benchmark                                | Time      | Change   | Status    |
|------------------------------------------|-----------|----------|-----------|
| select-all/roboto/2-patches              | 353.14 µs | -6.7629% | Improved  |
| select-all/notosanshigh/877-patches      | 1.4781 ms | -4.4606% | Improved  |
| apply-all/roboto/7-rounds                | 8.3287 ms | -2.0637% | Improved  |
| apply-all/notosanshigh/4-rounds          | 30.008 ms | -1.0130% | Noise     |
| apply-incremental/roboto/initial         | 184.60 µs | -10.191% | Improved  |
| apply-incremental/roboto/+vietnamese     | 898.99 µs | -6.2517% | Improved  |
| apply-incremental/roboto/+greek-cyrillic | 1.3571 ms | -4.1702% | Improved  |
| incremental/notosanshigh/initial         | 4.4191 ms | -0.9452% | No change |
| incremental/notosanshigh/+full-article   | 5.1852 ms | -0.5272% | Noise     |