### PR TITLE
Add skera benchmarks

### DIFF
--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -12,6 +12,10 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bench]]
+name = "skera-benchmarks"
+harness = false
+
 [[bin]]
 name = "skera"
 path = "src/main.rs"
@@ -30,6 +34,7 @@ write-fonts = { workspace = true, features = ["read"] }
 
 
 [dev-dependencies]
+criterion = { workspace = true }
 diff = "0.1.13"
 font-test-data = { workspace = true }
 rayon = { workspace = true }

--- a/skera/benches/skera-benchmarks.rs
+++ b/skera/benches/skera-benchmarks.rs
@@ -1,0 +1,67 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use skera::{subset_font, Plan, SubsetFlags, DEFAULT_DROP_TABLES, DEFAULT_LAYOUT_FEATURES};
+use std::path::Path;
+use write_fonts::{
+    read::{collections::IntSet, FontRef},
+    types::NameId,
+};
+
+fn read_test_font(file_name: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("test-data/fonts")
+        .join(file_name);
+    std::fs::read(&path).expect("failed to read test font file")
+}
+
+fn set_from_ranges<I>(ranges: I) -> IntSet<u32>
+where
+    I: IntoIterator<Item = std::ops::RangeInclusive<u32>>,
+{
+    let mut set = IntSet::empty();
+    for range in ranges {
+        set.insert_range(range);
+    }
+    set
+}
+
+/// Creates a subsetting plan using the same default options as running the src/main.rs with
+/// --unicodes.
+fn create_plan(font: &FontRef, unicodes: &IntSet<u32>) -> Plan {
+    Plan::new(
+        &IntSet::empty(), // gids (empty by default when using --unicodes)
+        unicodes,
+        font,
+        SubsetFlags::default(),
+        &DEFAULT_DROP_TABLES.iter().copied().collect(),
+        &IntSet::all(), // layout_scripts (default in CLI is all scripts)
+        &DEFAULT_LAYOUT_FEATURES.iter().copied().collect(),
+        // Keep name IDs 0 to 6 (Copyright through PostScript Name)
+        &(0..=6).map(NameId::from).collect(),
+        // Keep English (US) locale (0x0409) names
+        &[0x0409].into_iter().collect(),
+    )
+}
+
+fn benchmark_subset(c: &mut Criterion) {
+    let latin_codepoints = set_from_ranges([0x20..=0x7E, 0xA0..=0xFF, 0x100..=0x24F]);
+    c.benchmark_group("subset")
+        .bench_function("roboto-latin", |b| {
+            let font_bytes = read_test_font("Roboto-Regular.ttf");
+            b.iter(|| {
+                let font = FontRef::new(&font_bytes).unwrap();
+                let plan = create_plan(&font, &latin_codepoints);
+                subset_font(&font, &plan).unwrap()
+            });
+        })
+        .bench_function("roboto-variable-latin", |b| {
+            let font_bytes = read_test_font("Roboto-Variable.ttf");
+            b.iter(|| {
+                let font = FontRef::new(&font_bytes).unwrap();
+                let plan = create_plan(&font, &latin_codepoints);
+                subset_font(&font, &plan).unwrap()
+            });
+        });
+}
+
+criterion_group!(benches, benchmark_subset);
+criterion_main!(benches);


### PR DESCRIPTION
- Adds initial benchmarks for skera, should tweak to be more representative later
- Run with `cargo bench -p skera`

# Results

```sh
$ cargo bench -p skera
...

     Running benches/skera-benchmarks.rs (target/release/deps/skera_benchmarks-a8a3a110a3aae6dc)
roboto-latin-subset     time:   [405.89 µs 408.83 µs 412.40 µs]
                        change: [+0.9842% +1.9785% +2.9519%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

roboto-variable-latin-subset
                        time:   [712.32 µs 718.37 µs 725.85 µs]
                        change: [−0.3751% +0.4477% +1.3558%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe
```