### PR TITLE
[chore] Release skera and incremental-font-transfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ read-fonts = { version = "0.41.0", path = "read-fonts", default-features = false
 skrifa = { version = "0.44.0", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.50.0", path = "write-fonts", default-features = false }
 shared-brotli-patch-decoder = { version = "0.1.4", path = "shared-brotli-patch-decoder", default-features = false }
-incremental-font-transfer = { version = "0.4.1", path = "incremental-font-transfer" }
-skera = { version = "0.3.0", path = "skera" }
+incremental-font-transfer = { version = "0.5.0", path = "incremental-font-transfer" }
+skera = { version = "0.4.0", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental-font-transfer"
-version = "0.4.1"
+version = "0.5.0"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.3.0"
+version = "0.4.0"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]


### PR DESCRIPTION
     Changes for skera from skera-v0.3.0 to 0.4.0
             0f37300 [subset-repack] Add safety limits to repacker
             4de326f [subset] retain extension subtables
             c592c27 [subset] repacker bug fix
             963ee44 [subset-repack] cmp order by lookup index when subtables_per_byte are equal
             ae95aa6 [subset-repacker] use hashmap when collecting child_idxes
             83c438a [subset] add additional sorting after extension promotion
             938811c fix: address RUSTSEC advisories for unmaintained crates (#1923) (fix)
             c7e70d2 [subset] fix a bug in colrv1 VarColorStop
             45992a5 [subset] bug fix: always generate advMap even it's empty
             e324974 Parallelize skera integration test (#1912)
             3bb0854 [subset] don't err out in case of empty name str
     Changes for incremental-font-transfer from incremental-font-transfer-v0.4.1 to 0.5.0
             02c26de Implement custom encoder (#1950)