### PR TITLE
[subset] repacker bug fix

### DIFF
--- a/skera/src/graph.rs
+++ b/skera/src/graph.rs
@@ -1132,46 +1132,6 @@ impl Graph {
         made_changes
     }
 
-    // Creates a copy of child and re-assigns the link from parent to the clone.
-    // The copy is a shallow copy, objects linked from child are not duplicated.
-    // Returns the index of the newly created duplicate.
-    // If the child_idx only has incoming edges from parent_idx, duplication isn't possible and this will return None
-    #[allow(dead_code)]
-    fn duplicate_child(
-        &mut self,
-        parent_idx: ObjIdx,
-        child_idx: ObjIdx,
-    ) -> Result<Option<ObjIdx>, RepackError> {
-        self.update_parents()?;
-
-        let child_v = &self.vertices[child_idx];
-        if child_v.incoming_edges() <= child_v.incoming_edges_from_parent(parent_idx) as usize
-            || child_v.has_incoming_virtual_edges
-        {
-            return Ok(None);
-        }
-
-        let clone_idx = self.duplicate_vertex(child_idx)?;
-        let mut old_to_new_idx_parents = Vec::new();
-        for l in self.vertices[parent_idx].real_links.values_mut() {
-            if l.obj_idx() != child_idx {
-                continue;
-            }
-            l.update_obj_idx(clone_idx);
-            old_to_new_idx_parents.push((child_idx, clone_idx, parent_idx, false));
-        }
-
-        for l in self.vertices[parent_idx].virtual_links.iter_mut() {
-            if l.obj_idx() != child_idx {
-                continue;
-            }
-            l.update_obj_idx(clone_idx);
-            old_to_new_idx_parents.push((child_idx, clone_idx, parent_idx, true));
-        }
-        self.reassign_parents(&old_to_new_idx_parents)?;
-        Ok(Some(clone_idx))
-    }
-
     // Creates a copy of child and re-assigns the link from parents to the clone.
     // The copy is a shallow copy, objects linked from child are not duplicated.
     // Returns the index of the newly created duplicate.
@@ -1221,6 +1181,36 @@ impl Graph {
             }
         }
         self.reassign_parents(&old_to_new_idx_parents)?;
+        Ok(Some(clone_idx))
+    }
+
+    // Creates a copy of child and re-assigns the link at specified position from parent to the clone.
+    // The copy is a shallow copy, objects linked from child are not duplicated.
+    // Returns the index of the newly created duplicate.
+    fn duplicate_child_at_position(
+        &mut self,
+        parent_idx: ObjIdx,
+        child_idx: ObjIdx,
+        pos: u32,
+    ) -> Result<Option<ObjIdx>, RepackError> {
+        let clone_idx = self.duplicate_vertex(child_idx)?;
+        self.mut_vertex(child_idx)
+            .ok_or(RepackError::GraphErrorInvalidObjIndex)?
+            .remove_parent(parent_idx, false);
+
+        self.mut_vertex(clone_idx)
+            .ok_or(RepackError::GraphErrorInvalidObjIndex)?
+            .add_parent(parent_idx, false);
+
+        let Some(l) = self
+            .mut_vertex(parent_idx)
+            .ok_or(RepackError::GraphErrorInvalidObjIndex)?
+            .real_links
+            .get_mut(&pos)
+        else {
+            return Ok(None);
+        };
+        l.update_obj_idx(clone_idx);
         Ok(Some(clone_idx))
     }
 
@@ -1810,7 +1800,6 @@ pub(crate) mod test {
         let mut a = Serializer::new(buf_size);
         populate_serializer_complex_2(&mut a);
         let mut graph = Graph::from_serializer(&a).unwrap();
-        graph.duplicate_child(4, 1).unwrap();
         graph.normalize();
 
         let mut e = Serializer::new(buf_size);
@@ -1847,7 +1836,7 @@ pub(crate) mod test {
         let mut c = Serializer::new(buf_size);
         populate_serializer_complex_3(&mut c);
         let mut graph = Graph::from_serializer(&c).unwrap();
-        graph.duplicate_child(3, 2).unwrap();
+        graph.duplicate_child_at_position(3, 2, 3).unwrap();
 
         let data_bytes = &graph.data;
         let obj_6 = &graph.vertices[6];

--- a/skera/src/graph/ligature_graph.rs
+++ b/skera/src/graph/ligature_graph.rs
@@ -31,6 +31,7 @@ pub(crate) fn split_ligature_subst(
         return Ok(Vec::new());
     }
 
+    duplicate_shared_liga_sets(graph, table_idx)?;
     let cov_glyphs = coverage_glyphs(graph, coverage_idx)?;
     let mut out: Vec<usize> = Vec::with_capacity(split_points.len() + 1);
     for i in 0..split_points.len() {
@@ -58,6 +59,25 @@ pub(crate) fn split_ligature_subst(
 
     shrink(graph, table_idx, coverage_idx, &cov_glyphs, split_points[0])?;
     Ok(out)
+}
+
+fn duplicate_shared_liga_sets(graph: &mut Graph, table_idx: ObjIdx) -> Result<(), RepackError> {
+    let table_v = graph
+        .vertex(table_idx)
+        .ok_or(RepackError::GraphErrorInvalidObjIndex)?;
+    let mut visited = IntSet::empty();
+    let mut duplicates = Vec::new();
+    for (pos, l) in table_v.real_links() {
+        let obj_idx = l.obj_idx();
+        if !visited.insert(obj_idx as u32) {
+            duplicates.push((*pos, obj_idx));
+        }
+    }
+
+    for (pos, obj_idx) in duplicates {
+        graph.duplicate_child_at_position(table_idx, obj_idx, pos)?;
+    }
+    Ok(())
 }
 
 // ref:<https://github.com/harfbuzz/harfbuzz/blob/e1f2565db09823794e3d8ed404c47dae0f0cd3c9/src/graph/ligature-graph.hh#L124>


### PR DESCRIPTION
duplicate shared liga_sets before table splitting.
Ported from: https://github.com/harfbuzz/harfbuzz/pull/5972

plus removed an unused `fn duplicate_child()`