### PR TITLE
Support more fields when writing glyphs

### DIFF
--- a/write-fonts/src/tables/glyf/composite.rs
+++ b/write-fonts/src/tables/glyf/composite.rs
@@ -191,6 +191,10 @@ impl CompositeGlyph {
         &self.components
     }
 
+    pub fn components_mut(&mut self) -> &mut [Component] {
+        &mut self.components
+    }
+
     pub fn add_instructions(&mut self, instructions: impl Into<Vec<u8>>) {
         self._instructions.extend(instructions.into());
     }

--- a/write-fonts/src/tables/glyf/composite.rs
+++ b/write-fonts/src/tables/glyf/composite.rs
@@ -190,6 +190,14 @@ impl CompositeGlyph {
     pub fn components(&self) -> &[Component] {
         &self.components
     }
+
+    pub fn add_instructions(&mut self, instructions: impl Into<Vec<u8>>) {
+        self._instructions.extend(instructions.into());
+    }
+
+    pub fn instructions(&self) -> &[u8] {
+        &self._instructions
+    }
 }
 
 impl FontWrite for CompositeGlyph {

--- a/write-fonts/src/tables/glyf/composite.rs
+++ b/write-fonts/src/tables/glyf/composite.rs
@@ -16,7 +16,7 @@ pub use read_fonts::tables::glyf::{Anchor, Transform};
 pub struct CompositeGlyph {
     pub bbox: Bbox,
     components: Vec<Component>,
-    _instructions: Vec<u8>,
+    instructions: Vec<u8>,
 }
 
 /// A single component glyph (part of a [`CompositeGlyph`]).
@@ -76,7 +76,7 @@ impl FromObjRef<read_fonts::tables::glyf::CompositeGlyph<'_>> for CompositeGlyph
         Self {
             bbox,
             components,
-            _instructions: from
+            instructions: from
                 .instructions()
                 .map(|v| v.to_owned())
                 .unwrap_or_default(),
@@ -148,7 +148,7 @@ impl CompositeGlyph {
         Self {
             bbox: bbox.into(),
             components: vec![component],
-            _instructions: Default::default(),
+            instructions: Default::default(),
         }
     }
 
@@ -182,7 +182,7 @@ impl CompositeGlyph {
             Ok(CompositeGlyph {
                 bbox: union_box.unwrap(),
                 components,
-                _instructions: Default::default(),
+                instructions: Default::default(),
             })
         }
     }
@@ -195,12 +195,12 @@ impl CompositeGlyph {
         &mut self.components
     }
 
-    pub fn add_instructions(&mut self, instructions: impl Into<Vec<u8>>) {
-        self._instructions.extend(instructions.into());
+    pub fn set_instructions(&mut self, instructions: &[u8]) {
+        self.instructions = instructions.to_vec();
     }
 
     pub fn instructions(&self) -> &[u8] {
-        &self._instructions
+        &self.instructions
     }
 }
 
@@ -216,16 +216,16 @@ impl FontWrite for CompositeGlyph {
         for comp in rest {
             comp.write_into(writer, CompositeGlyphFlags::MORE_COMPONENTS);
         }
-        let last_flags = if self._instructions.is_empty() {
+        let last_flags = if self.instructions.is_empty() {
             CompositeGlyphFlags::empty()
         } else {
             CompositeGlyphFlags::WE_HAVE_INSTRUCTIONS
         };
         last.write_into(writer, last_flags);
 
-        if !self._instructions.is_empty() {
-            (self._instructions.len() as u16).write_into(writer);
-            self._instructions.write_into(writer);
+        if !self.instructions.is_empty() {
+            (self.instructions.len() as u16).write_into(writer);
+            self.instructions.write_into(writer);
         }
         writer.pad_to_2byte_aligned();
     }
@@ -236,7 +236,7 @@ impl crate::validate::Validate for CompositeGlyph {
         if self.components.is_empty() {
             ctx.report("composite glyph must have components");
         }
-        if self._instructions.len() > u16::MAX as usize {
+        if self.instructions.len() > u16::MAX as usize {
             ctx.report("instructions len overflows");
         }
     }
@@ -340,7 +340,7 @@ mod tests {
             .map(|comp| Component::new(comp.glyph, comp.anchor, comp.transform, comp.flags));
         let mut composite = CompositeGlyph::new(iter.next().unwrap(), bbox);
         composite.add_component(iter.next().unwrap(), bbox);
-        composite._instructions = orig.instructions().unwrap_or_default().to_vec();
+        composite.instructions = orig.instructions().unwrap_or_default().to_vec();
         assert!(iter.next().is_none());
         let bytes = crate::dump_table(&composite).unwrap();
         let ours = read_fonts::tables::glyf::CompositeGlyph::read(FontData::new(&bytes)).unwrap();

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -19,6 +19,9 @@ pub struct SimpleGlyph {
     pub bbox: Bbox,
     pub contours: Vec<Contour>,
     pub instructions: Vec<u8>,
+    /// If set, the contours of the glyph overlap
+    ///
+    /// The OVERLAP_SIMPLE bit will be set on the first point of the first contour if this is true.
     pub overlaps: bool,
 }
 


### PR DESCRIPTION
Currently people using write-fonts to create glyph structures do not have mutable access to

* components on composite glyphs (if you have obtained a CompositeGlyph, you can't edit the flags on its components without rebuilding it from scratch)
* instructions on composite glyphs
* the overlaps bit on simple glyphs

This allows access to these three fields.