### PR TITLE
[skrifa] tt hint: limit number of skipped instructions

### DIFF
--- a/skrifa/src/outline/glyf/hint/engine/control_flow.rs
+++ b/skrifa/src/outline/glyf/hint/engine/control_flow.rs
@@ -34,6 +34,7 @@ impl Engine<'_> {
             let mut out = false;
             while !out {
                 let opcode = self.decode_next_opcode()?;
+                self.work_budget.skipping_instruction()?;
                 match opcode {
                     Opcode::IF => nest_depth += 1,
                     Opcode::ELSE => out = nest_depth == 1,
@@ -62,6 +63,7 @@ impl Engine<'_> {
         let mut nest_depth = 1;
         while nest_depth != 0 {
             let opcode = self.decode_next_opcode()?;
+            self.work_budget.skipping_instruction()?;
             match opcode {
                 Opcode::IF => nest_depth += 1,
                 Opcode::EIF => nest_depth -= 1,
@@ -170,7 +172,7 @@ impl Engine<'_> {
                     // If the offset is -1, we'll just loop in place... forever
                     return Err(HintErrorKind::InvalidJump);
                 }
-                self.loop_budget.doing_backward_jump()?;
+                self.work_budget.doing_backward_jump()?;
             }
             self.program.decoder.pc = self
                 .program
@@ -193,7 +195,7 @@ impl Engine<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::MockEngine, HintErrorKind, Opcode};
+    use super::{super::MockEngine, super::MAX_RUN_INSTRUCTIONS, HintErrorKind, Opcode};
 
     #[test]
     fn if_else() {
@@ -301,7 +303,7 @@ mod tests {
         }
         // Exhaust backward jump loop budget
         {
-            engine.loop_budget.limit = 40;
+            engine.work_budget.loop_limit = 40;
             for i in 0..45 {
                 engine.value_stack.push(-5).unwrap();
                 let result = engine.op_jmpr();
@@ -315,5 +317,23 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn skipping_budget() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        let bytecode = [Opcode::IF, Opcode::EIF].map(|op| op as u8);
+        engine.program.decoder.bytecode = bytecode.as_slice();
+        // Simulate the budget being exhausted and trigger one more skipped
+        // instruction while scanning for matching control-flow opcodes.
+        engine.work_budget.skipped = MAX_RUN_INSTRUCTIONS;
+        engine.program.decoder.pc = 1;
+        engine.value_stack.push(0).unwrap();
+        let result = engine.op_if();
+        assert!(matches!(
+            result,
+            Err(HintErrorKind::ExceededExecutionBudget)
+        ));
     }
 }

--- a/skrifa/src/outline/glyf/hint/engine/definition.rs
+++ b/skrifa/src/outline/glyf/hint/engine/definition.rs
@@ -78,7 +78,7 @@ impl Engine<'_> {
         let f = self.value_stack.pop()?;
         let count = self.value_stack.pop()?;
         if count > 0 {
-            self.loop_budget.doing_loop_call(count as usize)?;
+            self.work_budget.doing_loop_call(count as usize)?;
             self.do_call(DefKind::Function, count as u32, f)
         } else {
             Ok(())
@@ -299,7 +299,7 @@ mod tests {
         use Opcode::*;
         let mut mock = MockEngine::new();
         let mut engine = mock.engine();
-        let limit = engine.loop_budget.limit;
+        let limit = engine.work_budget.loop_limit;
         #[rustfmt::skip]
         let font_code = [
             op(PUSHB001), 1, 0,

--- a/skrifa/src/outline/glyf/hint/engine/dispatch.rs
+++ b/skrifa/src/outline/glyf/hint/engine/dispatch.rs
@@ -2,12 +2,9 @@
 
 use read_fonts::tables::glyf::bytecode::Opcode;
 
-use super::{super::program::Program, Engine, HintError, HintErrorKind, Instruction};
-
-/// Maximum number of instructions we will execute in `Engine::run()`. This
-/// is used to ensure termination of a hinting program.
-/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/include/freetype/config/ftoption.h#L744>
-const MAX_RUN_INSTRUCTIONS: usize = 1_000_000;
+use super::{
+    super::program::Program, Engine, HintError, HintErrorKind, Instruction, MAX_RUN_INSTRUCTIONS,
+};
 
 impl<'a> Engine<'a> {
     /// Resets state for the specified program and executes all instructions.
@@ -22,7 +19,7 @@ impl<'a> Engine<'a> {
         // Reset overall graphics state, keeping the retained bits.
         self.graphics.reset();
         self.graphics.is_pedantic = is_pedantic;
-        self.loop_budget.reset();
+        self.work_budget.reset();
         // Program specific setup.
         match program {
             Program::Font => {

--- a/skrifa/src/outline/glyf/hint/engine/mod.rs
+++ b/skrifa/src/outline/glyf/hint/engine/mod.rs
@@ -33,6 +33,11 @@ use super::{
     zone::Zone,
 };
 
+/// Maximum number of instructions we will execute in `Engine::run()`. This
+/// is used to ensure termination of a hinting program.
+/// See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/include/freetype/config/ftoption.h#L744>
+const MAX_RUN_INSTRUCTIONS: usize = 1_000_000;
+
 pub type OpResult = Result<(), HintErrorKind>;
 
 /// TrueType bytecode interpreter.
@@ -43,7 +48,7 @@ pub struct Engine<'a> {
     cvt: Cvt<'a>,
     storage: Storage<'a>,
     value_stack: ValueStack<'a>,
-    loop_budget: LoopBudget,
+    work_budget: WorkBudget,
     axis_count: u16,
     coords: &'a [F2Dot14],
 }
@@ -82,7 +87,7 @@ impl<'a> Engine<'a> {
             cvt: cvt.into(),
             storage: storage.into(),
             value_stack,
-            loop_budget: LoopBudget::new(outlines, point_count),
+            work_budget: WorkBudget::new(outlines, point_count),
             axis_count,
             coords,
         }
@@ -97,23 +102,25 @@ impl<'a> Engine<'a> {
     }
 }
 
-/// Tracks budgets for loops to limit execution time.
-struct LoopBudget {
+/// Tracks budgets for control flow to limit execution time.
+struct WorkBudget {
     /// Maximum number of times we can do backward jumps or
     /// loop calls.
-    limit: usize,
+    loop_limit: usize,
     /// Current number of backward jumps executed.
     backward_jumps: usize,
     /// Current number of loop call iterations executed.
     loop_calls: usize,
+    /// Counts number of instructions skipped when handling if/else conditions.
+    skipped: usize,
 }
 
-impl LoopBudget {
+impl WorkBudget {
     fn new(outlines: &Outlines, point_count: Option<usize>) -> Self {
         let cvt_len = outlines.cvt_len as usize;
         // Compute limits for loop calls and backward jumps.
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L6955>
-        let limit = if let Some(point_count) = point_count {
+        let loop_limit = if let Some(point_count) = point_count {
             (point_count * 10).max(50) + (cvt_len / 10).max(50)
         } else {
             300 + 22 * cvt_len
@@ -122,20 +129,22 @@ impl LoopBudget {
         // loopcall_counter_max but sets them to the same value so
         // we'll just use a single limit.
         Self {
-            limit,
+            loop_limit,
             backward_jumps: 0,
             loop_calls: 0,
+            skipped: 0,
         }
     }
 
     fn reset(&mut self) {
         self.backward_jumps = 0;
         self.loop_calls = 0;
+        self.skipped = 0;
     }
 
     fn doing_backward_jump(&mut self) -> Result<(), HintErrorKind> {
         self.backward_jumps += 1;
-        if self.backward_jumps > self.limit {
+        if self.backward_jumps > self.loop_limit {
             Err(HintErrorKind::ExceededExecutionBudget)
         } else {
             Ok(())
@@ -144,7 +153,16 @@ impl LoopBudget {
 
     fn doing_loop_call(&mut self, count: usize) -> Result<(), HintErrorKind> {
         self.loop_calls += count;
-        if self.loop_calls > self.limit {
+        if self.loop_calls > self.loop_limit {
+            Err(HintErrorKind::ExceededExecutionBudget)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn skipping_instruction(&mut self) -> Result<(), HintErrorKind> {
+        self.skipped += 1;
+        if self.skipped > MAX_RUN_INSTRUCTIONS {
             Err(HintErrorKind::ExceededExecutionBudget)
         } else {
             Ok(())
@@ -165,7 +183,7 @@ mod mock {
             zone::Zone,
             Point, PointFlags,
         },
-        Engine, F26Dot6, GraphicsState, LoopBudget, ValueStack,
+        Engine, F26Dot6, GraphicsState, ValueStack, WorkBudget,
     };
 
     /// Mock engine for testing.
@@ -232,10 +250,11 @@ mod mock {
                 storage: CowSlice::new_mut(storage).into(),
                 value_stack: ValueStack::new(&mut self.value_stack, false),
                 program: ProgramState::new(font_code, cv_code, glyph_code, Program::Font),
-                loop_budget: LoopBudget {
-                    limit: 10,
+                work_budget: WorkBudget {
+                    loop_limit: 10,
                     backward_jumps: 0,
                     loop_calls: 0,
+                    skipped: 0,
                 },
                 definitions: definition,
                 axis_count: 0,


### PR DESCRIPTION
We currently limit the number of executed instructions but don't track the number of instructions skipped when handling conditional regions. A maliciously designed font can exhaust an excessive number of cycles by carefully constructing IF/ELSE regions.

This adds a counter to track the number of skipped instructions and reports an error when we surpass the limit. The budget is the same as the execution budget (1M instructions) but tracked separately, effectively limiting our instruction _decode_ count to 2M per run of the interpreter.