### PR TITLE
[skrifa] Don't panic drawing a VARC glyph with a null MultiItemVariationStore

### DIFF
--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -264,9 +264,7 @@ impl<'a> Outlines<'a> {
         expand_coords(&mut font_coords, self.axis_count, coords);
         let mut stack = GlyphStack::new();
         let pen: &mut dyn OutlinePen = pen;
-        let mut scalar_cache = self
-            .scalar_cache_from_store(self.var_store.as_ref())?
-            .unwrap();
+        let mut scalar_cache = self.scalar_cache_from_store(self.var_store.as_ref())?;
         let mut scratch = Scratchpad::new();
         let ctx = VarcSharedContext {
             font_coords: &font_coords,
@@ -389,7 +387,8 @@ impl<'a> Outlines<'a> {
                             if let Some(ref mut cache) = child_scalar_cache {
                                 cache.values.fill(ScalarCache::INVALID);
                             } else {
-                                child_scalar_cache = self.scalar_cache_from_store(ctx.var_store)?;
+                                child_scalar_cache =
+                                    Some(self.scalar_cache_from_store(ctx.var_store)?);
                             }
                             self.draw_glyph(
                                 component_gid,
@@ -733,12 +732,17 @@ impl<'a> Outlines<'a> {
     fn scalar_cache_from_store(
         &self,
         store: Option<&MultiItemVariationStore<'a>>,
-    ) -> Result<Option<ScalarCache>, DrawError> {
-        let Some(store) = store else {
-            return Ok(None);
+    ) -> Result<ScalarCache, DrawError> {
+        // The VARC `multiVarStore` offset is nullable, so a valid font may omit the
+        // store entirely. In that case there are no variation regions and an empty
+        // cache is correct: any component that references variation data will fail
+        // gracefully with `ReadError::NullOffset` when it resolves the missing store,
+        // rather than us panicking here.
+        let region_count = match store {
+            Some(store) => store.region_list()?.region_count() as usize,
+            None => 0,
         };
-        let region_count = store.region_list()?.region_count() as usize;
-        Ok(Some(ScalarCache::new(region_count)))
+        Ok(ScalarCache::new(region_count))
     }
 }
 
@@ -1362,5 +1366,44 @@ mod tests {
             0,
         )
         .unwrap());
+    }
+
+    /// The `multi_var_store_offset` field of the VARC table is `#[nullable]`, so a
+    /// spec-valid font may omit the `MultiItemVariationStore`. Drawing such a glyph
+    /// must not panic. Regression test for the `.unwrap()` on the `Option` returned
+    /// by `scalar_cache_from_store`.
+    #[test]
+    fn draw_varc_with_null_var_store_does_not_panic() {
+        use crate::{instance::LocationRef, outline::DrawSettings, MetadataProvider};
+        use read_fonts::types::Tag;
+
+        let mut bytes = font_test_data::varc::CJK_6868.to_vec();
+        // Find the VARC table via the public table directory rather than parsing the
+        // sfnt header by hand.
+        let varc_off = {
+            let font = FontRef::new(&bytes).unwrap();
+            font.table_directory()
+                .table_records()
+                .iter()
+                .find(|rec| rec.tag() == Tag::new(b"VARC"))
+                .expect("VARC table present")
+                .offset() as usize
+        };
+        // VARC layout: version (4) + coverage_offset (4) + multi_var_store_offset (4) ...
+        // Null the (nullable) multi_var_store_offset so `multi_var_store()` -> None.
+        for b in &mut bytes[varc_off + 8..varc_off + 12] {
+            *b = 0;
+        }
+
+        let font = FontRef::new(&bytes).unwrap();
+        let outlines = font.outline_glyphs();
+        let gid = font.cmap().unwrap().map_codepoint(0x6868_u32).unwrap();
+        let glyph = outlines.get(gid).expect("covered VARC glyph");
+        let mut pen = Vec::<PathElement>::new();
+        // Must complete without panicking (Ok, or a graceful DrawError).
+        let _ = glyph.draw(
+            DrawSettings::unhinted(Size::unscaled(), LocationRef::default()),
+            &mut pen,
+        );
     }
 }


### PR DESCRIPTION

## What

`Outlines::draw` in the VARC renderer unwraps the scalar cache returned by
`scalar_cache_from_store`, which is `None` whenever the VARC table has no variation
store. Since the `multiVarStore` offset is `#[nullable]`, a spec-valid font can omit
the store, and drawing any covered glyph from such a font panics:

```
thread '...' panicked at skrifa/src/outline/varc/mod.rs:269:14:
called `Option::unwrap()` on a `None` value
```

reachable through the public API (`FontRef::outline_glyphs().get(gid).draw(...)`) on an
untrusted font.

## Fix

`scalar_cache_from_store` now returns a `ScalarCache` directly, yielding an empty cache
(zero regions) when the store is absent instead of `Some`/`None`. This removes the
`.unwrap()` at the primary call site and the latent twin in `draw_glyph` (which would
otherwise panic at `child_scalar_cache.as_mut().unwrap()` for a null-store font with a
nested axis-bearing component).

The behavior is unchanged for well-formed fonts: an empty cache is only ever produced
when there are no regions, and any component that references variation data still
returns a graceful `ReadError::NullOffset` when it resolves the missing store — no more
panicking.

## Test

Adds `draw_varc_with_null_var_store_does_not_panic`, which nulls the `multiVarStore`
offset of the `varc-6868` fixture and draws through the public outline API. It fails
(panics) before this change and passes after.

```
cargo test -p skrifa
test result: ok. 393 passed; 0 failed; ...
   Doc-tests skrifa
test result: ok. 11 passed; 0 failed; ...
```

Found with rust-in-peace (https://github.com/scadastrangelove/rust-in-peace).

Closes #2010
