### PR TITLE
Fix cargo.toml version breakage

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -48,7 +48,7 @@ once_cell = { version = "1.21.4", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-read-fonts = { workspace = true, features = ["experimental_font_api"] }
+read-fonts = { path = ".", features = ["experimental_font_api"] }
 font-test-data = { workspace = true }
 criterion = { workspace = true }
 rand = "0.8.5"


### PR DESCRIPTION
The dev dependency with workspace=true was preventing publish, because the version declared in the workspace doesn't exist on the registry until _after_ it is published. This is the documented fix.