### PR TITLE
Bump Rust to 1.89 (Aug 7 2025)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/googlefonts/fontations"
-rust-version = "1.85"
+rust-version = "1.89"
 
 [workspace.dependencies]
 # note: bytemuck version must be available in all deployment environments,


### PR DESCRIPTION
- Matches the version used in CI