### PR TITLE
[chore] release all crates (except font-types) with minor bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,14 +44,14 @@ serde_json = "1.0"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.12.1", path = "font-types" }
-read-fonts = { version = "0.41.0", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.42.0", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.44.0", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.50.0", path = "write-fonts", default-features = false }
+skrifa = { version = "0.45.0", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.51.0", path = "write-fonts", default-features = false }
 shared-brotli-patch-decoder = { version = "0.1.4", path = "shared-brotli-patch-decoder", default-features = false }
-incremental-font-transfer = { version = "0.5.0", path = "incremental-font-transfer" }
-skera = { version = "0.4.0", path = "skera" }
+incremental-font-transfer = { version = "0.6.0", path = "incremental-font-transfer" }
+skera = { version = "0.5.0", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.7.0"
+version = "0.8.0"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental-font-transfer"
-version = "0.5.0"
+version = "0.6.0"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.41.0"
+version = "0.42.0"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.4.0"
+version = "0.5.0"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.44.0"
+version = "0.45.0"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.50.0"
+version = "0.51.0"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.41.0 to 0.42.0
             86d242f Make vhea version default, not computed (#1974)
             7be5935 Add alternate sparse bit set decoding method that allows specifying a maximum output set size.
             26503f2 [read-fonts] handle empty simple glyph with padding (#1965)
             b0160ad Fixup for new Font API
             f28b581 [read] Pass Args by value
             6090c3b [read] Simplifiy ResolveOffset
             e33ce2d [read] Combine FontRead/FontReadWithArgs
             a0bdb6e [read] Suppress a clippy false-positive (#1957)
             cb8b3eb Run rustfmt on the cmap4 overlap test
             df8598d [read-fonts] use real segment start code in cmap4 iterator
     Changes for font-test-data from font-test-data-v0.7.0 to 0.8.0
             87d4801 [skrifa] support cmap13 in Charmap (#1966)
             9b2a56d [test-data] Set glyphDataFormat=0 in VARC test fonts
             597549f Fix trivial clippy errors (#1940)
     Changes for write-fonts from write-fonts-v0.50.0 to 0.51.0
             86d242f Make vhea version default, not computed (#1974)
             fc82097 Support more fields when writing glyphs (#1960)
             f28b581 [read] Pass Args by value
             e33ce2d [read] Combine FontRead/FontReadWithArgs
     Changes for skrifa from skrifa-v0.44.0 to 0.45.0
             109f1d8 skrifa: Support obtaining `LocalizedStrings` from name table without a `FontRef` (#1900)
             87d4801 [skrifa] support cmap13 in Charmap (#1966)
             93d40d2 [skrifa] tt hint: overflow/OOB fixes (#1964)
             28ad033 [skrifa] tt hint: limit number of skipped instructions (#1963)
     Changes for skera from skera-v0.4.0 to 0.5.0
             bbedcb2 Add skera benchmarks (#1970)
             ed57bb9 [skera] increase MAX_FEATURE_INDICES
             b0160ad Fixup for new Font API
             e33ce2d [read] Combine FontRead/FontReadWithArgs
     Changes for incremental-font-transfer from incremental-font-transfer-v0.5.0 to 0.6.0
             37b6878 Short string optimization for IFT url_template (#1961)