### PR TITLE
Fix trivial clippy errors

### DIFF
--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -387,8 +387,7 @@ impl Table {
 
             let end_expr = if let Some(condition) = condition {
                 quote! {
-                    (#condition).then(|| start + #len_expr)
-                        .unwrap_or(start)
+                    if #condition { start + #len_expr } else { start }
                 }
             } else {
                 quote!( start + #len_expr)
@@ -397,7 +396,8 @@ impl Table {
                 pub fn #fn_name(&self) -> Range<usize> {
                     #( #required_field_decls )*
                     let start = #prev_field_end_expr;
-                    start..#end_expr
+                    let end = #end_expr;
+                    start..end
                 }
             };
             prev_field_end_expr = quote!( self.#fn_name().end );

--- a/font-test-data/src/ift.rs
+++ b/font-test-data/src/ift.rs
@@ -1399,7 +1399,7 @@ pub fn short_gvar_near_maximum_offset_size() -> BeBuffer {
     };
 
     // Glyph 0
-    let mut buffer = buffer.extend(iter::repeat(1u8).take(131065));
+    let mut buffer = buffer.extend(iter::repeat_n(1u8, 131065));
 
     let data_offset = buffer.offset_for("glyph_0");
     buffer.write_at("shared_tuples_offset", data_offset as u32);

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -75,33 +75,40 @@ impl<'a> TableDirectory<'a> {
 
     pub fn sfnt_version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_tables_byte_range(&self) -> Range<usize> {
         let start = self.sfnt_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.num_tables_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn table_records_byte_range(&self) -> Range<usize> {
         let num_tables = self.num_tables();
         let start = self.range_shift_byte_range().end;
-        start..start + (transforms::to_usize(num_tables)).saturating_mul(TableRecord::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_tables)).saturating_mul(TableRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -288,47 +295,57 @@ impl<'a> TTCHeader<'a> {
 
     pub fn ttc_tag_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Tag::RAW_BYTE_LEN
+        let end = start + Tag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = self.ttc_tag_byte_range().end;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_fonts_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn table_directory_offsets_byte_range(&self) -> Range<usize> {
         let num_fonts = self.num_fonts();
         let start = self.num_fonts_byte_range().end;
-        start..start + (transforms::to_usize(num_fonts)).saturating_mul(u32::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(num_fonts)).saturating_mul(u32::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn dsig_tag_byte_range(&self) -> Range<usize> {
         let start = self.table_directory_offsets_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + u32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn dsig_length_byte_range(&self) -> Range<usize> {
         let start = self.dsig_tag_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + u32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn dsig_offset_byte_range(&self) -> Range<usize> {
         let start = self.dsig_length_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + u32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -168,12 +168,15 @@ impl<'a> Lookup0<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn values_data_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -295,42 +298,48 @@ impl<'a> Lookup2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_units_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_units_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn segments_data_byte_range(&self) -> Range<usize> {
         let unit_size = self.unit_size();
         let n_units = self.n_units();
         let start = self.range_shift_byte_range().end;
-        start
-            ..start
-                + (transforms::add_multiply(unit_size, 0_usize, n_units))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add_multiply(unit_size, 0_usize, n_units))
+                .saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -447,38 +456,46 @@ impl<'a> Lookup4<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_units_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_units_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn segments_byte_range(&self) -> Range<usize> {
         let n_units = self.n_units();
         let start = self.range_shift_byte_range().end;
-        start..start + (transforms::to_usize(n_units)).saturating_mul(LookupSegment4::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_units)).saturating_mul(LookupSegment4::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -651,42 +668,48 @@ impl<'a> Lookup6<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_units_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_units_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entries_data_byte_range(&self) -> Range<usize> {
         let unit_size = self.unit_size();
         let n_units = self.n_units();
         let start = self.range_shift_byte_range().end;
-        start
-            ..start
-                + (transforms::add_multiply(unit_size, 0_usize, n_units))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add_multiply(unit_size, 0_usize, n_units))
+                .saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -781,23 +804,27 @@ impl<'a> Lookup8<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -897,32 +924,36 @@ impl<'a> Lookup10<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn unit_size_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = self.unit_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn values_data_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let unit_size = self.unit_size();
         let start = self.glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::add_multiply(glyph_count, 0_usize, unit_size))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add_multiply(glyph_count, 0_usize, unit_size))
+                .saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1030,22 +1061,26 @@ impl<'a> StateHeader<'a> {
 
     pub fn state_size_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.state_size_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn state_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.class_table_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.state_array_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1144,18 +1179,21 @@ impl<'a> ClassSubtable<'a> {
 
     pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_array_byte_range(&self) -> Range<usize> {
         let n_glyphs = self.n_glyphs();
         let start = self.n_glyphs_byte_range().end;
-        start..start + (transforms::to_usize(n_glyphs)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(n_glyphs)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1230,7 +1268,9 @@ impl<'a> RawBytes<'a> {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1344,22 +1384,26 @@ impl<'a> StxHeader<'a> {
 
     pub fn n_classes_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.n_classes_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn state_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.class_table_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.state_array_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1444,7 +1488,9 @@ impl<'a> RawWords<'a> {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_ankr.rs
+++ b/read-fonts/generated/generated_ankr.rs
@@ -76,22 +76,26 @@ impl<'a> Ankr<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_data_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.lookup_table_offset_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -179,13 +183,16 @@ impl<'a> GlyphDataEntry<'a> {
 
     pub fn num_points_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn anchor_points_byte_range(&self) -> Range<usize> {
         let num_points = self.num_points();
         let start = self.num_points_byte_range().end;
-        start..start + (transforms::to_usize(num_points)).saturating_mul(AnchorPoint::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_points)).saturating_mul(AnchorPoint::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -93,43 +93,51 @@ impl<'a> Avar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_segment_maps_byte_range(&self) -> Range<usize> {
         let axis_count = self.axis_count();
         let start = self.axis_count_byte_range().end;
-        start..start + {
+        let end = start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <SegmentMaps as VarSize>::total_len_for_count(data, transforms::to_usize(axis_count))
                 .unwrap_or(0)
-        }
+        };
+        start..end
     }
 
     pub fn axis_index_map_offset_byte_range(&self) -> Range<usize> {
         let start = self.axis_segment_maps_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn var_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_map_offset_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -88,25 +88,30 @@ impl<'a> Base<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn horiz_axis_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn vert_axis_offset_byte_range(&self) -> Range<usize> {
         let start = self.horiz_axis_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn item_var_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.vert_axis_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -211,12 +216,14 @@ impl<'a> Axis<'a> {
 
     pub fn base_tag_list_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_script_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_tag_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -305,13 +312,15 @@ impl<'a> BaseTagList<'a> {
 
     pub fn base_tag_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn baseline_tags_byte_range(&self) -> Range<usize> {
         let base_tag_count = self.base_tag_count();
         let start = self.base_tag_count_byte_range().end;
-        start..start + (transforms::to_usize(base_tag_count)).saturating_mul(Tag::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(base_tag_count)).saturating_mul(Tag::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -393,16 +402,17 @@ impl<'a> BaseScriptList<'a> {
 
     pub fn base_script_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_script_records_byte_range(&self) -> Range<usize> {
         let base_script_count = self.base_script_count();
         let start = self.base_script_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(base_script_count))
-                    .saturating_mul(BaseScriptRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(base_script_count))
+                .saturating_mul(BaseScriptRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -569,26 +579,29 @@ impl<'a> BaseScript<'a> {
 
     pub fn base_values_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn default_min_max_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_values_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_lang_sys_count_byte_range(&self) -> Range<usize> {
         let start = self.default_min_max_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_lang_sys_records_byte_range(&self) -> Range<usize> {
         let base_lang_sys_count = self.base_lang_sys_count();
         let start = self.base_lang_sys_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(base_lang_sys_count))
-                    .saturating_mul(BaseLangSysRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(base_lang_sys_count))
+                .saturating_mul(BaseLangSysRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -758,20 +771,22 @@ impl<'a> BaseValues<'a> {
 
     pub fn default_baseline_index_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_coord_count_byte_range(&self) -> Range<usize> {
         let start = self.default_baseline_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_coord_offsets_byte_range(&self) -> Range<usize> {
         let base_coord_count = self.base_coord_count();
         let start = self.base_coord_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(base_coord_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(base_coord_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -887,26 +902,29 @@ impl<'a> MinMax<'a> {
 
     pub fn min_coord_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_coord_offset_byte_range(&self) -> Range<usize> {
         let start = self.min_coord_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feat_min_max_count_byte_range(&self) -> Range<usize> {
         let start = self.max_coord_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feat_min_max_records_byte_range(&self) -> Range<usize> {
         let feat_min_max_count = self.feat_min_max_count();
         let start = self.feat_min_max_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(feat_min_max_count))
-                    .saturating_mul(FeatMinMaxRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(feat_min_max_count))
+                .saturating_mul(FeatMinMaxRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1185,12 +1203,14 @@ impl<'a> BaseCoordFormat1<'a> {
 
     pub fn base_coord_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1290,22 +1310,26 @@ impl<'a> BaseCoordFormat2<'a> {
 
     pub fn base_coord_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reference_glyph_byte_range(&self) -> Range<usize> {
         let start = self.coordinate_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_coord_point_byte_range(&self) -> Range<usize> {
         let start = self.reference_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1396,17 +1420,20 @@ impl<'a> BaseCoordFormat3<'a> {
 
     pub fn base_coord_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.base_coord_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn device_offset_byte_range(&self) -> Range<usize> {
         let start = self.coordinate_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_bitmap.rs
+++ b/read-fonts/generated/generated_bitmap.rs
@@ -804,10 +804,10 @@ impl<'a> IndexSubtableList<'a> {
     pub fn index_subtable_records_byte_range(&self) -> Range<usize> {
         let number_of_index_subtables = self.number_of_index_subtables();
         let start = 0;
-        start
-            ..start
-                + (transforms::to_usize(number_of_index_subtables))
-                    .saturating_mul(IndexSubtableRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(number_of_index_subtables))
+                .saturating_mul(IndexSubtableRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1013,27 +1013,30 @@ impl<'a> IndexSubtable1<'a> {
 
     pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sbit_offsets_byte_range(&self) -> Range<usize> {
         let last_glyph_index = self.last_glyph_index();
         let first_glyph_index = self.first_glyph_index();
         let start = self.image_data_offset_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
-                    .saturating_mul(u32::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
+                .saturating_mul(u32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1141,27 +1144,32 @@ impl<'a> IndexSubtable2<'a> {
 
     pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_size_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn big_metrics_byte_range(&self) -> Range<usize> {
         let start = self.image_size_byte_range().end;
-        start..start + BigGlyphMetrics::RAW_BYTE_LEN
+        let end = start + BigGlyphMetrics::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1295,27 +1303,30 @@ impl<'a> IndexSubtable3<'a> {
 
     pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sbit_offsets_byte_range(&self) -> Range<usize> {
         let last_glyph_index = self.last_glyph_index();
         let first_glyph_index = self.first_glyph_index();
         let start = self.image_data_offset_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
-                    .saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::subtract_add_two(last_glyph_index, first_glyph_index))
+                .saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1411,31 +1422,35 @@ impl<'a> IndexSubtable4<'a> {
 
     pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let num_glyphs = self.num_glyphs();
         let start = self.num_glyphs_byte_range().end;
-        start
-            ..start
-                + (transforms::add(num_glyphs, 1_usize))
-                    .saturating_mul(GlyphIdOffsetPair::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add(num_glyphs, 1_usize))
+                .saturating_mul(GlyphIdOffsetPair::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1596,38 +1611,46 @@ impl<'a> IndexSubtable5<'a> {
 
     pub fn index_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_format_byte_range(&self) -> Range<usize> {
         let start = self.index_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.image_format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn image_size_byte_range(&self) -> Range<usize> {
         let start = self.image_data_offset_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn big_metrics_byte_range(&self) -> Range<usize> {
         let start = self.image_size_byte_range().end;
-        start..start + BigGlyphMetrics::RAW_BYTE_LEN
+        let end = start + BigGlyphMetrics::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.big_metrics_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let num_glyphs = self.num_glyphs();
         let start = self.num_glyphs_byte_range().end;
-        start..start + (transforms::to_usize(num_glyphs)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_glyphs)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cbdt.rs
+++ b/read-fonts/generated/generated_cbdt.rs
@@ -55,12 +55,14 @@ impl<'a> Cbdt<'a> {
 
     pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cblc.rs
+++ b/read-fonts/generated/generated_cblc.rs
@@ -67,23 +67,28 @@ impl<'a> Cblc<'a> {
 
     pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_sizes_byte_range(&self) -> Range<usize> {
         let start = self.minor_version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
         let num_sizes = self.num_sizes();
         let start = self.num_sizes_byte_range().end;
-        start..start + (transforms::to_usize(num_sizes)).saturating_mul(BitmapSize::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_sizes)).saturating_mul(BitmapSize::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cff.rs
+++ b/read-fonts/generated/generated_cff.rs
@@ -75,33 +75,41 @@ impl<'a> CffHeader<'a> {
 
     pub fn major_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn minor_byte_range(&self) -> Range<usize> {
         let start = self.major_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn hdr_size_byte_range(&self) -> Range<usize> {
         let start = self.minor_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn off_size_byte_range(&self) -> Range<usize> {
         let start = self.hdr_size_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _padding_byte_range(&self) -> Range<usize> {
         let hdr_size = self.hdr_size();
         let start = self.off_size_byte_range().end;
-        start..start + (transforms::subtract(hdr_size, 4_usize)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::subtract(hdr_size, 4_usize)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self._padding_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -198,27 +206,30 @@ impl<'a> Index<'a> {
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn off_size_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let off_size = self.off_size();
         let start = self.off_size_byte_range().end;
-        start
-            ..start
-                + (transforms::add_multiply(count, 1_usize, off_size))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add_multiply(count, 1_usize, off_size)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.offsets_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -396,12 +407,15 @@ impl<'a> FdSelectFormat0<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn fds_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -500,23 +514,28 @@ impl<'a> FdSelectFormat3<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_ranges_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let n_ranges = self.n_ranges();
         let start = self.n_ranges_byte_range().end;
-        start..start + (transforms::to_usize(n_ranges)).saturating_mul(FdSelectRange3::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_ranges)).saturating_mul(FdSelectRange3::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn sentinel_byte_range(&self) -> Range<usize> {
         let start = self.ranges_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -654,23 +673,28 @@ impl<'a> FdSelectFormat4<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_ranges_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let n_ranges = self.n_ranges();
         let start = self.n_ranges_byte_range().end;
-        start..start + (transforms::to_usize(n_ranges)).saturating_mul(FdSelectRange4::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_ranges)).saturating_mul(FdSelectRange4::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn sentinel_byte_range(&self) -> Range<usize> {
         let start = self.ranges_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -887,12 +911,15 @@ impl<'a> CharsetFormat0<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -977,15 +1004,16 @@ impl<'a> CharsetFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start
-            ..start
-                + self.data.len().saturating_sub(start) / CharsetRange1::RAW_BYTE_LEN
-                    * CharsetRange1::RAW_BYTE_LEN
+        let end = start
+            + self.data.len().saturating_sub(start) / CharsetRange1::RAW_BYTE_LEN
+                * CharsetRange1::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1119,15 +1147,16 @@ impl<'a> CharsetFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start
-            ..start
-                + self.data.len().saturating_sub(start) / CharsetRange2::RAW_BYTE_LEN
-                    * CharsetRange2::RAW_BYTE_LEN
+        let end = start
+            + self.data.len().saturating_sub(start) / CharsetRange2::RAW_BYTE_LEN
+                * CharsetRange2::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cff2.rs
+++ b/read-fonts/generated/generated_cff2.rs
@@ -81,39 +81,48 @@ impl<'a> Cff2Header<'a> {
 
     pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn header_size_byte_range(&self) -> Range<usize> {
         let start = self.minor_version_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn top_dict_length_byte_range(&self) -> Range<usize> {
         let start = self.header_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _padding_byte_range(&self) -> Range<usize> {
         let header_size = self.header_size();
         let start = self.top_dict_length_byte_range().end;
-        start..start + (transforms::subtract(header_size, 5_usize)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::subtract(header_size, 5_usize)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn top_dict_data_byte_range(&self) -> Range<usize> {
         let top_dict_length = self.top_dict_length();
         let start = self._padding_byte_range().end;
-        start..start + (transforms::to_usize(top_dict_length)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(top_dict_length)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self.top_dict_data_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -211,27 +220,30 @@ impl<'a> Index<'a> {
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn off_size_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let off_size = self.off_size();
         let start = self.off_size_byte_range().end;
-        start
-            ..start
-                + (transforms::add_multiply(count, 1_usize, off_size))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add_multiply(count, 1_usize, off_size)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.offsets_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cmap.rs
+++ b/read-fonts/generated/generated_cmap.rs
@@ -60,20 +60,22 @@ impl<'a> Cmap<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_tables_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn encoding_records_byte_range(&self) -> Range<usize> {
         let num_tables = self.num_tables();
         let start = self.num_tables_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_tables)).saturating_mul(EncodingRecord::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_tables)).saturating_mul(EncodingRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -429,22 +431,26 @@ impl<'a> Cmap0<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + (256_usize).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (256_usize).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -546,22 +552,26 @@ impl<'a> Cmap2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sub_header_keys_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + (256_usize).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (256_usize).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -769,71 +779,85 @@ impl<'a> Cmap4<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seg_count_x2_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.seg_count_x2_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn end_code_byte_range(&self) -> Range<usize> {
         let seg_count_x2 = self.seg_count_x2();
         let start = self.range_shift_byte_range().end;
-        start..start + (transforms::half(seg_count_x2)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::half(seg_count_x2)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn reserved_pad_byte_range(&self) -> Range<usize> {
         let start = self.end_code_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn start_code_byte_range(&self) -> Range<usize> {
         let seg_count_x2 = self.seg_count_x2();
         let start = self.reserved_pad_byte_range().end;
-        start..start + (transforms::half(seg_count_x2)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::half(seg_count_x2)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn id_delta_byte_range(&self) -> Range<usize> {
         let seg_count_x2 = self.seg_count_x2();
         let start = self.start_code_byte_range().end;
-        start..start + (transforms::half(seg_count_x2)).saturating_mul(i16::RAW_BYTE_LEN)
+        let end = start + (transforms::half(seg_count_x2)).saturating_mul(i16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn id_range_offsets_byte_range(&self) -> Range<usize> {
         let seg_count_x2 = self.seg_count_x2();
         let start = self.id_delta_byte_range().end;
-        start..start + (transforms::half(seg_count_x2)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::half(seg_count_x2)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let start = self.id_range_offsets_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -947,33 +971,39 @@ impl<'a> Cmap6<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn first_code_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_count_byte_range(&self) -> Range<usize> {
         let start = self.first_code_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let entry_count = self.entry_count();
         let start = self.entry_count_byte_range().end;
-        start..start + (transforms::to_usize(entry_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(entry_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1084,41 +1114,46 @@ impl<'a> Cmap8<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn is32_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + (8192_usize).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (8192_usize).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn num_groups_byte_range(&self) -> Range<usize> {
         let start = self.is32_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn groups_byte_range(&self) -> Range<usize> {
         let num_groups = self.num_groups();
         let start = self.num_groups_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_groups))
-                    .saturating_mul(SequentialMapGroup::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_groups)).saturating_mul(SequentialMapGroup::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1292,38 +1327,45 @@ impl<'a> Cmap10<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn start_char_code_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_chars_byte_range(&self) -> Range<usize> {
         let start = self.start_char_code_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_id_array_byte_range(&self) -> Range<usize> {
         let num_chars = self.num_chars();
         let start = self.num_chars_byte_range().end;
-        start..start + (transforms::to_usize(num_chars)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(num_chars)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1425,36 +1467,40 @@ impl<'a> Cmap12<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_groups_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn groups_byte_range(&self) -> Range<usize> {
         let num_groups = self.num_groups();
         let start = self.num_groups_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_groups))
-                    .saturating_mul(SequentialMapGroup::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_groups)).saturating_mul(SequentialMapGroup::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1562,35 +1608,40 @@ impl<'a> Cmap13<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn language_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_groups_byte_range(&self) -> Range<usize> {
         let start = self.language_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn groups_byte_range(&self) -> Range<usize> {
         let num_groups = self.num_groups();
         let start = self.num_groups_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_groups)).saturating_mul(ConstantMapGroup::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_groups)).saturating_mul(ConstantMapGroup::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1739,26 +1790,29 @@ impl<'a> Cmap14<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_var_selector_records_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_selector_byte_range(&self) -> Range<usize> {
         let num_var_selector_records = self.num_var_selector_records();
         let start = self.num_var_selector_records_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_var_selector_records))
-                    .saturating_mul(VariationSelector::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_var_selector_records))
+                .saturating_mul(VariationSelector::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1923,16 +1977,17 @@ impl<'a> DefaultUvs<'a> {
 
     pub fn num_unicode_value_ranges_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ranges_byte_range(&self) -> Range<usize> {
         let num_unicode_value_ranges = self.num_unicode_value_ranges();
         let start = self.num_unicode_value_ranges_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_unicode_value_ranges))
-                    .saturating_mul(UnicodeRange::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_unicode_value_ranges))
+                .saturating_mul(UnicodeRange::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2021,15 +2076,16 @@ impl<'a> NonDefaultUvs<'a> {
 
     pub fn num_uvs_mappings_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn uvs_mapping_byte_range(&self) -> Range<usize> {
         let num_uvs_mappings = self.num_uvs_mappings();
         let start = self.num_uvs_mappings_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_uvs_mappings)).saturating_mul(UvsMapping::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_uvs_mappings)).saturating_mul(UvsMapping::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -163,67 +163,82 @@ impl<'a> Colr<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_base_glyph_records_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_glyph_records_offset_byte_range(&self) -> Range<usize> {
         let start = self.num_base_glyph_records_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn layer_records_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_glyph_records_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_layer_records_byte_range(&self) -> Range<usize> {
         let start = self.layer_records_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_glyph_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.num_layer_records_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn layer_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.base_glyph_list_offset_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn clip_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.layer_list_offset_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn var_index_map_offset_byte_range(&self) -> Range<usize> {
         let start = self.clip_list_offset_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.var_index_map_offset_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -442,16 +457,17 @@ impl<'a> BaseGlyphList<'a> {
 
     pub fn num_base_glyph_paint_records_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_glyph_paint_records_byte_range(&self) -> Range<usize> {
         let num_base_glyph_paint_records = self.num_base_glyph_paint_records();
         let start = self.num_base_glyph_paint_records_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_base_glyph_paint_records))
-                    .saturating_mul(BaseGlyphPaint::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_base_glyph_paint_records))
+                .saturating_mul(BaseGlyphPaint::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -601,13 +617,15 @@ impl<'a> LayerList<'a> {
 
     pub fn num_layers_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offsets_byte_range(&self) -> Range<usize> {
         let num_layers = self.num_layers();
         let start = self.num_layers_byte_range().end;
-        start..start + (transforms::to_usize(num_layers)).saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(num_layers)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -694,18 +712,21 @@ impl<'a> ClipList<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_clips_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn clips_byte_range(&self) -> Range<usize> {
         let num_clips = self.num_clips();
         let start = self.num_clips_byte_range().end;
-        start..start + (transforms::to_usize(num_clips)).saturating_mul(Clip::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(num_clips)).saturating_mul(Clip::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -998,27 +1019,32 @@ impl<'a> ClipBoxFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1135,32 +1161,38 @@ impl<'a> ClipBoxFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1441,18 +1473,21 @@ impl<'a> ColorLine<'a> {
 
     pub fn extend_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Extend::RAW_BYTE_LEN
+        let end = start + Extend::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_stops_byte_range(&self) -> Range<usize> {
         let start = self.extend_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_stops_byte_range(&self) -> Range<usize> {
         let num_stops = self.num_stops();
         let start = self.num_stops_byte_range().end;
-        start..start + (transforms::to_usize(num_stops)).saturating_mul(ColorStop::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(num_stops)).saturating_mul(ColorStop::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1547,18 +1582,22 @@ impl<'a> VarColorLine<'a> {
 
     pub fn extend_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Extend::RAW_BYTE_LEN
+        let end = start + Extend::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_stops_byte_range(&self) -> Range<usize> {
         let start = self.extend_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_stops_byte_range(&self) -> Range<usize> {
         let num_stops = self.num_stops();
         let start = self.num_stops_byte_range().end;
-        start..start + (transforms::to_usize(num_stops)).saturating_mul(VarColorStop::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_stops)).saturating_mul(VarColorStop::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2008,17 +2047,20 @@ impl<'a> PaintColrLayers<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_layers_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn first_layer_index_byte_range(&self) -> Range<usize> {
         let start = self.num_layers_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2112,17 +2154,20 @@ impl<'a> PaintSolid<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn palette_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn alpha_byte_range(&self) -> Range<usize> {
         let start = self.palette_index_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2211,22 +2256,26 @@ impl<'a> PaintVarSolid<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn palette_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn alpha_byte_range(&self) -> Range<usize> {
         let start = self.palette_index_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.alpha_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2352,42 +2401,50 @@ impl<'a> PaintLinearGradient<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x2_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y2_byte_range(&self) -> Range<usize> {
         let start = self.x2_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2533,47 +2590,56 @@ impl<'a> PaintVarLinearGradient<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x2_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y2_byte_range(&self) -> Range<usize> {
         let start = self.x2_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.y2_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2707,42 +2773,50 @@ impl<'a> PaintRadialGradient<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn radius0_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
-        start..start + UfWord::RAW_BYTE_LEN
+        let end = start + UfWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.radius0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn radius1_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
-        start..start + UfWord::RAW_BYTE_LEN
+        let end = start + UfWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2886,47 +2960,56 @@ impl<'a> PaintVarRadialGradient<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x0_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y0_byte_range(&self) -> Range<usize> {
         let start = self.x0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn radius0_byte_range(&self) -> Range<usize> {
         let start = self.y0_byte_range().end;
-        start..start + UfWord::RAW_BYTE_LEN
+        let end = start + UfWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x1_byte_range(&self) -> Range<usize> {
         let start = self.radius0_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y1_byte_range(&self) -> Range<usize> {
         let start = self.x1_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn radius1_byte_range(&self) -> Range<usize> {
         let start = self.y1_byte_range().end;
-        start..start + UfWord::RAW_BYTE_LEN
+        let end = start + UfWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.radius1_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3048,32 +3131,38 @@ impl<'a> PaintSweepGradient<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn start_angle_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn end_angle_byte_range(&self) -> Range<usize> {
         let start = self.start_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3201,37 +3290,44 @@ impl<'a> PaintVarSweepGradient<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_line_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.color_line_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn start_angle_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn end_angle_byte_range(&self) -> Range<usize> {
         let start = self.start_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.end_angle_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3327,17 +3423,20 @@ impl<'a> PaintGlyph<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + GlyphId16::RAW_BYTE_LEN
+        let end = start + GlyphId16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3416,12 +3515,14 @@ impl<'a> PaintColrGlyph<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + GlyphId16::RAW_BYTE_LEN
+        let end = start + GlyphId16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3515,17 +3616,20 @@ impl<'a> PaintTransform<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn transform_offset_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3626,17 +3730,20 @@ impl<'a> PaintVarTransform<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn transform_offset_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3743,32 +3850,38 @@ impl<'a> Affine2x3<'a> {
 
     pub fn xx_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn yx_byte_range(&self) -> Range<usize> {
         let start = self.xx_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn xy_byte_range(&self) -> Range<usize> {
         let start = self.yx_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn yy_byte_range(&self) -> Range<usize> {
         let start = self.xy_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.yy_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3893,37 +4006,44 @@ impl<'a> VarAffine2x3<'a> {
 
     pub fn xx_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn yx_byte_range(&self) -> Range<usize> {
         let start = self.xx_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn xy_byte_range(&self) -> Range<usize> {
         let start = self.yx_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn yy_byte_range(&self) -> Range<usize> {
         let start = self.xy_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.yy_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.dy_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4032,22 +4152,26 @@ impl<'a> PaintTranslate<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4155,27 +4279,32 @@ impl<'a> PaintVarTranslate<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dx_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn dy_byte_range(&self) -> Range<usize> {
         let start = self.dx_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.dy_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4275,22 +4404,26 @@ impl<'a> PaintScale<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4400,27 +4533,32 @@ impl<'a> PaintVarScale<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.scale_y_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4536,32 +4674,38 @@ impl<'a> PaintScaleAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_y_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4689,37 +4833,44 @@ impl<'a> PaintVarScaleAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_x_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_y_byte_range(&self) -> Range<usize> {
         let start = self.scale_x_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_y_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4814,17 +4965,20 @@ impl<'a> PaintScaleUniform<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4923,22 +5077,26 @@ impl<'a> PaintVarScaleUniform<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.scale_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5046,27 +5204,32 @@ impl<'a> PaintScaleUniformAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5185,32 +5348,38 @@ impl<'a> PaintVarScaleUniformAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scale_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.scale_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5305,17 +5474,20 @@ impl<'a> PaintRotate<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5414,22 +5586,26 @@ impl<'a> PaintVarRotate<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.angle_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5538,27 +5714,32 @@ impl<'a> PaintRotateAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.angle_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5677,32 +5858,38 @@ impl<'a> PaintVarRotateAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.angle_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5805,22 +5992,26 @@ impl<'a> PaintSkew<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5932,27 +6123,32 @@ impl<'a> PaintVarSkew<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.y_skew_angle_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -6070,32 +6266,38 @@ impl<'a> PaintSkewAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.y_skew_angle_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -6225,37 +6427,44 @@ impl<'a> PaintVarSkewAroundCenter<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.paint_offset_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_skew_angle_byte_range(&self) -> Range<usize> {
         let start = self.x_skew_angle_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_x_byte_range(&self) -> Range<usize> {
         let start = self.y_skew_angle_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn center_y_byte_range(&self) -> Range<usize> {
         let start = self.center_x_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_base_byte_range(&self) -> Range<usize> {
         let start = self.center_y_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -6365,22 +6574,26 @@ impl<'a> PaintComposite<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn source_paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn composite_mode_byte_range(&self) -> Range<usize> {
         let start = self.source_paint_offset_byte_range().end;
-        start..start + CompositeMode::RAW_BYTE_LEN
+        let end = start + CompositeMode::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backdrop_paint_offset_byte_range(&self) -> Range<usize> {
         let start = self.composite_mode_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -159,57 +159,69 @@ impl<'a> Cpal<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_palette_entries_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_palettes_byte_range(&self) -> Range<usize> {
         let start = self.num_palette_entries_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_color_records_byte_range(&self) -> Range<usize> {
         let start = self.num_palettes_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_records_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.num_color_records_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn color_record_indices_byte_range(&self) -> Range<usize> {
         let num_palettes = self.num_palettes();
         let start = self.color_records_array_offset_byte_range().end;
-        start..start + (transforms::to_usize(num_palettes)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(num_palettes)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn palette_types_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.color_record_indices_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn palette_labels_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.palette_types_array_offset_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn palette_entry_labels_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.palette_labels_array_offset_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_cvar.rs
+++ b/read-fonts/generated/generated_cvar.rs
@@ -80,22 +80,26 @@ impl<'a> Cvar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tuple_variation_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + TupleVariationCount::RAW_BYTE_LEN
+        let end = start + TupleVariationCount::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_offset_byte_range(&self) -> Range<usize> {
         let start = self.tuple_variation_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
         let start = self.data_offset_byte_range().end;
-        start..start + self.data.len().saturating_sub(start)
+        let end = start + self.data.len().saturating_sub(start);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_dsig.rs
+++ b/read-fonts/generated/generated_dsig.rs
@@ -68,26 +68,28 @@ impl<'a> Dsig<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_signatures_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.num_signatures_byte_range().end;
-        start..start + PermissionFlags::RAW_BYTE_LEN
+        let end = start + PermissionFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn signature_records_byte_range(&self) -> Range<usize> {
         let num_signatures = self.num_signatures();
         let start = self.flags_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_signatures))
-                    .saturating_mul(SignatureRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_signatures)).saturating_mul(SignatureRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -534,23 +536,27 @@ impl<'a> SignatureBlockFormat1<'a> {
 
     pub fn _reserved1_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved2_byte_range(&self) -> Range<usize> {
         let start = self._reserved1_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn signature_length_byte_range(&self) -> Range<usize> {
         let start = self._reserved2_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn signature_byte_range(&self) -> Range<usize> {
         let signature_length = self.signature_length();
         let start = self.signature_length_byte_range().end;
-        start..start + (transforms::to_usize(signature_length)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(signature_length)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_ebdt.rs
+++ b/read-fonts/generated/generated_ebdt.rs
@@ -55,12 +55,14 @@ impl<'a> Ebdt<'a> {
 
     pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_eblc.rs
+++ b/read-fonts/generated/generated_eblc.rs
@@ -67,23 +67,28 @@ impl<'a> Eblc<'a> {
 
     pub fn major_version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn minor_version_byte_range(&self) -> Range<usize> {
         let start = self.major_version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_sizes_byte_range(&self) -> Range<usize> {
         let start = self.minor_version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn bitmap_sizes_byte_range(&self) -> Range<usize> {
         let num_sizes = self.num_sizes();
         let start = self.num_sizes_byte_range().end;
-        start..start + (transforms::to_usize(num_sizes)).saturating_mul(BitmapSize::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_sizes)).saturating_mul(BitmapSize::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_feat.rs
+++ b/read-fonts/generated/generated_feat.rs
@@ -63,31 +63,34 @@ impl<'a> Feat<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_name_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved1_byte_range(&self) -> Range<usize> {
         let start = self.feature_name_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved2_byte_range(&self) -> Range<usize> {
         let start = self._reserved1_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn names_byte_range(&self) -> Range<usize> {
         let feature_name_count = self.feature_name_count();
         let start = self._reserved2_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(feature_name_count))
-                    .saturating_mul(FeatureName::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(feature_name_count)).saturating_mul(FeatureName::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -280,7 +283,9 @@ impl<'a> SettingNameArray<'a> {
     pub fn settings_byte_range(&self) -> Range<usize> {
         let n_settings = self.n_settings();
         let start = 0;
-        start..start + (transforms::to_usize(n_settings)).saturating_mul(SettingName::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_settings)).saturating_mul(SettingName::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_fvar.rs
+++ b/read-fonts/generated/generated_fvar.rs
@@ -99,37 +99,44 @@ impl<'a> Fvar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_instance_arrays_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.axis_instance_arrays_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_size_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn instance_count_byte_range(&self) -> Range<usize> {
         let start = self.axis_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn instance_size_byte_range(&self) -> Range<usize> {
         let start = self.instance_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -265,24 +272,23 @@ impl<'a> AxisInstanceArrays<'a> {
     pub fn axes_byte_range(&self) -> Range<usize> {
         let axis_count = self.axis_count();
         let start = 0;
-        start
-            ..start
-                + (transforms::to_usize(axis_count))
-                    .saturating_mul(VariationAxisRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(axis_count)).saturating_mul(VariationAxisRecord::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn instances_byte_range(&self) -> Range<usize> {
         let instance_count = self.instance_count();
         let start = self.axes_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(instance_count)).saturating_mul(
-                    <InstanceRecord as ComputeSize>::compute_size(&(
-                        self.axis_count(),
-                        self.instance_size(),
-                    ))
-                    .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(instance_count)).saturating_mul(
+                <InstanceRecord as ComputeSize>::compute_size(&(
+                    self.axis_count(),
+                    self.instance_size(),
+                ))
+                .unwrap_or(0),
+            );
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_gasp.rs
+++ b/read-fonts/generated/generated_gasp.rs
@@ -61,18 +61,22 @@ impl<'a> Gasp<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_ranges_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn gasp_ranges_byte_range(&self) -> Range<usize> {
         let num_ranges = self.num_ranges();
         let start = self.num_ranges_byte_range().end;
-        start..start + (transforms::to_usize(num_ranges)).saturating_mul(GaspRange::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_ranges)).saturating_mul(GaspRange::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -135,43 +135,52 @@ impl<'a> Gdef<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn attach_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.glyph_class_def_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lig_caret_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.attach_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_attach_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.lig_caret_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_glyph_sets_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_attach_class_def_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 2u16)))
-                .then(|| start + Offset16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 2u16)) {
+            start + Offset16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn item_var_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_glyph_sets_def_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 3u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 3u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -350,18 +359,22 @@ impl<'a> AttachList<'a> {
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn attach_point_offsets_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -449,13 +462,15 @@ impl<'a> AttachPoint<'a> {
 
     pub fn point_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn point_indices_byte_range(&self) -> Range<usize> {
         let point_count = self.point_count();
         let start = self.point_count_byte_range().end;
-        start..start + (transforms::to_usize(point_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(point_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -556,19 +571,22 @@ impl<'a> LigCaretList<'a> {
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lig_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lig_glyph_offsets_byte_range(&self) -> Range<usize> {
         let lig_glyph_count = self.lig_glyph_count();
         let start = self.lig_glyph_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(lig_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(lig_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -664,13 +682,16 @@ impl<'a> LigGlyph<'a> {
 
     pub fn caret_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_value_offsets_byte_range(&self) -> Range<usize> {
         let caret_count = self.caret_count();
         let start = self.caret_count_byte_range().end;
-        start..start + (transforms::to_usize(caret_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(caret_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -849,12 +870,14 @@ impl<'a> CaretValueFormat1<'a> {
 
     pub fn caret_value_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -941,12 +964,14 @@ impl<'a> CaretValueFormat2<'a> {
 
     pub fn caret_value_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_value_point_index_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1038,17 +1063,20 @@ impl<'a> CaretValueFormat3<'a> {
 
     pub fn caret_value_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coordinate_byte_range(&self) -> Range<usize> {
         let start = self.caret_value_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn device_offset_byte_range(&self) -> Range<usize> {
         let start = self.coordinate_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1141,21 +1169,22 @@ impl<'a> MarkGlyphSets<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_glyph_set_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
         let mark_glyph_set_count = self.mark_glyph_set_count();
         let start = self.mark_glyph_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(mark_glyph_set_count))
-                    .saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(mark_glyph_set_count)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_glyf.rs
+++ b/read-fonts/generated/generated_glyf.rs
@@ -163,49 +163,61 @@ impl<'a> SimpleGlyph<'a> {
 
     pub fn number_of_contours_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.number_of_contours_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn end_pts_of_contours_byte_range(&self) -> Range<usize> {
         let number_of_contours = self.number_of_contours();
         let start = self.y_max_byte_range().end;
-        start..start + (transforms::to_usize(number_of_contours)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(number_of_contours)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn instruction_length_byte_range(&self) -> Range<usize> {
         let start = self.end_pts_of_contours_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn instructions_byte_range(&self) -> Range<usize> {
         let instruction_length = self.instruction_length();
         let start = self.instruction_length_byte_range().end;
-        start..start + (transforms::to_usize(instruction_length)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(instruction_length)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn glyph_data_byte_range(&self) -> Range<usize> {
         let start = self.instructions_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -725,32 +737,39 @@ impl<'a> CompositeGlyph<'a> {
 
     pub fn number_of_contours_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.number_of_contours_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn component_data_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -102,30 +102,36 @@ impl<'a> Gpos<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn script_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.script_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.feature_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_variations_offset_byte_range(&self) -> Range<usize> {
         let start = self.lookup_list_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -778,17 +784,20 @@ impl<'a> AnchorFormat1<'a> {
 
     pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.anchor_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -887,22 +896,26 @@ impl<'a> AnchorFormat2<'a> {
 
     pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.anchor_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn anchor_point_byte_range(&self) -> Range<usize> {
         let start = self.y_coordinate_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1017,27 +1030,32 @@ impl<'a> AnchorFormat3<'a> {
 
     pub fn anchor_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.anchor_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_coordinate_byte_range(&self) -> Range<usize> {
         let start = self.x_coordinate_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_device_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_coordinate_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_device_offset_byte_range(&self) -> Range<usize> {
         let start = self.x_device_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1118,13 +1136,16 @@ impl<'a> MarkArray<'a> {
 
     pub fn mark_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_records_byte_range(&self) -> Range<usize> {
         let mark_count = self.mark_count();
         let start = self.mark_count_byte_range().end;
-        start..start + (transforms::to_usize(mark_count)).saturating_mul(MarkRecord::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(mark_count)).saturating_mul(MarkRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1391,22 +1412,27 @@ impl<'a> SinglePosFormat1<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_format_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + ValueFormat::RAW_BYTE_LEN
+        let end = start + ValueFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_record_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
-        start..start + <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0)
+        let end =
+            start + <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0);
+        start..end
     }
 }
 
@@ -1531,32 +1557,36 @@ impl<'a> SinglePosFormat2<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_format_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + ValueFormat::RAW_BYTE_LEN
+        let end = start + ValueFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_count_byte_range(&self) -> Range<usize> {
         let start = self.value_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_records_byte_range(&self) -> Range<usize> {
         let value_count = self.value_count();
         let start = self.value_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(value_count)).saturating_mul(
-                    <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(value_count)).saturating_mul(
+                <ValueRecord as ComputeSize>::compute_size(&self.value_format()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -1799,33 +1829,40 @@ impl<'a> PairPosFormat1<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_format1_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + ValueFormat::RAW_BYTE_LEN
+        let end = start + ValueFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_format2_byte_range(&self) -> Range<usize> {
         let start = self.value_format1_byte_range().end;
-        start..start + ValueFormat::RAW_BYTE_LEN
+        let end = start + ValueFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn pair_set_count_byte_range(&self) -> Range<usize> {
         let start = self.value_format2_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn pair_set_offsets_byte_range(&self) -> Range<usize> {
         let pair_set_count = self.pair_set_count();
         let start = self.pair_set_count_byte_range().end;
-        start..start + (transforms::to_usize(pair_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(pair_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1957,21 +1994,22 @@ impl<'a> PairSet<'a> {
 
     pub fn pair_value_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn pair_value_records_byte_range(&self) -> Range<usize> {
         let pair_value_count = self.pair_value_count();
         let start = self.pair_value_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(pair_value_count)).saturating_mul(
-                    <PairValueRecord as ComputeSize>::compute_size(&(
-                        self.value_format1(),
-                        self.value_format2(),
-                    ))
-                    .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(pair_value_count)).saturating_mul(
+                <PairValueRecord as ComputeSize>::compute_size(&(
+                    self.value_format1(),
+                    self.value_format2(),
+                ))
+                .unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -2250,57 +2288,65 @@ impl<'a> PairPosFormat2<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_format1_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + ValueFormat::RAW_BYTE_LEN
+        let end = start + ValueFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_format2_byte_range(&self) -> Range<usize> {
         let start = self.value_format1_byte_range().end;
-        start..start + ValueFormat::RAW_BYTE_LEN
+        let end = start + ValueFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_def1_offset_byte_range(&self) -> Range<usize> {
         let start = self.value_format2_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_def2_offset_byte_range(&self) -> Range<usize> {
         let start = self.class_def1_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class1_count_byte_range(&self) -> Range<usize> {
         let start = self.class_def2_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class2_count_byte_range(&self) -> Range<usize> {
         let start = self.class1_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class1_records_byte_range(&self) -> Range<usize> {
         let class1_count = self.class1_count();
         let start = self.class2_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(class1_count)).saturating_mul(
-                    <Class1Record as ComputeSize>::compute_size(&(
-                        self.class2_count(),
-                        self.value_format1(),
-                        self.value_format2(),
-                    ))
-                    .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(class1_count)).saturating_mul(
+                <Class1Record as ComputeSize>::compute_size(&(
+                    self.class2_count(),
+                    self.value_format1(),
+                    self.value_format2(),
+                ))
+                .unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -2590,26 +2636,29 @@ impl<'a> CursivePosFormat1<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_exit_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_exit_record_byte_range(&self) -> Range<usize> {
         let entry_exit_count = self.entry_exit_count();
         let start = self.entry_exit_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(entry_exit_count))
-                    .saturating_mul(EntryExitRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(entry_exit_count))
+                .saturating_mul(EntryExitRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2842,32 +2891,38 @@ impl<'a> MarkBasePosFormat1<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_coverage_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_class_count_byte_range(&self) -> Range<usize> {
         let start = self.base_coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_class_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2993,18 +3048,18 @@ impl<'a> BaseArray<'a> {
 
     pub fn base_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_records_byte_range(&self) -> Range<usize> {
         let base_count = self.base_count();
         let start = self.base_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(base_count)).saturating_mul(
-                    <BaseRecord as ComputeSize>::compute_size(&self.mark_class_count())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(base_count)).saturating_mul(
+                <BaseRecord as ComputeSize>::compute_size(&self.mark_class_count()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -3238,32 +3293,38 @@ impl<'a> MarkLigPosFormat1<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ligature_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_coverage_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_class_count_byte_range(&self) -> Range<usize> {
         let start = self.ligature_coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_class_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ligature_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_array_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3397,13 +3458,16 @@ impl<'a> LigatureArray<'a> {
 
     pub fn ligature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ligature_attach_offsets_byte_range(&self) -> Range<usize> {
         let ligature_count = self.ligature_count();
         let start = self.ligature_count_byte_range().end;
-        start..start + (transforms::to_usize(ligature_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(ligature_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3515,18 +3579,19 @@ impl<'a> LigatureAttach<'a> {
 
     pub fn component_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn component_records_byte_range(&self) -> Range<usize> {
         let component_count = self.component_count();
         let start = self.component_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(component_count)).saturating_mul(
-                    <ComponentRecord as ComputeSize>::compute_size(&self.mark_class_count())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(component_count)).saturating_mul(
+                <ComponentRecord as ComputeSize>::compute_size(&self.mark_class_count())
+                    .unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -3760,32 +3825,38 @@ impl<'a> MarkMarkPosFormat1<'a> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark1_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark2_coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark1_coverage_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark_class_count_byte_range(&self) -> Range<usize> {
         let start = self.mark2_coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark1_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark_class_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark2_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.mark1_array_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3911,18 +3982,18 @@ impl<'a> Mark2Array<'a> {
 
     pub fn mark2_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mark2_records_byte_range(&self) -> Range<usize> {
         let mark2_count = self.mark2_count();
         let start = self.mark2_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(mark2_count)).saturating_mul(
-                    <Mark2Record as ComputeSize>::compute_size(&self.mark_class_count())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(mark2_count)).saturating_mul(
+                <Mark2Record as ComputeSize>::compute_size(&self.mark_class_count()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -4137,17 +4208,20 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
         let start = self.pos_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -103,30 +103,36 @@ impl<'a> Gsub<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn script_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.script_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.feature_list_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_variations_offset_byte_range(&self) -> Range<usize> {
         let start = self.lookup_list_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -422,17 +428,20 @@ impl<'a> SingleSubstFormat1<'a> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn delta_glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -542,23 +551,28 @@ impl<'a> SingleSubstFormat2<'a> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -668,23 +682,28 @@ impl<'a> MultipleSubstFormat1<'a> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sequence_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sequence_offsets_byte_range(&self) -> Range<usize> {
         let sequence_count = self.sequence_count();
         let start = self.sequence_count_byte_range().end;
-        start..start + (transforms::to_usize(sequence_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(sequence_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -776,13 +795,16 @@ impl<'a> Sequence<'a> {
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -897,25 +919,28 @@ impl<'a> AlternateSubstFormat1<'a> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn alternate_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn alternate_set_offsets_byte_range(&self) -> Range<usize> {
         let alternate_set_count = self.alternate_set_count();
         let start = self.alternate_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(alternate_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(alternate_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1009,13 +1034,16 @@ impl<'a> AlternateSet<'a> {
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn alternate_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1130,25 +1158,28 @@ impl<'a> LigatureSubstFormat1<'a> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ligature_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ligature_set_offsets_byte_range(&self) -> Range<usize> {
         let ligature_set_count = self.ligature_set_count();
         let start = self.ligature_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(ligature_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(ligature_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1247,13 +1278,16 @@ impl<'a> LigatureSet<'a> {
 
     pub fn ligature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ligature_offsets_byte_range(&self) -> Range<usize> {
         let ligature_count = self.ligature_count();
         let start = self.ligature_count_byte_range().end;
-        start..start + (transforms::to_usize(ligature_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(ligature_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1344,21 +1378,23 @@ impl<'a> Ligature<'a> {
 
     pub fn ligature_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + GlyphId16::RAW_BYTE_LEN
+        let end = start + GlyphId16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn component_count_byte_range(&self) -> Range<usize> {
         let start = self.ligature_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn component_glyph_ids_byte_range(&self) -> Range<usize> {
         let component_count = self.component_count();
         let start = self.component_count_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract(component_count, 1_usize))
-                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::subtract(component_count, 1_usize))
+                .saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1486,17 +1522,20 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn extension_lookup_type_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn extension_offset_byte_range(&self) -> Range<usize> {
         let start = self.extension_lookup_type_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1737,51 +1776,56 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.subst_format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(backtrack_glyph_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(backtrack_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(lookahead_glyph_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(lookahead_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn substitute_glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_gvar.rs
+++ b/read-fonts/generated/generated_gvar.rs
@@ -115,47 +115,53 @@ impl<'a> Gvar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn shared_tuple_count_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn shared_tuples_offset_byte_range(&self) -> Range<usize> {
         let start = self.shared_tuple_count_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.shared_tuples_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + GvarFlags::RAW_BYTE_LEN
+        let end = start + GvarFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_variation_data_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_variation_data_offsets_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_variation_data_array_offset_byte_range().end;
-        start
-            ..start
-                + (transforms::add(glyph_count, 1_usize)).saturating_mul(
-                    <U16Or32 as ComputeSize>::compute_size(&self.flags()).unwrap_or(0),
-                )
+        let end = start
+            + (transforms::add(glyph_count, 1_usize))
+                .saturating_mul(<U16Or32 as ComputeSize>::compute_size(&self.flags()).unwrap_or(0));
+        start..end
     }
 }
 
@@ -583,11 +589,11 @@ impl<'a> SharedTuples<'a> {
     pub fn tuples_byte_range(&self) -> Range<usize> {
         let shared_tuple_count = self.shared_tuple_count();
         let start = 0;
-        start
-            ..start
-                + (transforms::to_usize(shared_tuple_count)).saturating_mul(
-                    <Tuple as ComputeSize>::compute_size(&self.axis_count()).unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(shared_tuple_count)).saturating_mul(
+                <Tuple as ComputeSize>::compute_size(&self.axis_count()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -692,17 +698,20 @@ impl<'a> GlyphVariationDataHeader<'a> {
 
     pub fn tuple_variation_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + TupleVariationCount::RAW_BYTE_LEN
+        let end = start + TupleVariationCount::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn serialized_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.tuple_variation_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tuple_variation_headers_byte_range(&self) -> Range<usize> {
         let start = self.serialized_data_offset_byte_range().end;
-        start..start + self.data.len().saturating_sub(start)
+        let end = start + self.data.len().saturating_sub(start);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_hdmx.rs
+++ b/read-fonts/generated/generated_hdmx.rs
@@ -91,31 +91,34 @@ impl<'a> Hdmx<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_records_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn size_device_record_byte_range(&self) -> Range<usize> {
         let start = self.num_records_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn records_byte_range(&self) -> Range<usize> {
         let num_records = self.num_records();
         let start = self.size_device_record_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_records)).saturating_mul(
-                    <DeviceRecord as ComputeSize>::compute_size(&(
-                        self.num_glyphs(),
-                        self.size_device_record(),
-                    ))
-                    .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(num_records)).saturating_mul(
+                <DeviceRecord as ComputeSize>::compute_size(&(
+                    self.num_glyphs(),
+                    self.size_device_record(),
+                ))
+                .unwrap_or(0),
+            );
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_head.rs
+++ b/read-fonts/generated/generated_head.rs
@@ -858,87 +858,104 @@ impl<'a> Head<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn font_revision_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn checksum_adjustment_byte_range(&self) -> Range<usize> {
         let start = self.font_revision_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn magic_number_byte_range(&self) -> Range<usize> {
         let start = self.checksum_adjustment_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.magic_number_byte_range().end;
-        start..start + Flags::RAW_BYTE_LEN
+        let end = start + Flags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn units_per_em_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn created_byte_range(&self) -> Range<usize> {
         let start = self.units_per_em_byte_range().end;
-        start..start + LongDateTime::RAW_BYTE_LEN
+        let end = start + LongDateTime::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn modified_byte_range(&self) -> Range<usize> {
         let start = self.created_byte_range().end;
-        start..start + LongDateTime::RAW_BYTE_LEN
+        let end = start + LongDateTime::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_min_byte_range(&self) -> Range<usize> {
         let start = self.modified_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_min_byte_range(&self) -> Range<usize> {
         let start = self.x_min_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_max_byte_range(&self) -> Range<usize> {
         let start = self.y_min_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_max_byte_range(&self) -> Range<usize> {
         let start = self.x_max_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn mac_style_byte_range(&self) -> Range<usize> {
         let start = self.y_max_byte_range().end;
-        start..start + MacStyle::RAW_BYTE_LEN
+        let end = start + MacStyle::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lowest_rec_ppem_byte_range(&self) -> Range<usize> {
         let start = self.mac_style_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn font_direction_hint_byte_range(&self) -> Range<usize> {
         let start = self.lowest_rec_ppem_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn index_to_loc_format_byte_range(&self) -> Range<usize> {
         let start = self.font_direction_hint_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_data_format_byte_range(&self) -> Range<usize> {
         let start = self.index_to_loc_format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_hhea.rs
+++ b/read-fonts/generated/generated_hhea.rs
@@ -143,87 +143,104 @@ impl<'a> Hhea<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ascender_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn descender_byte_range(&self) -> Range<usize> {
         let start = self.ascender_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn line_gap_byte_range(&self) -> Range<usize> {
         let start = self.descender_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn advance_width_max_byte_range(&self) -> Range<usize> {
         let start = self.line_gap_byte_range().end;
-        start..start + UfWord::RAW_BYTE_LEN
+        let end = start + UfWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn min_left_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.advance_width_max_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn min_right_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.min_left_side_bearing_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_max_extent_byte_range(&self) -> Range<usize> {
         let start = self.min_right_side_bearing_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_slope_rise_byte_range(&self) -> Range<usize> {
         let start = self.x_max_extent_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_slope_run_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_rise_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_offset_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_run_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved1_byte_range(&self) -> Range<usize> {
         let start = self.caret_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved2_byte_range(&self) -> Range<usize> {
         let start = self.reserved1_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved3_byte_range(&self) -> Range<usize> {
         let start = self.reserved2_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved4_byte_range(&self) -> Range<usize> {
         let start = self.reserved3_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn metric_data_format_byte_range(&self) -> Range<usize> {
         let start = self.reserved4_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn number_of_h_metrics_byte_range(&self) -> Range<usize> {
         let start = self.metric_data_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_hmtx.rs
+++ b/read-fonts/generated/generated_hmtx.rs
@@ -83,15 +83,16 @@ impl<'a> Hmtx<'a> {
     pub fn h_metrics_byte_range(&self) -> Range<usize> {
         let number_of_h_metrics = self.number_of_h_metrics();
         let start = 0;
-        start
-            ..start
-                + (transforms::to_usize(number_of_h_metrics))
-                    .saturating_mul(LongMetric::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(number_of_h_metrics)).saturating_mul(LongMetric::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn left_side_bearings_byte_range(&self) -> Range<usize> {
         let start = self.h_metrics_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / i16::RAW_BYTE_LEN * i16::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / i16::RAW_BYTE_LEN * i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_hvar.rs
+++ b/read-fonts/generated/generated_hvar.rs
@@ -102,27 +102,32 @@ impl<'a> Hvar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn advance_width_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_store_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.advance_width_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn rsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.lsb_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -580,102 +580,122 @@ impl<'a> PatchMapFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_0_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_1_byte_range(&self) -> Range<usize> {
         let start = self._reserved_0_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_2_byte_range(&self) -> Range<usize> {
         let start = self._reserved_1_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn field_flags_byte_range(&self) -> Range<usize> {
         let start = self._reserved_2_byte_range().end;
-        start..start + PatchMapFieldPresenceFlags::RAW_BYTE_LEN
+        let end = start + PatchMapFieldPresenceFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self.field_flags_byte_range().end;
-        start..start + CompatibilityId::RAW_BYTE_LEN
+        let end = start + CompatibilityId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_entry_index_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_glyph_map_entry_index_byte_range(&self) -> Range<usize> {
         let start = self.max_entry_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.max_glyph_map_entry_index_byte_range().end;
-        start..start + Uint24::RAW_BYTE_LEN
+        let end = start + Uint24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_map_offset_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_map_offset_byte_range(&self) -> Range<usize> {
         let start = self.glyph_map_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn applied_entries_bitmap_byte_range(&self) -> Range<usize> {
         let max_entry_index = self.max_entry_index();
         let start = self.feature_map_offset_byte_range().end;
-        start
-            ..start
-                + (transforms::max_value_bitmap_len(max_entry_index))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::max_value_bitmap_len(max_entry_index)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn url_template_length_byte_range(&self) -> Range<usize> {
         let start = self.applied_entries_bitmap_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn url_template_byte_range(&self) -> Range<usize> {
         let url_template_length = self.url_template_length();
         let start = self.url_template_length_byte_range().end;
-        start..start + (transforms::to_usize(url_template_length)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(url_template_length)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn patch_format_byte_range(&self) -> Range<usize> {
         let start = self.url_template_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn cff_charstrings_offset_byte_range(&self) -> Range<usize> {
         let start = self.patch_format_byte_range().end;
-        start
-            ..(self
-                .field_flags()
-                .contains(PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET))
-            .then(|| start + u32::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .field_flags()
+            .contains(PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET)
+        {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn cff2_charstrings_offset_byte_range(&self) -> Range<usize> {
         let start = self.cff_charstrings_offset_byte_range().end;
-        start
-            ..(self
-                .field_flags()
-                .contains(PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET))
-            .then(|| start + u32::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .field_flags()
+            .contains(PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET)
+        {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -840,18 +860,19 @@ impl<'a> GlyphMap<'a> {
 
     pub fn first_mapped_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_index_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let first_mapped_glyph = self.first_mapped_glyph();
         let start = self.first_mapped_glyph_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract(glyph_count, first_mapped_glyph)).saturating_mul(
-                    <U8Or16 as ComputeSize>::compute_size(&self.max_entry_index()).unwrap_or(0),
-                )
+        let end = start
+            + (transforms::subtract(glyph_count, first_mapped_glyph)).saturating_mul(
+                <U8Or16 as ComputeSize>::compute_size(&self.max_entry_index()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -963,23 +984,25 @@ impl<'a> FeatureMap<'a> {
 
     pub fn feature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_records_byte_range(&self) -> Range<usize> {
         let feature_count = self.feature_count();
         let start = self.feature_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(feature_count)).saturating_mul(
-                    <FeatureRecord as ComputeSize>::compute_size(&self.max_entry_index())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(feature_count)).saturating_mul(
+                <FeatureRecord as ComputeSize>::compute_size(&self.max_entry_index()).unwrap_or(0),
+            );
+        start..end
     }
 
     pub fn entry_map_data_byte_range(&self) -> Range<usize> {
         let start = self.feature_records_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1303,83 +1326,102 @@ impl<'a> PatchMapFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_0_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_1_byte_range(&self) -> Range<usize> {
         let start = self._reserved_0_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_2_byte_range(&self) -> Range<usize> {
         let start = self._reserved_1_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn field_flags_byte_range(&self) -> Range<usize> {
         let start = self._reserved_2_byte_range().end;
-        start..start + PatchMapFieldPresenceFlags::RAW_BYTE_LEN
+        let end = start + PatchMapFieldPresenceFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self.field_flags_byte_range().end;
-        start..start + CompatibilityId::RAW_BYTE_LEN
+        let end = start + CompatibilityId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn default_patch_format_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_count_byte_range(&self) -> Range<usize> {
         let start = self.default_patch_format_byte_range().end;
-        start..start + Uint24::RAW_BYTE_LEN
+        let end = start + Uint24::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entries_offset_byte_range(&self) -> Range<usize> {
         let start = self.entry_count_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_id_string_data_offset_byte_range(&self) -> Range<usize> {
         let start = self.entries_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn url_template_length_byte_range(&self) -> Range<usize> {
         let start = self.entry_id_string_data_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn url_template_byte_range(&self) -> Range<usize> {
         let url_template_length = self.url_template_length();
         let start = self.url_template_length_byte_range().end;
-        start..start + (transforms::to_usize(url_template_length)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(url_template_length)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn cff_charstrings_offset_byte_range(&self) -> Range<usize> {
         let start = self.url_template_byte_range().end;
-        start
-            ..(self
-                .field_flags()
-                .contains(PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET))
-            .then(|| start + u32::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .field_flags()
+            .contains(PatchMapFieldPresenceFlags::CFF_CHARSTRINGS_OFFSET)
+        {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn cff2_charstrings_offset_byte_range(&self) -> Range<usize> {
         let start = self.cff_charstrings_offset_byte_range().end;
-        start
-            ..(self
-                .field_flags()
-                .contains(PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET))
-            .then(|| start + u32::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .field_flags()
+            .contains(PatchMapFieldPresenceFlags::CFF2_CHARSTRINGS_OFFSET)
+        {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -1487,7 +1529,9 @@ impl<'a> MappingEntries<'a> {
 
     pub fn entry_data_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -1602,85 +1646,99 @@ impl<'a> EntryData<'a> {
 
     pub fn format_flags_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + EntryFormatFlags::RAW_BYTE_LEN
+        let end = start + EntryFormatFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_count_byte_range(&self) -> Range<usize> {
         let start = self.format_flags_byte_range().end;
-        start
-            ..(self
-                .format_flags()
-                .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE))
-            .then(|| start + u8::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .format_flags()
+            .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
+        {
+            start + u8::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn feature_tags_byte_range(&self) -> Range<usize> {
         let feature_count = self.feature_count().unwrap_or_default();
         let start = self.feature_count_byte_range().end;
-        start
-            ..(self
-                .format_flags()
-                .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE))
-            .then(|| {
-                start + (transforms::to_usize(feature_count)).saturating_mul(Tag::RAW_BYTE_LEN)
-            })
-            .unwrap_or(start)
+        let end = if self
+            .format_flags()
+            .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
+        {
+            start + (transforms::to_usize(feature_count)).saturating_mul(Tag::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn design_space_count_byte_range(&self) -> Range<usize> {
         let start = self.feature_tags_byte_range().end;
-        start
-            ..(self
-                .format_flags()
-                .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE))
-            .then(|| start + u16::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .format_flags()
+            .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
+        {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn design_space_segments_byte_range(&self) -> Range<usize> {
         let design_space_count = self.design_space_count().unwrap_or_default();
         let start = self.design_space_count_byte_range().end;
-        start
-            ..(self
-                .format_flags()
-                .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE))
-            .then(|| {
-                start
-                    + (transforms::to_usize(design_space_count))
-                        .saturating_mul(DesignSpaceSegment::RAW_BYTE_LEN)
-            })
-            .unwrap_or(start)
+        let end = if self
+            .format_flags()
+            .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE)
+        {
+            start
+                + (transforms::to_usize(design_space_count))
+                    .saturating_mul(DesignSpaceSegment::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn match_mode_and_count_byte_range(&self) -> Range<usize> {
         let start = self.design_space_segments_byte_range().end;
-        start
-            ..(self
-                .format_flags()
-                .contains(EntryFormatFlags::CHILD_INDICES))
-            .then(|| start + MatchModeAndCount::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .format_flags()
+            .contains(EntryFormatFlags::CHILD_INDICES)
+        {
+            start + MatchModeAndCount::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn child_indices_byte_range(&self) -> Range<usize> {
         let match_mode_and_count = self.match_mode_and_count().unwrap_or_default();
         let start = self.match_mode_and_count_byte_range().end;
-        start
-            ..(self
-                .format_flags()
-                .contains(EntryFormatFlags::CHILD_INDICES))
-            .then(|| {
-                start
-                    + (transforms::to_usize(match_mode_and_count))
-                        .saturating_mul(Uint24::RAW_BYTE_LEN)
-            })
-            .unwrap_or(start)
+        let end = if self
+            .format_flags()
+            .contains(EntryFormatFlags::CHILD_INDICES)
+        {
+            start
+                + (transforms::to_usize(match_mode_and_count)).saturating_mul(Uint24::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn trailing_data_byte_range(&self) -> Range<usize> {
         let start = self.child_indices_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2180,7 +2238,9 @@ impl<'a> IdStringData<'a> {
 
     pub fn id_data_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2278,30 +2338,34 @@ impl<'a> TableKeyedPatch<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Tag::RAW_BYTE_LEN
+        let end = start + Tag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
-        start..start + CompatibilityId::RAW_BYTE_LEN
+        let end = start + CompatibilityId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn patches_count_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn patch_offsets_byte_range(&self) -> Range<usize> {
         let patches_count = self.patches_count();
         let start = self.patches_count_byte_range().end;
-        start
-            ..start
-                + (transforms::add(patches_count, 1_usize)).saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add(patches_count, 1_usize)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2398,22 +2462,27 @@ impl<'a> TablePatch<'a> {
 
     pub fn tag_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Tag::RAW_BYTE_LEN
+        let end = start + Tag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.tag_byte_range().end;
-        start..start + TablePatchFlags::RAW_BYTE_LEN
+        let end = start + TablePatchFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_uncompressed_length_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -2821,32 +2890,39 @@ impl<'a> GlyphKeyedPatch<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Tag::RAW_BYTE_LEN
+        let end = start + Tag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
-        start..start + GlyphKeyedFlags::RAW_BYTE_LEN
+        let end = start + GlyphKeyedFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn compatibility_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + CompatibilityId::RAW_BYTE_LEN
+        let end = start + CompatibilityId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_uncompressed_length_byte_range(&self) -> Range<usize> {
         let start = self.compatibility_id_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn brotli_stream_byte_range(&self) -> Range<usize> {
         let start = self.max_uncompressed_length_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -3287,38 +3363,40 @@ impl<'a> GlyphPatches<'a> {
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn table_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_ids_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.table_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(glyph_count)).saturating_mul(
-                    <U16Or24 as ComputeSize>::compute_size(&self.flags()).unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(glyph_count))
+                .saturating_mul(<U16Or24 as ComputeSize>::compute_size(&self.flags()).unwrap_or(0));
+        start..end
     }
 
     pub fn tables_byte_range(&self) -> Range<usize> {
         let table_count = self.table_count();
         let start = self.glyph_ids_byte_range().end;
-        start..start + (transforms::to_usize(table_count)).saturating_mul(Tag::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(table_count)).saturating_mul(Tag::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let table_count = self.table_count();
         let start = self.tables_byte_range().end;
-        start
-            ..start
-                + (transforms::multiply_add(glyph_count, table_count, 1_usize))
-                    .saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::multiply_add(glyph_count, table_count, 1_usize))
+                .saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3398,7 +3476,9 @@ impl<'a> GlyphData<'a> {
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_kern.rs
+++ b/read-fonts/generated/generated_kern.rs
@@ -56,17 +56,21 @@ impl<'a> OtKern<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_tables_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn subtable_data_byte_range(&self) -> Range<usize> {
         let start = self.n_tables_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -154,17 +158,21 @@ impl<'a> AatKern<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_tables_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn subtable_data_byte_range(&self) -> Range<usize> {
         let start = self.n_tables_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -258,22 +266,27 @@ impl<'a> OtSubtable<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.coverage_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -368,22 +381,27 @@ impl<'a> AatSubtable<'a> {
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tuple_index_byte_range(&self) -> Range<usize> {
         let start = self.coverage_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_index_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -485,28 +503,34 @@ impl<'a> Subtable0<'a> {
 
     pub fn n_pairs_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_pairs_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn pairs_byte_range(&self) -> Range<usize> {
         let n_pairs = self.n_pairs();
         let start = self.range_shift_byte_range().end;
-        start..start + (transforms::to_usize(n_pairs)).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_pairs)).saturating_mul(Subtable0Pair::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -603,18 +627,21 @@ impl<'a> Subtable2ClassTable<'a> {
 
     pub fn first_glyph_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + GlyphId16::RAW_BYTE_LEN
+        let end = start + GlyphId16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.first_glyph_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn offsets_byte_range(&self) -> Range<usize> {
         let n_glyphs = self.n_glyphs();
         let start = self.n_glyphs_byte_range().end;
-        start..start + (transforms::to_usize(n_glyphs)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(n_glyphs)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -744,55 +771,64 @@ impl<'a> Subtable3<'a> {
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn kern_value_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn left_class_count_byte_range(&self) -> Range<usize> {
         let start = self.kern_value_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn right_class_count_byte_range(&self) -> Range<usize> {
         let start = self.left_class_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.right_class_count_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn kern_value_byte_range(&self) -> Range<usize> {
         let kern_value_count = self.kern_value_count();
         let start = self.flags_byte_range().end;
-        start..start + (transforms::to_usize(kern_value_count)).saturating_mul(i16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(kern_value_count)).saturating_mul(i16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn left_class_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.kern_value_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(glyph_count)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn right_class_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.left_class_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(glyph_count)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn kern_index_byte_range(&self) -> Range<usize> {
         let left_class_count = self.left_class_count();
         let right_class_count = self.right_class_count();
         let start = self.right_class_byte_range().end;
-        start
-            ..start
-                + (transforms::add_multiply(left_class_count, 0_usize, right_class_count))
-                    .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::add_multiply(left_class_count, 0_usize, right_class_count))
+                .saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_kerx.rs
+++ b/read-fonts/generated/generated_kerx.rs
@@ -63,27 +63,31 @@ impl<'a> Kerx<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn padding_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_tables_byte_range(&self) -> Range<usize> {
         let start = self.padding_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn subtables_byte_range(&self) -> Range<usize> {
         let n_tables = self.n_tables();
         let start = self.n_tables_byte_range().end;
-        start..start + {
+        let end = start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <Subtable as VarSize>::total_len_for_count(data, transforms::to_usize(n_tables))
                 .unwrap_or(0)
-        }
+        };
+        start..end
     }
 }
 
@@ -180,22 +184,27 @@ impl<'a> Subtable<'a> {
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tuple_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.tuple_count_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -297,28 +306,34 @@ impl<'a> Subtable0<'a> {
 
     pub fn n_pairs_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn search_range_byte_range(&self) -> Range<usize> {
         let start = self.n_pairs_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_selector_byte_range(&self) -> Range<usize> {
         let start = self.search_range_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_shift_byte_range(&self) -> Range<usize> {
         let start = self.entry_selector_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn pairs_byte_range(&self) -> Range<usize> {
         let n_pairs = self.n_pairs();
         let start = self.range_shift_byte_range().end;
-        start..start + (transforms::to_usize(n_pairs)).saturating_mul(Subtable0Pair::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_pairs)).saturating_mul(Subtable0Pair::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -50,15 +50,16 @@ impl<'a> ScriptList<'a> {
 
     pub fn script_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn script_records_byte_range(&self) -> Range<usize> {
         let script_count = self.script_count();
         let start = self.script_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(script_count)).saturating_mul(ScriptRecord::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(script_count)).saturating_mul(ScriptRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -213,20 +214,22 @@ impl<'a> Script<'a> {
 
     pub fn default_lang_sys_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lang_sys_count_byte_range(&self) -> Range<usize> {
         let start = self.default_lang_sys_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lang_sys_records_byte_range(&self) -> Range<usize> {
         let lang_sys_count = self.lang_sys_count();
         let start = self.lang_sys_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(lang_sys_count)).saturating_mul(LangSysRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(lang_sys_count)).saturating_mul(LangSysRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -378,23 +381,28 @@ impl<'a> LangSys<'a> {
 
     pub fn lookup_order_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn required_feature_index_byte_range(&self) -> Range<usize> {
         let start = self.lookup_order_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_index_count_byte_range(&self) -> Range<usize> {
         let start = self.required_feature_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_indices_byte_range(&self) -> Range<usize> {
         let feature_index_count = self.feature_index_count();
         let start = self.feature_index_count_byte_range().end;
-        start..start + (transforms::to_usize(feature_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(feature_index_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -483,15 +491,16 @@ impl<'a> FeatureList<'a> {
 
     pub fn feature_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_records_byte_range(&self) -> Range<usize> {
         let feature_count = self.feature_count();
         let start = self.feature_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(feature_count)).saturating_mul(FeatureRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(feature_count)).saturating_mul(FeatureRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -669,18 +678,22 @@ impl<'a> Feature<'a> {
 
     pub fn feature_params_offset_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_index_count_byte_range(&self) -> Range<usize> {
         let start = self.feature_params_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_list_indices_byte_range(&self) -> Range<usize> {
         let lookup_index_count = self.lookup_index_count();
         let start = self.lookup_index_count_byte_range().end;
-        start..start + (transforms::to_usize(lookup_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(lookup_index_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -795,13 +808,16 @@ impl<'a, T> LookupList<'a, T> {
 
     pub fn lookup_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_offsets_byte_range(&self) -> Range<usize> {
         let lookup_count = self.lookup_count();
         let start = self.lookup_count_byte_range().end;
-        start..start + (transforms::to_usize(lookup_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(lookup_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -942,34 +958,41 @@ impl<'a, T> Lookup<'a, T> {
 
     pub fn lookup_type_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_flag_byte_range(&self) -> Range<usize> {
         let start = self.lookup_type_byte_range().end;
-        start..start + LookupFlag::RAW_BYTE_LEN
+        let end = start + LookupFlag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sub_table_count_byte_range(&self) -> Range<usize> {
         let start = self.lookup_flag_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
         let sub_table_count = self.sub_table_count();
         let start = self.sub_table_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(sub_table_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(sub_table_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn mark_filtering_set_byte_range(&self) -> Range<usize> {
         let start = self.subtable_offsets_byte_range().end;
-        start
-            ..(self
-                .lookup_flag()
-                .contains(LookupFlag::USE_MARK_FILTERING_SET))
-            .then(|| start + u16::RAW_BYTE_LEN)
-            .unwrap_or(start)
+        let end = if self
+            .lookup_flag()
+            .contains(LookupFlag::USE_MARK_FILTERING_SET)
+        {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -1076,18 +1099,22 @@ impl<'a> CoverageFormat1<'a> {
 
     pub fn coverage_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1181,18 +1208,22 @@ impl<'a> CoverageFormat2<'a> {
 
     pub fn coverage_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_records_byte_range(&self) -> Range<usize> {
         let range_count = self.range_count();
         let start = self.range_count_byte_range().end;
-        start..start + (transforms::to_usize(range_count)).saturating_mul(RangeRecord::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(range_count)).saturating_mul(RangeRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1425,23 +1456,27 @@ impl<'a> ClassDefFormat1<'a> {
 
     pub fn class_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn start_glyph_id_byte_range(&self) -> Range<usize> {
         let start = self.class_format_byte_range().end;
-        start..start + GlyphId16::RAW_BYTE_LEN
+        let end = start + GlyphId16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.start_glyph_id_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_value_array_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.glyph_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(glyph_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1536,21 +1571,23 @@ impl<'a> ClassDefFormat2<'a> {
 
     pub fn class_format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_range_count_byte_range(&self) -> Range<usize> {
         let start = self.class_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_range_records_byte_range(&self) -> Range<usize> {
         let class_range_count = self.class_range_count();
         let start = self.class_range_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(class_range_count))
-                    .saturating_mul(ClassRangeRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(class_range_count))
+                .saturating_mul(ClassRangeRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1837,25 +1874,28 @@ impl<'a> SequenceContextFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let seq_rule_set_count = self.seq_rule_set_count();
         let start = self.seq_rule_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_rule_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_rule_set_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1954,13 +1994,16 @@ impl<'a> SequenceRuleSet<'a> {
 
     pub fn seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let seq_rule_count = self.seq_rule_count();
         let start = self.seq_rule_count_byte_range().end;
-        start..start + (transforms::to_usize(seq_rule_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(seq_rule_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2058,30 +2101,31 @@ impl<'a> SequenceRule<'a> {
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract(glyph_count, 1_usize))
-                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::subtract(glyph_count, 1_usize)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.input_sequence_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_lookup_count))
-                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_lookup_count))
+                .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2218,31 +2262,35 @@ impl<'a> SequenceContextFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.class_def_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let class_seq_rule_set_count = self.class_seq_rule_set_count();
         let start = self.class_seq_rule_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(class_seq_rule_set_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(class_seq_rule_set_count))
+                .saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2336,16 +2384,16 @@ impl<'a> ClassSequenceRuleSet<'a> {
 
     pub fn class_seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let class_seq_rule_count = self.class_seq_rule_count();
         let start = self.class_seq_rule_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(class_seq_rule_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(class_seq_rule_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2447,28 +2495,31 @@ impl<'a> ClassSequenceRule<'a> {
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start
-            ..start + (transforms::subtract(glyph_count, 1_usize)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::subtract(glyph_count, 1_usize)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.input_sequence_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_lookup_count))
-                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_lookup_count))
+                .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2590,32 +2641,37 @@ impl<'a> SequenceContextFormat3<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.glyph_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offsets_byte_range(&self) -> Range<usize> {
         let glyph_count = self.glyph_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start..start + (transforms::to_usize(glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.coverage_offsets_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_lookup_count))
-                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_lookup_count))
+                .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2822,26 +2878,29 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chained_seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chained_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let chained_seq_rule_set_count = self.chained_seq_rule_set_count();
         let start = self.chained_seq_rule_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(chained_seq_rule_set_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(chained_seq_rule_set_count))
+                .saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -2943,16 +3002,16 @@ impl<'a> ChainedSequenceRuleSet<'a> {
 
     pub fn chained_seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chained_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let chained_seq_rule_count = self.chained_seq_rule_count();
         let start = self.chained_seq_rule_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(chained_seq_rule_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(chained_seq_rule_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3078,58 +3137,60 @@ impl<'a> ChainedSequenceRule<'a> {
 
     pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(backtrack_glyph_count))
-                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(backtrack_glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let input_glyph_count = self.input_glyph_count();
         let start = self.input_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract(input_glyph_count, 1_usize))
-                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::subtract(input_glyph_count, 1_usize))
+                .saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.input_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(lookahead_glyph_count))
-                    .saturating_mul(GlyphId16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(lookahead_glyph_count)).saturating_mul(GlyphId16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_lookup_count))
-                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_lookup_count))
+                .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3308,41 +3369,47 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn input_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_class_def_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookahead_class_def_offset_byte_range(&self) -> Range<usize> {
         let start = self.input_class_def_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chained_class_seq_rule_set_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_class_def_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chained_class_seq_rule_set_offsets_byte_range(&self) -> Range<usize> {
         let chained_class_seq_rule_set_count = self.chained_class_seq_rule_set_count();
         let start = self.chained_class_seq_rule_set_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(chained_class_seq_rule_set_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(chained_class_seq_rule_set_count))
+                .saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3452,16 +3519,17 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
 
     pub fn chained_class_seq_rule_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chained_class_seq_rule_offsets_byte_range(&self) -> Range<usize> {
         let chained_class_seq_rule_count = self.chained_class_seq_rule_count();
         let start = self.chained_class_seq_rule_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(chained_class_seq_rule_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(chained_class_seq_rule_count))
+                .saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3588,56 +3656,59 @@ impl<'a> ChainedClassSequenceRule<'a> {
 
     pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_sequence_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(backtrack_glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(backtrack_glyph_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn input_sequence_byte_range(&self) -> Range<usize> {
         let input_glyph_count = self.input_glyph_count();
         let start = self.input_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::subtract(input_glyph_count, 1_usize))
-                    .saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::subtract(input_glyph_count, 1_usize)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.input_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookahead_sequence_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(lookahead_glyph_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(lookahead_glyph_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_sequence_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_lookup_count))
-                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_lookup_count))
+                .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -3810,62 +3881,65 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn backtrack_coverage_offsets_byte_range(&self) -> Range<usize> {
         let backtrack_glyph_count = self.backtrack_glyph_count();
         let start = self.backtrack_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(backtrack_glyph_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(backtrack_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn input_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.backtrack_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn input_coverage_offsets_byte_range(&self) -> Range<usize> {
         let input_glyph_count = self.input_glyph_count();
         let start = self.input_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(input_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(input_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn lookahead_glyph_count_byte_range(&self) -> Range<usize> {
         let start = self.input_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookahead_coverage_offsets_byte_range(&self) -> Range<usize> {
         let lookahead_glyph_count = self.lookahead_glyph_count();
         let start = self.lookahead_glyph_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(lookahead_glyph_count))
-                    .saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(lookahead_glyph_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn seq_lookup_count_byte_range(&self) -> Range<usize> {
         let start = self.lookahead_coverage_offsets_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn seq_lookup_records_byte_range(&self) -> Range<usize> {
         let seq_lookup_count = self.seq_lookup_count();
         let start = self.seq_lookup_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(seq_lookup_count))
-                    .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(seq_lookup_count))
+                .saturating_mul(SequenceLookupRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -4121,17 +4195,20 @@ impl<'a> Device<'a> {
 
     pub fn start_size_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn end_size_byte_range(&self) -> Range<usize> {
         let start = self.start_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn delta_format_byte_range(&self) -> Range<usize> {
         let start = self.end_size_byte_range().end;
-        start..start + DeltaFormat::RAW_BYTE_LEN
+        let end = start + DeltaFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn delta_value_byte_range(&self) -> Range<usize> {
@@ -4139,10 +4216,10 @@ impl<'a> Device<'a> {
         let start_size = self.start_size();
         let end_size = self.end_size();
         let start = self.delta_format_byte_range().end;
-        start
-            ..start
-                + (DeltaFormat::value_count(delta_format, start_size, end_size))
-                    .saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start
+            + (DeltaFormat::value_count(delta_format, start_size, end_size))
+                .saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -4233,17 +4310,20 @@ impl<'a> VariationIndex<'a> {
 
     pub fn delta_set_outer_index_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn delta_set_inner_index_byte_range(&self) -> Range<usize> {
         let start = self.delta_set_outer_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn delta_format_byte_range(&self) -> Range<usize> {
         let start = self.delta_set_inner_index_byte_range().end;
-        start..start + DeltaFormat::RAW_BYTE_LEN
+        let end = start + DeltaFormat::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4418,21 +4498,23 @@ impl<'a> FeatureVariations<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_variation_record_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feature_variation_records_byte_range(&self) -> Range<usize> {
         let feature_variation_record_count = self.feature_variation_record_count();
         let start = self.feature_variation_record_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(feature_variation_record_count))
-                    .saturating_mul(FeatureVariationRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(feature_variation_record_count))
+                .saturating_mul(FeatureVariationRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -4613,14 +4695,16 @@ impl<'a> ConditionSet<'a> {
 
     pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(condition_count)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -4832,22 +4916,26 @@ impl<'a> ConditionFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn filter_range_min_value_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn filter_range_max_value_byte_range(&self) -> Range<usize> {
         let start = self.filter_range_min_value_byte_range().end;
-        start..start + F2Dot14::RAW_BYTE_LEN
+        let end = start + F2Dot14::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -4948,17 +5036,20 @@ impl<'a> ConditionFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn default_value_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_index_byte_range(&self) -> Range<usize> {
         let start = self.default_value_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5047,19 +5138,22 @@ impl<'a> ConditionFormat3<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset24::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(condition_count)).saturating_mul(Offset24::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -5151,19 +5245,22 @@ impl<'a> ConditionFormat4<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset24::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(condition_count)).saturating_mul(Offset24::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -5248,12 +5345,14 @@ impl<'a> ConditionFormat5<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset24::RAW_BYTE_LEN
+        let end = start + Offset24::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5333,21 +5432,23 @@ impl<'a> FeatureTableSubstitution<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn substitution_count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn substitutions_byte_range(&self) -> Range<usize> {
         let substitution_count = self.substitution_count();
         let start = self.substitution_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(substitution_count))
-                    .saturating_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(substitution_count))
+                .saturating_mul(FeatureTableSubstitutionRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -5529,27 +5630,32 @@ impl<'a> SizeParams<'a> {
 
     pub fn design_size_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn identifier_byte_range(&self) -> Range<usize> {
         let start = self.design_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn name_entry_byte_range(&self) -> Range<usize> {
         let start = self.identifier_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_start_byte_range(&self) -> Range<usize> {
         let start = self.name_entry_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_end_byte_range(&self) -> Range<usize> {
         let start = self.range_start_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5639,12 +5745,14 @@ impl<'a> StylisticSetParams<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ui_name_id_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -5782,43 +5890,51 @@ impl<'a> CharacterVariantParams<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feat_ui_label_name_id_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn feat_ui_tooltip_text_name_id_byte_range(&self) -> Range<usize> {
         let start = self.feat_ui_label_name_id_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sample_text_name_id_byte_range(&self) -> Range<usize> {
         let start = self.feat_ui_tooltip_text_name_id_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_named_parameters_byte_range(&self) -> Range<usize> {
         let start = self.sample_text_name_id_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn first_param_ui_label_name_id_byte_range(&self) -> Range<usize> {
         let start = self.num_named_parameters_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn char_count_byte_range(&self) -> Range<usize> {
         let start = self.first_param_ui_label_name_id_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn character_byte_range(&self) -> Range<usize> {
         let char_count = self.char_count();
         let start = self.char_count_byte_range().end;
-        start..start + (transforms::to_usize(char_count)).saturating_mul(Uint24::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(char_count)).saturating_mul(Uint24::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_ltag.rs
+++ b/read-fonts/generated/generated_ltag.rs
@@ -67,23 +67,28 @@ impl<'a> Ltag<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_tags_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tag_ranges_byte_range(&self) -> Range<usize> {
         let num_tags = self.num_tags();
         let start = self.num_tags_byte_range().end;
-        start..start + (transforms::to_usize(num_tags)).saturating_mul(FTStringRange::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_tags)).saturating_mul(FTStringRange::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -163,116 +163,144 @@ impl<'a> Maxp<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Version16Dot16::RAW_BYTE_LEN
+        let end = start + Version16Dot16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_points_byte_range(&self) -> Range<usize> {
         let start = self.num_glyphs_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_contours_byte_range(&self) -> Range<usize> {
         let start = self.max_points_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_composite_points_byte_range(&self) -> Range<usize> {
         let start = self.max_contours_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_composite_contours_byte_range(&self) -> Range<usize> {
         let start = self.max_composite_points_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_zones_byte_range(&self) -> Range<usize> {
         let start = self.max_composite_contours_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_twilight_points_byte_range(&self) -> Range<usize> {
         let start = self.max_zones_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_storage_byte_range(&self) -> Range<usize> {
         let start = self.max_twilight_points_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_function_defs_byte_range(&self) -> Range<usize> {
         let start = self.max_storage_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_instruction_defs_byte_range(&self) -> Range<usize> {
         let start = self.max_function_defs_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_stack_elements_byte_range(&self) -> Range<usize> {
         let start = self.max_instruction_defs_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_size_of_instructions_byte_range(&self) -> Range<usize> {
         let start = self.max_stack_elements_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_component_elements_byte_range(&self) -> Range<usize> {
         let start = self.max_size_of_instructions_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn max_component_depth_byte_range(&self) -> Range<usize> {
         let start = self.max_component_elements_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_meta.rs
+++ b/read-fonts/generated/generated_meta.rs
@@ -68,31 +68,34 @@ impl<'a> Meta<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_maps_count_byte_range(&self) -> Range<usize> {
         let start = self.reserved_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_maps_byte_range(&self) -> Range<usize> {
         let data_maps_count = self.data_maps_count();
         let start = self.data_maps_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(data_maps_count))
-                    .saturating_mul(DataMapRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(data_maps_count)).saturating_mul(DataMapRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_morx.rs
+++ b/read-fonts/generated/generated_morx.rs
@@ -63,27 +63,31 @@ impl<'a> Morx<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn unused_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_chains_byte_range(&self) -> Range<usize> {
         let start = self.unused_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chains_byte_range(&self) -> Range<usize> {
         let n_chains = self.n_chains();
         let start = self.n_chains_byte_range().end;
-        start..start + {
+        let end = start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <Chain as VarSize>::total_len_for_count(data, transforms::to_usize(n_chains))
                 .unwrap_or(0)
-        }
+        };
+        start..end
     }
 }
 
@@ -196,40 +200,45 @@ impl<'a> Chain<'a> {
 
     pub fn default_flags_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn chain_length_byte_range(&self) -> Range<usize> {
         let start = self.default_flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_feature_entries_byte_range(&self) -> Range<usize> {
         let start = self.chain_length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_subtables_byte_range(&self) -> Range<usize> {
         let start = self.n_feature_entries_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn features_byte_range(&self) -> Range<usize> {
         let n_feature_entries = self.n_feature_entries();
         let start = self.n_subtables_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(n_feature_entries)).saturating_mul(Feature::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_feature_entries)).saturating_mul(Feature::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn subtables_byte_range(&self) -> Range<usize> {
         let n_subtables = self.n_subtables();
         let start = self.features_byte_range().end;
-        start..start + {
+        let end = start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <Subtable as VarSize>::total_len_for_count(data, transforms::to_usize(n_subtables))
                 .unwrap_or(0)
-        }
+        };
+        start..end
     }
 }
 
@@ -395,22 +404,27 @@ impl<'a> Subtable<'a> {
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sub_feature_flags_byte_range(&self) -> Range<usize> {
         let start = self.coverage_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.sub_feature_flags_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_mvar.rs
+++ b/read-fonts/generated/generated_mvar.rs
@@ -84,36 +84,40 @@ impl<'a> Mvar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_record_size_byte_range(&self) -> Range<usize> {
         let start = self._reserved_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_record_count_byte_range(&self) -> Range<usize> {
         let start = self.value_record_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.value_record_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_records_byte_range(&self) -> Range<usize> {
         let value_record_count = self.value_record_count();
         let start = self.item_variation_store_offset_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(value_record_count))
-                    .saturating_mul(ValueRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(value_record_count)).saturating_mul(ValueRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -83,44 +83,49 @@ impl<'a> Name<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn storage_offset_byte_range(&self) -> Range<usize> {
         let start = self.count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn name_record_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.storage_offset_byte_range().end;
-        start..start + (transforms::to_usize(count)).saturating_mul(NameRecord::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(count)).saturating_mul(NameRecord::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn lang_tag_count_byte_range(&self) -> Range<usize> {
         let start = self.name_record_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn lang_tag_record_byte_range(&self) -> Range<usize> {
         let lang_tag_count = self.lang_tag_count().unwrap_or_default();
         let start = self.lang_tag_count_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| {
-                    start
-                        + (transforms::to_usize(lang_tag_count))
-                            .saturating_mul(LangTagRecord::RAW_BYTE_LEN)
-                })
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start
+                + (transforms::to_usize(lang_tag_count)).saturating_mul(LangTagRecord::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -717,224 +717,272 @@ impl<'a> Os2<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn x_avg_char_width_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn us_weight_class_byte_range(&self) -> Range<usize> {
         let start = self.x_avg_char_width_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn us_width_class_byte_range(&self) -> Range<usize> {
         let start = self.us_weight_class_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn fs_type_byte_range(&self) -> Range<usize> {
         let start = self.us_width_class_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_subscript_x_size_byte_range(&self) -> Range<usize> {
         let start = self.fs_type_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_subscript_y_size_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_x_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_subscript_x_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_y_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_subscript_y_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_x_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_superscript_x_size_byte_range(&self) -> Range<usize> {
         let start = self.y_subscript_y_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_superscript_y_size_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_x_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_superscript_x_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_y_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_superscript_y_offset_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_x_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_strikeout_size_byte_range(&self) -> Range<usize> {
         let start = self.y_superscript_y_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_strikeout_position_byte_range(&self) -> Range<usize> {
         let start = self.y_strikeout_size_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn s_family_class_byte_range(&self) -> Range<usize> {
         let start = self.y_strikeout_position_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn panose_10_byte_range(&self) -> Range<usize> {
         let start = self.s_family_class_byte_range().end;
-        start..start + (10_usize).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start + (10_usize).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn ul_unicode_range_1_byte_range(&self) -> Range<usize> {
         let start = self.panose_10_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ul_unicode_range_2_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_1_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ul_unicode_range_3_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_2_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ul_unicode_range_4_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_3_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ach_vend_id_byte_range(&self) -> Range<usize> {
         let start = self.ul_unicode_range_4_byte_range().end;
-        start..start + Tag::RAW_BYTE_LEN
+        let end = start + Tag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn fs_selection_byte_range(&self) -> Range<usize> {
         let start = self.ach_vend_id_byte_range().end;
-        start..start + SelectionFlags::RAW_BYTE_LEN
+        let end = start + SelectionFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn us_first_char_index_byte_range(&self) -> Range<usize> {
         let start = self.fs_selection_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn us_last_char_index_byte_range(&self) -> Range<usize> {
         let start = self.us_first_char_index_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn s_typo_ascender_byte_range(&self) -> Range<usize> {
         let start = self.us_last_char_index_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn s_typo_descender_byte_range(&self) -> Range<usize> {
         let start = self.s_typo_ascender_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn s_typo_line_gap_byte_range(&self) -> Range<usize> {
         let start = self.s_typo_descender_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn us_win_ascent_byte_range(&self) -> Range<usize> {
         let start = self.s_typo_line_gap_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn us_win_descent_byte_range(&self) -> Range<usize> {
         let start = self.us_win_ascent_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ul_code_page_range_1_byte_range(&self) -> Range<usize> {
         let start = self.us_win_descent_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + u32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn ul_code_page_range_2_byte_range(&self) -> Range<usize> {
         let start = self.ul_code_page_range_1_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + u32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn sx_height_byte_range(&self) -> Range<usize> {
         let start = self.ul_code_page_range_2_byte_range().end;
-        start
-            ..(self.version().compatible(2u16))
-                .then(|| start + i16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(2u16) {
+            start + i16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn s_cap_height_byte_range(&self) -> Range<usize> {
         let start = self.sx_height_byte_range().end;
-        start
-            ..(self.version().compatible(2u16))
-                .then(|| start + i16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(2u16) {
+            start + i16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn us_default_char_byte_range(&self) -> Range<usize> {
         let start = self.s_cap_height_byte_range().end;
-        start
-            ..(self.version().compatible(2u16))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(2u16) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn us_break_char_byte_range(&self) -> Range<usize> {
         let start = self.us_default_char_byte_range().end;
-        start
-            ..(self.version().compatible(2u16))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(2u16) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn us_max_context_byte_range(&self) -> Range<usize> {
         let start = self.us_break_char_byte_range().end;
-        start
-            ..(self.version().compatible(2u16))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(2u16) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn us_lower_optical_point_size_byte_range(&self) -> Range<usize> {
         let start = self.us_max_context_byte_range().end;
-        start
-            ..(self.version().compatible(5u16))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(5u16) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn us_upper_optical_point_size_byte_range(&self) -> Range<usize> {
         let start = self.us_lower_optical_point_size_byte_range().end;
-        start
-            ..(self.version().compatible(5u16))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible(5u16) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -150,74 +150,87 @@ impl<'a> Post<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Version16Dot16::RAW_BYTE_LEN
+        let end = start + Version16Dot16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn italic_angle_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn underline_position_byte_range(&self) -> Range<usize> {
         let start = self.italic_angle_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn underline_thickness_byte_range(&self) -> Range<usize> {
         let start = self.underline_position_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn is_fixed_pitch_byte_range(&self) -> Range<usize> {
         let start = self.underline_thickness_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn min_mem_type42_byte_range(&self) -> Range<usize> {
         let start = self.is_fixed_pitch_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_mem_type42_byte_range(&self) -> Range<usize> {
         let start = self.min_mem_type42_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn min_mem_type1_byte_range(&self) -> Range<usize> {
         let start = self.max_mem_type42_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn max_mem_type1_byte_range(&self) -> Range<usize> {
         let start = self.min_mem_type1_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_glyphs_byte_range(&self) -> Range<usize> {
         let start = self.max_mem_type1_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn glyph_name_index_byte_range(&self) -> Range<usize> {
         let num_glyphs = self.num_glyphs().unwrap_or_default();
         let start = self.num_glyphs_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| {
-                    start + (transforms::to_usize(num_glyphs)).saturating_mul(u16::RAW_BYTE_LEN)
-                })
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + (transforms::to_usize(num_glyphs)).saturating_mul(u16::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn string_data_byte_range(&self) -> Range<usize> {
         let start = self.glyph_name_index_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + self.data.len().saturating_sub(start))
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + self.data.len().saturating_sub(start)
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_sbix.rs
+++ b/read-fonts/generated/generated_sbix.rs
@@ -407,23 +407,28 @@ impl<'a> Sbix<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + HeaderFlags::RAW_BYTE_LEN
+        let end = start + HeaderFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_strikes_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn strike_offsets_byte_range(&self) -> Range<usize> {
         let num_strikes = self.num_strikes();
         let start = self.num_strikes_byte_range().end;
-        start..start + (transforms::to_usize(num_strikes)).saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(num_strikes)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -538,18 +543,21 @@ impl<'a> Strike<'a> {
 
     pub fn ppem_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ppi_byte_range(&self) -> Range<usize> {
         let start = self.ppem_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn glyph_data_offsets_byte_range(&self) -> Range<usize> {
         let num_glyphs = self.num_glyphs();
         let start = self.ppi_byte_range().end;
-        start..start + (transforms::add(num_glyphs, 1_usize)).saturating_mul(u32::RAW_BYTE_LEN)
+        let end = start + (transforms::add(num_glyphs, 1_usize)).saturating_mul(u32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -644,22 +652,27 @@ impl<'a> GlyphData<'a> {
 
     pub fn origin_offset_x_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn origin_offset_y_byte_range(&self) -> Range<usize> {
         let start = self.origin_offset_x_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn graphic_type_byte_range(&self) -> Range<usize> {
         let start = self.origin_offset_y_byte_range().end;
-        start..start + Tag::RAW_BYTE_LEN
+        let end = start + Tag::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.graphic_type_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -118,40 +118,48 @@ impl<'a> Stat<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn design_axis_size_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn design_axis_count_byte_range(&self) -> Range<usize> {
         let start = self.design_axis_size_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn design_axes_offset_byte_range(&self) -> Range<usize> {
         let start = self.design_axis_count_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_value_count_byte_range(&self) -> Range<usize> {
         let start = self.design_axes_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn offset_to_axis_value_offsets_byte_range(&self) -> Range<usize> {
         let start = self.axis_value_count_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn elided_fallback_name_id_byte_range(&self) -> Range<usize> {
         let start = self.offset_to_axis_value_offsets_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + NameId::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + NameId::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -338,9 +346,9 @@ impl<'a> AxisValueArray<'a> {
     pub fn axis_value_offsets_byte_range(&self) -> Range<usize> {
         let axis_value_count = self.axis_value_count();
         let start = 0;
-        start
-            ..start
-                + (transforms::to_usize(axis_value_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(axis_value_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -573,27 +581,32 @@ impl<'a> AxisValueFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
-        start..start + AxisValueTableFlags::RAW_BYTE_LEN
+        let end = start + AxisValueTableFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -724,37 +737,44 @@ impl<'a> AxisValueFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
-        start..start + AxisValueTableFlags::RAW_BYTE_LEN
+        let end = start + AxisValueTableFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn nominal_value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_min_value_byte_range(&self) -> Range<usize> {
         let start = self.nominal_value_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn range_max_value_byte_range(&self) -> Range<usize> {
         let start = self.range_min_value_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -866,32 +886,38 @@ impl<'a> AxisValueFormat3<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_index_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_index_byte_range().end;
-        start..start + AxisValueTableFlags::RAW_BYTE_LEN
+        let end = start + AxisValueTableFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.value_name_id_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn linked_value_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
-        start..start + Fixed::RAW_BYTE_LEN
+        let end = start + Fixed::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -994,30 +1020,34 @@ impl<'a> AxisValueFormat4<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
-        start..start + AxisValueTableFlags::RAW_BYTE_LEN
+        let end = start + AxisValueTableFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_name_id_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start..start + NameId::RAW_BYTE_LEN
+        let end = start + NameId::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_values_byte_range(&self) -> Range<usize> {
         let axis_count = self.axis_count();
         let start = self.value_name_id_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(axis_count)).saturating_mul(AxisValueRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(axis_count)).saturating_mul(AxisValueRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_svg.rs
+++ b/read-fonts/generated/generated_svg.rs
@@ -62,17 +62,20 @@ impl<'a> Svg<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn svg_document_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.svg_document_list_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -156,16 +159,16 @@ impl<'a> SVGDocumentList<'a> {
 
     pub fn num_entries_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn document_records_byte_range(&self) -> Range<usize> {
         let num_entries = self.num_entries();
         let start = self.num_entries_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_entries))
-                    .saturating_mul(SVGDocumentRecord::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_entries)).saturating_mul(SVGDocumentRecord::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -61,28 +61,34 @@ impl<'a> MajorMinorVersion<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn always_present_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn if_11_byte_range(&self) -> Range<usize> {
         let start = self.always_present_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn if_20_byte_range(&self) -> Range<usize> {
         let start = self.if_11_byte_range().end;
-        start
-            ..(self.version().compatible((2u16, 0u16)))
-                .then(|| start + u32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((2u16, 0u16)) {
+            start + u32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -487,28 +493,34 @@ impl<'a> FlagDay<'a> {
 
     pub fn volume_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flags_byte_range(&self) -> Range<usize> {
         let start = self.volume_byte_range().end;
-        start..start + GotFlags::RAW_BYTE_LEN
+        let end = start + GotFlags::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn foo_byte_range(&self) -> Range<usize> {
         let start = self.flags_byte_range().end;
-        start
-            ..(self.flags().contains(GotFlags::FOO))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.flags().contains(GotFlags::FOO) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn bar_byte_range(&self) -> Range<usize> {
         let start = self.foo_byte_range().end;
-        start
-            ..(self.flags().contains(GotFlags::BAR))
-                .then(|| start + u16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.flags().contains(GotFlags::BAR) {
+            start + u16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_count_all.rs
+++ b/read-fonts/generated/generated_test_count_all.rs
@@ -47,12 +47,15 @@ impl<'a> CountAll16<'a> {
 
     pub fn some_field_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn remainder_byte_range(&self) -> Range<usize> {
         let start = self.some_field_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u16::RAW_BYTE_LEN * u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -130,12 +133,15 @@ impl<'a> CountAll32<'a> {
 
     pub fn some_field_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn remainder_byte_range(&self) -> Range<usize> {
         let start = self.some_field_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u32::RAW_BYTE_LEN * u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_formats.rs
+++ b/read-fonts/generated/generated_test_formats.rs
@@ -56,17 +56,20 @@ impl<'a> Table1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn heft_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn flex_byte_range(&self) -> Range<usize> {
         let start = self.heft_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -154,18 +157,21 @@ impl<'a> Table2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn values_byte_range(&self) -> Range<usize> {
         let value_count = self.value_count();
         let start = self.value_count_byte_range().end;
-        start..start + (transforms::to_usize(value_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(value_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -238,12 +244,14 @@ impl<'a> Table3<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn something_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_generic_group.rs
+++ b/read-fonts/generated/generated_test_generic_group.rs
@@ -87,19 +87,22 @@ impl<'a, T> MyLookup<'a, T> {
 
     pub fn lookup_type_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn sub_table_count_byte_range(&self) -> Range<usize> {
         let start = self.lookup_type_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn subtable_offsets_byte_range(&self) -> Range<usize> {
         let sub_table_count = self.sub_table_count();
         let start = self.sub_table_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(sub_table_count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(sub_table_count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -269,12 +272,14 @@ impl<'a> MySubtableFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -363,18 +368,21 @@ impl<'a> MySubtableFormat2<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn values_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -512,12 +520,14 @@ impl<'a> ContainsLookupGroup<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn lookup_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -148,56 +148,68 @@ impl<'a> KindsOfOffsets<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn nonnullable_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn nullable_offset_byte_range(&self) -> Range<usize> {
         let start = self.nonnullable_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn array_offset_count_byte_range(&self) -> Range<usize> {
         let start = self.nullable_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn array_offset_byte_range(&self) -> Range<usize> {
         let start = self.array_offset_count_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn record_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.array_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn versioned_nullable_record_array_offset_byte_range(&self) -> Range<usize> {
         let start = self.record_array_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + Offset16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + Offset16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn versioned_nonnullable_offset_byte_range(&self) -> Range<usize> {
         let start = self.versioned_nullable_record_array_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + Offset16::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + Offset16::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn versioned_nullable_offset_byte_range(&self) -> Range<usize> {
         let start = self.versioned_nonnullable_offset_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| start + Offset32::RAW_BYTE_LEN)
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + Offset32::RAW_BYTE_LEN
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -377,46 +389,50 @@ impl<'a> KindsOfArraysOfOffsets<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn nonnullable_offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn nullable_offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.nonnullable_offsets_byte_range().end;
-        start..start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn versioned_nonnullable_offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.nullable_offsets_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| {
-                    start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
-                })
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn versioned_nullable_offsets_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.versioned_nonnullable_offsets_byte_range().end;
-        start
-            ..(self.version().compatible((1u16, 1u16)))
-                .then(|| {
-                    start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
-                })
-                .unwrap_or(start)
+        let end = if self.version().compatible((1u16, 1u16)) {
+            start + (transforms::to_usize(count)).saturating_mul(Offset16::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -541,44 +557,50 @@ impl<'a> KindsOfArrays<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn scalars_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn records_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.scalars_byte_range().end;
-        start..start + (transforms::to_usize(count)).saturating_mul(Shmecord::RAW_BYTE_LEN)
+        let end = start + (transforms::to_usize(count)).saturating_mul(Shmecord::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn versioned_scalars_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.records_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN))
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + (transforms::to_usize(count)).saturating_mul(u16::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 
     pub fn versioned_records_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.versioned_scalars_byte_range().end;
-        start
-            ..(self.version().compatible(1u16))
-                .then(|| {
-                    start + (transforms::to_usize(count)).saturating_mul(Shmecord::RAW_BYTE_LEN)
-                })
-                .unwrap_or(start)
+        let end = if self.version().compatible(1u16) {
+            start + (transforms::to_usize(count)).saturating_mul(Shmecord::RAW_BYTE_LEN)
+        } else {
+            start
+        };
+        start..end
     }
 }
 
@@ -670,7 +692,7 @@ impl<'a> VarLenHaver<'a> {
         self.data.read_at(range.start).ok().unwrap()
     }
 
-    pub fn var_len(&self) -> VarLenArray<'a, VarSizeDummy> {
+    pub fn var_len(&self) -> VarLenArray<'a, VarSizeDummy<'a>> {
         let range = self.var_len_byte_range();
         self.data
             .split_off(range.start)
@@ -685,22 +707,25 @@ impl<'a> VarLenHaver<'a> {
 
     pub fn count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_len_byte_range(&self) -> Range<usize> {
         let count = self.count();
         let start = self.count_byte_range().end;
-        start..start + {
+        let end = start + {
             let data = self.data.split_off(start).unwrap_or_default();
             <VarSizeDummy as VarSize>::total_len_for_count(data, transforms::to_usize(count))
                 .unwrap_or(0)
-        }
+        };
+        start..end
     }
 
     pub fn other_field_byte_range(&self) -> Range<usize> {
         let start = self.var_len_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -774,12 +799,14 @@ impl<'a> Dummy<'a> {
 
     pub fn value_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn _reserved_byte_range(&self) -> Range<usize> {
         let start = self.value_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_read_args.rs
+++ b/read-fonts/generated/generated_test_read_args.rs
@@ -88,34 +88,34 @@ impl<'a> BaseArray<'a> {
 
     pub fn base_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn base_records_byte_range(&self) -> Range<usize> {
         let base_count = self.base_count();
         let start = self.base_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(base_count)).saturating_mul(
-                    <BaseRecord as ComputeSize>::compute_size(&self.mark_class_count())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(base_count)).saturating_mul(
+                <BaseRecord as ComputeSize>::compute_size(&self.mark_class_count()).unwrap_or(0),
+            );
+        start..end
     }
 
     pub fn face_count_byte_range(&self) -> Range<usize> {
         let start = self.base_records_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn face_records_byte_range(&self) -> Range<usize> {
         let base_count = self.base_count();
         let start = self.face_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(base_count)).saturating_mul(
-                    <FaceRecord as ComputeSize>::compute_size(&self.mark_class_count())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(base_count)).saturating_mul(
+                <FaceRecord as ComputeSize>::compute_size(&self.mark_class_count()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -345,7 +345,8 @@ impl<'a> Face<'a> {
 
     pub fn field_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_test_records.rs
+++ b/read-fonts/generated/generated_test_records.rs
@@ -64,36 +64,39 @@ impl<'a> BasicTable<'a> {
 
     pub fn simple_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn simple_records_byte_range(&self) -> Range<usize> {
         let simple_count = self.simple_count();
         let start = self.simple_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(simple_count)).saturating_mul(SimpleRecord::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(simple_count)).saturating_mul(SimpleRecord::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn arrays_inner_count_byte_range(&self) -> Range<usize> {
         let start = self.simple_records_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn array_records_count_byte_range(&self) -> Range<usize> {
         let start = self.arrays_inner_count_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn array_records_byte_range(&self) -> Range<usize> {
         let array_records_count = self.array_records_count();
         let start = self.array_records_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(array_records_count)).saturating_mul(
-                    <ContainsArrays as ComputeSize>::compute_size(&self.arrays_inner_count())
-                        .unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(array_records_count)).saturating_mul(
+                <ContainsArrays as ComputeSize>::compute_size(&self.arrays_inner_count())
+                    .unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -379,12 +382,15 @@ impl<'a> VarLenItem<'a> {
 
     pub fn length_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn data_byte_range(&self) -> Range<usize> {
         let start = self.length_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_trak.rs
+++ b/read-fonts/generated/generated_trak.rs
@@ -83,27 +83,32 @@ impl<'a> Trak<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn horiz_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn vert_offset_byte_range(&self) -> Range<usize> {
         let start = self.horiz_offset_byte_range().end;
-        start..start + Offset16::RAW_BYTE_LEN
+        let end = start + Offset16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved_byte_range(&self) -> Range<usize> {
         let start = self.vert_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -204,24 +209,28 @@ impl<'a> TrackData<'a> {
 
     pub fn n_tracks_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn n_sizes_byte_range(&self) -> Range<usize> {
         let start = self.n_tracks_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn size_table_offset_byte_range(&self) -> Range<usize> {
         let start = self.n_sizes_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn track_table_byte_range(&self) -> Range<usize> {
         let n_tracks = self.n_tracks();
         let start = self.size_table_offset_byte_range().end;
-        start
-            ..start + (transforms::to_usize(n_tracks)).saturating_mul(TrackTableEntry::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(n_tracks)).saturating_mul(TrackTableEntry::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_varc.rs
+++ b/read-fonts/generated/generated_varc.rs
@@ -111,32 +111,38 @@ impl<'a> Varc<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn multi_var_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.coverage_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.multi_var_store_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn axis_indices_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.condition_list_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn var_composite_glyphs_offset_byte_range(&self) -> Range<usize> {
         let start = self.axis_indices_list_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -265,26 +271,28 @@ impl<'a> MultiItemVariationStore<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn variation_data_count_byte_range(&self) -> Range<usize> {
         let start = self.region_list_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn variation_data_offsets_byte_range(&self) -> Range<usize> {
         let variation_data_count = self.variation_data_count();
         let start = self.variation_data_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(variation_data_count))
-                    .saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(variation_data_count)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -382,13 +390,16 @@ impl<'a> SparseVariationRegionList<'a> {
 
     pub fn region_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_offsets_byte_range(&self) -> Range<usize> {
         let region_count = self.region_count();
         let start = self.region_count_byte_range().end;
-        start..start + (transforms::to_usize(region_count)).saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(region_count)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -471,16 +482,17 @@ impl<'a> SparseVariationRegion<'a> {
 
     pub fn region_axis_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_axes_byte_range(&self) -> Range<usize> {
         let region_axis_count = self.region_axis_count();
         let start = self.region_axis_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(region_axis_count))
-                    .saturating_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(region_axis_count))
+                .saturating_mul(SparseRegionAxisCoordinates::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -631,23 +643,29 @@ impl<'a> MultiItemVariationData<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_index_count_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_indices_byte_range(&self) -> Range<usize> {
         let region_index_count = self.region_index_count();
         let start = self.region_index_count_byte_range().end;
-        start..start + (transforms::to_usize(region_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(region_index_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn raw_delta_sets_byte_range(&self) -> Range<usize> {
         let start = self.region_indices_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / u8::RAW_BYTE_LEN * u8::RAW_BYTE_LEN;
+        start..end
     }
 }
 
@@ -736,14 +754,16 @@ impl<'a> ConditionList<'a> {
 
     pub fn condition_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn condition_offsets_byte_range(&self) -> Range<usize> {
         let condition_count = self.condition_count();
         let start = self.condition_count_byte_range().end;
-        start
-            ..start + (transforms::to_usize(condition_count)).saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(condition_count)).saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -74,42 +74,44 @@ impl<'a> TupleVariationHeader<'a> {
 
     pub fn variation_data_size_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tuple_index_byte_range(&self) -> Range<usize> {
         let start = self.variation_data_size_byte_range().end;
-        start..start + TupleIndex::RAW_BYTE_LEN
+        let end = start + TupleIndex::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn peak_tuple_byte_range(&self) -> Range<usize> {
         let tuple_index = self.tuple_index();
         let axis_count = self.axis_count();
         let start = self.tuple_index_byte_range().end;
-        start
-            ..start
-                + (TupleIndex::tuple_len(tuple_index, axis_count, 0_usize))
-                    .saturating_mul(F2Dot14::RAW_BYTE_LEN)
+        let end = start
+            + (TupleIndex::tuple_len(tuple_index, axis_count, 0_usize))
+                .saturating_mul(F2Dot14::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn intermediate_start_tuple_byte_range(&self) -> Range<usize> {
         let tuple_index = self.tuple_index();
         let axis_count = self.axis_count();
         let start = self.peak_tuple_byte_range().end;
-        start
-            ..start
-                + (TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))
-                    .saturating_mul(F2Dot14::RAW_BYTE_LEN)
+        let end = start
+            + (TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))
+                .saturating_mul(F2Dot14::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn intermediate_end_tuple_byte_range(&self) -> Range<usize> {
         let tuple_index = self.tuple_index();
         let axis_count = self.axis_count();
         let start = self.intermediate_start_tuple_byte_range().end;
-        start
-            ..start
-                + (TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))
-                    .saturating_mul(F2Dot14::RAW_BYTE_LEN)
+        let end = start
+            + (TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))
+                .saturating_mul(F2Dot14::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -285,26 +287,29 @@ impl<'a> DeltaSetIndexMapFormat0<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_format_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + EntryFormat::RAW_BYTE_LEN
+        let end = start + EntryFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn map_count_byte_range(&self) -> Range<usize> {
         let start = self.entry_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn map_data_byte_range(&self) -> Range<usize> {
         let entry_format = self.entry_format();
         let map_count = self.map_count();
         let start = self.map_count_byte_range().end;
-        start
-            ..start
-                + (EntryFormat::map_size(entry_format, map_count)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (EntryFormat::map_size(entry_format, map_count)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -406,26 +411,29 @@ impl<'a> DeltaSetIndexMapFormat1<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u8::RAW_BYTE_LEN
+        let end = start + u8::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn entry_format_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + EntryFormat::RAW_BYTE_LEN
+        let end = start + EntryFormat::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn map_count_byte_range(&self) -> Range<usize> {
         let start = self.entry_format_byte_range().end;
-        start..start + u32::RAW_BYTE_LEN
+        let end = start + u32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn map_data_byte_range(&self) -> Range<usize> {
         let entry_format = self.entry_format();
         let map_count = self.map_count();
         let start = self.map_count_byte_range().end;
-        start
-            ..start
-                + (EntryFormat::map_size(entry_format, map_count)).saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (EntryFormat::map_size(entry_format, map_count)).saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -932,22 +940,24 @@ impl<'a> VariationRegionList<'a> {
 
     pub fn axis_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_count_byte_range(&self) -> Range<usize> {
         let start = self.axis_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn variation_regions_byte_range(&self) -> Range<usize> {
         let region_count = self.region_count();
         let start = self.region_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(region_count)).saturating_mul(
-                    <VariationRegion as ComputeSize>::compute_size(&self.axis_count()).unwrap_or(0),
-                )
+        let end = start
+            + (transforms::to_usize(region_count)).saturating_mul(
+                <VariationRegion as ComputeSize>::compute_size(&self.axis_count()).unwrap_or(0),
+            );
+        start..end
     }
 }
 
@@ -1189,26 +1199,29 @@ impl<'a> ItemVariationStore<'a> {
 
     pub fn format_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn variation_region_list_offset_byte_range(&self) -> Range<usize> {
         let start = self.format_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn item_variation_data_count_byte_range(&self) -> Range<usize> {
         let start = self.variation_region_list_offset_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn item_variation_data_offsets_byte_range(&self) -> Range<usize> {
         let item_variation_data_count = self.item_variation_data_count();
         let start = self.item_variation_data_count_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(item_variation_data_count))
-                    .saturating_mul(Offset32::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(item_variation_data_count))
+                .saturating_mul(Offset32::RAW_BYTE_LEN);
+        start..end
     }
 }
 
@@ -1324,23 +1337,28 @@ impl<'a> ItemVariationData<'a> {
 
     pub fn item_count_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn word_delta_count_byte_range(&self) -> Range<usize> {
         let start = self.item_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_index_count_byte_range(&self) -> Range<usize> {
         let start = self.word_delta_count_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn region_indexes_byte_range(&self) -> Range<usize> {
         let region_index_count = self.region_index_count();
         let start = self.region_index_count_byte_range().end;
-        start..start + (transforms::to_usize(region_index_count)).saturating_mul(u16::RAW_BYTE_LEN)
+        let end =
+            start + (transforms::to_usize(region_index_count)).saturating_mul(u16::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn delta_sets_byte_range(&self) -> Range<usize> {
@@ -1348,14 +1366,10 @@ impl<'a> ItemVariationData<'a> {
         let word_delta_count = self.word_delta_count();
         let region_index_count = self.region_index_count();
         let start = self.region_indexes_byte_range().end;
-        start
-            ..start
-                + (ItemVariationData::delta_sets_len(
-                    item_count,
-                    word_delta_count,
-                    region_index_count,
-                ))
-                .saturating_mul(u8::RAW_BYTE_LEN)
+        let end = start
+            + (ItemVariationData::delta_sets_len(item_count, word_delta_count, region_index_count))
+                .saturating_mul(u8::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_vhea.rs
+++ b/read-fonts/generated/generated_vhea.rs
@@ -142,87 +142,104 @@ impl<'a> Vhea<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + Version16Dot16::RAW_BYTE_LEN
+        let end = start + Version16Dot16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn ascender_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn descender_byte_range(&self) -> Range<usize> {
         let start = self.ascender_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn line_gap_byte_range(&self) -> Range<usize> {
         let start = self.descender_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn advance_height_max_byte_range(&self) -> Range<usize> {
         let start = self.line_gap_byte_range().end;
-        start..start + UfWord::RAW_BYTE_LEN
+        let end = start + UfWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn min_top_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.advance_height_max_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn min_bottom_side_bearing_byte_range(&self) -> Range<usize> {
         let start = self.min_top_side_bearing_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn y_max_extent_byte_range(&self) -> Range<usize> {
         let start = self.min_bottom_side_bearing_byte_range().end;
-        start..start + FWord::RAW_BYTE_LEN
+        let end = start + FWord::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_slope_rise_byte_range(&self) -> Range<usize> {
         let start = self.y_max_extent_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_slope_run_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_rise_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn caret_offset_byte_range(&self) -> Range<usize> {
         let start = self.caret_slope_run_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved1_byte_range(&self) -> Range<usize> {
         let start = self.caret_offset_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved2_byte_range(&self) -> Range<usize> {
         let start = self.reserved1_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved3_byte_range(&self) -> Range<usize> {
         let start = self.reserved2_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn reserved4_byte_range(&self) -> Range<usize> {
         let start = self.reserved3_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn metric_data_format_byte_range(&self) -> Range<usize> {
         let start = self.reserved4_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn number_of_long_ver_metrics_byte_range(&self) -> Range<usize> {
         let start = self.metric_data_format_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_vmtx.rs
+++ b/read-fonts/generated/generated_vmtx.rs
@@ -82,15 +82,17 @@ impl<'a> Vmtx<'a> {
     pub fn v_metrics_byte_range(&self) -> Range<usize> {
         let number_of_long_ver_metrics = self.number_of_long_ver_metrics();
         let start = 0;
-        start
-            ..start
-                + (transforms::to_usize(number_of_long_ver_metrics))
-                    .saturating_mul(LongMetric::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(number_of_long_ver_metrics))
+                .saturating_mul(LongMetric::RAW_BYTE_LEN);
+        start..end
     }
 
     pub fn top_side_bearings_byte_range(&self) -> Range<usize> {
         let start = self.v_metrics_byte_range().end;
-        start..start + self.data.len().saturating_sub(start) / i16::RAW_BYTE_LEN * i16::RAW_BYTE_LEN
+        let end =
+            start + self.data.len().saturating_sub(start) / i16::RAW_BYTE_LEN * i16::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_vorg.rs
+++ b/read-fonts/generated/generated_vorg.rs
@@ -69,26 +69,29 @@ impl<'a> Vorg<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn default_vert_origin_y_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + i16::RAW_BYTE_LEN
+        let end = start + i16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn num_vert_origin_y_metrics_byte_range(&self) -> Range<usize> {
         let start = self.default_vert_origin_y_byte_range().end;
-        start..start + u16::RAW_BYTE_LEN
+        let end = start + u16::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn vert_origin_y_metrics_byte_range(&self) -> Range<usize> {
         let num_vert_origin_y_metrics = self.num_vert_origin_y_metrics();
         let start = self.num_vert_origin_y_metrics_byte_range().end;
-        start
-            ..start
-                + (transforms::to_usize(num_vert_origin_y_metrics))
-                    .saturating_mul(VertOriginYMetrics::RAW_BYTE_LEN)
+        let end = start
+            + (transforms::to_usize(num_vert_origin_y_metrics))
+                .saturating_mul(VertOriginYMetrics::RAW_BYTE_LEN);
+        start..end
     }
 }
 

--- a/read-fonts/generated/generated_vvar.rs
+++ b/read-fonts/generated/generated_vvar.rs
@@ -115,32 +115,38 @@ impl<'a> Vvar<'a> {
 
     pub fn version_byte_range(&self) -> Range<usize> {
         let start = 0;
-        start..start + MajorMinor::RAW_BYTE_LEN
+        let end = start + MajorMinor::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn item_variation_store_offset_byte_range(&self) -> Range<usize> {
         let start = self.version_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn advance_height_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.item_variation_store_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn tsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.advance_height_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn bsb_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.tsb_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 
     pub fn v_org_mapping_offset_byte_range(&self) -> Range<usize> {
         let start = self.bsb_mapping_offset_byte_range().end;
-        start..start + Offset32::RAW_BYTE_LEN
+        let end = start + Offset32::RAW_BYTE_LEN;
+        start..end
     }
 }
 

--- a/read-fonts/src/ps/cff/index.rs
+++ b/read-fonts/src/ps/cff/index.rs
@@ -342,7 +342,7 @@ mod tests {
         }
         // Now the data
         for i in 0..count {
-            buf = buf.extend(std::iter::repeat(i as u8).take((i + 1) * 10));
+            buf = buf.extend(std::iter::repeat_n(i as u8, (i + 1) * 10));
         }
         buf
     }

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -891,7 +891,7 @@ mod tests {
     }
 
     // Test helper to enumerate all TrueType glyphs in the given font
-    fn all_glyphs(font_data: &[u8]) -> impl Iterator<Item = Option<Glyph>> {
+    fn all_glyphs(font_data: &[u8]) -> impl Iterator<Item = Option<Glyph<'_>>> {
         let font = FontRef::new(font_data).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();

--- a/read-fonts/src/tables/glyf/bytecode/instruction.rs
+++ b/read-fonts/src/tables/glyf/bytecode/instruction.rs
@@ -94,7 +94,7 @@ impl MockInlineOperands {
         }
     }
 
-    pub fn operands(&self) -> InlineOperands {
+    pub fn operands(&self) -> InlineOperands<'_> {
         InlineOperands {
             bytes: &self.bytes,
             is_words: self.is_words,

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -96,7 +96,7 @@ table VarLenHaver {
     count: u16,
     #[count($count)]
     #[traverse_with(skip)]
-    var_len: VarLenArray<VarSizeDummy>,
+    var_len: VarLenArray<VarSizeDummy<'_>>,
     other_field: u32,
 }
 

--- a/skrifa/src/outline/glyf/hint/engine/definition.rs
+++ b/skrifa/src/outline/glyf/hint/engine/definition.rs
@@ -498,7 +498,7 @@ mod tests {
         let mut engine = mock.engine();
         let mut font_code = vec![];
         font_code.extend_from_slice(&[op(PUSHB000), 0, op(FDEF)]);
-        font_code.extend(core::iter::repeat(op(NEG)).take(MAX_DEFINITION_SIZE + 1));
+        font_code.extend(std::iter::repeat_n(op(NEG), MAX_DEFINITION_SIZE + 1));
         font_code.push(op(ENDF));
         engine.set_font_code(&font_code);
         engine.graphics.is_pedantic = true;

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -196,7 +196,7 @@ mod mock {
             }
         }
 
-        pub fn engine(&mut self) -> Engine {
+        pub fn engine(&mut self) -> Engine<'_> {
             let font_code = &[];
             let cv_code = &[];
             let glyph_code = &[];

--- a/skrifa/src/outline/glyf/hint/zone.rs
+++ b/skrifa/src/outline/glyf/hint/zone.rs
@@ -801,7 +801,7 @@ mod tests {
             }
         }
 
-        fn graphics_state(&mut self, fv_x: i32, fv_y: i32) -> GraphicsState {
+        fn graphics_state(&mut self, fv_x: i32, fv_y: i32) -> GraphicsState<'_> {
             let glyph = Zone {
                 unscaled: &mut [],
                 original: &mut self.original,

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -1405,8 +1405,8 @@ mod tests {
 
     #[test]
     fn repeatable_flags_repeats() {
-        let some_dupes = std::iter::repeat(SimpleGlyphFlags::ON_CURVE_POINT).take(4);
-        let many_dupes = std::iter::repeat(SimpleGlyphFlags::Y_SHORT_VECTOR).take(257);
+        let some_dupes = std::iter::repeat_n(SimpleGlyphFlags::ON_CURVE_POINT, 4);
+        let many_dupes = std::iter::repeat_n(SimpleGlyphFlags::Y_SHORT_VECTOR, 257);
         let repeatable =
             RepeatableFlag::iter_from_flags(some_dupes.chain(many_dupes)).collect::<Vec<_>>();
         assert_eq!(repeatable.len(), 3);

--- a/write-fonts/src/tables/variations/ivs_builder.rs
+++ b/write-fonts/src/tables/variations/ivs_builder.rs
@@ -535,7 +535,7 @@ impl RowShape {
             "we can only pack 128 bits"
         );
 
-        let has_long_word = self.0.iter().any(|bits| *bits == ColumnBits::Four);
+        let has_long_word = self.0.contains(&ColumnBits::Four);
         let mut chars = 0;
         let mut i = 1;
 


### PR DESCRIPTION
- Clippy doesn't like `Bool::then(..).unwrap_or(..)`
- `repeat(v).take(n)` replaced with `repeat_n(v, n)`
- `slice.iter().any(|x| x == &const)` replaced with `slice.contains(&const)`
