### PR TITLE
[chore] release patch update for types, read, skrifa, skera

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.12.1", path = "font-types" }
-read-fonts = { version = "0.42.0", path = "read-fonts", default-features = false }
+font-types = { version = "0.12.2", path = "font-types" }
+read-fonts = { version = "0.42.1", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.45.0", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.45.1", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.51.0", path = "write-fonts", default-features = false }
 shared-brotli-patch-decoder = { version = "0.1.4", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.6.0", path = "incremental-font-transfer" }
-skera = { version = "0.5.0", path = "skera" }
+skera = { version = "0.5.1", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.12.1"
+version = "0.12.2"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.42.0"
+version = "0.42.1"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.5.0"
+version = "0.5.1"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.45.0"
+version = "0.45.1"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for font-types from font-types-v0.12.1 to 0.12.2
             5f74c0d [font-types] use wrapping abs/neg for Fixed (#1979)
     Changes for read-fonts from read-fonts-v0.42.0 to 0.42.1
             dd9af71 [read-fonts] avoid panic in BitmapSize::location() (#1977)
     Changes for skrifa from skrifa-v0.45.0 to 0.45.1
             d2d296e [skrifa] avoid infinite loop in autohinter (#1980)
             8c1fedf [skrifa] limit TT composite glyph work (#1978)
     Changes for skera from skera-v0.5.0 to 0.5.1
             634bf4d [skera] increase MAX_VERTICES limit to 800000