### PR TITLE
[chore] Better manage github actions deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Actions are pinned to commit hashes (required by the unpinned-uses scan);
+  # dependabot updates both the hash and the trailing version comment.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    # Don't adopt a release until it has been public for a week: a compromised
+    # release is usually caught and yanked well inside that window.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,8 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - run: rustup component add rustfmt
 
       - name: rustfmt check
@@ -36,9 +36,9 @@ jobs:
     name: Clippy lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.89
       - run: rustup component add clippy
@@ -68,10 +68,10 @@ jobs:
     name: cargo test stable
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       # test all packages individually to ensure deterministic resolution
       # of dependencies for each package
@@ -130,7 +130,7 @@ jobs:
     name: Verify licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Verify licenses
         run: resources/scripts/check_licenses.sh
 
@@ -138,10 +138,10 @@ jobs:
     name: check codegen is up-to-date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: run codegen
         run: cargo run --bin=codegen resources/codegen_plan.toml
@@ -155,10 +155,10 @@ jobs:
     name: cargo check no std
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: 1.89
           # Use a target without `std` to make sure we don't link to `std`
@@ -179,10 +179,10 @@ jobs:
     name: cargo check wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           target: wasm32-unknown-unknown
           toolchain: 1.89
@@ -203,9 +203,9 @@ jobs:
     name: Check for typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: check typos
-        uses: crate-ci/typos@v1.30.2
+        uses: crate-ci/typos@7bc041cbb7ca9167c9e0e4ccbb26f48eb0f9d4e0 # v1.30.2
       - name: typo instructions
         if: failure()
         run: |
@@ -216,8 +216,8 @@ jobs:
     name: fauntlet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: fauntlet compare
         run: cargo run --release -p fauntlet -- compare-glyphs --print-paths --hinting-engine all --hinting-target all --exit-on-fail fauntlet/test_fonts/*.*tf


### PR DESCRIPTION
This makes sure that we are pinning actions to git shas, and additionally configures dependabot to bother us monthly if there are updates to our actions.


This was motivated by a failing CI check on #1997; this check is new (afaik) and there is a go/ link in the failure log that I don't have access to, if someone wants to sanity check this patch against go/github-zizmor-help?