### PR TITLE
[ift-breaking] Use SmolStr for cheaper string building and copying

### DIFF
--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -33,6 +33,7 @@ data-encoding = "2.6.0"
 data-encoding-macro = "0.1.15"
 clap = { version = "4.5.4", features = ["derive"], optional = true }
 regex = { version = "1.11.1", optional = true }
+smol_str = "0.3.6"
 
 [dev-dependencies]
 brotlic = {version = "0.8.2"}

--- a/incremental-font-transfer/src/patch_group.rs
+++ b/incremental-font-transfer/src/patch_group.rs
@@ -709,15 +709,9 @@ mod tests {
     const TABLE_1_FINAL_STATE: &[u8] = "hijkabcdeflmnohijkabcdeflmno\n".as_bytes();
     const TABLE_2_FINAL_STATE: &[u8] = "foobarbaz foobarbaz foobarbaz\n".as_bytes();
 
-    impl PatchUrl {
-        fn new(url: &str) -> Self {
-            Self(url.to_string())
-        }
-    }
-
     impl OrderedPatchUrl {
-        fn url(order: usize, url: &str) -> Self {
-            OrderedPatchUrl(order, PatchUrl(url.to_string()))
+        fn from_url(order: usize, url: &str) -> Self {
+            OrderedPatchUrl(order, PatchUrl::new(url))
         }
     }
 
@@ -1292,11 +1286,11 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                     NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                 )]))
             }
@@ -1321,11 +1315,11 @@ mod tests {
                 ift: ScopedGroup::NoInvalidation(Default::default()),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([
                     (
-                        OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                        OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                         NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                     ),
                     (
-                        OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                        OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                         NoInvalidationPatch(patch_info_iftx("//foo.bar/0G"))
                     )
                 ]))
@@ -1368,11 +1362,11 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                     NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                 )]))
             }
@@ -1401,7 +1395,7 @@ mod tests {
                     "//foo.bar/08"
                 ),)),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                     NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                 )]))
             }
@@ -1421,7 +1415,7 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::PartialInvalidation(PartialInvalidationPatch(patch_info_iftx(
@@ -1510,7 +1504,7 @@ mod tests {
                     "//foo.bar/08"
                 ),)),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                     NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                 )]))
             }
@@ -1533,7 +1527,7 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::PartialInvalidation(PartialInvalidationPatch(patch_info_iftx(
@@ -1623,7 +1617,7 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::new()),
@@ -1644,11 +1638,11 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                     NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                 )])),
             }
@@ -1693,7 +1687,7 @@ mod tests {
                     "//foo.bar/08"
                 ))),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0K"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0K"),
                     NoInvalidationPatch(patch_info_iftx("//foo.bar/0K"))
                 )])),
             }
@@ -1712,7 +1706,7 @@ mod tests {
             group,
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "//foo.bar/0G"),
+                    OrderedPatchUrl::from_url(0, "//foo.bar/0G"),
                     NoInvalidationPatch(patch_info_ift("//foo.bar/0G"))
                 )])),
                 iftx: ScopedGroup::PartialInvalidation(PartialInvalidationPatch(patch_info_iftx(
@@ -2303,7 +2297,7 @@ mod tests {
             CompatibleGroup::Mixed {
                 ift: ScopedGroup::NoInvalidation(Default::default()),
                 iftx: ScopedGroup::NoInvalidation(BTreeMap::from([(
-                    OrderedPatchUrl::url(0, "foo/04"),
+                    OrderedPatchUrl::from_url(0, "foo/04"),
                     NoInvalidationPatch(info)
                 )])),
             }

--- a/incremental-font-transfer/src/patchmap.rs
+++ b/incremental-font-transfer/src/patchmap.rs
@@ -14,7 +14,6 @@ use std::ops::RangeInclusive;
 use font_types::Fixed;
 use font_types::Int24;
 use font_types::Tag;
-
 use read_fonts::{
     collections::{IntSet, RangeSet},
     tables::ift::{
@@ -24,8 +23,8 @@ use read_fonts::{
     types::Uint24,
     FontData, FontRead, FontRef, ReadError, TableProvider,
 };
-
 use skrifa::charmap::Charmap;
+use smol_str::SmolStr;
 
 use crate::url_templates;
 use crate::url_templates::UrlTemplateError;
@@ -1010,14 +1009,22 @@ impl PatchMapEntry {
 
 /// An expanded PatchUrl string which identifies where a patch is located.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
-pub struct PatchUrl(pub String);
+pub struct PatchUrl(SmolStr);
 
 impl PatchUrl {
+    pub fn new(s: &str) -> Self {
+        PatchUrl(SmolStr::from(s))
+    }
+
     pub(crate) fn expand_template(
         template_string: &[u8],
         patch_id: &PatchId,
     ) -> Result<Self, UrlTemplateError> {
-        url_templates::expand_template(template_string, patch_id).map(Self)
+        url_templates::expand_template(template_string, patch_id).map(PatchUrl)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
     }
 
     pub(crate) fn into_format_1_entry(

--- a/incremental-font-transfer/src/url_templates.rs
+++ b/incremental-font-transfer/src/url_templates.rs
@@ -5,6 +5,7 @@
 //! URL templates in IFT use an series of one byte opcodes to insert literals or expand template variables.
 use data_encoding::BASE64URL;
 use data_encoding_macro::new_encoding;
+use smol_str::{format_smolstr, SmolStr, SmolStrBuilder};
 
 use crate::patchmap::PatchId;
 
@@ -71,8 +72,8 @@ impl TryFrom<u8> for Variable {
 
 struct CachedEncoder<'a> {
     patch_id: &'a PatchId,
-    id32: Option<String>,
-    id64: Option<String>,
+    id32: Option<SmolStr>,
+    id64: Option<SmolStr>,
 }
 
 impl<'a> CachedEncoder<'a> {
@@ -90,9 +91,11 @@ impl<'a> CachedEncoder<'a> {
                 PatchId::Numeric(id) => {
                     let id = id.to_be_bytes();
                     let id = &id[count_leading_zeroes(&id)..];
-                    BASE32HEX_NO_PADDING.encode(id)
+                    format_smolstr!("{}", BASE32HEX_NO_PADDING.encode_display(id))
                 }
-                PatchId::String(id) => BASE32HEX_NO_PADDING.encode(id),
+                PatchId::String(id) => {
+                    format_smolstr!("{}", BASE32HEX_NO_PADDING.encode_display(id))
+                }
             })
             .as_str()
     }
@@ -103,9 +106,11 @@ impl<'a> CachedEncoder<'a> {
                 PatchId::Numeric(id) => {
                     let id = id.to_be_bytes();
                     let id = &id[count_leading_zeroes(&id)..];
-                    BASE64URL.encode(id)
+                    format_smolstr!("{}", BASE64URL.encode_display(id))
                 }
-                PatchId::String(id) => BASE64URL.encode(id),
+                PatchId::String(id) => {
+                    format_smolstr!("{}", BASE64URL.encode_display(id))
+                }
             })
             .as_str()
     }
@@ -128,9 +133,9 @@ impl std::error::Error for UrlTemplateError {}
 pub(crate) fn expand_template(
     mut template_bytes: &[u8],
     patch_id: &PatchId,
-) -> Result<String, UrlTemplateError> {
+) -> Result<SmolStr, UrlTemplateError> {
     let mut cached_encoder = CachedEncoder::new(patch_id);
-    let mut output_buffer = String::new();
+    let mut output_buffer = SmolStrBuilder::new();
     while let Some((opcode, rest)) = template_bytes.split_first() {
         template_bytes = rest;
         match OpCode::try_from(*opcode)? {
@@ -161,7 +166,7 @@ pub(crate) fn expand_template(
             }
         }
     }
-    Ok(output_buffer)
+    Ok(output_buffer.finish())
 }
 
 const BASE32HEX_NO_PADDING: data_encoding::Encoding = new_encoding! {
@@ -182,14 +187,14 @@ pub(crate) mod tests {
     fn check_numeric(bytes: &[u8], id: u32, expected: &str) {
         assert_eq!(
             expand_template(bytes, &PatchId::Numeric(id),),
-            Ok(expected.to_string())
+            Ok(expected.into())
         );
     }
 
     fn check_string(bytes: &[u8], id: &[u8], expected: &str) {
         assert_eq!(
             expand_template(bytes, &PatchId::String(Vec::from(id)),),
-            Ok(expected.to_string())
+            Ok(expected.into())
         );
     }
 


### PR DESCRIPTION
- Use SmolStr for cheaper string building and copying
- Breaking changes
  - `PatchUrl.0` is no longer public. Use `.as_ref` or `.as_str` to get an `&str`
  - `url_templates::expand_template` returns a `SmolStr`. 

# Benchmark Results

| Benchmark                                | Time      | Change   | Result   |
|:-----------------------------------------|:----------|:---------|:---------|
| select-all/roboto/2-patches              | 298.73 µs | -11.108% | Improved |
| select-all/notosanshigh/877-patches      | 1.3030 ms | -9.4230% | Improved |
| apply-all/roboto/7-rounds                | 8.2041 ms | -0.6226% | Noise    |
| apply-all/notosanshigh/4-rounds          | 28.392 ms | -4.4637% | Improved |
| apply-incremental/roboto/initial         | 156.54 µs | -0.9217% | Noise    |
| apply-incremental/roboto/+vietnamese     | 801.66 µs | -4.0768% | Improved |
| apply-incremental/roboto/+greek-cyrillic | 1.2161 ms | -4.6000% | Improved |
| incremental/notosanshigh/initial         | 4.1319 ms | -2.7152% | Improved |
| incremental/notosanshigh/+full-article   | 5.0140 ms | -2.2843% | Improved |

