### PR TITLE
Lower MSRV to 1.85 and add MSRV CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,20 @@ jobs:
       - name: cargo clippy incremental-font-transfer (1.89)
         run: cargo clippy -p incremental-font-transfer --all-features --all-targets -- -D warnings
 
+  check-msrv:
+    name: cargo check msrv
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.85
+
+      - name: cargo check
+        run: cargo check --workspace
+
   test-stable:
     name: cargo test stable
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/googlefonts/fontations"
-rust-version = "1.89"
+rust-version = "1.85"
 
 [workspace.dependencies]
 # note: bytemuck version must be available in all deployment environments,
@@ -46,15 +46,15 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.12.2", path = "font-types" }
-read-fonts = { version = "0.42.1", path = "read-fonts", default-features = false }
+font-types = { version = "0.12.3", path = "font-types" }
+read-fonts = { version = "0.42.2", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.45.1", path = "skrifa", default-features = false, features = ["std"] }
-write-fonts = { version = "0.51.0", path = "write-fonts", default-features = false }
-shared-brotli-patch-decoder = { version = "0.1.4", path = "shared-brotli-patch-decoder", default-features = false }
-incremental-font-transfer = { version = "0.6.0", path = "incremental-font-transfer" }
-skera = { version = "0.5.1", path = "skera" }
+skrifa = { version = "0.45.2", path = "skrifa", default-features = false, features = ["std"] }
+write-fonts = { version = "0.51.1", path = "write-fonts", default-features = false }
+shared-brotli-patch-decoder = { version = "0.1.5", path = "shared-brotli-patch-decoder", default-features = false }
+incremental-font-transfer = { version = "0.6.1", path = "incremental-font-transfer" }
+skera = { version = "0.5.2", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/font-test-data/Cargo.toml
+++ b/font-test-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-test-data"
-version = "0.8.0"
+version = "0.8.1"
 description = "Test data for the fontations crates"
 readme = "README.md"
 

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.12.2"
+version = "0.12.3"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/incremental-font-transfer/Cargo.toml
+++ b/incremental-font-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental-font-transfer"
-version = "0.6.0"
+version = "0.6.1"
 description = "Client side implementation of the Incremental Font Transfer standard (https://w3c.github.io/IFT/Overview.html)"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.42.1"
+version = "0.42.2"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/shared-brotli-patch-decoder/Cargo.toml
+++ b/shared-brotli-patch-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared-brotli-patch-decoder"
-version = "0.1.4"
+version = "0.1.5"
 description = "Wrapper around brotli-sys which allows for decoding shared brotli (https://datatracker.ietf.org/doc/draft-vandevenne-shared-brotli-format/) encoded patch data."
 edition.workspace = true
 license.workspace = true

--- a/skera/Cargo.toml
+++ b/skera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skera"
-version = "0.5.1"
+version = "0.5.2"
 description = "Subsetting a font file according to provided input."
 readme = "README.md"
 categories = ["text-processing"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.45.1"
+version = "0.45.2"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/write-fonts/Cargo.toml
+++ b/write-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "write-fonts"
-version = "0.51.0"
+version = "0.51.1"
 description = "Writing font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
The MSRV was bumped to 1.89 in #1967 to match the rustc version running in CI, but this bump is not actually required (entire workspace builds with 1.85).

Changes:
- Reduce MSRV back to 1.85
- Add a CI job that runs 'cargo check --workspace' on the MSRV toolchain.
- Patch-bump all publishable crates so the lowered MSRV can be released.

(Servo is still on MSRV 1.88, so can't upgrade to the latest versions atm)

We could also just reduce the rustc version used for all of CI. https://github.com/googlefonts/fontations/pull/1942 bumped to 1.89 to match the version supported by Skia, but it is unclear to me why this repo would need to run CI with the rustc version used by Skia.