### PR TITLE
[skrifa] smallvec: don't pretend we do fallible alloc

### DIFF
--- a/skrifa/src/collections.rs
+++ b/skrifa/src/collections.rs
@@ -45,8 +45,7 @@ where
             Storage::Inline(buf, len) => {
                 let new_cap = len.saturating_add(additional);
                 if new_cap > N {
-                    let mut vec = Vec::new();
-                    vec.reserve(new_cap);
+                    let mut vec = Vec::with_capacity(new_cap);
                     vec.extend_from_slice(&buf[..*len]);
                     self.0 = Storage::Heap(vec);
                 }

--- a/skrifa/src/collections.rs
+++ b/skrifa/src/collections.rs
@@ -39,27 +39,22 @@ where
         }
     }
 
-    /// Tries to reserve capacity for at least `additional` more elements.
-    pub fn try_reserve(&mut self, additional: usize) -> bool {
+    /// Reserves capacity for at least `additional` more elements.
+    pub fn reserve(&mut self, additional: usize) {
         match &mut self.0 {
             Storage::Inline(buf, len) => {
-                let new_cap = *len + additional;
+                let new_cap = len.saturating_add(additional);
                 if new_cap > N {
                     let mut vec = Vec::new();
-                    if vec.try_reserve(new_cap).is_err() {
-                        return false;
-                    }
+                    vec.reserve(new_cap);
                     vec.extend_from_slice(&buf[..*len]);
                     self.0 = Storage::Heap(vec);
                 }
             }
             Storage::Heap(vec) => {
-                if vec.try_reserve(additional).is_err() {
-                    return false;
-                }
+                vec.reserve(additional);
             }
         }
-        true
     }
 
     /// Appends an element to the back of the collection.
@@ -346,10 +341,10 @@ mod test {
             vec.push(i);
         }
         assert!(matches!(vec.0, Storage::Inline(..)));
-        assert!(vec.try_reserve(1));
+        vec.reserve(1);
         // still inline after reserving 1
         assert!(matches!(vec.0, Storage::Inline(..)));
-        assert!(vec.try_reserve(2));
+        vec.reserve(2);
         // reserving 2 spills to heap
         assert!(matches!(vec.0, Storage::Heap(..)));
     }

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -529,12 +529,8 @@ impl Contour {
 }
 
 impl UnscaledOutlineSink for Outline {
-    fn try_reserve(&mut self, additional: usize) -> Result<(), DrawError> {
-        if self.points.try_reserve(additional) {
-            Ok(())
-        } else {
-            Err(DrawError::InsufficientMemory)
-        }
+    fn reserve(&mut self, additional: usize) {
+        self.points.reserve(additional);
     }
 
     fn push(&mut self, point: UnscaledPoint) -> Result<(), DrawError> {

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -477,7 +477,7 @@ impl<'a> OutlineGlyph<'a> {
                 with_temporary_memory(self, Hinting::None, user_memory, |buf| {
                     let outline = FreeTypeScaler::unhinted(glyf, outline, buf, ppem, coords)?
                         .scale(&outline.glyph, outline.glyph_id)?;
-                    sink.try_reserve(outline.points.len())?;
+                    sink.reserve(outline.points.len());
                     let mut contour_start = 0;
                     for contour_end in outline.contours.iter().map(|contour| *contour as usize) {
                         if contour_end >= contour_start {

--- a/skrifa/src/outline/unscaled.rs
+++ b/skrifa/src/outline/unscaled.rs
@@ -39,7 +39,7 @@ impl UnscaledPoint {
 }
 
 pub(super) trait UnscaledOutlineSink {
-    fn try_reserve(&mut self, additional: usize) -> Result<(), DrawError>;
+    fn reserve(&mut self, additional: usize);
     fn push(&mut self, point: UnscaledPoint) -> Result<(), DrawError>;
     fn extend(&mut self, points: impl IntoIterator<Item = UnscaledPoint>) -> Result<(), DrawError> {
         for point in points.into_iter() {
@@ -69,12 +69,8 @@ impl<const INLINE_CAP: usize> UnscaledOutlineBuf<INLINE_CAP> {
 }
 
 impl<const INLINE_CAP: usize> UnscaledOutlineSink for UnscaledOutlineBuf<INLINE_CAP> {
-    fn try_reserve(&mut self, additional: usize) -> Result<(), DrawError> {
-        if !self.0.try_reserve(additional) {
-            Err(DrawError::InsufficientMemory)
-        } else {
-            Ok(())
-        }
+    fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
     }
 
     fn push(&mut self, point: UnscaledPoint) -> Result<(), DrawError> {


### PR DESCRIPTION
We used the `try_reserve` name in `SmallVec` and `UnscaledOutlineSink` even though we don't really guarantee fallible allocation from the system. AI analysis tools don't like this so just rename the methods to `reserve` to accurately represent our intent.