### PR TITLE
[skrifa] tt hint: overflow/OOB fixes

### DIFF
--- a/skrifa/src/outline/glyf/hint/engine/data.rs
+++ b/skrifa/src/outline/glyf/hint/engine/data.rs
@@ -146,7 +146,7 @@ impl Engine<'_> {
         // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttdriver.c#L392>
         // which is mul_div(ppem, 64 * 72, resolution) where resolution
         // is always 72 for our purposes (Skia), resulting in ppem * 64.
-        self.value_stack.push(self.graphics.ppem * 64)
+        self.value_stack.push(self.graphics.ppem.saturating_mul(64))
     }
 }
 
@@ -165,6 +165,15 @@ mod tests {
         assert_eq!(engine.value_stack.pop().unwrap(), ppem);
         engine.op_mps().unwrap();
         assert_eq!(engine.value_stack.pop().unwrap(), ppem * 64);
+    }
+
+    #[test]
+    fn mps_saturates_on_large_ppem() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        engine.graphics.ppem = i32::MAX;
+        engine.op_mps().unwrap();
+        assert_eq!(engine.value_stack.pop().unwrap(), i32::MAX);
     }
 
     #[test]

--- a/skrifa/src/outline/glyf/hint/engine/outline.rs
+++ b/skrifa/src/outline/glyf/hint/engine/outline.rs
@@ -626,15 +626,15 @@ impl Engine<'_> {
             let z = gs.zp0();
             [z.point(b0)?, z.point(b1)?].map(|p| p.map(F26Dot6::to_bits))
         };
-        let dbx = pb1.x - pb0.x;
-        let dby = pb1.y - pb0.y;
-        let dax = pa1.x - pa0.x;
-        let day = pa1.y - pa0.y;
-        let dx = pb0.x - pa0.x;
-        let dy = pb0.y - pa0.y;
+        let dbx = pb1.x.wrapping_sub(pb0.x);
+        let dby = pb1.y.wrapping_sub(pb0.y);
+        let dax = pa1.x.wrapping_sub(pa0.x);
+        let day = pa1.y.wrapping_sub(pa0.y);
+        let dx = pb0.x.wrapping_sub(pa0.x);
+        let dy = pb0.y.wrapping_sub(pa0.y);
         use math::mul_div;
-        let discriminant = mul_div(dax, -dby, 0x40) + mul_div(day, dbx, 0x40);
-        let dotproduct = mul_div(dax, dbx, 0x40) + mul_div(day, dby, 0x40);
+        let discriminant = mul_div(dax, -dby, 0x40).wrapping_add(mul_div(day, dbx, 0x40));
+        let dotproduct = mul_div(dax, dbx, 0x40).wrapping_add(mul_div(day, dby, 0x40));
         // Useful context from FreeType:
         //
         // "The discriminant above is actually a cross product of vectors
@@ -647,17 +647,29 @@ impl Engine<'_> {
         // thresholding abs(tan(angle)) at 1/19, corresponding to 3 degrees."
         //
         // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L5986>
-        if discriminant.wrapping_abs().wrapping_mul(19) > dotproduct.abs() {
-            let v = mul_div(dx, -dby, 0x40) + mul_div(dy, dbx, 0x40);
+        if discriminant.wrapping_abs().wrapping_mul(19) > dotproduct.wrapping_abs() {
+            let v = mul_div(dx, -dby, 0x40).wrapping_add(mul_div(dy, dbx, 0x40));
             let x = mul_div(v, dax, discriminant);
             let y = mul_div(v, day, discriminant);
             let point = gs.zp2_mut().point_mut(point_ix)?;
-            point.x = F26Dot6::from_bits(pa0.x + x);
-            point.y = F26Dot6::from_bits(pa0.y + y);
+            point.x = F26Dot6::from_bits(pa0.x.wrapping_add(x));
+            point.y = F26Dot6::from_bits(pa0.y.wrapping_add(y));
         } else {
             let point = gs.zp2_mut().point_mut(point_ix)?;
-            point.x = F26Dot6::from_bits((pa0.x + pa1.x + pb0.x + pb1.x) / 4);
-            point.y = F26Dot6::from_bits((pa0.y + pa1.y + pb0.y + pb1.y) / 4);
+            point.x = F26Dot6::from_bits(
+                (pa0.x
+                    .wrapping_add(pa1.x)
+                    .wrapping_add(pb0.x)
+                    .wrapping_add(pb1.x))
+                    / 4,
+            );
+            point.y = F26Dot6::from_bits(
+                (pa0.y
+                    .wrapping_add(pa1.y)
+                    .wrapping_add(pb0.y)
+                    .wrapping_add(pb1.y))
+                    / 4,
+            );
         }
         gs.zp2_mut().touch(point_ix, CoordAxis::Both)?;
         Ok(())
@@ -1330,6 +1342,25 @@ mod tests {
         engine.op_isect().unwrap();
         let point = engine.graphics.zones[1].point(4).unwrap();
         assert_eq!(point.map(F26Dot6::to_bits), Point::new(50, 50));
+    }
+
+    #[test]
+    fn isect_does_not_panic_with_extreme_coords() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        engine.graphics.zp0 = ZonePointer::Glyph;
+        engine.graphics.zp1 = ZonePointer::Glyph;
+        engine.graphics.zp2 = ZonePointer::Glyph;
+        // Set two lines with extreme coordinates to stress the wrapping math.
+        engine.set_point_f26dot6(1, 0, (i32::MIN, i32::MAX));
+        engine.set_point_f26dot6(1, 1, (i32::MAX, i32::MIN));
+        engine.set_point_f26dot6(1, 2, (i32::MAX, i32::MAX));
+        engine.set_point_f26dot6(1, 3, (i32::MIN, i32::MIN));
+        for ix in [4, 0, 1, 2, 3] {
+            engine.value_stack.push(ix).unwrap();
+        }
+        // Don't panic on overflow!
+        engine.op_isect().unwrap();
     }
 
     #[test]

--- a/skrifa/src/outline/glyf/hint/math.rs
+++ b/skrifa/src/outline/glyf/hint/math.rs
@@ -11,11 +11,11 @@ pub fn floor(x: i32) -> i32 {
 }
 
 pub fn round(x: i32) -> i32 {
-    floor(x + 32)
+    floor(x.wrapping_add(32))
 }
 
 pub fn ceil(x: i32) -> i32 {
-    floor(x + 63)
+    floor(x.wrapping_add(63))
 }
 
 fn floor_pad(x: i32, n: i32) -> i32 {
@@ -23,7 +23,7 @@ fn floor_pad(x: i32, n: i32) -> i32 {
 }
 
 pub fn round_pad(x: i32, n: i32) -> i32 {
-    floor_pad(x + n / 2, n)
+    floor_pad(x.wrapping_add(n / 2), n)
 }
 
 #[inline(always)]
@@ -45,29 +45,32 @@ pub fn mul_div(a: i32, b: i32, c: i32) -> i32 {
 /// Fixed point multiply and divide without rounding: a * b / c
 ///
 /// Based on <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/base/ftcalc.c#L200>
-pub fn mul_div_no_round(mut a: i32, mut b: i32, mut c: i32) -> i32 {
-    let mut s = 1;
+pub fn mul_div_no_round(a: i32, b: i32, c: i32) -> i32 {
+    let mut sign = 1;
+    let mut au = a as u64;
+    let mut bu = b as u64;
+    let mut cu = c as u64;
     if a < 0 {
-        a = -a;
-        s = -1;
+        au = 0u64.wrapping_sub(au);
+        sign = -1;
     }
     if b < 0 {
-        b = -b;
-        s = -s;
+        bu = 0u64.wrapping_sub(bu);
+        sign = -sign;
     }
     if c < 0 {
-        c = -c;
-        s = -s;
+        cu = 0u64.wrapping_sub(cu);
+        sign = -sign;
     }
-    let d = if c > 0 {
-        ((a as i64) * (b as i64)) / c as i64
+    let result = if cu > 0 {
+        au.wrapping_mul(bu) / cu
     } else {
         0x7FFFFFFF
     };
-    if s < 0 {
-        -(d as i32)
+    if sign < 0 {
+        (result as i32).wrapping_neg()
     } else {
-        d as i32
+        result as i32
     }
 }
 
@@ -320,5 +323,20 @@ mod tests {
             let flen = (fx * fx + fy * fy).sqrt();
             assert!((flen - 1.0).abs() <= FLOAT_TOLERANCE);
         }
+    }
+
+    #[test]
+    fn wrapping_rounding_extremes() {
+        // Note: wrapping behavior is ugly but matches FreeType and no
+        // real font should produce values that trigger this.
+        assert_eq!(super::round(i32::MAX), i32::MIN);
+        assert_eq!(super::ceil(i32::MAX), i32::MIN);
+        assert_eq!(super::round_pad(i32::MAX, 32), i32::MIN);
+    }
+
+    #[test]
+    fn mul_div_no_round_handles_min_value() {
+        assert_eq!(super::mul_div_no_round(i32::MIN, 1, 1), i32::MIN);
+        assert_eq!(super::mul_div_no_round(i32::MIN, -1, 1), i32::MIN);
     }
 }

--- a/skrifa/src/outline/glyf/hint/round.rs
+++ b/skrifa/src/outline/glyf/hint/round.rs
@@ -74,13 +74,14 @@ impl RoundState {
         use super::math;
         use RoundMode::*;
         let distance = distance.to_bits();
+        let neg_distance = distance.wrapping_neg();
         let result = match self.mode {
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L1958>
             HalfGrid => {
                 if distance >= 0 {
                     (math::floor(distance) + 32).max(0)
                 } else {
-                    (-(math::floor(-distance) + 32)).min(0)
+                    ((math::floor(neg_distance) + 32).wrapping_neg()).min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L1913>
@@ -88,7 +89,7 @@ impl RoundState {
                 if distance >= 0 {
                     math::round(distance).max(0)
                 } else {
-                    (-math::round(-distance)).min(0)
+                    (math::round(neg_distance).wrapping_neg()).min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2094>
@@ -96,7 +97,7 @@ impl RoundState {
                 if distance >= 0 {
                     math::round_pad(distance, 32).max(0)
                 } else {
-                    (-math::round_pad(-distance, 32)).min(0)
+                    (math::round_pad(neg_distance, 32).wrapping_neg()).min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2005>
@@ -104,7 +105,7 @@ impl RoundState {
                 if distance >= 0 {
                     math::floor(distance).max(0)
                 } else {
-                    (-math::floor(-distance)).min(0)
+                    (math::floor(neg_distance).wrapping_neg()).min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2049>
@@ -112,7 +113,7 @@ impl RoundState {
                 if distance >= 0 {
                     math::ceil(distance).max(0)
                 } else {
-                    (-math::ceil(-distance)).min(0)
+                    (math::ceil(neg_distance).wrapping_neg()).min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2145>
@@ -220,6 +221,25 @@ mod tests {
             RoundMode::Off,
             &[(0, 0), (32, 32), (-32, -32), (64, 64), (50, 50)],
         );
+    }
+
+    #[test]
+    fn negative_min_value_does_not_panic_with_overflow() {
+        let value = F26Dot6::from_bits(i32::MIN);
+        for mode in [
+            RoundMode::Grid,
+            RoundMode::HalfGrid,
+            RoundMode::DoubleGrid,
+            RoundMode::DownToGrid,
+            RoundMode::UpToGrid,
+            RoundMode::Off,
+        ] {
+            let state = RoundState {
+                mode,
+                ..Default::default()
+            };
+            let _ = state.round(value);
+        }
     }
 
     fn round_cases(mode: RoundMode, cases: &[(i32, i32)]) {

--- a/skrifa/src/outline/glyf/hint/zone.rs
+++ b/skrifa/src/outline/glyf/hint/zone.rs
@@ -165,7 +165,7 @@ impl<'a> Zone<'a> {
             let mut end_point = self.contour(i)? as usize;
             let first_point = point;
             if end_point >= self.points.len() {
-                end_point = self.points.len() - 1;
+                end_point = self.points.len().saturating_sub(1);
             }
             while point <= end_point && !self.is_touched(point, axis)? {
                 point += 1;
@@ -335,7 +335,7 @@ impl<'a> GraphicsState<'a> {
     /// all accesses would be valid.
     pub fn in_bounds<const N: usize>(&self, pairs: [(ZonePointer, usize); N]) -> bool {
         for (zp, index) in pairs {
-            if index > self.zone(zp).points.len() {
+            if index >= self.zone(zp).points.len() {
                 return false;
             }
         }
@@ -639,6 +639,19 @@ mod tests {
     }
 
     #[test]
+    fn iup_does_not_panic_with_empty_points() {
+        let mut zone = Zone {
+            unscaled: &[],
+            original: &mut [],
+            points: &mut [],
+            contours: &[0],
+            flags: &mut [],
+        };
+        let _ = zone.iup(CoordAxis::X);
+        let _ = zone.iup(CoordAxis::Y);
+    }
+
+    #[test]
     fn move_point_x() {
         let mut mock = MockGraphicsState::new();
         let mut gs = mock.graphics_state(100, 0);
@@ -782,6 +795,15 @@ mod tests {
                 dy: F26Dot6::from_f64(0.203125),
             }
         );
+    }
+
+    #[test]
+    fn in_bounds_rejects_index_equal_to_len() {
+        let mut mock = MockGraphicsState::new();
+        let gs = mock.graphics_state(100, 50);
+        let len = gs.zones[ZonePointer::Glyph as usize].points.len();
+        assert!(!gs.in_bounds([(ZonePointer::Glyph, len)]));
+        assert!(gs.in_bounds([(ZonePointer::Glyph, len.saturating_sub(1))]));
     }
 
     struct MockGraphicsState {


### PR DESCRIPTION
A small assortment of changes to prevent panic on overflowing arithmetic or out of bounds indexing. This certainly isn't the last of these bugs but we'll fix 'em and we find 'em.

These were identified by an internal vulnerability analysis tool.