### PR TITLE
Upgrade CI Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,28 +40,28 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85
+          toolchain: 1.89
       - run: rustup component add clippy
 
-      - name: cargo clippy font-types (1.85)
+      - name: cargo clippy font-types (1.89)
         run: cargo clippy -p font-types --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy read-fonts (1.85)
+      - name: cargo clippy read-fonts (1.89)
         run: cargo clippy -p read-fonts --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy write-fonts (1.85)
+      - name: cargo clippy write-fonts (1.89)
         run: cargo clippy -p write-fonts --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy skrifa (1.85)
+      - name: cargo clippy skrifa (1.89)
         run: cargo clippy -p skrifa --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy skera (1.85)
+      - name: cargo clippy skera (1.89)
         run: cargo clippy -p skera --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy fauntlet (1.85)
+      - name: cargo clippy fauntlet (1.89)
         run: cargo clippy -p fauntlet --all-features --all-targets -- -D warnings
 
-      - name: cargo clippy incremental-font-transfer (1.85)
+      - name: cargo clippy incremental-font-transfer (1.89)
         run: cargo clippy -p incremental-font-transfer --all-features --all-targets -- -D warnings
 
   test-stable:
@@ -160,7 +160,7 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85
+          toolchain: 1.89
           # Use a target without `std` to make sure we don't link to `std`
           target: thumbv7em-none-eabihf
 
@@ -185,7 +185,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown
-          toolchain: 1.85
+          toolchain: 1.89
 
       - name: cargo build font-types
         run: cargo build -p font-types --target wasm32-unknown-unknown

--- a/read-fonts/src/font_data.rs
+++ b/read-fonts/src/font_data.rs
@@ -71,11 +71,6 @@ impl FontData<'static> {
     }
 
     /// Return `true` if our default data can represent a table `n_bytes` long
-    ///
-    /// This is used in codegen'd asserts
-    // only used to evaluate anonymous const items (const_: () = ...) which isn't
-    // visible to the dead_code lint
-    #[expect(dead_code)]
     pub(crate) const fn default_data_long_enough(n_bytes: usize) -> bool {
         n_bytes <= Self::NULL_POOL_SIZE
     }

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -251,6 +251,7 @@ fn checksum_and_padding(table: &[u8]) -> (u32, u32) {
 }
 
 impl TTCHeader {
+    #[allow(dead_code)] // compute_version is required by codegen even though sometimes unused
     fn compute_version(&self) -> MajorMinor {
         panic!("TTCHeader writing not supported (yet)")
     }


### PR DESCRIPTION
- Fix the remaining dead code errors
- Upgrade to Rust 1.89 which is supported by Skia https://skia.googlesource.com/skia/+/refs/heads/main/MODULE.bazel#99