### PR TITLE
[skrifa] avoid more overflow panics in TT hinting

### DIFF
--- a/skrifa/src/outline/glyf/hint/engine/outline.rs
+++ b/skrifa/src/outline/glyf/hint/engine/outline.rs
@@ -488,7 +488,7 @@ impl Engine<'_> {
     /// and <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L5731>
     pub(super) fn op_mirp(&mut self, opcode: u8) -> OpResult {
         let gs = &mut self.graphics;
-        let n = (self.value_stack.pop()? + 1) as usize;
+        let n = (self.value_stack.pop()?.wrapping_add(1)) as usize;
         let p = self.value_stack.pop_usize()?;
         if !gs.is_pedantic
             && (!gs.in_bounds([(gs.zp1, p), (gs.zp0, gs.rp0)]) || (n > self.cvt.len()))
@@ -1302,6 +1302,15 @@ mod tests {
         engine.op_mirp(Opcode::MIRP00100 as _).unwrap();
         let point = engine.graphics.zones[1].point(2).unwrap();
         assert_eq!(point.map(F26Dot6::to_bits), Point::new(147, -223));
+    }
+
+    #[test]
+    fn mirp_does_not_panic_with_overflow() {
+        let mut mock = MockEngine::new();
+        let mut engine = mock.engine();
+        engine.value_stack.push(i32::MAX).unwrap();
+        // Just don't panic on overflow
+        engine.op_mirp(Opcode::MIRP10000 as _).unwrap();
     }
 
     #[test]

--- a/skrifa/src/outline/glyf/hint/round.rs
+++ b/skrifa/src/outline/glyf/hint/round.rs
@@ -74,14 +74,18 @@ impl RoundState {
         use super::math;
         use RoundMode::*;
         let distance = distance.to_bits();
+        let round_bias = self.threshold.wrapping_sub(self.phase);
         let neg_distance = distance.wrapping_neg();
         let result = match self.mode {
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L1958>
             HalfGrid => {
                 if distance >= 0 {
-                    (math::floor(distance) + 32).max(0)
+                    math::floor(distance).wrapping_add(32).max(0)
                 } else {
-                    ((math::floor(neg_distance) + 32).wrapping_neg()).min(0)
+                    (math::floor(neg_distance)
+                        .wrapping_add(32)
+                        .wrapping_neg())
+                    .min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L1913>
@@ -119,18 +123,21 @@ impl RoundState {
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2145>
             Super => {
                 if distance >= 0 {
-                    let val =
-                        ((distance + (self.threshold - self.phase)) & -self.period) + self.phase;
+                    let val = (distance
+                        .wrapping_add(round_bias)
+                        & self.period.wrapping_neg())
+                        .wrapping_add(self.phase);
                     if val < 0 {
                         self.phase
                     } else {
                         val
                     }
                 } else {
-                    let val =
-                        -(((self.threshold - self.phase) - distance) & -self.period) - self.phase;
+                    let val = ((round_bias.wrapping_sub(distance)) & self.period.wrapping_neg())
+                        .wrapping_neg()
+                        .wrapping_sub(self.phase);
                     if val > 0 {
-                        -self.phase
+                        self.phase.wrapping_neg()
                     } else {
                         val
                     }
@@ -139,20 +146,25 @@ impl RoundState {
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2199>
             Super45 => {
                 if distance >= 0 {
-                    let val = (((distance + (self.threshold - self.phase)) / self.period)
-                        * self.period)
-                        + self.phase;
+                    let val = distance
+                        .wrapping_add(round_bias)
+                        .wrapping_div(self.period)
+                        .wrapping_mul(self.period)
+                        .wrapping_add(self.phase);
                     if val < 0 {
                         self.phase
                     } else {
                         val
                     }
                 } else {
-                    let val = -((((self.threshold - self.phase) - distance) / self.period)
-                        * self.period)
-                        - self.phase;
+                    let val = round_bias
+                        .wrapping_sub(distance)
+                        .wrapping_div(self.period)
+                        .wrapping_mul(self.period)
+                        .wrapping_neg()
+                        .wrapping_sub(self.phase);
                     if val > 0 {
-                        -self.phase
+                        self.phase.wrapping_neg()
                     } else {
                         val
                     }
@@ -240,6 +252,30 @@ mod tests {
             };
             let _ = state.round(value);
         }
+    }
+
+    #[test]
+    fn super_round_does_not_panic_with_extreme_values() {
+        let state = RoundState {
+            mode: RoundMode::Super,
+            threshold: i32::MAX,
+            phase: i32::MIN,
+            period: i32::MIN,
+        };
+        let _ = state.round(F26Dot6::from_bits(i32::MAX));
+        let _ = state.round(F26Dot6::from_bits(i32::MIN));
+    }
+
+    #[test]
+    fn super45_round_does_not_panic_with_extreme_values() {
+        let state = RoundState {
+            mode: RoundMode::Super45,
+            threshold: i32::MAX,
+            phase: i32::MIN,
+            period: -1,
+        };
+        let _ = state.round(F26Dot6::from_bits(i32::MAX));
+        let _ = state.round(F26Dot6::from_bits(i32::MIN));
     }
 
     fn round_cases(mode: RoundMode, cases: &[(i32, i32)]) {

--- a/skrifa/src/outline/glyf/hint/round.rs
+++ b/skrifa/src/outline/glyf/hint/round.rs
@@ -82,10 +82,7 @@ impl RoundState {
                 if distance >= 0 {
                     math::floor(distance).wrapping_add(32).max(0)
                 } else {
-                    (math::floor(neg_distance)
-                        .wrapping_add(32)
-                        .wrapping_neg())
-                    .min(0)
+                    (math::floor(neg_distance).wrapping_add(32).wrapping_neg()).min(0)
                 }
             }
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L1913>
@@ -123,9 +120,7 @@ impl RoundState {
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/57617782464411201ce7bbc93b086c1b4d7d84a5/src/truetype/ttinterp.c#L2145>
             Super => {
                 if distance >= 0 {
-                    let val = (distance
-                        .wrapping_add(round_bias)
-                        & self.period.wrapping_neg())
+                    let val = (distance.wrapping_add(round_bias) & self.period.wrapping_neg())
                         .wrapping_add(self.phase);
                     if val < 0 {
                         self.phase


### PR DESCRIPTION
Use wrapping arithmetic in a few more places:
* CVT index + 1 in MIRP instruction (b/537782380)
* Everywhere in `RoundState::round`