### PR TITLE
enable Link-Time Optimization (LTO) and codegen-units = 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ skera = { version = "0.5.1", path = "skera" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]
+
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
See: https://github.com/googlefonts/fontations/issues/1413 