### PR TITLE
Update bytemuck to 1.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,11 @@ rust-version = "1.89"
 
 [workspace.dependencies]
 # note: bytemuck version must be available in all deployment environments,
-# specifically the floor of the versions supported by google3 and Chrome
-bytemuck = "1.24.0"
+# specifically the floor of the versions supported by google3, Chrome and
+# Android.
+# Chrome: https://chromium.googlesource.com/chromium/src/third_party/rust/+/refs/heads/main/bytemuck/v1/BUILD.gn
+# Android: https://android.googlesource.com/platform/external/rust/crates/bytemuck/+/refs/heads/main/Cargo.toml
+bytemuck = "1.14.0"
 # dev dependencies
 env_logger = "0.11"
 pretty_assertions = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rust-version = "1.89"
 [workspace.dependencies]
 # note: bytemuck version must be available in all deployment environments,
 # specifically the floor of the versions supported by google3 and Chrome
-bytemuck = "1.13.1"
+bytemuck = "1.24.0"
 # dev dependencies
 env_logger = "0.11"
 pretty_assertions = "1.3.0"


### PR DESCRIPTION
This matches the version in Android (https://android.googlesource.com/platform/external/rust/crates/bytemuck/+/refs/heads/main/Cargo.toml). Chromium is currently on 1.25.1 (https://chromium.googlesource.com/chromium/src/third_party/rust/+/refs/heads/main/bytemuck/v1/BUILD.gn#42). Google3 is on 1.24.0.

Motivation: mostly because I keep getting hundreds of compiler warnings about unused `check` functions caused by our ancient version of bytemuck.