### PR TITLE
[skrifa] varc: bound condition-evaluation recursion

### DIFF
--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -640,7 +640,7 @@ impl<'a> Outlines<'a> {
         let condition_list = condition_list?;
         let condition = condition_list.conditions().get(condition_index as usize)?;
         let (store, regions) = store_regions.ok_or(ReadError::NullOffset)?;
-        Self::eval_condition(&condition, coords, store, regions, scalar_cache, scratch)
+        Self::eval_condition(&condition, coords, store, regions, scalar_cache, scratch, 0)
     }
 
     fn eval_condition(
@@ -650,7 +650,15 @@ impl<'a> Outlines<'a> {
         regions: &SparseVariationRegionList<'a>,
         scalar_cache: &mut ScalarCache,
         scratch: &mut Scratchpad,
+        depth: usize,
     ) -> Result<bool, DrawError> {
+        // Format 3/4/5 conditions nest child conditions by offset, and the tree
+        // is fully attacker-controlled. Bound the recursion so a deeply nested
+        // (or degenerate) condition tree returns an error instead of overflowing
+        // the stack, mirroring the component-recursion guard in `draw_glyph`.
+        if depth >= GLYF_COMPOSITE_RECURSION_LIMIT {
+            return Err(DrawError::RecursionLimitExceeded(GlyphId::NOTDEF));
+        }
         match condition {
             Condition::Format1AxisRange(condition) => {
                 let axis_index = condition.axis_index() as usize;
@@ -683,6 +691,7 @@ impl<'a> Outlines<'a> {
                         regions,
                         scalar_cache,
                         scratch,
+                        depth + 1,
                     )? {
                         return Ok(false);
                     }
@@ -699,6 +708,7 @@ impl<'a> Outlines<'a> {
                         regions,
                         scalar_cache,
                         scratch,
+                        depth + 1,
                     )? {
                         return Ok(true);
                     }
@@ -714,6 +724,7 @@ impl<'a> Outlines<'a> {
                     regions,
                     scalar_cache,
                     scratch,
+                    depth + 1,
                 )?)
             }
         }
@@ -1258,5 +1269,98 @@ mod tests {
                 "Q704.43,783.31 717.03,804.56".to_string(),
             ]
         );
+    }
+
+    // Build the store/regions needed by `eval_condition`'s signature. The
+    // conditions exercised below never touch the variation store, so any valid
+    // VARC store works here.
+    fn condition_eval_env() -> (
+        FontRef<'static>,
+        MultiItemVariationStore<'static>,
+        SparseVariationRegionList<'static>,
+    ) {
+        let font = FontRef::new(font_test_data::varc::CJK_6868).unwrap();
+        let varc = font.varc().unwrap();
+        let store = varc.multi_var_store().unwrap().unwrap();
+        let regions = store.region_list().unwrap();
+        (font, store, regions)
+    }
+
+    // A deeply nested condition tree must return an error instead of overflowing
+    // the stack. Regression test for the unbounded recursion in `eval_condition`.
+    #[test]
+    fn eval_condition_bounds_recursion_depth() {
+        use read_fonts::{FontData, FontRead};
+        // Linear chain of Format5Negate tables: each is `format(u16 BE = 5)` +
+        // `condition_offset(Offset24 BE = 5)`, so every table points 5 bytes
+        // forward to the next -> an arbitrarily deep condition tree. `CHAIN_LEN`
+        // is far larger than the limit, proving evaluation bails out early rather
+        // than walking (and recursing into) the whole chain.
+        const CHAIN_LEN: usize = 4096;
+        let mut bytes = Vec::with_capacity(CHAIN_LEN * 5);
+        for _ in 0..CHAIN_LEN {
+            bytes.extend_from_slice(&[0x00, 0x05, 0x00, 0x00, 0x05]);
+        }
+        let cond = Condition::read(FontData::new(&bytes)).unwrap();
+
+        let (_font, store, regions) = condition_eval_env();
+        let mut cache = ScalarCache::new(regions.region_count() as usize);
+        let mut scratch = Scratchpad::new();
+
+        let result =
+            Outlines::eval_condition(&cond, &[], &store, &regions, &mut cache, &mut scratch, 0);
+        assert!(
+            matches!(result, Err(DrawError::RecursionLimitExceeded(_))),
+            "expected RecursionLimitExceeded, got {result:?}"
+        );
+    }
+
+    // A normal (shallow) condition tree must still evaluate correctly.
+    #[test]
+    fn eval_condition_shallow_is_correct() {
+        use read_fonts::{FontData, FontRead};
+        let (_font, store, regions) = condition_eval_env();
+        let mut cache = ScalarCache::new(regions.region_count() as usize);
+        let mut scratch = Scratchpad::new();
+
+        // ConditionFormat1: axis 0, filter range [-1.0, 1.0].
+        let leaf: [u8; 8] = [0x00, 0x01, 0x00, 0x00, 0xC0, 0x00, 0x40, 0x00];
+        let cond = Condition::read(FontData::new(&leaf)).unwrap();
+        assert!(Outlines::eval_condition(
+            &cond,
+            &[coord(0.5)],
+            &store,
+            &regions,
+            &mut cache,
+            &mut scratch,
+            0,
+        )
+        .unwrap());
+        assert!(!Outlines::eval_condition(
+            &cond,
+            &[coord(1.5)],
+            &store,
+            &regions,
+            &mut cache,
+            &mut scratch,
+            0,
+        )
+        .unwrap());
+
+        // Format5Negate wrapping the same leaf must negate the result, proving a
+        // shallow nested tree still evaluates through the recursion guard.
+        let mut negate = vec![0x00, 0x05, 0x00, 0x00, 0x05];
+        negate.extend_from_slice(&leaf);
+        let cond = Condition::read(FontData::new(&negate)).unwrap();
+        assert!(!Outlines::eval_condition(
+            &cond,
+            &[coord(0.5)],
+            &store,
+            &regions,
+            &mut cache,
+            &mut scratch,
+            0,
+        )
+        .unwrap());
     }
 }


### PR DESCRIPTION

### What

`skrifa::outline::varc::Outlines::eval_condition` recurses over the VARC
`Condition` expression tree (`Format3And` / `Format4Or` / `Format5Negate`) with
no depth limit. Because the condition tree is attacker-controlled font data, a
crafted VARC table with a deeply nested condition tree drives it into unbounded
recursion and overflows the stack — an uncatchable process abort (`SIGABRT`)
reachable from the public outline API (`OutlineGlyph::draw` → VARC) on untrusted
font input.

This mirrors #1993 (`type1: remove unbounded recursion`), applied to the VARC
condition evaluator. Memory-safe (no corruption); it is a DoS / robustness fix
for untrusted (e.g. system) fonts. Not reachable via the browser web-font path,
where OTS strips `VARC` before skrifa sees it.

### Fix

Thread a `depth` counter through `eval_condition`, incrementing it on each
recursive descent, and return `DrawError::RecursionLimitExceeded` once it
reaches the bound — the same pattern as the existing VARC **component**
recursion guard in `draw_glyph`. The bound reuses the crate's existing
`GLYF_COMPOSITE_RECURSION_LIMIT` (32): it is already the limit used for the
sibling VARC component recursion in this file, and it is far deeper than any
legitimate condition tree (a real `ConditionSet` is a flat AND of a few axis
conditions, nesting depth ≤ ~4), so it cannot trip on valid fonts.

The error carries `GlyphId::NOTDEF` as a neutral sentinel, since the recursion
is over the condition expression rather than any single component glyph; if you
would prefer the error to carry the enclosing component's `gid`, I'm happy to
thread it through `component_condition_met` instead.

### Tests

Added to the `skrifa::outline::varc` test module:

- `eval_condition_bounds_recursion_depth` — a deeply nested condition tree
  (a chain of `Format5Negate` tables built as raw bytes and parsed through the
  public `read-fonts` API) now returns `Err(RecursionLimitExceeded)` instead of
  overflowing the stack.
- `eval_condition_shallow_is_correct` — a plain `Format1AxisRange` and a
  `Format5Negate`-wrapped `Format1` still evaluate to the correct boolean,
  confirming normal condition trees are unaffected.

`cargo test -p skrifa` is green (394 unit tests + 11 doctests), including the
existing real-VARC-font drawing tests; `cargo fmt --check` and `cargo clippy`
are clean for the changed file.

### Diff

Fix is 8 lines (signature + guard + three `depth + 1` recursive calls); the
remainder is tests. See `fix.diff`.

---
Found with rust-in-peace (https://github.com/scadastrangelove/rust-in-peace).

Closes #2013
