### PR TITLE
[sanitize] Implement max offset depth

### DIFF
--- a/font-codegen/src/lib.rs
+++ b/font-codegen/src/lib.rs
@@ -101,9 +101,7 @@ pub(crate) fn generate_compile_module(
         .iter()
         .map(|item| match item {
             Item::Record(item) => record::generate_compile(item, &items.parse_module_path),
-            Item::Table(item) => {
-                table::generate_compile(item, &items.parse_module_path, items.sanitize)
-            }
+            Item::Table(item) => table::generate_compile(item, items),
             Item::GenericGroup(item) => {
                 generic_group::generate_compile(item, &items.parse_module_path)
             }

--- a/font-codegen/src/table.rs
+++ b/font-codegen/src/table.rs
@@ -346,11 +346,7 @@ fn generate_debug(item: &Table, sanitize: bool) -> syn::Result<TokenStream> {
     })
 }
 
-pub(crate) fn generate_compile(
-    item: &Table,
-    parse_module: &syn::Path,
-    sanitize: bool,
-) -> syn::Result<TokenStream> {
+pub(crate) fn generate_compile(item: &Table, items: &Items) -> syn::Result<TokenStream> {
     let decl = super::record::generate_compile_impl(item.raw_name(), &item.attrs, &item.fields)?;
     if decl.is_empty() {
         return Ok(decl);
@@ -360,7 +356,7 @@ pub(crate) fn generate_compile(
         .attrs
         .skip_from_obj
         .is_none()
-        .then(|| generate_to_owned_impl(item, parse_module, sanitize))
+        .then(|| generate_to_owned_impl(item, items))
         .transpose()?;
     let top_level = item.attrs.tag.as_ref().map(|tag| {
         let name = item.raw_name();
@@ -378,11 +374,7 @@ pub(crate) fn generate_compile(
     })
 }
 
-fn generate_to_owned_impl(
-    item: &Table,
-    parse_module: &syn::Path,
-    sanitize: bool,
-) -> syn::Result<TokenStream> {
+fn generate_to_owned_impl(item: &Table, items: &Items) -> syn::Result<TokenStream> {
     let name = item.raw_name();
     let field_to_owned_stmts = item.fields.iter_from_obj_ref_stmts(false);
     let comp_generic = item.attrs.generic_offset.as_ref().map(|attr| &attr.attr);
@@ -391,17 +383,20 @@ fn generate_to_owned_impl(
         .then(|| syn::Ident::new("U", Span::call_site()));
     let impl_generics = comp_generic.into_iter().chain(parse_generic.as_ref());
     let impl_generics2 = impl_generics.clone();
-    // In sanitize modules, generic-offset accessors resolve via `fast_resolve` /
-    // `SanitizedArrayOfOffsets`, which require the parse type to be `Sanitize + Default`.
-    let sanitize_bounds = sanitize.then(|| quote!(+ Sanitize<'a> + Default));
+    let u_bound = if items.sanitize {
+        quote!(Sanitize<'a, Args = ()> + Default)
+    } else {
+        quote!(FontRead<'a>)
+    };
     let where_clause = comp_generic.map(|t| {
         quote! {
             where
-                U: FontRead<'a, Args = ()> #sanitize_bounds,
+                U: #u_bound,
                 #t: FromTableRef<U> + Default + 'static,
         }
     });
 
+    let parse_module = &items.parse_module_path;
     let impl_font_read = item.attrs.read_args.is_none() && item.attrs.generic_offset.is_none();
     let maybe_font_read = impl_font_read.then(|| {
         quote! {

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -26,11 +26,27 @@ impl ReadArgs for Gdef<'_> {
 
 impl<'a> FontRead<'a> for Gdef<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Gdef<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let version = ctx.read::<MajorMinor>()?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        ctx.sanitize_offset::<Offset16, AttachList>(())?;
+        ctx.sanitize_offset::<Offset16, LigCaretList>(())?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        if version.compatible((1u16, 2u16)) {
+            ctx.sanitize_offset::<Offset16, MarkGlyphSets>(())?;
         }
-        Ok(Self { data })
+        if version.compatible((1u16, 3u16)) {
+            ctx.sanitize_offset::<Offset32, ItemVariationStore>(())?;
+        }
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -65,7 +81,7 @@ impl<'a> Gdef<'a> {
     /// Attempt to resolve [`glyph_class_def_offset`][Self::glyph_class_def_offset].
     pub fn glyph_class_def(&self) -> Option<Result<ClassDef<'a>, ReadError>> {
         let data = self.data;
-        self.glyph_class_def_offset().resolve(data)
+        self.glyph_class_def_offset().fast_resolve(data, ())
     }
 
     /// Offset to attachment point list table, from beginning of GDEF
@@ -78,7 +94,7 @@ impl<'a> Gdef<'a> {
     /// Attempt to resolve [`attach_list_offset`][Self::attach_list_offset].
     pub fn attach_list(&self) -> Option<Result<AttachList<'a>, ReadError>> {
         let data = self.data;
-        self.attach_list_offset().resolve(data)
+        self.attach_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to ligature caret list table, from beginning of GDEF
@@ -91,7 +107,7 @@ impl<'a> Gdef<'a> {
     /// Attempt to resolve [`lig_caret_list_offset`][Self::lig_caret_list_offset].
     pub fn lig_caret_list(&self) -> Option<Result<LigCaretList<'a>, ReadError>> {
         let data = self.data;
-        self.lig_caret_list_offset().resolve(data)
+        self.lig_caret_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to class definition table for mark attachment type, from
@@ -104,7 +120,7 @@ impl<'a> Gdef<'a> {
     /// Attempt to resolve [`mark_attach_class_def_offset`][Self::mark_attach_class_def_offset].
     pub fn mark_attach_class_def(&self) -> Option<Result<ClassDef<'a>, ReadError>> {
         let data = self.data;
-        self.mark_attach_class_def_offset().resolve(data)
+        self.mark_attach_class_def_offset().fast_resolve(data, ())
     }
 
     /// Offset to the table of mark glyph set definitions, from
@@ -119,7 +135,8 @@ impl<'a> Gdef<'a> {
     /// Attempt to resolve [`mark_glyph_sets_def_offset`][Self::mark_glyph_sets_def_offset].
     pub fn mark_glyph_sets_def(&self) -> Option<Result<MarkGlyphSets<'a>, ReadError>> {
         let data = self.data;
-        self.mark_glyph_sets_def_offset().map(|x| x.resolve(data))?
+        self.mark_glyph_sets_def_offset()
+            .map(|x| x.fast_resolve(data, ()))?
     }
 
     /// Offset to the Item Variation Store table, from beginning of
@@ -134,7 +151,8 @@ impl<'a> Gdef<'a> {
     /// Attempt to resolve [`item_var_store_offset`][Self::item_var_store_offset].
     pub fn item_var_store(&self) -> Option<Result<ItemVariationStore<'a>, ReadError>> {
         let data = self.data;
-        self.item_var_store_offset().map(|x| x.resolve(data))?
+        self.item_var_store_offset()
+            .map(|x| x.fast_resolve(data, ()))?
     }
 
     pub fn version_byte_range(&self) -> Range<usize> {
@@ -314,11 +332,22 @@ impl ReadArgs for AttachList<'_> {
 
 impl<'a> FontRead<'a> for AttachList<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AttachList<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, AttachPoint>(
+            transforms::to_usize(glyph_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -342,7 +371,7 @@ impl<'a> AttachList<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of glyphs with attachment points
@@ -359,10 +388,10 @@ impl<'a> AttachList<'a> {
     }
 
     /// A dynamically resolving wrapper for [`attach_point_offsets`][Self::attach_point_offsets].
-    pub fn attach_points(&self) -> ArrayOfOffsets<'a, AttachPoint<'a>, Offset16> {
+    pub fn attach_points(&self) -> SanitizedArrayOfOffsets<'a, AttachPoint<'a>, Offset16> {
         let data = self.data;
         let offsets = self.attach_point_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
@@ -441,11 +470,18 @@ impl ReadArgs for AttachPoint<'_> {
 
 impl<'a> FontRead<'a> for AttachPoint<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AttachPoint<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let point_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(point_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -534,11 +570,22 @@ impl ReadArgs for LigCaretList<'_> {
 
 impl<'a> FontRead<'a> for LigCaretList<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for LigCaretList<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let lig_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, LigGlyph>(
+            transforms::to_usize(lig_glyph_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -562,7 +609,7 @@ impl<'a> LigCaretList<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of ligature glyphs
@@ -579,10 +626,10 @@ impl<'a> LigCaretList<'a> {
     }
 
     /// A dynamically resolving wrapper for [`lig_glyph_offsets`][Self::lig_glyph_offsets].
-    pub fn lig_glyphs(&self) -> ArrayOfOffsets<'a, LigGlyph<'a>, Offset16> {
+    pub fn lig_glyphs(&self) -> SanitizedArrayOfOffsets<'a, LigGlyph<'a>, Offset16> {
         let data = self.data;
         let offsets = self.lig_glyph_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn coverage_offset_byte_range(&self) -> Range<usize> {
@@ -661,11 +708,21 @@ impl ReadArgs for LigGlyph<'_> {
 
 impl<'a> FontRead<'a> for LigGlyph<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for LigGlyph<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let caret_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CaretValue>(
+            transforms::to_usize(caret_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -694,10 +751,10 @@ impl<'a> LigGlyph<'a> {
     }
 
     /// A dynamically resolving wrapper for [`caret_value_offsets`][Self::caret_value_offsets].
-    pub fn caret_values(&self) -> ArrayOfOffsets<'a, CaretValue<'a>, Offset16> {
+    pub fn caret_values(&self) -> SanitizedArrayOfOffsets<'a, CaretValue<'a>, Offset16> {
         let data = self.data;
         let offsets = self.caret_value_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn caret_count_byte_range(&self) -> Range<usize> {
@@ -790,13 +847,7 @@ impl ReadArgs for CaretValue<'_> {
 
 impl<'a> FontRead<'a> for CaretValue<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            CaretValueFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            CaretValueFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            CaretValueFormat3::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -813,6 +864,35 @@ impl<'a> MinByteRange<'a> for CaretValue<'a> {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
             Self::Format3(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for CaretValue<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            CaretValueFormat1::FORMAT => CaretValueFormat1::sanitize(ctx, ()),
+            CaretValueFormat2::FORMAT => CaretValueFormat2::sanitize(ctx, ()),
+            CaretValueFormat3::FORMAT => CaretValueFormat3::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return CaretValue::default();
+        };
+        match format {
+            CaretValueFormat1::FORMAT => {
+                CaretValue::Format1(CaretValueFormat1::read_fast(data, ()))
+            }
+            CaretValueFormat2::FORMAT => {
+                CaretValue::Format2(CaretValueFormat2::read_fast(data, ()))
+            }
+            CaretValueFormat3::FORMAT => {
+                CaretValue::Format3(CaretValueFormat3::read_fast(data, ()))
+            }
+            _ => CaretValue::default(),
         }
     }
 }
@@ -865,11 +945,18 @@ impl ReadArgs for CaretValueFormat1<'_> {
 
 impl<'a> FontRead<'a> for CaretValueFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CaretValueFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<i16>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -963,11 +1050,18 @@ impl ReadArgs for CaretValueFormat2<'_> {
 
 impl<'a> FontRead<'a> for CaretValueFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CaretValueFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1052,11 +1146,19 @@ impl ReadArgs for CaretValueFormat3<'_> {
 
 impl<'a> FontRead<'a> for CaretValueFormat3<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CaretValueFormat3<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<i16>();
+        ctx.sanitize_offset::<Offset16, DeviceOrVariationIndex>(())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1094,7 +1196,7 @@ impl<'a> CaretValueFormat3<'a> {
     /// Attempt to resolve [`device_offset`][Self::device_offset].
     pub fn device(&self) -> Result<DeviceOrVariationIndex<'a>, ReadError> {
         let data = self.data;
-        self.device_offset().resolve(data)
+        self.device_offset().fast_resolve(data, ())
     }
 
     pub fn caret_value_format_byte_range(&self) -> Range<usize> {
@@ -1162,11 +1264,22 @@ impl ReadArgs for MarkGlyphSets<'_> {
 
 impl<'a> FontRead<'a> for MarkGlyphSets<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for MarkGlyphSets<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let mark_glyph_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset32, CoverageTable>(
+            transforms::to_usize(mark_glyph_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1201,10 +1314,10 @@ impl<'a> MarkGlyphSets<'a> {
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset32> {
+    pub fn coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset32> {
         let data = self.data;
         let offsets = self.coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -26,11 +26,23 @@ impl ReadArgs for Gpos<'_> {
 
 impl<'a> FontRead<'a> for Gpos<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Gpos<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let version = ctx.read::<MajorMinor>()?;
+        ctx.sanitize_offset::<Offset16, ScriptList>(())?;
+        ctx.sanitize_offset::<Offset16, FeatureList>(())?;
+        ctx.sanitize_offset::<Offset16, PositionLookupList>(())?;
+        if version.compatible((1u16, 1u16)) {
+            ctx.sanitize_offset::<Offset32, FeatureVariations>(())?;
         }
-        Ok(Self { data })
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -64,7 +76,7 @@ impl<'a> Gpos<'a> {
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
     pub fn script_list(&self) -> Result<ScriptList<'a>, ReadError> {
         let data = self.data;
-        self.script_list_offset().resolve(data)
+        self.script_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to FeatureList table, from beginning of GPOS table
@@ -76,7 +88,7 @@ impl<'a> Gpos<'a> {
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
     pub fn feature_list(&self) -> Result<FeatureList<'a>, ReadError> {
         let data = self.data;
-        self.feature_list_offset().resolve(data)
+        self.feature_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to LookupList table, from beginning of GPOS table
@@ -88,7 +100,7 @@ impl<'a> Gpos<'a> {
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
     pub fn lookup_list(&self) -> Result<PositionLookupList<'a>, ReadError> {
         let data = self.data;
-        self.lookup_list_offset().resolve(data)
+        self.lookup_list_offset().fast_resolve(data, ())
     }
 
     pub fn feature_variations_offset(&self) -> Option<Nullable<Offset32>> {
@@ -101,7 +113,8 @@ impl<'a> Gpos<'a> {
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
     pub fn feature_variations(&self) -> Option<Result<FeatureVariations<'a>, ReadError>> {
         let data = self.data;
-        self.feature_variations_offset().map(|x| x.resolve(data))?
+        self.feature_variations_offset()
+            .map(|x| x.fast_resolve(data, ()))?
     }
 
     pub fn version_byte_range(&self) -> Range<usize> {
@@ -246,6 +259,42 @@ impl<'a> PositionLookup<'a> {
             PositionLookup::Contextual(inner) => inner.of_unit_type(),
             PositionLookup::ChainContextual(inner) => inner.of_unit_type(),
             PositionLookup::Extension(inner) => inner.of_unit_type(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for PositionLookup<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let discriminant = Lookup::read_discriminant(ctx.data())?;
+        match discriminant {
+            1 => Lookup::<SinglePos>::sanitize(ctx, _args),
+            2 => Lookup::<PairPos>::sanitize(ctx, _args),
+            3 => Lookup::<CursivePosFormat1>::sanitize(ctx, _args),
+            4 => Lookup::<MarkBasePosFormat1>::sanitize(ctx, _args),
+            5 => Lookup::<MarkLigPosFormat1>::sanitize(ctx, _args),
+            6 => Lookup::<MarkMarkPosFormat1>::sanitize(ctx, _args),
+            7 => Lookup::<PositionSequenceContext>::sanitize(ctx, _args),
+            8 => Lookup::<PositionChainContext>::sanitize(ctx, _args),
+            9 => Lookup::<ExtensionSubtable>::sanitize(ctx, _args),
+            other => Err(ReadError::InvalidFormat(other as _)),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        match Lookup::read_discriminant(data) {
+            Ok(1) => PositionLookup::Single(Lookup::<SinglePos>::read_fast(data, ())),
+            Ok(2) => PositionLookup::Pair(Lookup::<PairPos>::read_fast(data, ())),
+            Ok(3) => PositionLookup::Cursive(Lookup::<CursivePosFormat1>::read_fast(data, ())),
+            Ok(4) => PositionLookup::MarkToBase(Lookup::<MarkBasePosFormat1>::read_fast(data, ())),
+            Ok(5) => PositionLookup::MarkToLig(Lookup::<MarkLigPosFormat1>::read_fast(data, ())),
+            Ok(6) => PositionLookup::MarkToMark(Lookup::<MarkMarkPosFormat1>::read_fast(data, ())),
+            Ok(7) => {
+                PositionLookup::Contextual(Lookup::<PositionSequenceContext>::read_fast(data, ()))
+            }
+            Ok(8) => {
+                PositionLookup::ChainContextual(Lookup::<PositionChainContext>::read_fast(data, ()))
+            }
+            Ok(9) => PositionLookup::Extension(Lookup::<ExtensionSubtable>::read_fast(data, ())),
+            _ => PositionLookup::default(),
         }
     }
 }
@@ -686,13 +735,7 @@ impl ReadArgs for AnchorTable<'_> {
 
 impl<'a> FontRead<'a> for AnchorTable<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            AnchorFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            AnchorFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            AnchorFormat3::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -709,6 +752,29 @@ impl<'a> MinByteRange<'a> for AnchorTable<'a> {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
             Self::Format3(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for AnchorTable<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            AnchorFormat1::FORMAT => AnchorFormat1::sanitize(ctx, ()),
+            AnchorFormat2::FORMAT => AnchorFormat2::sanitize(ctx, ()),
+            AnchorFormat3::FORMAT => AnchorFormat3::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return AnchorTable::default();
+        };
+        match format {
+            AnchorFormat1::FORMAT => AnchorTable::Format1(AnchorFormat1::read_fast(data, ())),
+            AnchorFormat2::FORMAT => AnchorTable::Format2(AnchorFormat2::read_fast(data, ())),
+            AnchorFormat3::FORMAT => AnchorTable::Format3(AnchorFormat3::read_fast(data, ())),
+            _ => AnchorTable::default(),
         }
     }
 }
@@ -761,11 +827,19 @@ impl ReadArgs for AnchorFormat1<'_> {
 
 impl<'a> FontRead<'a> for AnchorFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AnchorFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<i16>();
+        ctx.advance::<i16>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -870,11 +944,20 @@ impl ReadArgs for AnchorFormat2<'_> {
 
 impl<'a> FontRead<'a> for AnchorFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AnchorFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<i16>();
+        ctx.advance::<i16>();
+        ctx.advance::<u16>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -983,11 +1066,21 @@ impl ReadArgs for AnchorFormat3<'_> {
 
 impl<'a> FontRead<'a> for AnchorFormat3<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AnchorFormat3<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<i16>();
+        ctx.advance::<i16>();
+        ctx.sanitize_offset::<Offset16, DeviceOrVariationIndex>(())?;
+        ctx.sanitize_offset::<Offset16, DeviceOrVariationIndex>(())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1035,7 +1128,7 @@ impl<'a> AnchorFormat3<'a> {
     /// Attempt to resolve [`x_device_offset`][Self::x_device_offset].
     pub fn x_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
-        self.x_device_offset().resolve(data)
+        self.x_device_offset().fast_resolve(data, ())
     }
 
     /// Offset to Device table (non-variable font) / VariationIndex
@@ -1049,7 +1142,7 @@ impl<'a> AnchorFormat3<'a> {
     /// Attempt to resolve [`y_device_offset`][Self::y_device_offset].
     pub fn y_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
         let data = self.data;
-        self.y_device_offset().resolve(data)
+        self.y_device_offset().fast_resolve(data, ())
     }
 
     pub fn anchor_format_byte_range(&self) -> Range<usize> {
@@ -1130,11 +1223,18 @@ impl ReadArgs for MarkArray<'_> {
 
 impl<'a> FontRead<'a> for MarkArray<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for MarkArray<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let mark_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<MarkRecord>(transforms::to_usize(mark_count), ())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1243,12 +1343,24 @@ impl MarkRecord {
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
     pub fn mark_anchor<'a>(&self, data: FontData<'a>) -> Result<AnchorTable<'a>, ReadError> {
-        self.mark_anchor_offset().resolve(data)
+        self.mark_anchor_offset().fast_resolve(data, ())
     }
 }
 
 impl FixedSize for MarkRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+impl ReadArgs for MarkRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for MarkRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.mark_anchor_offset()
+            .sanitize_offset::<AnchorTable>(ctx, ())?;
+        ctx.finish()
+    }
 }
 
 #[cfg(feature = "experimental_traverse")]
@@ -1322,12 +1434,7 @@ impl ReadArgs for SinglePos<'_> {
 
 impl<'a> FontRead<'a> for SinglePos<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            SinglePosFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            SinglePosFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -1342,6 +1449,27 @@ impl<'a> MinByteRange<'a> for SinglePos<'a> {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for SinglePos<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            SinglePosFormat1::FORMAT => SinglePosFormat1::sanitize(ctx, ()),
+            SinglePosFormat2::FORMAT => SinglePosFormat2::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return SinglePos::default();
+        };
+        match format {
+            SinglePosFormat1::FORMAT => SinglePos::Format1(SinglePosFormat1::read_fast(data, ())),
+            SinglePosFormat2::FORMAT => SinglePos::Format2(SinglePosFormat2::read_fast(data, ())),
+            _ => SinglePos::default(),
         }
     }
 }
@@ -1393,11 +1521,20 @@ impl ReadArgs for SinglePosFormat1<'_> {
 
 impl<'a> FontRead<'a> for SinglePosFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SinglePosFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let value_format = ctx.read::<ValueFormat>()?;
+        sanitize_value_record(ctx, value_format)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1428,7 +1565,7 @@ impl<'a> SinglePosFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Defines the types of data in the ValueRecord.
@@ -1534,11 +1671,21 @@ impl ReadArgs for SinglePosFormat2<'_> {
 
 impl<'a> FontRead<'a> for SinglePosFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SinglePosFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let value_format = ctx.read::<ValueFormat>()?;
+        let value_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<ValueRecord>(value_count as _, value_format, true)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1571,7 +1718,7 @@ impl<'a> SinglePosFormat2<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Defines the types of data in the ValueRecords.
@@ -1728,12 +1875,7 @@ impl ReadArgs for PairPos<'_> {
 
 impl<'a> FontRead<'a> for PairPos<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            PairPosFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            PairPosFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -1748,6 +1890,27 @@ impl<'a> MinByteRange<'a> for PairPos<'a> {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for PairPos<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            PairPosFormat1::FORMAT => PairPosFormat1::sanitize(ctx, ()),
+            PairPosFormat2::FORMAT => PairPosFormat2::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return PairPos::default();
+        };
+        match format {
+            PairPosFormat1::FORMAT => PairPos::Format1(PairPosFormat1::read_fast(data, ())),
+            PairPosFormat2::FORMAT => PairPos::Format2(PairPosFormat2::read_fast(data, ())),
+            _ => PairPos::default(),
         }
     }
 }
@@ -1799,11 +1962,25 @@ impl ReadArgs for PairPosFormat1<'_> {
 
 impl<'a> FontRead<'a> for PairPosFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for PairPosFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let value_format1 = ctx.read::<ValueFormat>()?;
+        let value_format2 = ctx.read::<ValueFormat>()?;
+        let pair_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, PairSet>(
+            transforms::to_usize(pair_set_count),
+            (value_format1, value_format2),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1837,7 +2014,7 @@ impl<'a> PairPosFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Defines the types of data in valueRecord1 — for the first
@@ -1868,11 +2045,11 @@ impl<'a> PairPosFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`pair_set_offsets`][Self::pair_set_offsets].
-    pub fn pair_sets(&self) -> ArrayOfOffsets<'a, PairSet<'a>, Offset16> {
+    pub fn pair_sets(&self) -> SanitizedArrayOfOffsets<'a, PairSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.pair_set_offsets();
         let args = (self.value_format1(), self.value_format2());
-        ArrayOfOffsets::new(offsets, data, args)
+        SanitizedArrayOfOffsets::new(offsets, data, args)
     }
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
@@ -1975,17 +2152,7 @@ impl<'a> FontRead<'a> for PairSet<'a> {
         data: FontData<'a>,
         args: (ValueFormat, ValueFormat),
     ) -> Result<Self, ReadError> {
-        let (value_format1, value_format2) = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self {
-            data,
-            value_format1,
-            value_format2,
-        })
+        Self::read_checked(data, args)
     }
 }
 
@@ -2001,6 +2168,30 @@ impl<'a> PairSet<'a> {
     ) -> Result<Self, ReadError> {
         let args = (value_format1, value_format2);
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for PairSet<'a> {
+    fn sanitize(
+        ctx: &mut SanitizeContext<'a, '_>,
+        args: (ValueFormat, ValueFormat),
+    ) -> Result<(), ReadError> {
+        let (value_format1, value_format2) = args;
+        let pair_value_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<PairValueRecord>(
+            pair_value_count as _,
+            (value_format1, value_format2),
+            true,
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: (ValueFormat, ValueFormat)) -> Self {
+        let (value_format1, value_format2) = args;
+        Self {
+            data,
+            value_format1,
+            value_format2,
+        }
     }
 }
 
@@ -2185,6 +2376,19 @@ impl<'a> PairValueRecord {
     }
 }
 
+impl SanitizeStruct for PairValueRecord {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(
+        &self,
+        ctx: &mut SanitizeContext,
+        _args: (ValueFormat, ValueFormat),
+    ) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for PairValueRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -2227,11 +2431,29 @@ impl ReadArgs for PairPosFormat2<'_> {
 
 impl<'a> FontRead<'a> for PairPosFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for PairPosFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let value_format1 = ctx.read::<ValueFormat>()?;
+        let value_format2 = ctx.read::<ValueFormat>()?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        let class1_count = ctx.read::<u16>()?;
+        let class2_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<Class1Record>(
+            class1_count as _,
+            (class2_count, value_format1, value_format2),
+            true,
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2268,7 +2490,7 @@ impl<'a> PairPosFormat2<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// ValueRecord definition — for the first glyph of the pair (may
@@ -2295,7 +2517,7 @@ impl<'a> PairPosFormat2<'a> {
     /// Attempt to resolve [`class_def1_offset`][Self::class_def1_offset].
     pub fn class_def1(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
-        self.class_def1_offset().resolve(data)
+        self.class_def1_offset().fast_resolve(data, ())
     }
 
     /// Offset to ClassDef table, from beginning of PairPos subtable
@@ -2308,7 +2530,7 @@ impl<'a> PairPosFormat2<'a> {
     /// Attempt to resolve [`class_def2_offset`][Self::class_def2_offset].
     pub fn class_def2(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
-        self.class_def2_offset().resolve(data)
+        self.class_def2_offset().fast_resolve(data, ())
     }
 
     /// Number of classes in classDef1 table — includes Class 0.
@@ -2509,6 +2731,19 @@ impl<'a> Class1Record<'a> {
     }
 }
 
+impl SanitizeStruct for Class1Record<'_> {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(
+        &self,
+        ctx: &mut SanitizeContext,
+        _args: (u16, ValueFormat, ValueFormat),
+    ) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for Class1Record<'a> {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -2600,6 +2835,19 @@ impl<'a> Class2Record {
     }
 }
 
+impl SanitizeStruct for Class2Record {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(
+        &self,
+        ctx: &mut SanitizeContext,
+        _args: (ValueFormat, ValueFormat),
+    ) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for Class2Record {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -2641,11 +2889,23 @@ impl ReadArgs for CursivePosFormat1<'_> {
 
 impl<'a> FontRead<'a> for CursivePosFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CursivePosFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let entry_exit_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<EntryExitRecord>(
+            transforms::to_usize(entry_exit_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2675,7 +2935,7 @@ impl<'a> CursivePosFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of EntryExit records
@@ -2793,7 +3053,7 @@ impl EntryExitRecord {
         &self,
         data: FontData<'a>,
     ) -> Option<Result<AnchorTable<'a>, ReadError>> {
-        self.entry_anchor_offset().resolve(data)
+        self.entry_anchor_offset().fast_resolve(data, ())
     }
 
     /// Offset to exitAnchor table, from beginning of CursivePos
@@ -2811,12 +3071,26 @@ impl EntryExitRecord {
         &self,
         data: FontData<'a>,
     ) -> Option<Result<AnchorTable<'a>, ReadError>> {
-        self.exit_anchor_offset().resolve(data)
+        self.exit_anchor_offset().fast_resolve(data, ())
     }
 }
 
 impl FixedSize for EntryExitRecord {
     const RAW_BYTE_LEN: usize = Offset16::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+impl ReadArgs for EntryExitRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for EntryExitRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.entry_anchor_offset()
+            .sanitize_offset::<AnchorTable>(ctx, ())?;
+        self.exit_anchor_offset()
+            .sanitize_offset::<AnchorTable>(ctx, ())?;
+        ctx.finish()
+    }
 }
 
 #[cfg(feature = "experimental_traverse")]
@@ -2860,11 +3134,22 @@ impl ReadArgs for MarkBasePosFormat1<'_> {
 
 impl<'a> FontRead<'a> for MarkBasePosFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for MarkBasePosFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let mark_class_count = ctx.read::<u16>()?;
+        ctx.sanitize_offset::<Offset16, MarkArray>(())?;
+        ctx.sanitize_offset::<Offset16, BaseArray>(mark_class_count)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2900,7 +3185,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
     pub fn mark_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.mark_coverage_offset().resolve(data)
+        self.mark_coverage_offset().fast_resolve(data, ())
     }
 
     /// Offset to baseCoverage table, from beginning of MarkBasePos
@@ -2913,7 +3198,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Attempt to resolve [`base_coverage_offset`][Self::base_coverage_offset].
     pub fn base_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.base_coverage_offset().resolve(data)
+        self.base_coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of classes defined for marks
@@ -2932,7 +3217,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
     pub fn mark_array(&self) -> Result<MarkArray<'a>, ReadError> {
         let data = self.data;
-        self.mark_array_offset().resolve(data)
+        self.mark_array_offset().fast_resolve(data, ())
     }
 
     /// Offset to BaseArray table, from beginning of MarkBasePos
@@ -2946,7 +3231,7 @@ impl<'a> MarkBasePosFormat1<'a> {
     pub fn base_array(&self) -> Result<BaseArray<'a>, ReadError> {
         let data = self.data;
         let args = self.mark_class_count();
-        self.base_array_offset().resolve_with_args(data, args)
+        self.base_array_offset().fast_resolve(data, args)
     }
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
@@ -3052,16 +3337,7 @@ impl ReadArgs for BaseArray<'_> {
 
 impl<'a> FontRead<'a> for BaseArray<'a> {
     fn read_with_args(data: FontData<'a>, args: u16) -> Result<Self, ReadError> {
-        let mark_class_count = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self {
-            data,
-            mark_class_count,
-        })
+        Self::read_checked(data, args)
     }
 }
 
@@ -3073,6 +3349,22 @@ impl<'a> BaseArray<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for BaseArray<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: u16) -> Result<(), ReadError> {
+        let mark_class_count = args;
+        let base_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<BaseRecord>(base_count as _, mark_class_count, true)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: u16) -> Self {
+        let mark_class_count = args;
+        Self {
+            data,
+            mark_class_count,
+        }
     }
 }
 
@@ -3189,9 +3481,9 @@ impl<'a> BaseRecord<'a> {
     pub fn base_anchors(
         &self,
         data: FontData<'a>,
-    ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
         let offsets = self.base_anchor_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -3226,6 +3518,15 @@ impl<'a> BaseRecord<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl SanitizeStruct for BaseRecord<'_> {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, args: u16) -> Result<(), ReadError> {
+        let _mark_class_count = args;
+        self.base_anchor_offsets()
+            .sanitize_offset::<AnchorTable>(ctx, ())?;
+        ctx.finish()
     }
 }
 
@@ -3266,11 +3567,22 @@ impl ReadArgs for MarkLigPosFormat1<'_> {
 
 impl<'a> FontRead<'a> for MarkLigPosFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for MarkLigPosFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let mark_class_count = ctx.read::<u16>()?;
+        ctx.sanitize_offset::<Offset16, MarkArray>(())?;
+        ctx.sanitize_offset::<Offset16, LigatureArray>(mark_class_count)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3306,7 +3618,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Attempt to resolve [`mark_coverage_offset`][Self::mark_coverage_offset].
     pub fn mark_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.mark_coverage_offset().resolve(data)
+        self.mark_coverage_offset().fast_resolve(data, ())
     }
 
     /// Offset to ligatureCoverage table, from beginning of MarkLigPos
@@ -3319,7 +3631,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Attempt to resolve [`ligature_coverage_offset`][Self::ligature_coverage_offset].
     pub fn ligature_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.ligature_coverage_offset().resolve(data)
+        self.ligature_coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of defined mark classes
@@ -3338,7 +3650,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     /// Attempt to resolve [`mark_array_offset`][Self::mark_array_offset].
     pub fn mark_array(&self) -> Result<MarkArray<'a>, ReadError> {
         let data = self.data;
-        self.mark_array_offset().resolve(data)
+        self.mark_array_offset().fast_resolve(data, ())
     }
 
     /// Offset to LigatureArray table, from beginning of MarkLigPos
@@ -3352,7 +3664,7 @@ impl<'a> MarkLigPosFormat1<'a> {
     pub fn ligature_array(&self) -> Result<LigatureArray<'a>, ReadError> {
         let data = self.data;
         let args = self.mark_class_count();
-        self.ligature_array_offset().resolve_with_args(data, args)
+        self.ligature_array_offset().fast_resolve(data, args)
     }
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
@@ -3458,16 +3770,7 @@ impl ReadArgs for LigatureArray<'_> {
 
 impl<'a> FontRead<'a> for LigatureArray<'a> {
     fn read_with_args(data: FontData<'a>, args: u16) -> Result<Self, ReadError> {
-        let mark_class_count = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self {
-            data,
-            mark_class_count,
-        })
+        Self::read_checked(data, args)
     }
 }
 
@@ -3479,6 +3782,25 @@ impl<'a> LigatureArray<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for LigatureArray<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: u16) -> Result<(), ReadError> {
+        let mark_class_count = args;
+        let ligature_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, LigatureAttach>(
+            transforms::to_usize(ligature_count),
+            mark_class_count,
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: u16) -> Self {
+        let mark_class_count = args;
+        Self {
+            data,
+            mark_class_count,
+        }
     }
 }
 
@@ -3509,11 +3831,11 @@ impl<'a> LigatureArray<'a> {
     }
 
     /// A dynamically resolving wrapper for [`ligature_attach_offsets`][Self::ligature_attach_offsets].
-    pub fn ligature_attaches(&self) -> ArrayOfOffsets<'a, LigatureAttach<'a>, Offset16> {
+    pub fn ligature_attaches(&self) -> SanitizedArrayOfOffsets<'a, LigatureAttach<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_attach_offsets();
         let args = self.mark_class_count();
-        ArrayOfOffsets::new(offsets, data, args)
+        SanitizedArrayOfOffsets::new(offsets, data, args)
     }
 
     pub(crate) fn mark_class_count(&self) -> u16 {
@@ -3587,16 +3909,7 @@ impl ReadArgs for LigatureAttach<'_> {
 
 impl<'a> FontRead<'a> for LigatureAttach<'a> {
     fn read_with_args(data: FontData<'a>, args: u16) -> Result<Self, ReadError> {
-        let mark_class_count = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self {
-            data,
-            mark_class_count,
-        })
+        Self::read_checked(data, args)
     }
 }
 
@@ -3608,6 +3921,26 @@ impl<'a> LigatureAttach<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for LigatureAttach<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: u16) -> Result<(), ReadError> {
+        let mark_class_count = args;
+        let component_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<ComponentRecord>(
+            component_count as _,
+            mark_class_count,
+            true,
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: u16) -> Self {
+        let mark_class_count = args;
+        Self {
+            data,
+            mark_class_count,
+        }
     }
 }
 
@@ -3725,9 +4058,9 @@ impl<'a> ComponentRecord<'a> {
     pub fn ligature_anchors(
         &self,
         data: FontData<'a>,
-    ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
         let offsets = self.ligature_anchor_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -3762,6 +4095,15 @@ impl<'a> ComponentRecord<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl SanitizeStruct for ComponentRecord<'_> {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, args: u16) -> Result<(), ReadError> {
+        let _mark_class_count = args;
+        self.ligature_anchor_offsets()
+            .sanitize_offset::<AnchorTable>(ctx, ())?;
+        ctx.finish()
     }
 }
 
@@ -3802,11 +4144,22 @@ impl ReadArgs for MarkMarkPosFormat1<'_> {
 
 impl<'a> FontRead<'a> for MarkMarkPosFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for MarkMarkPosFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let mark_class_count = ctx.read::<u16>()?;
+        ctx.sanitize_offset::<Offset16, MarkArray>(())?;
+        ctx.sanitize_offset::<Offset16, Mark2Array>(mark_class_count)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3842,7 +4195,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Attempt to resolve [`mark1_coverage_offset`][Self::mark1_coverage_offset].
     pub fn mark1_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.mark1_coverage_offset().resolve(data)
+        self.mark1_coverage_offset().fast_resolve(data, ())
     }
 
     /// Offset to Base Mark Coverage table, from beginning of
@@ -3855,7 +4208,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Attempt to resolve [`mark2_coverage_offset`][Self::mark2_coverage_offset].
     pub fn mark2_coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.mark2_coverage_offset().resolve(data)
+        self.mark2_coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of Combining Mark classes defined
@@ -3874,7 +4227,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     /// Attempt to resolve [`mark1_array_offset`][Self::mark1_array_offset].
     pub fn mark1_array(&self) -> Result<MarkArray<'a>, ReadError> {
         let data = self.data;
-        self.mark1_array_offset().resolve(data)
+        self.mark1_array_offset().fast_resolve(data, ())
     }
 
     /// Offset to Mark2Array table for mark2, from beginning of
@@ -3888,7 +4241,7 @@ impl<'a> MarkMarkPosFormat1<'a> {
     pub fn mark2_array(&self) -> Result<Mark2Array<'a>, ReadError> {
         let data = self.data;
         let args = self.mark_class_count();
-        self.mark2_array_offset().resolve_with_args(data, args)
+        self.mark2_array_offset().fast_resolve(data, args)
     }
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
@@ -3994,16 +4347,7 @@ impl ReadArgs for Mark2Array<'_> {
 
 impl<'a> FontRead<'a> for Mark2Array<'a> {
     fn read_with_args(data: FontData<'a>, args: u16) -> Result<Self, ReadError> {
-        let mark_class_count = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self {
-            data,
-            mark_class_count,
-        })
+        Self::read_checked(data, args)
     }
 }
 
@@ -4015,6 +4359,22 @@ impl<'a> Mark2Array<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for Mark2Array<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: u16) -> Result<(), ReadError> {
+        let mark_class_count = args;
+        let mark2_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<Mark2Record>(mark2_count as _, mark_class_count, true)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: u16) -> Self {
+        let mark_class_count = args;
+        Self {
+            data,
+            mark_class_count,
+        }
     }
 }
 
@@ -4131,9 +4491,9 @@ impl<'a> Mark2Record<'a> {
     pub fn mark2_anchors(
         &self,
         data: FontData<'a>,
-    ) -> ArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, AnchorTable<'a>, Offset16> {
         let offsets = self.mark2_anchor_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 }
 
@@ -4168,6 +4528,15 @@ impl<'a> Mark2Record<'a> {
     pub fn read(data: FontData<'a>, mark_class_count: u16) -> Result<Self, ReadError> {
         let args = mark_class_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl SanitizeStruct for Mark2Record<'_> {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, args: u16) -> Result<(), ReadError> {
+        let _mark_class_count = args;
+        self.mark2_anchor_offsets()
+            .sanitize_offset::<AnchorTable>(ctx, ())?;
+        ctx.finish()
     }
 }
 
@@ -4236,6 +4605,21 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     }
 }
 
+impl<'a, T: Sanitize<'a, Args = ()>> Sanitize<'a> for ExtensionPosFormat1<'a, T> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset32, T>(())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self {
+            data,
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 /// [Extension Positioning Subtable Format 1](https://docs.microsoft.com/en-us/typography/opentype/spec/gpos#extension-positioning-subtable-format-1)
 #[derive(Clone)]
 pub struct ExtensionPosFormat1<'a, T = ()> {
@@ -4272,10 +4656,10 @@ impl<'a, T> ExtensionPosFormat1<'a, T> {
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].
     pub fn extension(&self) -> Result<T, ReadError>
     where
-        T: FontRead<'a, Args = ()>,
+        T: Sanitize<'a, Args = ()> + Default,
     {
         let data = self.data;
-        self.extension_offset().resolve(data)
+        self.extension_offset().fast_resolve(data, ())
     }
 
     pub fn pos_format_byte_range(&self) -> Range<usize> {
@@ -4311,7 +4695,7 @@ impl<T> Default for ExtensionPosFormat1<'_, T> {
 }
 
 #[cfg(feature = "experimental_traverse")]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a>
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> SomeTable<'a>
     for ExtensionPosFormat1<'a, T>
 {
     fn type_name(&self) -> &str {
@@ -4335,7 +4719,7 @@ impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a>
 
 #[cfg(feature = "experimental_traverse")]
 #[allow(clippy::needless_lifetimes)]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> std::fmt::Debug
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> std::fmt::Debug
     for ExtensionPosFormat1<'a, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4397,6 +4781,50 @@ impl<'a> ExtensionSubtable<'a> {
             ExtensionSubtable::MarkToMark(inner) => inner.of_unit_type(),
             ExtensionSubtable::Contextual(inner) => inner.of_unit_type(),
             ExtensionSubtable::ChainContextual(inner) => inner.of_unit_type(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for ExtensionSubtable<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let discriminant = ExtensionPosFormat1::read_discriminant(ctx.data())?;
+        match discriminant {
+            1 => ExtensionPosFormat1::<SinglePos>::sanitize(ctx, _args),
+            2 => ExtensionPosFormat1::<PairPos>::sanitize(ctx, _args),
+            3 => ExtensionPosFormat1::<CursivePosFormat1>::sanitize(ctx, _args),
+            4 => ExtensionPosFormat1::<MarkBasePosFormat1>::sanitize(ctx, _args),
+            5 => ExtensionPosFormat1::<MarkLigPosFormat1>::sanitize(ctx, _args),
+            6 => ExtensionPosFormat1::<MarkMarkPosFormat1>::sanitize(ctx, _args),
+            7 => ExtensionPosFormat1::<PositionSequenceContext>::sanitize(ctx, _args),
+            8 => ExtensionPosFormat1::<PositionChainContext>::sanitize(ctx, _args),
+            other => Err(ReadError::InvalidFormat(other as _)),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        match ExtensionPosFormat1::read_discriminant(data) {
+            Ok(1) => {
+                ExtensionSubtable::Single(ExtensionPosFormat1::<SinglePos>::read_fast(data, ()))
+            }
+            Ok(2) => ExtensionSubtable::Pair(ExtensionPosFormat1::<PairPos>::read_fast(data, ())),
+            Ok(3) => ExtensionSubtable::Cursive(
+                ExtensionPosFormat1::<CursivePosFormat1>::read_fast(data, ()),
+            ),
+            Ok(4) => ExtensionSubtable::MarkToBase(
+                ExtensionPosFormat1::<MarkBasePosFormat1>::read_fast(data, ()),
+            ),
+            Ok(5) => ExtensionSubtable::MarkToLig(
+                ExtensionPosFormat1::<MarkLigPosFormat1>::read_fast(data, ()),
+            ),
+            Ok(6) => ExtensionSubtable::MarkToMark(
+                ExtensionPosFormat1::<MarkMarkPosFormat1>::read_fast(data, ()),
+            ),
+            Ok(7) => ExtensionSubtable::Contextual(
+                ExtensionPosFormat1::<PositionSequenceContext>::read_fast(data, ()),
+            ),
+            Ok(8) => ExtensionSubtable::ChainContextual(
+                ExtensionPosFormat1::<PositionChainContext>::read_fast(data, ()),
+            ),
+            _ => ExtensionSubtable::default(),
         }
     }
 }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -26,11 +26,23 @@ impl ReadArgs for Gsub<'_> {
 
 impl<'a> FontRead<'a> for Gsub<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Gsub<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let version = ctx.read::<MajorMinor>()?;
+        ctx.sanitize_offset::<Offset16, ScriptList>(())?;
+        ctx.sanitize_offset::<Offset16, FeatureList>(())?;
+        ctx.sanitize_offset::<Offset16, SubstitutionLookupList>(())?;
+        if version.compatible((1u16, 1u16)) {
+            ctx.sanitize_offset::<Offset32, FeatureVariations>(())?;
         }
-        Ok(Self { data })
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -63,7 +75,7 @@ impl<'a> Gsub<'a> {
     /// Attempt to resolve [`script_list_offset`][Self::script_list_offset].
     pub fn script_list(&self) -> Result<ScriptList<'a>, ReadError> {
         let data = self.data;
-        self.script_list_offset().resolve(data)
+        self.script_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to FeatureList table, from beginning of GSUB table
@@ -75,7 +87,7 @@ impl<'a> Gsub<'a> {
     /// Attempt to resolve [`feature_list_offset`][Self::feature_list_offset].
     pub fn feature_list(&self) -> Result<FeatureList<'a>, ReadError> {
         let data = self.data;
-        self.feature_list_offset().resolve(data)
+        self.feature_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to LookupList table, from beginning of GSUB table
@@ -87,7 +99,7 @@ impl<'a> Gsub<'a> {
     /// Attempt to resolve [`lookup_list_offset`][Self::lookup_list_offset].
     pub fn lookup_list(&self) -> Result<SubstitutionLookupList<'a>, ReadError> {
         let data = self.data;
-        self.lookup_list_offset().resolve(data)
+        self.lookup_list_offset().fast_resolve(data, ())
     }
 
     /// Offset to FeatureVariations table, from beginning of the GSUB
@@ -102,7 +114,8 @@ impl<'a> Gsub<'a> {
     /// Attempt to resolve [`feature_variations_offset`][Self::feature_variations_offset].
     pub fn feature_variations(&self) -> Option<Result<FeatureVariations<'a>, ReadError>> {
         let data = self.data;
-        self.feature_variations_offset().map(|x| x.resolve(data))?
+        self.feature_variations_offset()
+            .map(|x| x.fast_resolve(data, ()))?
     }
 
     pub fn version_byte_range(&self) -> Range<usize> {
@@ -248,6 +261,50 @@ impl<'a> SubstitutionLookup<'a> {
     }
 }
 
+impl<'a> Sanitize<'a> for SubstitutionLookup<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let discriminant = Lookup::read_discriminant(ctx.data())?;
+        match discriminant {
+            1 => Lookup::<SingleSubst>::sanitize(ctx, _args),
+            2 => Lookup::<MultipleSubstFormat1>::sanitize(ctx, _args),
+            3 => Lookup::<AlternateSubstFormat1>::sanitize(ctx, _args),
+            4 => Lookup::<LigatureSubstFormat1>::sanitize(ctx, _args),
+            5 => Lookup::<SubstitutionSequenceContext>::sanitize(ctx, _args),
+            6 => Lookup::<SubstitutionChainContext>::sanitize(ctx, _args),
+            7 => Lookup::<ExtensionSubtable>::sanitize(ctx, _args),
+            8 => Lookup::<ReverseChainSingleSubstFormat1>::sanitize(ctx, _args),
+            other => Err(ReadError::InvalidFormat(other as _)),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        match Lookup::read_discriminant(data) {
+            Ok(1) => SubstitutionLookup::Single(Lookup::<SingleSubst>::read_fast(data, ())),
+            Ok(2) => {
+                SubstitutionLookup::Multiple(Lookup::<MultipleSubstFormat1>::read_fast(data, ()))
+            }
+            Ok(3) => {
+                SubstitutionLookup::Alternate(Lookup::<AlternateSubstFormat1>::read_fast(data, ()))
+            }
+            Ok(4) => {
+                SubstitutionLookup::Ligature(Lookup::<LigatureSubstFormat1>::read_fast(data, ()))
+            }
+            Ok(5) => SubstitutionLookup::Contextual(
+                Lookup::<SubstitutionSequenceContext>::read_fast(data, ()),
+            ),
+            Ok(6) => SubstitutionLookup::ChainContextual(
+                Lookup::<SubstitutionChainContext>::read_fast(data, ()),
+            ),
+            Ok(7) => {
+                SubstitutionLookup::Extension(Lookup::<ExtensionSubtable>::read_fast(data, ()))
+            }
+            Ok(8) => SubstitutionLookup::Reverse(
+                Lookup::<ReverseChainSingleSubstFormat1>::read_fast(data, ()),
+            ),
+            _ => SubstitutionLookup::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SubstitutionLookup<'a> {
     fn dyn_inner(&self) -> &(dyn SomeTable<'a> + 'a) {
@@ -327,12 +384,7 @@ impl ReadArgs for SingleSubst<'_> {
 
 impl<'a> FontRead<'a> for SingleSubst<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            SingleSubstFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            SingleSubstFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -347,6 +399,31 @@ impl<'a> MinByteRange<'a> for SingleSubst<'a> {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for SingleSubst<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            SingleSubstFormat1::FORMAT => SingleSubstFormat1::sanitize(ctx, ()),
+            SingleSubstFormat2::FORMAT => SingleSubstFormat2::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return SingleSubst::default();
+        };
+        match format {
+            SingleSubstFormat1::FORMAT => {
+                SingleSubst::Format1(SingleSubstFormat1::read_fast(data, ()))
+            }
+            SingleSubstFormat2::FORMAT => {
+                SingleSubst::Format2(SingleSubstFormat2::read_fast(data, ()))
+            }
+            _ => SingleSubst::default(),
         }
     }
 }
@@ -398,11 +475,19 @@ impl ReadArgs for SingleSubstFormat1<'_> {
 
 impl<'a> FontRead<'a> for SingleSubstFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SingleSubstFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        ctx.advance::<i16>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -433,7 +518,7 @@ impl<'a> SingleSubstFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Add to original glyph ID to get substitute glyph ID
@@ -519,11 +604,20 @@ impl ReadArgs for SingleSubstFormat2<'_> {
 
 impl<'a> FontRead<'a> for SingleSubstFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SingleSubstFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(glyph_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -554,7 +648,7 @@ impl<'a> SingleSubstFormat2<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of glyph IDs in the substituteGlyphIDs array
@@ -646,11 +740,23 @@ impl ReadArgs for MultipleSubstFormat1<'_> {
 
 impl<'a> FontRead<'a> for MultipleSubstFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for MultipleSubstFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let sequence_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, Sequence>(
+            transforms::to_usize(sequence_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -681,7 +787,7 @@ impl<'a> MultipleSubstFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of Sequence table offsets in the sequenceOffsets array
@@ -698,10 +804,10 @@ impl<'a> MultipleSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`sequence_offsets`][Self::sequence_offsets].
-    pub fn sequences(&self) -> ArrayOfOffsets<'a, Sequence<'a>, Offset16> {
+    pub fn sequences(&self) -> SanitizedArrayOfOffsets<'a, Sequence<'a>, Offset16> {
         let data = self.data;
         let offsets = self.sequence_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
@@ -789,11 +895,18 @@ impl ReadArgs for Sequence<'_> {
 
 impl<'a> FontRead<'a> for Sequence<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Sequence<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(glyph_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -891,11 +1004,23 @@ impl ReadArgs for AlternateSubstFormat1<'_> {
 
 impl<'a> FontRead<'a> for AlternateSubstFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AlternateSubstFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let alternate_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, AlternateSet>(
+            transforms::to_usize(alternate_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -926,7 +1051,7 @@ impl<'a> AlternateSubstFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of AlternateSet tables
@@ -943,10 +1068,10 @@ impl<'a> AlternateSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`alternate_set_offsets`][Self::alternate_set_offsets].
-    pub fn alternate_sets(&self) -> ArrayOfOffsets<'a, AlternateSet<'a>, Offset16> {
+    pub fn alternate_sets(&self) -> SanitizedArrayOfOffsets<'a, AlternateSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.alternate_set_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
@@ -1037,11 +1162,18 @@ impl ReadArgs for AlternateSet<'_> {
 
 impl<'a> FontRead<'a> for AlternateSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for AlternateSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(glyph_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1138,11 +1270,23 @@ impl ReadArgs for LigatureSubstFormat1<'_> {
 
 impl<'a> FontRead<'a> for LigatureSubstFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for LigatureSubstFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let ligature_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, LigatureSet>(
+            transforms::to_usize(ligature_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1173,7 +1317,7 @@ impl<'a> LigatureSubstFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of LigatureSet tables
@@ -1190,10 +1334,10 @@ impl<'a> LigatureSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`ligature_set_offsets`][Self::ligature_set_offsets].
-    pub fn ligature_sets(&self) -> ArrayOfOffsets<'a, LigatureSet<'a>, Offset16> {
+    pub fn ligature_sets(&self) -> SanitizedArrayOfOffsets<'a, LigatureSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_set_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
@@ -1281,11 +1425,21 @@ impl ReadArgs for LigatureSet<'_> {
 
 impl<'a> FontRead<'a> for LigatureSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for LigatureSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let ligature_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, Ligature>(
+            transforms::to_usize(ligature_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1314,10 +1468,10 @@ impl<'a> LigatureSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`ligature_offsets`][Self::ligature_offsets].
-    pub fn ligatures(&self) -> ArrayOfOffsets<'a, Ligature<'a>, Offset16> {
+    pub fn ligatures(&self) -> SanitizedArrayOfOffsets<'a, Ligature<'a>, Offset16> {
         let data = self.data;
         let offsets = self.ligature_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn ligature_count_byte_range(&self) -> Range<usize> {
@@ -1386,11 +1540,19 @@ impl ReadArgs for Ligature<'_> {
 
 impl<'a> FontRead<'a> for Ligature<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Ligature<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<GlyphId16>();
+        let component_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::subtract(component_count, 1_usize))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1530,6 +1692,21 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     }
 }
 
+impl<'a, T: Sanitize<'a, Args = ()>> Sanitize<'a> for ExtensionSubstFormat1<'a, T> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset32, T>(())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self {
+            data,
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 /// [Extension Substitution Subtable Format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#71-extension-substitution-subtable-format-1)
 #[derive(Clone)]
 pub struct ExtensionSubstFormat1<'a, T = ()> {
@@ -1566,10 +1743,10 @@ impl<'a, T> ExtensionSubstFormat1<'a, T> {
     /// Attempt to resolve [`extension_offset`][Self::extension_offset].
     pub fn extension(&self) -> Result<T, ReadError>
     where
-        T: FontRead<'a, Args = ()>,
+        T: Sanitize<'a, Args = ()> + Default,
     {
         let data = self.data;
-        self.extension_offset().resolve(data)
+        self.extension_offset().fast_resolve(data, ())
     }
 
     pub fn subst_format_byte_range(&self) -> Range<usize> {
@@ -1605,7 +1782,7 @@ impl<T> Default for ExtensionSubstFormat1<'_, T> {
 }
 
 #[cfg(feature = "experimental_traverse")]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a>
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> SomeTable<'a>
     for ExtensionSubstFormat1<'a, T>
 {
     fn type_name(&self) -> &str {
@@ -1629,7 +1806,7 @@ impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a>
 
 #[cfg(feature = "experimental_traverse")]
 #[allow(clippy::needless_lifetimes)]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> std::fmt::Debug
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> std::fmt::Debug
     for ExtensionSubstFormat1<'a, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1692,6 +1869,48 @@ impl<'a> ExtensionSubtable<'a> {
     }
 }
 
+impl<'a> Sanitize<'a> for ExtensionSubtable<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let discriminant = ExtensionSubstFormat1::read_discriminant(ctx.data())?;
+        match discriminant {
+            1 => ExtensionSubstFormat1::<SingleSubst>::sanitize(ctx, _args),
+            2 => ExtensionSubstFormat1::<MultipleSubstFormat1>::sanitize(ctx, _args),
+            3 => ExtensionSubstFormat1::<AlternateSubstFormat1>::sanitize(ctx, _args),
+            4 => ExtensionSubstFormat1::<LigatureSubstFormat1>::sanitize(ctx, _args),
+            5 => ExtensionSubstFormat1::<SubstitutionSequenceContext>::sanitize(ctx, _args),
+            6 => ExtensionSubstFormat1::<SubstitutionChainContext>::sanitize(ctx, _args),
+            8 => ExtensionSubstFormat1::<ReverseChainSingleSubstFormat1>::sanitize(ctx, _args),
+            other => Err(ReadError::InvalidFormat(other as _)),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        match ExtensionSubstFormat1::read_discriminant(data) {
+            Ok(1) => {
+                ExtensionSubtable::Single(ExtensionSubstFormat1::<SingleSubst>::read_fast(data, ()))
+            }
+            Ok(2) => ExtensionSubtable::Multiple(
+                ExtensionSubstFormat1::<MultipleSubstFormat1>::read_fast(data, ()),
+            ),
+            Ok(3) => ExtensionSubtable::Alternate(
+                ExtensionSubstFormat1::<AlternateSubstFormat1>::read_fast(data, ()),
+            ),
+            Ok(4) => ExtensionSubtable::Ligature(
+                ExtensionSubstFormat1::<LigatureSubstFormat1>::read_fast(data, ()),
+            ),
+            Ok(5) => ExtensionSubtable::Contextual(ExtensionSubstFormat1::<
+                SubstitutionSequenceContext,
+            >::read_fast(data, ())),
+            Ok(6) => ExtensionSubtable::ChainContextual(ExtensionSubstFormat1::<
+                SubstitutionChainContext,
+            >::read_fast(data, ())),
+            Ok(8) => ExtensionSubtable::Reverse(ExtensionSubstFormat1::<
+                ReverseChainSingleSubstFormat1,
+            >::read_fast(data, ())),
+            _ => ExtensionSubtable::default(),
+        }
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> ExtensionSubtable<'a> {
     fn dyn_inner(&self) -> &(dyn SomeTable<'a> + 'a) {
@@ -1744,11 +1963,30 @@ impl ReadArgs for ReverseChainSingleSubstFormat1<'_> {
 
 impl<'a> FontRead<'a> for ReverseChainSingleSubstFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ReverseChainSingleSubstFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let backtrack_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CoverageTable>(
+            transforms::to_usize(backtrack_glyph_count),
+            (),
+        )?;
+        let lookahead_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CoverageTable>(
+            transforms::to_usize(lookahead_glyph_count),
+            (),
+        )?;
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(glyph_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1783,7 +2021,7 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of glyphs in the backtrack sequence.
@@ -1800,10 +2038,10 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    pub fn backtrack_coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.backtrack_coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyphs in lookahead sequence.
@@ -1820,10 +2058,10 @@ impl<'a> ReverseChainSingleSubstFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    pub fn lookahead_coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.lookahead_coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyph IDs in the substituteGlyphIDs array.

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -21,11 +21,18 @@ impl ReadArgs for ScriptList<'_> {
 
 impl<'a> FontRead<'a> for ScriptList<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ScriptList<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let script_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<ScriptRecord>(transforms::to_usize(script_count), ())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -133,12 +140,23 @@ impl ScriptRecord {
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
     pub fn script<'a>(&self, data: FontData<'a>) -> Result<Script<'a>, ReadError> {
-        self.script_offset().resolve(data)
+        self.script_offset().fast_resolve(data, ())
     }
 }
 
 impl FixedSize for ScriptRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+impl ReadArgs for ScriptRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for ScriptRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.script_offset().sanitize_offset::<Script>(ctx, ())?;
+        ctx.finish()
+    }
 }
 
 #[cfg(feature = "experimental_traverse")]
@@ -175,11 +193,19 @@ impl ReadArgs for Script<'_> {
 
 impl<'a> FontRead<'a> for Script<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Script<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.sanitize_offset::<Offset16, LangSys>(())?;
+        let lang_sys_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<LangSysRecord>(transforms::to_usize(lang_sys_count), ())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -204,7 +230,7 @@ impl<'a> Script<'a> {
     /// Attempt to resolve [`default_lang_sys_offset`][Self::default_lang_sys_offset].
     pub fn default_lang_sys(&self) -> Option<Result<LangSys<'a>, ReadError>> {
         let data = self.data;
-        self.default_lang_sys_offset().resolve(data)
+        self.default_lang_sys_offset().fast_resolve(data, ())
     }
 
     /// Number of LangSysRecords for this script — excluding the
@@ -310,12 +336,23 @@ impl LangSysRecord {
     /// The `data` argument should be retrieved from the parent table
     /// By calling its `offset_data` method.
     pub fn lang_sys<'a>(&self, data: FontData<'a>) -> Result<LangSys<'a>, ReadError> {
-        self.lang_sys_offset().resolve(data)
+        self.lang_sys_offset().fast_resolve(data, ())
     }
 }
 
 impl FixedSize for LangSysRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+impl ReadArgs for LangSysRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for LangSysRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.lang_sys_offset().sanitize_offset::<LangSys>(ctx, ())?;
+        ctx.finish()
+    }
 }
 
 #[cfg(feature = "experimental_traverse")]
@@ -352,11 +389,20 @@ impl ReadArgs for LangSys<'_> {
 
 impl<'a> FontRead<'a> for LangSys<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for LangSys<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        let feature_index_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(feature_index_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -473,11 +519,18 @@ impl ReadArgs for FeatureList<'_> {
 
 impl<'a> FontRead<'a> for FeatureList<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for FeatureList<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let feature_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<FeatureRecord>(transforms::to_usize(feature_count), ())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -587,12 +640,24 @@ impl FeatureRecord {
     /// By calling its `offset_data` method.
     pub fn feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
         let args = self.feature_tag();
-        self.feature_offset().resolve_with_args(data, args)
+        self.feature_offset().fast_resolve(data, args)
     }
 }
 
 impl FixedSize for FeatureRecord {
     const RAW_BYTE_LEN: usize = Tag::RAW_BYTE_LEN + Offset16::RAW_BYTE_LEN;
+}
+
+impl ReadArgs for FeatureRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for FeatureRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.feature_offset()
+            .sanitize_offset::<Feature>(ctx, self.feature_tag())?;
+        ctx.finish()
+    }
 }
 
 #[cfg(feature = "experimental_traverse")]
@@ -629,13 +694,7 @@ impl ReadArgs for Feature<'_> {
 
 impl<'a> FontRead<'a> for Feature<'a> {
     fn read_with_args(data: FontData<'a>, args: Tag) -> Result<Self, ReadError> {
-        let feature_tag = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data, feature_tag })
+        Self::read_checked(data, args)
     }
 }
 
@@ -647,6 +706,20 @@ impl<'a> Feature<'a> {
     pub fn read(data: FontData<'a>, feature_tag: Tag) -> Result<Self, ReadError> {
         let args = feature_tag;
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for Feature<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: Tag) -> Result<(), ReadError> {
+        let feature_tag = args;
+        ctx.sanitize_offset::<Offset16, FeatureParams>(feature_tag)?;
+        let lookup_index_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(lookup_index_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: Tag) -> Self {
+        let feature_tag = args;
+        Self { data, feature_tag }
     }
 }
 
@@ -672,7 +745,7 @@ impl<'a> Feature<'a> {
     pub fn feature_params(&self) -> Option<Result<FeatureParams<'a>, ReadError>> {
         let data = self.data;
         let args = self.feature_tag();
-        self.feature_params_offset().resolve_with_args(data, args)
+        self.feature_params_offset().fast_resolve(data, args)
     }
 
     /// Number of LookupList indices for this feature
@@ -791,6 +864,20 @@ impl<'a, T> LookupList<'a, T> {
     }
 }
 
+impl<'a, T: Sanitize<'a, Args = ()>> Sanitize<'a> for LookupList<'a, T> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, T>(transforms::to_usize(lookup_count), ())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self {
+            data,
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 /// [Lookup List Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-list-table)
 #[derive(Clone)]
 pub struct LookupList<'a, T = ()> {
@@ -817,13 +904,13 @@ impl<'a, T> LookupList<'a, T> {
     }
 
     /// A dynamically resolving wrapper for [`lookup_offsets`][Self::lookup_offsets].
-    pub fn lookups(&self) -> ArrayOfOffsets<'a, T, Offset16>
+    pub fn lookups(&self) -> SanitizedArrayOfOffsets<'a, T, Offset16>
     where
-        T: FontRead<'a, Args = ()>,
+        T: Sanitize<'a, Args = ()> + Default,
     {
         let data = self.data;
         let offsets = self.lookup_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn lookup_count_byte_range(&self) -> Range<usize> {
@@ -855,7 +942,9 @@ impl<T> Default for LookupList<'_, T> {
 }
 
 #[cfg(feature = "experimental_traverse")]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a> for LookupList<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> SomeTable<'a>
+    for LookupList<'a, T>
+{
     fn type_name(&self) -> &str {
         "LookupList"
     }
@@ -873,7 +962,9 @@ impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a> for Look
 
 #[cfg(feature = "experimental_traverse")]
 #[allow(clippy::needless_lifetimes)]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> std::fmt::Debug for LookupList<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> std::fmt::Debug
+    for LookupList<'a, T>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
@@ -923,6 +1014,25 @@ impl<'a, T> Lookup<'a, T> {
     }
 }
 
+impl<'a, T: Sanitize<'a, Args = ()>> Sanitize<'a> for Lookup<'a, T> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let lookup_flag = ctx.read::<LookupFlag>()?;
+        let sub_table_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, T>(transforms::to_usize(sub_table_count), ())?;
+        if lookup_flag.contains(LookupFlag::USE_MARK_FILTERING_SET) {
+            ctx.advance::<u16>();
+        }
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self {
+            data,
+            offset_type: std::marker::PhantomData,
+        }
+    }
+}
+
 /// [Lookup Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookup-table)
 #[derive(Clone)]
 pub struct Lookup<'a, T = ()> {
@@ -961,13 +1071,13 @@ impl<'a, T> Lookup<'a, T> {
     }
 
     /// A dynamically resolving wrapper for [`subtable_offsets`][Self::subtable_offsets].
-    pub fn subtables(&self) -> ArrayOfOffsets<'a, T, Offset16>
+    pub fn subtables(&self) -> SanitizedArrayOfOffsets<'a, T, Offset16>
     where
-        T: FontRead<'a, Args = ()>,
+        T: Sanitize<'a, Args = ()> + Default,
     {
         let data = self.data;
         let offsets = self.subtable_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Index (base 0) into GDEF mark glyph sets structure. This field
@@ -1032,7 +1142,9 @@ impl<T> Default for Lookup<'_, T> {
 }
 
 #[cfg(feature = "experimental_traverse")]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a> for Lookup<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> SomeTable<'a>
+    for Lookup<'a, T>
+{
     fn type_name(&self) -> &str {
         "Lookup"
     }
@@ -1062,7 +1174,9 @@ impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a> for Look
 
 #[cfg(feature = "experimental_traverse")]
 #[allow(clippy::needless_lifetimes)]
-impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> std::fmt::Debug for Lookup<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default + SomeTable<'a> + 'a> std::fmt::Debug
+    for Lookup<'a, T>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         (self as &dyn SomeTable<'a>).fmt(f)
     }
@@ -1088,11 +1202,19 @@ impl ReadArgs for CoverageFormat1<'_> {
 
 impl<'a> FontRead<'a> for CoverageFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CoverageFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(glyph_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1201,11 +1323,19 @@ impl ReadArgs for CoverageFormat2<'_> {
 
 impl<'a> FontRead<'a> for CoverageFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CoverageFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let range_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<RangeRecord>(transforms::to_usize(range_count), ())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1324,6 +1454,19 @@ impl FixedSize for RangeRecord {
         GlyphId16::RAW_BYTE_LEN + GlyphId16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl ReadArgs for RangeRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for RangeRecord {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for RangeRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1380,12 +1523,7 @@ impl ReadArgs for CoverageTable<'_> {
 
 impl<'a> FontRead<'a> for CoverageTable<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            CoverageFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            CoverageFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -1400,6 +1538,27 @@ impl<'a> MinByteRange<'a> for CoverageTable<'a> {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for CoverageTable<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            CoverageFormat1::FORMAT => CoverageFormat1::sanitize(ctx, ()),
+            CoverageFormat2::FORMAT => CoverageFormat2::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return CoverageTable::default();
+        };
+        match format {
+            CoverageFormat1::FORMAT => CoverageTable::Format1(CoverageFormat1::read_fast(data, ())),
+            CoverageFormat2::FORMAT => CoverageTable::Format2(CoverageFormat2::read_fast(data, ())),
+            _ => CoverageTable::default(),
         }
     }
 }
@@ -1451,11 +1610,20 @@ impl ReadArgs for ClassDefFormat1<'_> {
 
 impl<'a> FontRead<'a> for ClassDefFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ClassDefFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<GlyphId16>();
+        let glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(glyph_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1576,11 +1744,22 @@ impl ReadArgs for ClassDefFormat2<'_> {
 
 impl<'a> FontRead<'a> for ClassDefFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ClassDefFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let class_range_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<ClassRangeRecord>(
+            transforms::to_usize(class_range_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1700,6 +1879,19 @@ impl FixedSize for ClassRangeRecord {
         GlyphId16::RAW_BYTE_LEN + GlyphId16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl ReadArgs for ClassRangeRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for ClassRangeRecord {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for ClassRangeRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1753,12 +1945,7 @@ impl ReadArgs for ClassDef<'_> {
 
 impl<'a> FontRead<'a> for ClassDef<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            ClassDefFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            ClassDefFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -1773,6 +1960,27 @@ impl<'a> MinByteRange<'a> for ClassDef<'a> {
         match self {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for ClassDef<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            ClassDefFormat1::FORMAT => ClassDefFormat1::sanitize(ctx, ()),
+            ClassDefFormat2::FORMAT => ClassDefFormat2::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return ClassDef::default();
+        };
+        match format {
+            ClassDefFormat1::FORMAT => ClassDef::Format1(ClassDefFormat1::read_fast(data, ())),
+            ClassDefFormat2::FORMAT => ClassDef::Format2(ClassDefFormat2::read_fast(data, ())),
+            _ => ClassDef::default(),
         }
     }
 }
@@ -1831,6 +2039,19 @@ impl FixedSize for SequenceLookupRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + u16::RAW_BYTE_LEN;
 }
 
+impl ReadArgs for SequenceLookupRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for SequenceLookupRecord {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for SequenceLookupRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1866,11 +2087,23 @@ impl ReadArgs for SequenceContextFormat1<'_> {
 
 impl<'a> FontRead<'a> for SequenceContextFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SequenceContextFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let seq_rule_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, SequenceRuleSet>(
+            transforms::to_usize(seq_rule_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1901,7 +2134,7 @@ impl<'a> SequenceContextFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of SequenceRuleSet tables
@@ -1918,10 +2151,12 @@ impl<'a> SequenceContextFormat1<'a> {
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_set_offsets`][Self::seq_rule_set_offsets].
-    pub fn seq_rule_sets(&self) -> ArrayOfNullableOffsets<'a, SequenceRuleSet<'a>, Offset16> {
+    pub fn seq_rule_sets(
+        &self,
+    ) -> SanitizedArrayOfNullableOffsets<'a, SequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.seq_rule_set_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -2009,11 +2244,21 @@ impl ReadArgs for SequenceRuleSet<'_> {
 
 impl<'a> FontRead<'a> for SequenceRuleSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SequenceRuleSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let seq_rule_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, SequenceRule>(
+            transforms::to_usize(seq_rule_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2042,10 +2287,10 @@ impl<'a> SequenceRuleSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`seq_rule_offsets`][Self::seq_rule_offsets].
-    pub fn seq_rules(&self) -> ArrayOfOffsets<'a, SequenceRule<'a>, Offset16> {
+    pub fn seq_rules(&self) -> SanitizedArrayOfOffsets<'a, SequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.seq_rule_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn seq_rule_count_byte_range(&self) -> Range<usize> {
@@ -2116,11 +2361,23 @@ impl ReadArgs for SequenceRule<'_> {
 
 impl<'a> FontRead<'a> for SequenceRule<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SequenceRule<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let glyph_count = ctx.read::<u16>()?;
+        let seq_lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::subtract(glyph_count, 1_usize))?;
+        ctx.sanitize_array_of_structs::<SequenceLookupRecord>(
+            transforms::to_usize(seq_lookup_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2250,11 +2507,24 @@ impl ReadArgs for SequenceContextFormat2<'_> {
 
 impl<'a> FontRead<'a> for SequenceContextFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SequenceContextFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        let class_seq_rule_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, ClassSequenceRuleSet>(
+            transforms::to_usize(class_seq_rule_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2286,7 +2556,7 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Offset to ClassDef table, from beginning of
@@ -2299,7 +2569,7 @@ impl<'a> SequenceContextFormat2<'a> {
     /// Attempt to resolve [`class_def_offset`][Self::class_def_offset].
     pub fn class_def(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
-        self.class_def_offset().resolve(data)
+        self.class_def_offset().fast_resolve(data, ())
     }
 
     /// Number of ClassSequenceRuleSet tables
@@ -2318,10 +2588,10 @@ impl<'a> SequenceContextFormat2<'a> {
     /// A dynamically resolving wrapper for [`class_seq_rule_set_offsets`][Self::class_seq_rule_set_offsets].
     pub fn class_seq_rule_sets(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ClassSequenceRuleSet<'a>, Offset16> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, ClassSequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.class_seq_rule_set_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -2411,11 +2681,21 @@ impl ReadArgs for ClassSequenceRuleSet<'_> {
 
 impl<'a> FontRead<'a> for ClassSequenceRuleSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ClassSequenceRuleSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let class_seq_rule_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, ClassSequenceRule>(
+            transforms::to_usize(class_seq_rule_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2444,10 +2724,10 @@ impl<'a> ClassSequenceRuleSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`class_seq_rule_offsets`][Self::class_seq_rule_offsets].
-    pub fn class_seq_rules(&self) -> ArrayOfOffsets<'a, ClassSequenceRule<'a>, Offset16> {
+    pub fn class_seq_rules(&self) -> SanitizedArrayOfOffsets<'a, ClassSequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.class_seq_rule_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn class_seq_rule_count_byte_range(&self) -> Range<usize> {
@@ -2521,11 +2801,23 @@ impl ReadArgs for ClassSequenceRule<'_> {
 
 impl<'a> FontRead<'a> for ClassSequenceRule<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ClassSequenceRule<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let glyph_count = ctx.read::<u16>()?;
+        let seq_lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::subtract(glyph_count, 1_usize))?;
+        ctx.sanitize_array_of_structs::<SequenceLookupRecord>(
+            transforms::to_usize(seq_lookup_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2658,11 +2950,27 @@ impl ReadArgs for SequenceContextFormat3<'_> {
 
 impl<'a> FontRead<'a> for SequenceContextFormat3<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SequenceContextFormat3<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let glyph_count = ctx.read::<u16>()?;
+        let seq_lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CoverageTable>(
+            transforms::to_usize(glyph_count),
+            (),
+        )?;
+        ctx.sanitize_array_of_structs::<SequenceLookupRecord>(
+            transforms::to_usize(seq_lookup_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2703,10 +3011,10 @@ impl<'a> SequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`coverage_offsets`][Self::coverage_offsets].
-    pub fn coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    pub fn coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Array of SequenceLookupRecords
@@ -2825,13 +3133,7 @@ impl ReadArgs for SequenceContext<'_> {
 
 impl<'a> FontRead<'a> for SequenceContext<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            SequenceContextFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            SequenceContextFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            SequenceContextFormat3::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -2848,6 +3150,35 @@ impl<'a> MinByteRange<'a> for SequenceContext<'a> {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
             Self::Format3(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for SequenceContext<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            SequenceContextFormat1::FORMAT => SequenceContextFormat1::sanitize(ctx, ()),
+            SequenceContextFormat2::FORMAT => SequenceContextFormat2::sanitize(ctx, ()),
+            SequenceContextFormat3::FORMAT => SequenceContextFormat3::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return SequenceContext::default();
+        };
+        match format {
+            SequenceContextFormat1::FORMAT => {
+                SequenceContext::Format1(SequenceContextFormat1::read_fast(data, ()))
+            }
+            SequenceContextFormat2::FORMAT => {
+                SequenceContext::Format2(SequenceContextFormat2::read_fast(data, ()))
+            }
+            SequenceContextFormat3::FORMAT => {
+                SequenceContext::Format3(SequenceContextFormat3::read_fast(data, ()))
+            }
+            _ => SequenceContext::default(),
         }
     }
 }
@@ -2900,11 +3231,23 @@ impl ReadArgs for ChainedSequenceContextFormat1<'_> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedSequenceContextFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        let chained_seq_rule_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, ChainedSequenceRuleSet>(
+            transforms::to_usize(chained_seq_rule_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -2935,7 +3278,7 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Number of ChainedSequenceRuleSet tables
@@ -2954,10 +3297,10 @@ impl<'a> ChainedSequenceContextFormat1<'a> {
     /// A dynamically resolving wrapper for [`chained_seq_rule_set_offsets`][Self::chained_seq_rule_set_offsets].
     pub fn chained_seq_rule_sets(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ChainedSequenceRuleSet<'a>, Offset16> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, ChainedSequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_seq_rule_set_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -3049,11 +3392,21 @@ impl ReadArgs for ChainedSequenceRuleSet<'_> {
 
 impl<'a> FontRead<'a> for ChainedSequenceRuleSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedSequenceRuleSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let chained_seq_rule_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, ChainedSequenceRule>(
+            transforms::to_usize(chained_seq_rule_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3082,10 +3435,12 @@ impl<'a> ChainedSequenceRuleSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`chained_seq_rule_offsets`][Self::chained_seq_rule_offsets].
-    pub fn chained_seq_rules(&self) -> ArrayOfOffsets<'a, ChainedSequenceRule<'a>, Offset16> {
+    pub fn chained_seq_rules(
+        &self,
+    ) -> SanitizedArrayOfOffsets<'a, ChainedSequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_seq_rule_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn chained_seq_rule_count_byte_range(&self) -> Range<usize> {
@@ -3159,11 +3514,27 @@ impl ReadArgs for ChainedSequenceRule<'_> {
 
 impl<'a> FontRead<'a> for ChainedSequenceRule<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedSequenceRule<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let backtrack_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(backtrack_glyph_count))?;
+        let input_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::subtract(input_glyph_count, 1_usize))?;
+        let lookahead_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<GlyphId16>(transforms::to_usize(lookahead_glyph_count))?;
+        let seq_lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<SequenceLookupRecord>(
+            transforms::to_usize(seq_lookup_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3359,11 +3730,26 @@ impl ReadArgs for ChainedSequenceContextFormat2<'_> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedSequenceContextFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset16, CoverageTable>(())?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        ctx.sanitize_offset::<Offset16, ClassDef>(())?;
+        let chained_class_seq_rule_set_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, ChainedClassSequenceRuleSet>(
+            transforms::to_usize(chained_class_seq_rule_set_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3399,7 +3785,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Attempt to resolve [`coverage_offset`][Self::coverage_offset].
     pub fn coverage(&self) -> Result<CoverageTable<'a>, ReadError> {
         let data = self.data;
-        self.coverage_offset().resolve(data)
+        self.coverage_offset().fast_resolve(data, ())
     }
 
     /// Offset to ClassDef table containing backtrack sequence context,
@@ -3412,7 +3798,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Attempt to resolve [`backtrack_class_def_offset`][Self::backtrack_class_def_offset].
     pub fn backtrack_class_def(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
-        self.backtrack_class_def_offset().resolve(data)
+        self.backtrack_class_def_offset().fast_resolve(data, ())
     }
 
     /// Offset to ClassDef table containing input sequence context,
@@ -3425,7 +3811,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Attempt to resolve [`input_class_def_offset`][Self::input_class_def_offset].
     pub fn input_class_def(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
-        self.input_class_def_offset().resolve(data)
+        self.input_class_def_offset().fast_resolve(data, ())
     }
 
     /// Offset to ClassDef table containing lookahead sequence context,
@@ -3438,7 +3824,7 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// Attempt to resolve [`lookahead_class_def_offset`][Self::lookahead_class_def_offset].
     pub fn lookahead_class_def(&self) -> Result<ClassDef<'a>, ReadError> {
         let data = self.data;
-        self.lookahead_class_def_offset().resolve(data)
+        self.lookahead_class_def_offset().fast_resolve(data, ())
     }
 
     /// Number of ChainedClassSequenceRuleSet tables
@@ -3457,10 +3843,10 @@ impl<'a> ChainedSequenceContextFormat2<'a> {
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_set_offsets`][Self::chained_class_seq_rule_set_offsets].
     pub fn chained_class_seq_rule_sets(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ChainedClassSequenceRuleSet<'a>, Offset16> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, ChainedClassSequenceRuleSet<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_class_seq_rule_set_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -3576,11 +3962,21 @@ impl ReadArgs for ChainedClassSequenceRuleSet<'_> {
 
 impl<'a> FontRead<'a> for ChainedClassSequenceRuleSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedClassSequenceRuleSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let chained_class_seq_rule_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, ChainedClassSequenceRule>(
+            transforms::to_usize(chained_class_seq_rule_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3611,10 +4007,10 @@ impl<'a> ChainedClassSequenceRuleSet<'a> {
     /// A dynamically resolving wrapper for [`chained_class_seq_rule_offsets`][Self::chained_class_seq_rule_offsets].
     pub fn chained_class_seq_rules(
         &self,
-    ) -> ArrayOfOffsets<'a, ChainedClassSequenceRule<'a>, Offset16> {
+    ) -> SanitizedArrayOfOffsets<'a, ChainedClassSequenceRule<'a>, Offset16> {
         let data = self.data;
         let offsets = self.chained_class_seq_rule_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn chained_class_seq_rule_count_byte_range(&self) -> Range<usize> {
@@ -3689,11 +4085,27 @@ impl ReadArgs for ChainedClassSequenceRule<'_> {
 
 impl<'a> FontRead<'a> for ChainedClassSequenceRule<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedClassSequenceRule<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let backtrack_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(backtrack_glyph_count))?;
+        let input_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::subtract(input_glyph_count, 1_usize))?;
+        let lookahead_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(lookahead_glyph_count))?;
+        let seq_lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<SequenceLookupRecord>(
+            transforms::to_usize(seq_lookup_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3889,11 +4301,37 @@ impl ReadArgs for ChainedSequenceContextFormat3<'_> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContextFormat3<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedSequenceContextFormat3<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let backtrack_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CoverageTable>(
+            transforms::to_usize(backtrack_glyph_count),
+            (),
+        )?;
+        let input_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CoverageTable>(
+            transforms::to_usize(input_glyph_count),
+            (),
+        )?;
+        let lookahead_glyph_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset16, CoverageTable>(
+            transforms::to_usize(lookahead_glyph_count),
+            (),
+        )?;
+        let seq_lookup_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<SequenceLookupRecord>(
+            transforms::to_usize(seq_lookup_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -3931,10 +4369,10 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`backtrack_coverage_offsets`][Self::backtrack_coverage_offsets].
-    pub fn backtrack_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    pub fn backtrack_coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.backtrack_coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyphs in the input sequence
@@ -3950,10 +4388,10 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`input_coverage_offsets`][Self::input_coverage_offsets].
-    pub fn input_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    pub fn input_coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.input_coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of glyphs in the lookahead sequence
@@ -3969,10 +4407,10 @@ impl<'a> ChainedSequenceContextFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`lookahead_coverage_offsets`][Self::lookahead_coverage_offsets].
-    pub fn lookahead_coverages(&self) -> ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    pub fn lookahead_coverages(&self) -> SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
         let data = self.data;
         let offsets = self.lookahead_coverage_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     /// Number of SequenceLookupRecords
@@ -4141,13 +4579,7 @@ impl ReadArgs for ChainedSequenceContext<'_> {
 
 impl<'a> FontRead<'a> for ChainedSequenceContext<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            ChainedSequenceContextFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            ChainedSequenceContextFormat2::FORMAT => Ok(Self::Format2(FontRead::read(data)?)),
-            ChainedSequenceContextFormat3::FORMAT => Ok(Self::Format3(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -4164,6 +4596,41 @@ impl<'a> MinByteRange<'a> for ChainedSequenceContext<'a> {
             Self::Format1(item) => item.min_table_bytes(),
             Self::Format2(item) => item.min_table_bytes(),
             Self::Format3(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for ChainedSequenceContext<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            ChainedSequenceContextFormat1::FORMAT => {
+                ChainedSequenceContextFormat1::sanitize(ctx, ())
+            }
+            ChainedSequenceContextFormat2::FORMAT => {
+                ChainedSequenceContextFormat2::sanitize(ctx, ())
+            }
+            ChainedSequenceContextFormat3::FORMAT => {
+                ChainedSequenceContextFormat3::sanitize(ctx, ())
+            }
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return ChainedSequenceContext::default();
+        };
+        match format {
+            ChainedSequenceContextFormat1::FORMAT => {
+                ChainedSequenceContext::Format1(ChainedSequenceContextFormat1::read_fast(data, ()))
+            }
+            ChainedSequenceContextFormat2::FORMAT => {
+                ChainedSequenceContext::Format2(ChainedSequenceContextFormat2::read_fast(data, ()))
+            }
+            ChainedSequenceContextFormat3::FORMAT => {
+                ChainedSequenceContext::Format3(ChainedSequenceContextFormat3::read_fast(data, ()))
+            }
+            _ => ChainedSequenceContext::default(),
         }
     }
 }
@@ -4266,11 +4733,20 @@ impl ReadArgs for Device<'_> {
 
 impl<'a> FontRead<'a> for Device<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for Device<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let start_size = ctx.read::<u16>()?;
+        let end_size = ctx.read::<u16>()?;
+        let delta_format = ctx.read::<DeltaFormat>()?;
+        ctx.sanitize_array::<u16>(DeltaFormat::value_count(delta_format, start_size, end_size))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -4389,11 +4865,19 @@ impl ReadArgs for VariationIndex<'_> {
 
 impl<'a> FontRead<'a> for VariationIndex<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for VariationIndex<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.advance::<DeltaFormat>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -4515,18 +4999,7 @@ impl ReadArgs for DeviceOrVariationIndex<'_> {
 
 impl<'a> FontRead<'a> for DeviceOrVariationIndex<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: DeltaFormat = data.read_at(4usize)?;
-
-        #[allow(clippy::redundant_guards)]
-        match format {
-            format if format != DeltaFormat::VariationIndex => {
-                Ok(Self::Device(FontRead::read(data)?))
-            }
-            format if format == DeltaFormat::VariationIndex => {
-                Ok(Self::VariationIndex(FontRead::read(data)?))
-            }
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -4541,6 +5014,35 @@ impl<'a> MinByteRange<'a> for DeviceOrVariationIndex<'a> {
         match self {
             Self::Device(item) => item.min_table_bytes(),
             Self::VariationIndex(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for DeviceOrVariationIndex<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: DeltaFormat = ctx.peek_at(4usize)?;
+
+        #[allow(clippy::redundant_guards)]
+        match format {
+            format if format != DeltaFormat::VariationIndex => Device::sanitize(ctx, ()),
+            format if format == DeltaFormat::VariationIndex => VariationIndex::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<DeltaFormat>(4usize) else {
+            return DeviceOrVariationIndex::default();
+        };
+
+        #[allow(clippy::redundant_guards)]
+        match format {
+            format if format != DeltaFormat::VariationIndex => {
+                DeviceOrVariationIndex::Device(Device::read_fast(data, ()))
+            }
+            format if format == DeltaFormat::VariationIndex => {
+                DeviceOrVariationIndex::VariationIndex(VariationIndex::read_fast(data, ()))
+            }
+            _ => DeviceOrVariationIndex::default(),
         }
     }
 }
@@ -4588,11 +5090,22 @@ impl ReadArgs for FeatureVariations<'_> {
 
 impl<'a> FontRead<'a> for FeatureVariations<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for FeatureVariations<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<MajorMinor>();
+        let feature_variation_record_count = ctx.read::<u32>()?;
+        ctx.sanitize_array_of_structs::<FeatureVariationRecord>(
+            transforms::to_usize(feature_variation_record_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -4720,7 +5233,7 @@ impl FeatureVariationRecord {
         &self,
         data: FontData<'a>,
     ) -> Option<Result<ConditionSet<'a>, ReadError>> {
-        self.condition_set_offset().resolve(data)
+        self.condition_set_offset().fast_resolve(data, ())
     }
 
     /// Offset to a feature table substitution table, from beginning of
@@ -4738,12 +5251,27 @@ impl FeatureVariationRecord {
         &self,
         data: FontData<'a>,
     ) -> Option<Result<FeatureTableSubstitution<'a>, ReadError>> {
-        self.feature_table_substitution_offset().resolve(data)
+        self.feature_table_substitution_offset()
+            .fast_resolve(data, ())
     }
 }
 
 impl FixedSize for FeatureVariationRecord {
     const RAW_BYTE_LEN: usize = Offset32::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
+}
+
+impl ReadArgs for FeatureVariationRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for FeatureVariationRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.condition_set_offset()
+            .sanitize_offset::<ConditionSet>(ctx, ())?;
+        self.feature_table_substitution_offset()
+            .sanitize_offset::<FeatureTableSubstitution>(ctx, ())?;
+        ctx.finish()
+    }
 }
 
 #[cfg(feature = "experimental_traverse")]
@@ -4786,11 +5314,21 @@ impl ReadArgs for ConditionSet<'_> {
 
 impl<'a> FontRead<'a> for ConditionSet<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ConditionSet<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let condition_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset32, Condition>(
+            transforms::to_usize(condition_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -4819,10 +5357,10 @@ impl<'a> ConditionSet<'a> {
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
-    pub fn conditions(&self) -> ArrayOfOffsets<'a, Condition<'a>, Offset32> {
+    pub fn conditions(&self) -> SanitizedArrayOfOffsets<'a, Condition<'a>, Offset32> {
         let data = self.data;
         let offsets = self.condition_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn condition_count_byte_range(&self) -> Range<usize> {
@@ -4924,15 +5462,7 @@ impl ReadArgs for Condition<'_> {
 
 impl<'a> FontRead<'a> for Condition<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u16 = data.read_at(0usize)?;
-        match format {
-            ConditionFormat1::FORMAT => Ok(Self::Format1AxisRange(FontRead::read(data)?)),
-            ConditionFormat2::FORMAT => Ok(Self::Format2VariableValue(FontRead::read(data)?)),
-            ConditionFormat3::FORMAT => Ok(Self::Format3And(FontRead::read(data)?)),
-            ConditionFormat4::FORMAT => Ok(Self::Format4Or(FontRead::read(data)?)),
-            ConditionFormat5::FORMAT => Ok(Self::Format5Negate(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -4953,6 +5483,41 @@ impl<'a> MinByteRange<'a> for Condition<'a> {
             Self::Format3And(item) => item.min_table_bytes(),
             Self::Format4Or(item) => item.min_table_bytes(),
             Self::Format5Negate(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for Condition<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u16 = ctx.peek_at(0usize)?;
+        match format {
+            ConditionFormat1::FORMAT => ConditionFormat1::sanitize(ctx, ()),
+            ConditionFormat2::FORMAT => ConditionFormat2::sanitize(ctx, ()),
+            ConditionFormat3::FORMAT => ConditionFormat3::sanitize(ctx, ()),
+            ConditionFormat4::FORMAT => ConditionFormat4::sanitize(ctx, ()),
+            ConditionFormat5::FORMAT => ConditionFormat5::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u16>(0usize) else {
+            return Condition::default();
+        };
+        match format {
+            ConditionFormat1::FORMAT => {
+                Condition::Format1AxisRange(ConditionFormat1::read_fast(data, ()))
+            }
+            ConditionFormat2::FORMAT => {
+                Condition::Format2VariableValue(ConditionFormat2::read_fast(data, ()))
+            }
+            ConditionFormat3::FORMAT => {
+                Condition::Format3And(ConditionFormat3::read_fast(data, ()))
+            }
+            ConditionFormat4::FORMAT => Condition::Format4Or(ConditionFormat4::read_fast(data, ())),
+            ConditionFormat5::FORMAT => {
+                Condition::Format5Negate(ConditionFormat5::read_fast(data, ()))
+            }
+            _ => Condition::default(),
         }
     }
 }
@@ -5007,11 +5572,20 @@ impl ReadArgs for ConditionFormat1<'_> {
 
 impl<'a> FontRead<'a> for ConditionFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ConditionFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.advance::<F2Dot14>();
+        ctx.advance::<F2Dot14>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5141,11 +5715,19 @@ impl ReadArgs for ConditionFormat2<'_> {
 
 impl<'a> FontRead<'a> for ConditionFormat2<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ConditionFormat2<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<i16>();
+        ctx.advance::<u32>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5240,11 +5822,22 @@ impl ReadArgs for ConditionFormat3<'_> {
 
 impl<'a> FontRead<'a> for ConditionFormat3<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ConditionFormat3<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let condition_count = ctx.read::<u8>()?;
+        ctx.sanitize_array_of_offsets::<Offset24, Condition>(
+            transforms::to_usize(condition_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5278,10 +5871,10 @@ impl<'a> ConditionFormat3<'a> {
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
-    pub fn conditions(&self) -> ArrayOfOffsets<'a, Condition<'a>, Offset24> {
+    pub fn conditions(&self) -> SanitizedArrayOfOffsets<'a, Condition<'a>, Offset24> {
         let data = self.data;
         let offsets = self.condition_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -5351,11 +5944,22 @@ impl ReadArgs for ConditionFormat4<'_> {
 
 impl<'a> FontRead<'a> for ConditionFormat4<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ConditionFormat4<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        let condition_count = ctx.read::<u8>()?;
+        ctx.sanitize_array_of_offsets::<Offset24, Condition>(
+            transforms::to_usize(condition_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5389,10 +5993,10 @@ impl<'a> ConditionFormat4<'a> {
     }
 
     /// A dynamically resolving wrapper for [`condition_offsets`][Self::condition_offsets].
-    pub fn conditions(&self) -> ArrayOfOffsets<'a, Condition<'a>, Offset24> {
+    pub fn conditions(&self) -> SanitizedArrayOfOffsets<'a, Condition<'a>, Offset24> {
         let data = self.data;
         let offsets = self.condition_offsets();
-        ArrayOfOffsets::new(offsets, data, ())
+        SanitizedArrayOfOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -5462,11 +6066,18 @@ impl ReadArgs for ConditionFormat5<'_> {
 
 impl<'a> FontRead<'a> for ConditionFormat5<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ConditionFormat5<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset24, Condition>(())?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5496,7 +6107,7 @@ impl<'a> ConditionFormat5<'a> {
     /// Attempt to resolve [`condition_offset`][Self::condition_offset].
     pub fn condition(&self) -> Result<Condition<'a>, ReadError> {
         let data = self.data;
-        self.condition_offset().resolve(data)
+        self.condition_offset().fast_resolve(data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -5553,11 +6164,22 @@ impl ReadArgs for FeatureTableSubstitution<'_> {
 
 impl<'a> FontRead<'a> for FeatureTableSubstitution<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for FeatureTableSubstitution<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<MajorMinor>();
+        let substitution_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_structs::<FeatureTableSubstitutionRecord>(
+            transforms::to_usize(substitution_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5683,6 +6305,17 @@ impl FixedSize for FeatureTableSubstitutionRecord {
     const RAW_BYTE_LEN: usize = u16::RAW_BYTE_LEN + Offset32::RAW_BYTE_LEN;
 }
 
+impl ReadArgs for FeatureTableSubstitutionRecord {
+    type Args = ();
+}
+
+impl SanitizeStruct for FeatureTableSubstitutionRecord {
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        self.sanitize_alternate_feature_offset(ctx)?;
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for FeatureTableSubstitutionRecord {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -5720,11 +6353,21 @@ impl ReadArgs for SizeParams<'_> {
 
 impl<'a> FontRead<'a> for SizeParams<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for SizeParams<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.advance::<u16>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5874,11 +6517,18 @@ impl ReadArgs for StylisticSetParams<'_> {
 
 impl<'a> FontRead<'a> for StylisticSetParams<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for StylisticSetParams<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<NameId>();
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -5978,11 +6628,24 @@ impl ReadArgs for CharacterVariantParams<'_> {
 
 impl<'a> FontRead<'a> for CharacterVariantParams<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for CharacterVariantParams<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.advance::<NameId>();
+        ctx.advance::<NameId>();
+        ctx.advance::<NameId>();
+        ctx.advance::<u16>();
+        ctx.advance::<NameId>();
+        let char_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<Uint24>(transforms::to_usize(char_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 

--- a/read-fonts/generated/generated_variations.rs
+++ b/read-fonts/generated/generated_variations.rs
@@ -21,13 +21,7 @@ impl ReadArgs for TupleVariationHeader<'_> {
 
 impl<'a> FontRead<'a> for TupleVariationHeader<'a> {
     fn read_with_args(data: FontData<'a>, args: u16) -> Result<Self, ReadError> {
-        let axis_count = args;
-
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data, axis_count })
+        Self::read_checked(data, args)
     }
 }
 
@@ -39,6 +33,22 @@ impl<'a> TupleVariationHeader<'a> {
     pub fn read(data: FontData<'a>, axis_count: u16) -> Result<Self, ReadError> {
         let args = axis_count;
         Self::read_with_args(data, args)
+    }
+}
+
+impl<'a> Sanitize<'a> for TupleVariationHeader<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: u16) -> Result<(), ReadError> {
+        let axis_count = args;
+        ctx.advance::<u16>();
+        let tuple_index = ctx.read::<TupleIndex>()?;
+        ctx.sanitize_array::<F2Dot14>(TupleIndex::tuple_len(tuple_index, axis_count, 0_usize))?;
+        ctx.sanitize_array::<F2Dot14>(TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))?;
+        ctx.sanitize_array::<F2Dot14>(TupleIndex::tuple_len(tuple_index, axis_count, 1_usize))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, args: u16) -> Self {
+        let axis_count = args;
+        Self { data, axis_count }
     }
 }
 
@@ -211,6 +221,15 @@ impl<'a> Tuple<'a> {
     }
 }
 
+impl SanitizeStruct for Tuple<'_> {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: u16) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for Tuple<'a> {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -245,11 +264,20 @@ impl ReadArgs for DeltaSetIndexMapFormat0<'_> {
 
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat0<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for DeltaSetIndexMapFormat0<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u8>();
+        let entry_format = ctx.read::<EntryFormat>()?;
+        let map_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u8>(EntryFormat::map_size(entry_format, map_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -373,11 +401,20 @@ impl ReadArgs for DeltaSetIndexMapFormat1<'_> {
 
 impl<'a> FontRead<'a> for DeltaSetIndexMapFormat1<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for DeltaSetIndexMapFormat1<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u8>();
+        let entry_format = ctx.read::<EntryFormat>()?;
+        let map_count = ctx.read::<u32>()?;
+        ctx.sanitize_array::<u8>(EntryFormat::map_size(entry_format, map_count))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -535,12 +572,7 @@ impl ReadArgs for DeltaSetIndexMap<'_> {
 
 impl<'a> FontRead<'a> for DeltaSetIndexMap<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        let format: u8 = data.read_at(0usize)?;
-        match format {
-            DeltaSetIndexMapFormat0::FORMAT => Ok(Self::Format0(FontRead::read(data)?)),
-            DeltaSetIndexMapFormat1::FORMAT => Ok(Self::Format1(FontRead::read(data)?)),
-            other => Err(ReadError::InvalidFormat(other.into())),
-        }
+        Self::read_checked(data, ())
     }
 }
 
@@ -555,6 +587,31 @@ impl<'a> MinByteRange<'a> for DeltaSetIndexMap<'a> {
         match self {
             Self::Format0(item) => item.min_table_bytes(),
             Self::Format1(item) => item.min_table_bytes(),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for DeltaSetIndexMap<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let format: u8 = ctx.peek_at(0usize)?;
+        match format {
+            DeltaSetIndexMapFormat0::FORMAT => DeltaSetIndexMapFormat0::sanitize(ctx, ()),
+            DeltaSetIndexMapFormat1::FORMAT => DeltaSetIndexMapFormat1::sanitize(ctx, ()),
+            other => Err(ReadError::InvalidFormat(other.into())),
+        }
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        let Ok(format) = data.read_at::<u8>(0usize) else {
+            return DeltaSetIndexMap::default();
+        };
+        match format {
+            DeltaSetIndexMapFormat0::FORMAT => {
+                DeltaSetIndexMap::Format0(DeltaSetIndexMapFormat0::read_fast(data, ()))
+            }
+            DeltaSetIndexMapFormat1::FORMAT => {
+                DeltaSetIndexMap::Format1(DeltaSetIndexMapFormat1::read_fast(data, ()))
+            }
+            _ => DeltaSetIndexMap::default(),
         }
     }
 }
@@ -913,11 +970,19 @@ impl ReadArgs for VariationRegionList<'_> {
 
 impl<'a> FontRead<'a> for VariationRegionList<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for VariationRegionList<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let axis_count = ctx.read::<u16>()?;
+        let region_count = ctx.read::<u16>()?;
+        ctx.sanitize_computed_array::<VariationRegion>(region_count as _, axis_count, true)?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1069,6 +1134,15 @@ impl<'a> VariationRegion<'a> {
     }
 }
 
+impl SanitizeStruct for VariationRegion<'_> {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: u16) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for VariationRegion<'a> {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1125,6 +1199,19 @@ impl FixedSize for RegionAxisCoordinates {
         F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN + F2Dot14::RAW_BYTE_LEN;
 }
 
+impl ReadArgs for RegionAxisCoordinates {
+    type Args = ();
+}
+
+impl SanitizeStruct for RegionAxisCoordinates {
+    fn can_skip() -> bool {
+        true
+    }
+    fn sanitize_struct(&self, ctx: &mut SanitizeContext, _args: ()) -> Result<(), ReadError> {
+        ctx.finish()
+    }
+}
+
 #[cfg(feature = "experimental_traverse")]
 impl<'a> SomeRecord<'a> for RegionAxisCoordinates {
     fn traverse(self, data: FontData<'a>) -> RecordResolver<'a> {
@@ -1157,11 +1244,23 @@ impl ReadArgs for ItemVariationStore<'_> {
 
 impl<'a> FontRead<'a> for ItemVariationStore<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ItemVariationStore<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        ctx.advance::<u16>();
+        ctx.sanitize_offset::<Offset32, VariationRegionList>(())?;
+        let item_variation_data_count = ctx.read::<u16>()?;
+        ctx.sanitize_array_of_offsets::<Offset32, ItemVariationData>(
+            transforms::to_usize(item_variation_data_count),
+            (),
+        )?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 
@@ -1192,7 +1291,7 @@ impl<'a> ItemVariationStore<'a> {
     /// Attempt to resolve [`variation_region_list_offset`][Self::variation_region_list_offset].
     pub fn variation_region_list(&self) -> Result<VariationRegionList<'a>, ReadError> {
         let data = self.data;
-        self.variation_region_list_offset().resolve(data)
+        self.variation_region_list_offset().fast_resolve(data, ())
     }
 
     /// The number of item variation data subtables.
@@ -1211,10 +1310,10 @@ impl<'a> ItemVariationStore<'a> {
     /// A dynamically resolving wrapper for [`item_variation_data_offsets`][Self::item_variation_data_offsets].
     pub fn item_variation_data(
         &self,
-    ) -> ArrayOfNullableOffsets<'a, ItemVariationData<'a>, Offset32> {
+    ) -> SanitizedArrayOfNullableOffsets<'a, ItemVariationData<'a>, Offset32> {
         let data = self.data;
         let offsets = self.item_variation_data_offsets();
-        ArrayOfNullableOffsets::new(offsets, data, ())
+        SanitizedArrayOfNullableOffsets::new(offsets, data, ())
     }
 
     pub fn format_byte_range(&self) -> Range<usize> {
@@ -1309,11 +1408,25 @@ impl ReadArgs for ItemVariationData<'_> {
 
 impl<'a> FontRead<'a> for ItemVariationData<'a> {
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
-        #[allow(clippy::absurd_extreme_comparisons)]
-        if data.len() < Self::MIN_SIZE {
-            return Err(ReadError::OutOfBounds);
-        }
-        Ok(Self { data })
+        Self::read_checked(data, ())
+    }
+}
+
+impl<'a> Sanitize<'a> for ItemVariationData<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, _args: ()) -> Result<(), ReadError> {
+        let item_count = ctx.read::<u16>()?;
+        let word_delta_count = ctx.read::<u16>()?;
+        let region_index_count = ctx.read::<u16>()?;
+        ctx.sanitize_array::<u16>(transforms::to_usize(region_index_count))?;
+        ctx.sanitize_array::<u8>(ItemVariationData::delta_sets_len(
+            item_count,
+            word_delta_count,
+            region_index_count,
+        ))?;
+        ctx.finish()
+    }
+    fn read_fast(data: FontData<'a>, _args: ()) -> Self {
+        Self { data }
     }
 }
 

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -99,7 +99,6 @@ pub use offset_array::{
     SanitizedArrayOfOffsets,
 };
 pub use read::{ComputeSize, FontRead, ReadArgs, ReadError, VarSize};
-#[cfg(any(test, feature = "codegen_test"))]
 pub use sanitize::Sanitize;
 pub use table_provider::{TableProvider, TopLevelTable};
 pub use table_ref::MinByteRange;

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -94,10 +94,7 @@ pub mod codegen_test;
 
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
-pub use offset_array::{
-    ArrayOfNullableOffsets, ArrayOfOffsets, SanitizedArrayOfNullableOffsets,
-    SanitizedArrayOfOffsets,
-};
+pub use offset_array::{ArrayOfOffsets, SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets};
 pub use read::{ComputeSize, FontRead, ReadArgs, ReadError, VarSize};
 pub use sanitize::Sanitize;
 pub use table_provider::{TableProvider, TopLevelTable};
@@ -113,8 +110,7 @@ pub(crate) mod codegen_prelude {
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
     pub use crate::offset_array::{
-        ArrayOfNullableOffsets, ArrayOfOffsets, SanitizedArrayOfNullableOffsets,
-        SanitizedArrayOfOffsets,
+        ArrayOfOffsets, SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets,
     };
     pub use crate::read::{
         ComputeSize, Discriminant, FontRead, Format, ReadArgs, ReadError, VarSize,

--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -87,7 +87,6 @@ pub mod tables;
 #[cfg(feature = "experimental_traverse")]
 pub mod traversal;
 
-#[cfg(any(test, feature = "codegen_test"))]
 mod sanitize;
 
 #[cfg(any(test, feature = "codegen_test"))]
@@ -95,9 +94,10 @@ pub mod codegen_test;
 
 pub use font_data::FontData;
 pub use offset::{Offset, ResolveNullableOffset, ResolveOffset};
-pub use offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
-#[cfg(any(test, feature = "codegen_test"))]
-pub use offset_array::{SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets};
+pub use offset_array::{
+    ArrayOfNullableOffsets, ArrayOfOffsets, SanitizedArrayOfNullableOffsets,
+    SanitizedArrayOfOffsets,
+};
 pub use read::{ComputeSize, FontRead, ReadArgs, ReadError, VarSize};
 #[cfg(any(test, feature = "codegen_test"))]
 pub use sanitize::Sanitize;
@@ -113,13 +113,13 @@ pub(crate) mod codegen_prelude {
     pub use crate::array::{ComputedArray, VarLenArray};
     pub use crate::font_data::{Cursor, FontData};
     pub use crate::offset::{Offset, ResolveNullableOffset, ResolveOffset};
-    pub use crate::offset_array::{ArrayOfNullableOffsets, ArrayOfOffsets};
-    #[cfg(any(test, feature = "codegen_test"))]
-    pub use crate::offset_array::{SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets};
+    pub use crate::offset_array::{
+        ArrayOfNullableOffsets, ArrayOfOffsets, SanitizedArrayOfNullableOffsets,
+        SanitizedArrayOfOffsets,
+    };
     pub use crate::read::{
         ComputeSize, Discriminant, FontRead, Format, ReadArgs, ReadError, VarSize,
     };
-    #[cfg(any(test, feature = "codegen_test"))]
     pub(crate) use crate::sanitize::{
         FastResolveNullableOffset, FastResolveOffset, Sanitize, SanitizeContext, SanitizeOffset,
         SanitizeStruct,
@@ -200,6 +200,13 @@ pub(crate) mod codegen_prelude {
                 offset: O,
             ) -> Result<R, ReadError> {
                 offset.resolve(self.data)
+            }
+
+            pub fn fast_resolve<O: Offset, R: Sanitize<'a, Args = ()> + Default>(
+                &self,
+                offset: O,
+            ) -> Result<R, ReadError> {
+                offset.fast_resolve(self.data, ())
             }
 
             /// Return a reference to this table's raw data.

--- a/read-fonts/src/model/font/tables.rs
+++ b/read-fonts/src/model/font/tables.rs
@@ -1,7 +1,7 @@
 //! Table validation, caching and access.
 
 use super::{super::once::Once, FontBlob, FontSource};
-use crate::{tables, types::Tag, FontRead, ReadError, TableProvider, TopLevelTable};
+use crate::{tables, types::Tag, FontRead, ReadError, Sanitize, TableProvider, TopLevelTable};
 use alloc::{boxed::Box, sync::Arc};
 use core::sync::atomic::{AtomicU8, Ordering};
 
@@ -182,6 +182,17 @@ impl FontTables {
         )
     }
 
+    fn load_sanitized_table<'a, T: TopLevelTable + Sanitize<'a, Args = ()>>(
+        &'a self,
+        state: Option<TableState<'a>>,
+    ) -> Result<T, ReadError> {
+        let state = state.ok_or(ReadError::TableIsMissing(T::TAG))?;
+        state.try_load(
+            |data| T::read_checked(data.into(), ()),
+            |data| Ok(T::read_fast(data.into(), ())),
+        )
+    }
+
     fn load_table_with_args<'a, T: TopLevelTable + FontRead<'a>>(
         &'a self,
         state: Option<TableState<'a>>,
@@ -319,15 +330,15 @@ impl<'a> TableProvider<'a> for &'a FontTables {
     }
 
     fn gdef(&self) -> Result<tables::gdef::Gdef<'a>, ReadError> {
-        self.load_table(self.gdef_state())
+        self.load_sanitized_table(self.gdef_state())
     }
 
     fn gpos(&self) -> Result<tables::gpos::Gpos<'a>, ReadError> {
-        self.load_table(self.gpos_state())
+        self.load_sanitized_table(self.gpos_state())
     }
 
     fn gsub(&self) -> Result<tables::gsub::Gsub<'a>, ReadError> {
-        self.load_table(self.gsub_state())
+        self.load_sanitized_table(self.gsub_state())
     }
 
     fn feat(&self) -> Result<tables::feat::Feat<'a>, ReadError> {
@@ -425,6 +436,8 @@ impl<'a> TableProvider<'a> for &'a FontTables {
 
 #[cfg(test)]
 mod tests {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
     use crate::FontRef;
 
     use super::*;
@@ -455,5 +468,57 @@ mod tests {
             let font_ref_data = font.data_for_tag(Tag::new(tag)).map(|d| d.as_bytes());
             assert_eq!(data, font_ref_data);
         }
+    }
+
+    #[test]
+    fn sanitized_table_uses_fast_load_after_validation() {
+        static SANITIZES: AtomicUsize = AtomicUsize::new(0);
+        static FAST_READS: AtomicUsize = AtomicUsize::new(0);
+
+        #[allow(dead_code)]
+        struct CountingTable<'a>(crate::FontData<'a>);
+
+        impl crate::ReadArgs for CountingTable<'_> {
+            type Args = ();
+        }
+
+        impl TopLevelTable for CountingTable<'_> {
+            const TAG: Tag = Tag::new(b"test");
+        }
+
+        impl<'a> Sanitize<'a> for CountingTable<'a> {
+            fn sanitize(
+                _ctx: &mut crate::sanitize::SanitizeContext<'a, '_>,
+                _args: (),
+            ) -> Result<(), ReadError> {
+                SANITIZES.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+
+            fn read_fast(data: crate::FontData<'a>, _args: ()) -> Self {
+                FAST_READS.fetch_add(1, Ordering::Relaxed);
+                Self(data)
+            }
+        }
+
+        SANITIZES.store(0, Ordering::Relaxed);
+        FAST_READS.store(0, Ordering::Relaxed);
+
+        let flag = AtomicU8::new(TableState::UNCHECKED);
+        let table_bytes = [0u8; 4];
+        let state = TableState {
+            flag: &flag,
+            data: &table_bytes,
+        };
+
+        EMPTY_FONT_TABLES
+            .load_sanitized_table::<CountingTable>(Some(state))
+            .unwrap();
+        EMPTY_FONT_TABLES
+            .load_sanitized_table::<CountingTable>(Some(state))
+            .unwrap();
+
+        assert_eq!(SANITIZES.load(Ordering::Relaxed), 1);
+        assert_eq!(FAST_READS.load(Ordering::Relaxed), 2);
     }
 }

--- a/read-fonts/src/offset_array.rs
+++ b/read-fonts/src/offset_array.rs
@@ -3,7 +3,6 @@
 //! This module provides a number of types that wrap arrays of offsets, dynamically
 //! resolving individual offsets as they are accessed.
 
-use crate::offset::ResolveNullableOffset;
 use crate::sanitize::{FastResolveNullableOffset, FastResolveOffset, Sanitize};
 use font_types::{BigEndian, Nullable, Offset16, Scalar};
 
@@ -18,17 +17,6 @@ use crate::{FontData, FontRead, Offset, ReadArgs, ReadError, ResolveOffset};
 #[derive(Clone)]
 pub struct ArrayOfOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
     offsets: &'a [BigEndian<O>],
-    data: FontData<'a>,
-    args: T::Args,
-}
-
-/// An array of nullable offsets that can be resolved on access.
-///
-/// This is identical to [`ArrayOfOffsets`], except that each offset is
-/// allowed to be null.
-#[derive(Clone)]
-pub struct ArrayOfNullableOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
-    offsets: &'a [BigEndian<Nullable<O>>],
     data: FontData<'a>,
     args: T::Args,
 }
@@ -78,78 +66,6 @@ where
     ///
     /// Each offset will be resolved as it is encountered.
     pub fn iter(&self) -> impl Iterator<Item = Result<T, ReadError>> + 'a {
-        let mut iter = self.offsets.iter();
-        let args = self.args;
-        let data = self.data;
-        std::iter::from_fn(move || {
-            iter.next()
-                .map(|off| off.get().resolve_with_args(data, args))
-        })
-    }
-
-    /// Iterate over all of the offset targets.
-    ///
-    /// Offset is treated as nullable and each offset will be resolved as it is encountered.
-    pub(crate) fn iter_as_nullable(
-        &self,
-    ) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
-        self.iter().map(|off| match off {
-            Err(ReadError::NullOffset) => None,
-            other => Some(other),
-        })
-    }
-}
-
-impl<'a, T, O> ArrayOfNullableOffsets<'a, T, O>
-where
-    O: Scalar + Offset,
-    T: ReadArgs,
-{
-    pub(crate) fn new(
-        offsets: &'a [BigEndian<Nullable<O>>],
-        data: FontData<'a>,
-        args: T::Args,
-    ) -> Self {
-        Self {
-            offsets,
-            data,
-            args,
-        }
-    }
-}
-
-impl<'a, T, O> ArrayOfNullableOffsets<'a, T, O>
-where
-    O: Scalar + Offset,
-    T: FontRead<'a>,
-    T::Args: Copy + 'static,
-{
-    /// The number of offsets in the array
-    pub fn len(&self) -> usize {
-        self.offsets.len()
-    }
-
-    /// `true` if the array is empty
-    pub fn is_empty(&self) -> bool {
-        self.offsets.is_empty()
-    }
-
-    /// Resolve the offset at the provided index.
-    ///
-    /// This will return `None` only if the offset *exists*, but is null. if the
-    /// provided index does not exist, this will return the `InvalidCollectionIndex`
-    /// error variant.
-    pub fn get(&self, idx: usize) -> Option<Result<T, ReadError>> {
-        let Some(offset) = self.offsets.get(idx) else {
-            return Some(Err(ReadError::InvalidCollectionIndex(idx as _)));
-        };
-        offset.get().resolve_with_args(self.data, self.args)
-    }
-
-    /// Iterate over all of the offset targets.
-    ///
-    /// Each offset will be resolved as it is encountered.
-    pub fn iter(&self) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
         let mut iter = self.offsets.iter();
         let args = self.args;
         let data = self.data;
@@ -308,30 +224,6 @@ where
 impl<'a, T, O> crate::traversal::SomeArray<'a> for ArrayOfOffsets<'a, T, O>
 where
     O: Scalar + Offset + Into<crate::traversal::OffsetType>,
-    T: FontRead<'a> + crate::traversal::SomeTable<'a> + 'a,
-    T::Args: Copy + 'static,
-{
-    fn type_name(&self) -> &str {
-        let full_name = std::any::type_name::<T>();
-        full_name.split("::").last().unwrap_or(full_name)
-    }
-
-    fn len(&self) -> usize {
-        self.offsets.len()
-    }
-
-    fn get(&self, idx: usize) -> Option<crate::traversal::FieldType<'a>> {
-        let off = self.offsets.get(idx)?;
-        let raw = off.get();
-        let result = raw.resolve_with_args::<T>(self.data, self.args);
-        Some(crate::traversal::FieldType::offset(raw, result))
-    }
-}
-
-#[cfg(feature = "experimental_traverse")]
-impl<'a, T, O> crate::traversal::SomeArray<'a> for ArrayOfNullableOffsets<'a, T, O>
-where
-    O: Scalar + Offset + Into<crate::traversal::OffsetType> + Clone,
     T: FontRead<'a> + crate::traversal::SomeTable<'a> + 'a,
     T::Args: Copy + 'static,
 {

--- a/read-fonts/src/offset_array.rs
+++ b/read-fonts/src/offset_array.rs
@@ -4,7 +4,6 @@
 //! resolving individual offsets as they are accessed.
 
 use crate::offset::ResolveNullableOffset;
-#[cfg(any(test, feature = "codegen_test"))]
 use crate::sanitize::{FastResolveNullableOffset, FastResolveOffset, Sanitize};
 use font_types::{BigEndian, Nullable, Offset16, Scalar};
 
@@ -165,7 +164,6 @@ where
 ///
 /// This is identical to [`ArrayOfOffsets`], except that each offset is resolved
 /// using `fast_resolve` instead of `resolve_with_args`, skipping re-validation.
-#[cfg(any(test, feature = "codegen_test"))]
 #[derive(Clone)]
 pub struct SanitizedArrayOfOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
     offsets: &'a [BigEndian<O>],
@@ -178,7 +176,6 @@ pub struct SanitizedArrayOfOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
 /// This is identical to [`ArrayOfNullableOffsets`], except that each offset is
 /// resolved using `fast_resolve` instead of `resolve_with_args`, skipping
 /// re-validation.
-#[cfg(any(test, feature = "codegen_test"))]
 #[derive(Clone)]
 pub struct SanitizedArrayOfNullableOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
     offsets: &'a [BigEndian<Nullable<O>>],
@@ -186,7 +183,6 @@ pub struct SanitizedArrayOfNullableOffsets<'a, T: ReadArgs, O: Scalar = Offset16
     args: T::Args,
 }
 
-#[cfg(any(test, feature = "codegen_test"))]
 impl<'a, T, O> SanitizedArrayOfOffsets<'a, T, O>
 where
     O: Scalar,
@@ -201,7 +197,6 @@ where
     }
 }
 
-#[cfg(any(test, feature = "codegen_test"))]
 impl<'a, T, O> SanitizedArrayOfOffsets<'a, T, O>
 where
     O: Scalar + Offset,
@@ -238,9 +233,20 @@ where
         let data = self.data;
         std::iter::from_fn(move || iter.next().map(|off| off.get().fast_resolve(data, args)))
     }
+
+    /// Iterate over all of the offset targets.
+    ///
+    /// Offset is treated as nullable and each offset will be resolved as it is encountered.
+    pub(crate) fn iter_as_nullable(
+        &self,
+    ) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
+        self.iter().map(|off| match off {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        })
+    }
 }
 
-#[cfg(any(test, feature = "codegen_test"))]
 impl<'a, T, O> SanitizedArrayOfNullableOffsets<'a, T, O>
 where
     O: Scalar + Offset,
@@ -259,7 +265,6 @@ where
     }
 }
 
-#[cfg(any(test, feature = "codegen_test"))]
 impl<'a, T, O> SanitizedArrayOfNullableOffsets<'a, T, O>
 where
     O: Scalar + Offset,
@@ -347,7 +352,7 @@ where
     }
 }
 
-#[cfg(all(feature = "experimental_traverse", any(test, feature = "codegen_test")))]
+#[cfg(feature = "experimental_traverse")]
 impl<'a, T, O> crate::traversal::SomeArray<'a> for SanitizedArrayOfOffsets<'a, T, O>
 where
     O: Scalar + Offset + Into<crate::traversal::OffsetType>,
@@ -371,7 +376,7 @@ where
     }
 }
 
-#[cfg(all(feature = "experimental_traverse", any(test, feature = "codegen_test")))]
+#[cfg(feature = "experimental_traverse")]
 impl<'a, T, O> crate::traversal::SomeArray<'a> for SanitizedArrayOfNullableOffsets<'a, T, O>
 where
     O: Scalar + Offset + Into<crate::traversal::OffsetType> + Clone,

--- a/read-fonts/src/offset_array.rs
+++ b/read-fonts/src/offset_array.rs
@@ -88,10 +88,6 @@ pub struct SanitizedArrayOfOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
 }
 
 /// An array of nullable offsets that resolves using `read_fast` (post-sanitize).
-///
-/// This is identical to [`ArrayOfNullableOffsets`], except that each offset is
-/// resolved using `fast_resolve` instead of `resolve_with_args`, skipping
-/// re-validation.
 #[derive(Clone)]
 pub struct SanitizedArrayOfNullableOffsets<'a, T: ReadArgs, O: Scalar = Offset16> {
     offsets: &'a [BigEndian<Nullable<O>>],

--- a/read-fonts/src/read.rs
+++ b/read-fonts/src/read.rs
@@ -131,6 +131,8 @@ pub enum ReadError {
     TableIsMissing(Tag),
     MetricIsMissing(Tag),
     MalformedData(&'static str),
+    /// Sanitize descended through more nested offsets than we permit.
+    RecursionLimitExceeded,
 }
 
 impl std::fmt::Display for ReadError {
@@ -151,6 +153,9 @@ impl std::fmt::Display for ReadError {
             ReadError::TableIsMissing(tag) => write!(f, "the {tag} table is missing"),
             ReadError::MetricIsMissing(tag) => write!(f, "the {tag} metric is missing"),
             ReadError::MalformedData(msg) => write!(f, "Malformed data: '{msg}'"),
+            ReadError::RecursionLimitExceeded => {
+                write!(f, "Offset graph exceeded max MAX_SANITIZE_DEPTH",)
+            }
         }
     }
 }

--- a/read-fonts/src/sanitize.rs
+++ b/read-fonts/src/sanitize.rs
@@ -3,10 +3,10 @@
 use bytemuck::AnyBitPattern;
 use types::{BigEndian, FixedSize, Nullable, Scalar};
 
-use crate::{
-    array::VarLenArray, font_data::Cursor, read::VarSize, ComputeSize, FontData, FontRead, Offset,
-    ReadArgs, ReadError, ResolveOffset,
-};
+use crate::{font_data::Cursor, ComputeSize, FontData, FontRead, Offset, ReadArgs, ReadError};
+
+#[cfg(any(test, feature = "codegen_test"))]
+use crate::ResolveOffset;
 
 /// The bytes of the current table being sanitized, along with shared sanitize state.
 ///
@@ -125,7 +125,7 @@ impl<'a> SanitizeContext<'a, '_> {
     ///
     /// this has a slightly funny signature because it needs to handle both
     /// scalar and struct members, and the structs might need to be recursed
-    #[expect(dead_code)] // not yet used in a real table
+    #[cfg(any(test, feature = "codegen_test"))]
     pub(crate) fn sanitize_offset_to_array<O, T, F>(
         &mut self,
         count: u16,
@@ -145,7 +145,7 @@ impl<'a> SanitizeContext<'a, '_> {
     ///
     /// Used in records, where the offset is accessed via a getter rather than
     /// read from the cursor.
-    #[expect(dead_code)] // not yet used in a real table
+    #[cfg(any(test, feature = "codegen_test"))]
     pub(crate) fn sanitize_resolved_offset_to_array<O, T, F>(
         &mut self,
         offset: O,
@@ -204,19 +204,19 @@ impl<'a> SanitizeContext<'a, '_> {
         }
     }
 
-    #[expect(dead_code)] // not yet used in a real table
+    #[cfg(any(test, feature = "codegen_test"))]
     pub(crate) fn sanitize_var_len_array<T>(
         &mut self,
         count: usize,
         recurse: bool,
     ) -> Result<(), ReadError>
     where
-        T: VarSize + SanitizeStruct<Args = ()> + FontRead<'a>,
+        T: crate::VarSize + SanitizeStruct<Args = ()> + FontRead<'a>,
     {
         let remaining = self.cursor.remaining().ok_or(ReadError::OutOfBounds)?;
         let total_len = T::total_len_for_count(remaining, count)?;
         if recurse {
-            let array = VarLenArray::<T>::read(remaining)?;
+            let array = crate::VarLenArray::<T>::read(remaining)?;
             for item in array.iter().take(count) {
                 item?.sanitize_struct(self, ())?;
             }
@@ -274,6 +274,17 @@ pub trait SanitizeStruct: ReadArgs {
     /// Sanitize `self`, recursing into any offsets
     fn sanitize_struct(&self, ctx: &mut SanitizeContext, args: Self::Args)
         -> Result<(), ReadError>;
+}
+
+impl ReadArgs for () {
+    type Args = ();
+}
+impl<'a> Sanitize<'a> for () {
+    fn sanitize(_ctx: &mut SanitizeContext<'a, '_>, _args: Self::Args) -> Result<(), ReadError> {
+        Ok(())
+    }
+
+    fn read_fast(_data: FontData<'a>, _args: Self::Args) -> Self {}
 }
 
 /// Recursively sanitize the table pointed at by an offset.

--- a/read-fonts/src/sanitize.rs
+++ b/read-fonts/src/sanitize.rs
@@ -17,11 +17,21 @@ pub struct SanitizeContext<'a, 's> {
     state: &'s mut SanitizeState,
 }
 
+/// The deepest offset graph we will descend through while sanitizing.
+///
+/// Sanitize follows offsets eagerly, so a self-referential table (a chain of
+/// `ConditionFormat5` negations, a cyclic COLRv1 paint graph) would otherwise
+/// recurse until the stack is exhausted.
+///
+/// 64 is the limit set by HB.
+/// <https://github.com/harfbuzz/harfbuzz/blob/aba63bb5f8/src/hb-limits.hh#L52>
+pub(crate) const MAX_SANITIZE_DEPTH: u32 = 64;
+
 /// State tracked during during a sanitize pass
 #[derive(Clone, Debug, Default)]
 struct SanitizeState {
-    // only used in COLRv1
-    _recursion_depth: u32,
+    /// How many offsets deep we currently are; bounded by [`MAX_SANITIZE_DEPTH`].
+    recursion_depth: u32,
     // gpos/gsub
     _subtable_depth: u32,
     _max_ops: u32,
@@ -78,13 +88,19 @@ impl<'a> SanitizeContext<'a, '_> {
             .split_off(offset)
             .ok_or(ReadError::OutOfBounds)?;
 
-        //TODO: track descent here?
+        if self.state.recursion_depth >= MAX_SANITIZE_DEPTH {
+            return Err(ReadError::RecursionLimitExceeded);
+        }
+        self.state.recursion_depth += 1;
+
         let mut child_ctx = SanitizeContext {
             cursor: offset_data.cursor(),
             state: self.state,
         };
+        let result = f(&mut child_ctx);
 
-        f(&mut child_ctx)
+        self.state.recursion_depth -= 1;
+        result
     }
 
     /// Advance the cursor past a scalar
@@ -393,6 +409,45 @@ mod tests {
     use types::Offset16;
 
     use super::*;
+
+    fn sanitize_condition_chain(len: usize) -> Result<(), ReadError> {
+        /// A linear chain of `ConditionFormat5` negations, `len` nodes long.
+        ///
+        /// Each node is `format(u16 = 5)` + `condition_offset(Offset24 = 5)`, so
+        /// every node points 5 bytes forward to the next.
+        fn condition_chain(len: usize) -> Vec<u8> {
+            let mut bytes = Vec::with_capacity(len * 5 + 8);
+            for _ in 0..len {
+                bytes.extend_from_slice(&[0x00, 0x05, 0x00, 0x00, 0x05]);
+            }
+            // ConditionFormat1: axis 0, filter range [-1.0, 1.0]
+            bytes.extend_from_slice(&[0x00, 0x01, 0x00, 0x00, 0xC0, 0x00, 0x40, 0x00]);
+            bytes
+        }
+
+        use crate::tables::layout::Condition;
+        let bytes = condition_chain(len);
+        Condition::read_checked(FontData::new(&bytes), ()).map(|_| ())
+    }
+
+    #[test]
+    fn deep_offset_chain_is_rejected_not_overflowed() {
+        assert_eq!(
+            sanitize_condition_chain(4096),
+            Err(ReadError::RecursionLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn depth_limit_is_exactly_max_sanitize_depth() {
+        // the chain root is depth 0, so a chain of MAX nodes descends MAX times
+        let max = MAX_SANITIZE_DEPTH as usize;
+        assert_eq!(sanitize_condition_chain(max), Ok(()));
+        assert_eq!(
+            sanitize_condition_chain(max + 1),
+            Err(ReadError::RecursionLimitExceeded)
+        );
+    }
 
     #[test]
     fn verify_that_various_things_compile() {

--- a/read-fonts/src/sanitize.rs
+++ b/read-fonts/src/sanitize.rs
@@ -13,7 +13,7 @@ use crate::{
 /// This is bundled together because we need to update the shared state as we
 /// navigate the bytes.
 pub struct SanitizeContext<'a, 's> {
-    cursor: Cursor<'a>,
+    pub(crate) cursor: Cursor<'a>,
     state: &'s mut SanitizeState,
 }
 
@@ -125,6 +125,7 @@ impl<'a> SanitizeContext<'a, '_> {
     ///
     /// this has a slightly funny signature because it needs to handle both
     /// scalar and struct members, and the structs might need to be recursed
+    #[expect(dead_code)] // not yet used in a real table
     pub(crate) fn sanitize_offset_to_array<O, T, F>(
         &mut self,
         count: u16,
@@ -144,6 +145,7 @@ impl<'a> SanitizeContext<'a, '_> {
     ///
     /// Used in records, where the offset is accessed via a getter rather than
     /// read from the cursor.
+    #[expect(dead_code)] // not yet used in a real table
     pub(crate) fn sanitize_resolved_offset_to_array<O, T, F>(
         &mut self,
         offset: O,
@@ -202,6 +204,7 @@ impl<'a> SanitizeContext<'a, '_> {
         }
     }
 
+    #[expect(dead_code)] // not yet used in a real table
     pub(crate) fn sanitize_var_len_array<T>(
         &mut self,
         count: usize,

--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -53,7 +53,9 @@ impl<'a> AnchorTable<'a> {
     }
 }
 
-impl<'a, T: FontRead<'a, Args = ()>> ExtensionLookup<'a, T> for ExtensionPosFormat1<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default> ExtensionLookup<'a, T>
+    for ExtensionPosFormat1<'a, T>
+{
     fn extension(&self) -> Result<T, ReadError> {
         self.extension()
     }
@@ -182,6 +184,12 @@ impl PairPosFormat2<'_> {
             Value::read(data, record_offset + format1_len, format2, context)?,
         ])
     }
+}
+
+// called from codegen
+fn sanitize_value_record(ctx: &mut SanitizeContext, args: ValueFormat) -> Result<(), ReadError> {
+    let record: ValueRecord = ctx.cursor.read_with_args(args)?;
+    record.sanitize_struct(ctx, args)
 }
 
 #[cfg(test)]

--- a/read-fonts/src/tables/gpos/closure.rs
+++ b/read-fonts/src/tables/gpos/closure.rs
@@ -6,7 +6,7 @@ use super::{
     PositionLookup, PositionLookupList, PositionSubtables, SinglePos, SinglePosFormat1,
     SinglePosFormat2,
 };
-use crate::{collections::IntSet, FontRead, GlyphId, ReadError, Tag};
+use crate::{collections::IntSet, sanitize::Sanitize, GlyphId, ReadError, Tag};
 
 #[cfg(feature = "std")]
 use crate::tables::layout::{Intersect, LayoutLookupList, LookupClosure, LookupClosureCtx};
@@ -149,7 +149,7 @@ impl Intersect for ExtensionSubtable<'_> {
 
 impl<'a, T> Intersect for ExtensionPosFormat1<'a, T>
 where
-    T: Intersect + FontRead<'a, Args = ()>,
+    T: Intersect + Sanitize<'a, Args = ()> + Default,
 {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
         if self.extension_offset().is_null() {

--- a/read-fonts/src/tables/gsub.rs
+++ b/read-fonts/src/tables/gsub.rs
@@ -25,7 +25,9 @@ pub type SubstitutionSequenceContext<'a> = super::layout::SequenceContext<'a>;
 /// A GSUB [ChainedSequenceContext]
 pub type SubstitutionChainContext<'a> = super::layout::ChainedSequenceContext<'a>;
 
-impl<'a, T: FontRead<'a, Args = ()>> ExtensionLookup<'a, T> for ExtensionSubstFormat1<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default> ExtensionLookup<'a, T>
+    for ExtensionSubstFormat1<'a, T>
+{
     fn extension(&self) -> Result<T, ReadError> {
         self.extension()
     }

--- a/read-fonts/src/tables/gsub/closure.rs
+++ b/read-fonts/src/tables/gsub/closure.rs
@@ -6,8 +6,9 @@ use font_types::GlyphId;
 
 use crate::{
     collections::{FnvHashMap, IntSet},
+    sanitize::Sanitize,
     tables::layout::{ExtensionLookup, Subtables},
-    FontRead, ReadError, Tag,
+    ReadError, Tag,
 };
 
 use super::{
@@ -356,8 +357,11 @@ impl GlyphClosure for SubstitutionSubtables<'_> {
     }
 }
 
-impl<'a, T: FontRead<'a, Args = ()> + GlyphClosure + 'a, Ext: ExtensionLookup<'a, T> + 'a>
-    GlyphClosure for Subtables<'a, T, Ext>
+impl<
+        'a,
+        T: Sanitize<'a, Args = ()> + Default + GlyphClosure + 'a,
+        Ext: ExtensionLookup<'a, T> + 'a,
+    > GlyphClosure for Subtables<'a, T, Ext>
 {
     fn closure_glyphs(
         &self,
@@ -1098,7 +1102,7 @@ impl Intersect for ExtensionSubtable<'_> {
 
 impl<'a, T> Intersect for ExtensionSubstFormat1<'a, T>
 where
-    T: Intersect + FontRead<'a, Args = ()>,
+    T: Intersect + Sanitize<'a, Args = ()> + Default,
 {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
         if self.extension_offset().is_null() {

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -31,9 +31,9 @@ mod spec_tests;
 
 include!("../../generated/generated_layout.rs");
 
-impl<'a, T: FontRead<'a, Args = ()>> Lookup<'a, T> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default> Lookup<'a, T> {
     pub fn get_subtable(&self, offset: Offset16) -> Result<T, ReadError> {
-        self.resolve_offset(offset)
+        self.fast_resolve(offset)
     }
 
     #[cfg(feature = "experimental_traverse")]
@@ -46,7 +46,9 @@ impl<'a, T: FontRead<'a, Args = ()>> Lookup<'a, T> {
 ///
 /// This is necessary because GPOS and GSUB have different concrete types
 /// for their extension lookups.
-pub trait ExtensionLookup<'a, T: FontRead<'a, Args = ()>>: FontRead<'a, Args = ()> {
+pub trait ExtensionLookup<'a, T: Sanitize<'a, Args = ()> + Default>:
+    Sanitize<'a, Args = ()> + Default
+{
     fn extension(&self) -> Result<T, ReadError>;
 }
 
@@ -54,20 +56,22 @@ pub trait ExtensionLookup<'a, T: FontRead<'a, Args = ()>>: FontRead<'a, Args = (
 ///
 /// This is used to implement more ergonomic access to lookup subtables for
 /// GPOS & GSUB lookup tables.
-pub enum Subtables<'a, T: FontRead<'a, Args = ()>, Ext: ExtensionLookup<'a, T>> {
-    Subtable(ArrayOfOffsets<'a, T>),
-    Extension(ArrayOfOffsets<'a, Ext>),
+pub enum Subtables<'a, T: Sanitize<'a, Args = ()> + Default, Ext: ExtensionLookup<'a, T>> {
+    Subtable(SanitizedArrayOfOffsets<'a, T>),
+    Extension(SanitizedArrayOfOffsets<'a, Ext>),
 }
 
-impl<'a, T: FontRead<'a, Args = ()> + 'a, Ext: ExtensionLookup<'a, T> + 'a> Subtables<'a, T, Ext> {
+impl<'a, T: Sanitize<'a, Args = ()> + Default + 'a, Ext: ExtensionLookup<'a, T> + 'a>
+    Subtables<'a, T, Ext>
+{
     /// create a new subtables array given offsets to non-extension subtables
     pub(crate) fn new(offsets: &'a [BigEndian<Offset16>], data: FontData<'a>) -> Self {
-        Subtables::Subtable(ArrayOfOffsets::new(offsets, data, ()))
+        Subtables::Subtable(SanitizedArrayOfOffsets::new(offsets, data, ()))
     }
 
     /// create a new subtables array given offsets to extension subtables
     pub(crate) fn new_ext(offsets: &'a [BigEndian<Offset16>], data: FontData<'a>) -> Self {
-        Subtables::Extension(ArrayOfOffsets::new(offsets, data, ()))
+        Subtables::Extension(SanitizedArrayOfOffsets::new(offsets, data, ()))
     }
 
     /// The number of subtables in this collection
@@ -116,6 +120,12 @@ impl ReadArgs for FeatureParams<'_> {
     type Args = Tag;
 }
 
+impl Default for FeatureParams<'_> {
+    fn default() -> Self {
+        Self::Size(Default::default())
+    }
+}
+
 impl<'a> FontRead<'a> for FeatureParams<'a> {
     fn read_with_args(bytes: FontData<'a>, args: Tag) -> Result<FeatureParams<'a>, ReadError> {
         match args {
@@ -130,6 +140,34 @@ impl<'a> FontRead<'a> for FeatureParams<'a> {
             // NOTE: what even is our error condition here? an offset exists but
             // we don't know the tag?
             _ => Err(ReadError::InvalidFormat(0xdead)),
+        }
+    }
+}
+
+impl<'a> Sanitize<'a> for FeatureParams<'a> {
+    fn sanitize(ctx: &mut SanitizeContext<'a, '_>, args: Self::Args) -> Result<(), ReadError> {
+        match args {
+            t if t == Tag::new(b"size") => SizeParams::sanitize(ctx, ()),
+            t if &t.to_raw()[..2] == b"ss" => StylisticSetParams::sanitize(ctx, ()),
+            t if &t.to_raw()[..2] == b"cv" => CharacterVariantParams::sanitize(ctx, ()),
+            // NOTE: what even is our error condition here? an offset exists but
+            // we don't know the tag?
+            _ => Err(ReadError::InvalidFormat(0xdead)),
+        }
+    }
+
+    fn read_fast(data: FontData<'a>, args: Self::Args) -> Self {
+        match args {
+            t if t == Tag::new(b"size") => Self::Size(SizeParams::read_fast(data, ())),
+            t if &t.to_raw()[..2] == b"ss" => {
+                Self::StylisticSet(StylisticSetParams::read_fast(data, ()))
+            }
+            t if &t.to_raw()[..2] == b"cv" => {
+                Self::CharacterVariant(CharacterVariantParams::read_fast(data, ()))
+            }
+            // NOTE: what even is our error condition here? an offset exists but
+            // we don't know the tag?
+            _ => panic!("should have been validated"),
         }
     }
 }
@@ -157,6 +195,14 @@ impl FeatureTableSubstitutionRecord {
     pub fn alternate_feature<'a>(&self, data: FontData<'a>) -> Result<Feature<'a>, ReadError> {
         self.alternate_feature_offset()
             .resolve_with_args(data, Tag::new(b"NULL"))
+    }
+
+    fn sanitize_alternate_feature_offset(
+        &self,
+        ctx: &mut SanitizeContext,
+    ) -> Result<(), ReadError> {
+        self.alternate_feature_offset()
+            .sanitize_offset::<Feature>(ctx, Tag::new(b"NULL"))
     }
 }
 

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -3,7 +3,7 @@
 use types::{BigEndian, GlyphId16, Offset16};
 
 use super::{
-    ArrayOfOffsets, ChainedClassSequenceRule, ChainedClassSequenceRuleSet, ChainedSequenceContext,
+    ChainedClassSequenceRule, ChainedClassSequenceRuleSet, ChainedSequenceContext,
     ChainedSequenceContextFormat1, ChainedSequenceContextFormat2, ChainedSequenceContextFormat3,
     ChainedSequenceRule, ChainedSequenceRuleSet, ClassDef, ClassDefFormat1, ClassDefFormat2,
     ClassSequenceRule, ClassSequenceRuleSet, CoverageTable, ExtensionLookup, Feature, FeatureList,
@@ -13,8 +13,9 @@ use super::{
 };
 use crate::{
     collections::{FnvHashMap, IntSet},
+    sanitize::Sanitize,
     tables::{gpos::PositionLookupList, gsub::SubstitutionLookupList},
-    FontRead,
+    SanitizedArrayOfOffsets,
 };
 
 const MAX_SCRIPTS: u16 = 500;
@@ -449,7 +450,7 @@ impl Intersect for ClassDefFormat2<'_> {
 
 impl<'a, T, Ext> LookupClosure for Subtables<'a, T, Ext>
 where
-    T: LookupClosure + Intersect + FontRead<'a, Args = ()> + 'a,
+    T: LookupClosure + Intersect + Sanitize<'a, Args = ()> + Default + 'a,
     Ext: ExtensionLookup<'a, T> + 'a,
 {
     fn closure_lookups(&self, c: &mut LookupClosureCtx, arg: u16) -> Result<(), ReadError> {
@@ -463,9 +464,9 @@ where
     }
 }
 
-impl<'a, T> Intersect for ArrayOfOffsets<'a, T, Offset16>
+impl<'a, T> Intersect for SanitizedArrayOfOffsets<'a, T, Offset16>
 where
-    T: Intersect + FontRead<'a, Args = ()> + 'a,
+    T: Intersect + Sanitize<'a, Args = ()> + Default + 'a,
 {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
         for t in self.iter().filter_map(|table| match table {
@@ -837,7 +838,7 @@ pub(crate) enum ContextFormat3<'a> {
 }
 
 impl ContextFormat3<'_> {
-    pub(crate) fn coverages(&self) -> ArrayOfOffsets<'_, CoverageTable<'_>> {
+    pub(crate) fn coverages(&self) -> SanitizedArrayOfOffsets<'_, CoverageTable<'_>> {
         match self {
             ContextFormat3::Plain(table) => table.coverages(),
             ContextFormat3::Chain(table) => table.input_coverages(),

--- a/read-fonts/src/tables/layout/spec_tests.rs
+++ b/read-fonts/src/tables/layout/spec_tests.rs
@@ -5,7 +5,7 @@ use font_test_data::layout as test_data;
 fn example_1_scripts() {
     // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#example-1-scriptlist-table-and-scriptrecords
 
-    let table = ScriptList::read(test_data::SCRIPTS.into()).unwrap();
+    let table = ScriptList::read_fast(test_data::SCRIPTS.into(), ());
     assert_eq!(table.script_count(), 3);
     assert_eq!(table.script_records()[0].script_tag(), Tag::new(b"hani"));
     assert_eq!(table.script_records()[1].script_tag(), Tag::new(b"kana"));

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -5,6 +5,7 @@ use types::{BigEndian, F2Dot14, FixedSize, Offset16};
 
 use super::ValueFormat;
 use crate::{
+    sanitize::{SanitizeOffset, SanitizeStruct},
     tables::{
         layout::DeviceOrVariationIndex,
         variations::{DeltaSetIndex, ItemVariationStore},
@@ -334,6 +335,29 @@ impl ComputeSize for ValueRecord {
     #[inline]
     fn compute_size(args: ValueFormat) -> Result<usize, ReadError> {
         Ok(args.record_byte_len())
+    }
+}
+
+impl SanitizeStruct for ValueRecord {
+    fn sanitize_struct(
+        &self,
+        ctx: &mut crate::sanitize::SanitizeContext,
+        _args: Self::Args,
+    ) -> Result<(), ReadError> {
+        //NOTE: I don't think harfbuzz sanitizes these greedily? but we can
+        //do this for now and change it later
+        self.x_placement_device
+            .get()
+            .sanitize_offset::<DeviceOrVariationIndex>(ctx, ())?;
+        self.y_placement_device
+            .get()
+            .sanitize_offset::<DeviceOrVariationIndex>(ctx, ())?;
+        self.x_advance_device
+            .get()
+            .sanitize_offset::<DeviceOrVariationIndex>(ctx, ())?;
+        self.y_advance_device
+            .get()
+            .sanitize_offset::<DeviceOrVariationIndex>(ctx, ())
     }
 }
 

--- a/read-fonts/src/tests/test_gdef.rs
+++ b/read-fonts/src/tests/test_gdef.rs
@@ -6,7 +6,7 @@ use font_test_data::gdef as test_data;
 
 #[test]
 fn gdef_header() {
-    let table = Gdef::read(test_data::GDEF_HEADER.into()).unwrap();
+    let table = Gdef::read_fast(test_data::GDEF_HEADER.into(), ());
     assert_eq!(table.version(), MajorMinor::VERSION_1_0);
     assert_eq!(table.mark_attach_class_def_offset(), 0x5a);
 }

--- a/resources/codegen_inputs/gdef.rs
+++ b/resources/codegen_inputs/gdef.rs
@@ -1,4 +1,5 @@
 #![parse_module(read_fonts::tables::gdef)]
+#![sanitize]
 
 /// [GDEF](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#gdef-header) 1.0
 #[tag = "GDEF"]

--- a/resources/codegen_inputs/gpos.rs
+++ b/resources/codegen_inputs/gpos.rs
@@ -1,5 +1,6 @@
 // path (from compile crate) to the generated parse module for this table.
 #![parse_module(read_fonts::tables::gpos)]
+#![sanitize]
 
 extern record ValueRecord;
 
@@ -150,6 +151,7 @@ table SinglePosFormat1 {
     /// Defines positioning value(s) — applied to all glyphs in the
     /// Coverage table.
     #[read_with($value_format)]
+    #[sanitize_with(sanitize_value_record, $value_format)]
     value_record: ValueRecord,
 }
 

--- a/resources/codegen_inputs/gsub.rs
+++ b/resources/codegen_inputs/gsub.rs
@@ -1,5 +1,6 @@
 // path (from compile crate) to the generated parse module for this table.
 #![parse_module(read_fonts::tables::gsub)]
+#![sanitize]
 
 /// [GSUB](https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#gsub-header)
 #[tag = "GSUB"]

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -1,5 +1,6 @@
 // path (from compile crate) to the generated parse module for this table.
 #![parse_module(read_fonts::tables::layout)]
+#![sanitize]
 
 extern scalar LookupFlag;
 
@@ -708,6 +709,7 @@ record FeatureTableSubstitutionRecord {
     /// Offset to an alternate feature table, from start of the
     /// FeatureTableSubstitution table.
     #[offset_getter(alternate_feature)] // custom impl, we need to pass a fake tag
+    #[sanitize_with(sanitize_alternate_feature_offset)]
     alternate_feature_offset: Offset32<Feature>,
 }
 

--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -1,4 +1,5 @@
 #![parse_module(read_fonts::tables::variations)]
+#![sanitize]
 
 extern scalar TupleIndex;
 

--- a/skera/src/gpos.rs
+++ b/skera/src/gpos.rs
@@ -29,7 +29,7 @@ use write_fonts::{
             layout::{ExtensionLookup, Intersect, LookupFlag, Subtables},
         },
         types::Tag,
-        FontRead, FontRef, ReadError, TopLevelTable,
+        FontRef, ReadError, Sanitize, TopLevelTable,
     },
     types::{MajorMinor, Offset16, Offset32},
     FontBuilder,
@@ -289,7 +289,8 @@ where
             'a,
             ArgsForSubset = (&'a SubsetState, &'a FontRef<'a>, &'a FnvHashMap<u16, u16>),
             Output = (),
-        > + FontRead<'a, Args = ()>,
+        > + Sanitize<'a, Args = ()>
+        + Default,
 {
     type ArgsForSubset = (&'a SubsetState, &'a FontRef<'a>, &'a FnvHashMap<u16, u16>);
     type Output = ();
@@ -365,7 +366,7 @@ impl CollectVariationIndices for PositionSubtables<'_> {
 
 impl<'a, T, Ext> CollectVariationIndices for Subtables<'a, T, Ext>
 where
-    T: CollectVariationIndices + Intersect + FontRead<'a, Args = ()> + 'a,
+    T: CollectVariationIndices + Intersect + Sanitize<'a, Args = ()> + Default + 'a,
     Ext: ExtensionLookup<'a, T> + 'a,
 {
     fn collect_variation_indices(&self, plan: &Plan, varidx_set: &mut IntSet<u32>) {

--- a/skera/src/gsub.rs
+++ b/skera/src/gsub.rs
@@ -22,7 +22,7 @@ use write_fonts::{
             layout::LookupFlag,
         },
         types::{MajorMinor, Offset16, Offset32, Tag},
-        FontRead, FontRef, TopLevelTable,
+        FontRef, Sanitize, TopLevelTable,
     },
     FontBuilder,
 };
@@ -287,7 +287,8 @@ where
             'a,
             ArgsForSubset = (&'a SubsetState, &'a FontRef<'a>, &'a FnvHashMap<u16, u16>),
             Output = (),
-        > + FontRead<'a, Args = ()>,
+        > + Sanitize<'a, Args = ()>
+        + Default,
 {
     type ArgsForSubset = (&'a SubsetState, &'a FontRef<'a>, &'a FnvHashMap<u16, u16>);
     type Output = ();

--- a/skera/src/gsubgpos.rs
+++ b/skera/src/gsubgpos.rs
@@ -17,7 +17,7 @@ use write_fonts::{
             SequenceContextFormat1, SequenceContextFormat2, SequenceContextFormat3,
             SequenceLookupRecord, SequenceRule, SequenceRuleSet,
         },
-        ArrayOfOffsets, FontRef,
+        ArrayOfOffsets, FontRef, SanitizedArrayOfOffsets,
     },
     types::{BigEndian, FixedSize, GlyphId, GlyphId16, Offset16},
 };
@@ -402,6 +402,31 @@ impl<'a> SubsetTable<'a> for ClassSequenceRule<'_> {
 }
 
 impl<'a> SubsetTable<'a> for ArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
+    type ArgsForSubset = ();
+    type Output = ();
+    fn subset(
+        &self,
+        plan: &Plan,
+        s: &mut Serializer,
+        _args: Self::ArgsForSubset,
+    ) -> Result<Self::Output, SerializeErrorFlags> {
+        let snap = s.snapshot();
+        for cov in self.iter_as_nullable() {
+            let Some(cov) = cov
+                .transpose()
+                .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?
+            else {
+                s.revert_snapshot(snap);
+                return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
+            };
+            let offset_pos = s.allocate_size(Offset16::RAW_BYTE_LEN, true)?;
+            Offset16::serialize_subset(&cov, s, plan, (), offset_pos)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> SubsetTable<'a> for SanitizedArrayOfOffsets<'a, CoverageTable<'a>, Offset16> {
     type ArgsForSubset = ();
     type Output = ();
     fn subset(

--- a/skera/src/layout.rs
+++ b/skera/src/layout.rs
@@ -25,7 +25,8 @@ use write_fonts::{
             },
         },
         types::{GlyphId, GlyphId16, NameId},
-        ArrayOfOffsets, FontData, FontRead, FontRef, MinByteRange, ReadError, TopLevelTable,
+        FontData, FontRef, MinByteRange, ReadError, Sanitize, SanitizedArrayOfOffsets,
+        TopLevelTable,
     },
     types::{FixedSize, Offset16, Offset32, Tag},
 };
@@ -1514,7 +1515,8 @@ impl SubsetTable<'_> for FeatureParams<'_> {
 
 impl<
         'a,
-        T: FontRead<'a, Args = ()>
+        T: Sanitize<'a, Args = ()>
+            + Default
             + SubsetTable<
                 'a,
                 ArgsForSubset = (&'a SubsetState, &'a FontRef<'a>, &'a FnvHashMap<u16, u16>),
@@ -1768,13 +1770,14 @@ impl<'a> SubsetTable<'a> for FeatureTableSubstitutionRecord {
     }
 }
 
-impl<'a, T> SubsetTable<'a> for ArrayOfOffsets<'a, T, Offset16>
+impl<'a, T> SubsetTable<'a> for SanitizedArrayOfOffsets<'a, T, Offset16>
 where
     T: SubsetTable<
             'a,
             ArgsForSubset = (&'a SubsetState, &'a FontRef<'a>, &'a FnvHashMap<u16, u16>),
         > + Intersect
-        + FontRead<'a, Args = ()>
+        + Sanitize<'a, Args = ()>
+        + Default
         + 'a,
 {
     type ArgsForSubset = T::ArgsForSubset;

--- a/skera/src/offset_array.rs
+++ b/skera/src/offset_array.rs
@@ -2,7 +2,7 @@
 use crate::{offset::SerializeSubset, Plan, SerializeErrorFlags, Serializer, SubsetTable};
 use write_fonts::{
     read::{
-        ArrayOfNullableOffsets, ArrayOfOffsets, FontRead, Offset, ReadArgs, ReadError, Sanitize,
+        ArrayOfOffsets, FontRead, Offset, ReadArgs, ReadError, Sanitize,
         SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets,
     },
     types::{FixedSize, Scalar},
@@ -45,38 +45,6 @@ where
         }
 
         Ok(())
-    }
-}
-
-impl<'a, T, O> SubsetOffsetArray<'a, T> for ArrayOfNullableOffsets<'a, T, O>
-where
-    O: Scalar + Offset + FixedSize + SerializeSubset,
-    T: FontRead<'a> + SubsetTable<'a>,
-    T::Args: Copy + 'static,
-{
-    fn subset_offset(
-        &self,
-        idx: usize,
-        s: &mut Serializer,
-        plan: &Plan,
-        args: T::ArgsForSubset,
-    ) -> Result<(), SerializeErrorFlags> {
-        match self.get(idx) {
-            Some(Ok(t)) => {
-                let snap = s.snapshot();
-                let offset_pos = s.allocate_size(O::RAW_BYTE_LEN, true)?;
-
-                match O::serialize_subset(&t, s, plan, args, offset_pos) {
-                    Ok(_) => Ok(()),
-                    Err(e) => {
-                        s.revert_snapshot(snap);
-                        Err(e)
-                    }
-                }
-            }
-            None => Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY),
-            Some(Err(_)) => Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
-        }
     }
 }
 

--- a/skera/src/offset_array.rs
+++ b/skera/src/offset_array.rs
@@ -1,7 +1,10 @@
 //! Subset arrays of offsets
 use crate::{offset::SerializeSubset, Plan, SerializeErrorFlags, Serializer, SubsetTable};
 use write_fonts::{
-    read::{ArrayOfNullableOffsets, ArrayOfOffsets, FontRead, Offset, ReadError},
+    read::{
+        ArrayOfNullableOffsets, ArrayOfOffsets, FontRead, Offset, ReadArgs, ReadError, Sanitize,
+        SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets,
+    },
     types::{FixedSize, Scalar},
 };
 
@@ -86,6 +89,82 @@ impl<'a, T, O> IterNullableHelper<'a, T> for ArrayOfOffsets<'a, T, O>
 where
     O: Scalar + Offset,
     T: FontRead<'a>,
+    T::Args: Copy + 'static,
+{
+    fn iter_as_nullable(&self) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {
+        self.iter().map(|off| match off {
+            Err(ReadError::NullOffset) => None,
+            other => Some(other),
+        })
+    }
+}
+
+impl<'a, T, O> SubsetOffsetArray<'a, T> for SanitizedArrayOfOffsets<'a, T, O>
+where
+    O: Scalar + Offset + FixedSize + SerializeSubset,
+    T: ReadArgs + Sanitize<'a> + Default + SubsetTable<'a>,
+    T::Args: Copy + 'static,
+{
+    fn subset_offset(
+        &self,
+        idx: usize,
+        s: &mut Serializer,
+        plan: &Plan,
+        args: T::ArgsForSubset,
+    ) -> Result<(), SerializeErrorFlags> {
+        let t = match self.get(idx) {
+            Err(ReadError::NullOffset) => return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY),
+            Ok(table) => table,
+            Err(_) => return Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
+        };
+        let snap = s.snapshot();
+        let offset_pos = s.allocate_size(O::RAW_BYTE_LEN, true)?;
+
+        if let Err(e) = O::serialize_subset(&t, s, plan, args, offset_pos) {
+            s.revert_snapshot(snap);
+            return Err(e);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, T, O> SubsetOffsetArray<'a, T> for SanitizedArrayOfNullableOffsets<'a, T, O>
+where
+    O: Scalar + Offset + FixedSize + SerializeSubset,
+    T: ReadArgs + Sanitize<'a> + Default + SubsetTable<'a>,
+    T::Args: Copy + 'static,
+{
+    fn subset_offset(
+        &self,
+        idx: usize,
+        s: &mut Serializer,
+        plan: &Plan,
+        args: T::ArgsForSubset,
+    ) -> Result<(), SerializeErrorFlags> {
+        match self.get(idx) {
+            Some(Ok(t)) => {
+                let snap = s.snapshot();
+                let offset_pos = s.allocate_size(O::RAW_BYTE_LEN, true)?;
+
+                match O::serialize_subset(&t, s, plan, args, offset_pos) {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        s.revert_snapshot(snap);
+                        Err(e)
+                    }
+                }
+            }
+            None => Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY),
+            Some(Err(_)) => Err(s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR)),
+        }
+    }
+}
+
+impl<'a, T, O> IterNullableHelper<'a, T> for SanitizedArrayOfOffsets<'a, T, O>
+where
+    O: Scalar + Offset,
+    T: ReadArgs + Sanitize<'a> + Default,
     T::Args: Copy + 'static,
 {
     fn iter_as_nullable(&self) -> impl Iterator<Item = Option<Result<T, ReadError>>> + 'a {

--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -1297,14 +1297,21 @@ mod tests {
         use read_fonts::{FontData, FontRead};
         // Linear chain of Format5Negate tables: each is `format(u16 BE = 5)` +
         // `condition_offset(Offset24 BE = 5)`, so every table points 5 bytes
-        // forward to the next -> an arbitrarily deep condition tree. `CHAIN_LEN`
-        // is far larger than the limit, proving evaluation bails out early rather
-        // than walking (and recursing into) the whole chain.
-        const CHAIN_LEN: usize = 4096;
-        let mut bytes = Vec::with_capacity(CHAIN_LEN * 5);
+        // forward to the next, terminated by a ConditionFormat1 leaf so the
+        // graph is well formed.
+        //
+        // `Condition::read` sanitizes, which walks the chain eagerly and
+        // enforces its own (higher) depth limit. Sitting between the two limits
+        // keeps the chain readable while still out-running evaluation, so this
+        // exercises `eval_condition`'s guard rather than riding on sanitize
+        // having already rejected the input.
+        const CHAIN_LEN: usize = GLYF_COMPOSITE_RECURSION_LIMIT + 8;
+        let mut bytes = Vec::with_capacity(CHAIN_LEN * 5 + 8);
         for _ in 0..CHAIN_LEN {
             bytes.extend_from_slice(&[0x00, 0x05, 0x00, 0x00, 0x05]);
         }
+        // ConditionFormat1: axis 0, filter range [-1.0, 1.0].
+        bytes.extend_from_slice(&[0x00, 0x01, 0x00, 0x00, 0xC0, 0x00, 0x40, 0x00]);
         let cond = Condition::read(FontData::new(&bytes)).unwrap();
 
         let (_font, store, regions) = condition_eval_env();

--- a/write-fonts/generated/generated_gpos.rs
+++ b/write-fonts/generated/generated_gpos.rs
@@ -2219,7 +2219,7 @@ impl<T: Validate> Validate for ExtensionPosFormat1<T> {
 impl<'a, T, U> FromObjRef<read_fonts::tables::gpos::ExtensionPosFormat1<'a, U>>
     for ExtensionPosFormat1<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(
@@ -2237,7 +2237,7 @@ where
 impl<'a, T, U> FromTableRef<read_fonts::tables::gpos::ExtensionPosFormat1<'a, U>>
     for ExtensionPosFormat1<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
 }

--- a/write-fonts/generated/generated_gsub.rs
+++ b/write-fonts/generated/generated_gsub.rs
@@ -980,7 +980,7 @@ impl<T: Validate> Validate for ExtensionSubstFormat1<T> {
 impl<'a, T, U> FromObjRef<read_fonts::tables::gsub::ExtensionSubstFormat1<'a, U>>
     for ExtensionSubstFormat1<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(
@@ -998,7 +998,7 @@ where
 impl<'a, T, U> FromTableRef<read_fonts::tables::gsub::ExtensionSubstFormat1<'a, U>>
     for ExtensionSubstFormat1<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
 }

--- a/write-fonts/generated/generated_layout.rs
+++ b/write-fonts/generated/generated_layout.rs
@@ -538,7 +538,7 @@ impl<T: Validate> Validate for LookupList<T> {
 
 impl<'a, T, U> FromObjRef<read_fonts::tables::layout::LookupList<'a, U>> for LookupList<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(obj: &read_fonts::tables::layout::LookupList<'a, U>, _: FontData) -> Self {
@@ -551,7 +551,7 @@ where
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T, U> FromTableRef<read_fonts::tables::layout::LookupList<'a, U>> for LookupList<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
 }
@@ -613,7 +613,7 @@ impl<T: Validate> Validate for Lookup<T> {
 
 impl<'a, T, U> FromObjRef<read_fonts::tables::layout::Lookup<'a, U>> for Lookup<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(obj: &read_fonts::tables::layout::Lookup<'a, U>, _: FontData) -> Self {
@@ -628,7 +628,7 @@ where
 #[allow(clippy::needless_lifetimes)]
 impl<'a, T, U> FromTableRef<read_fonts::tables::layout::Lookup<'a, U>> for Lookup<T>
 where
-    U: FontRead<'a, Args = ()>,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
 }

--- a/write-fonts/generated/generated_test_generic_group.rs
+++ b/write-fonts/generated/generated_test_generic_group.rs
@@ -48,7 +48,7 @@ impl<T: Validate> Validate for MyLookup<T> {
 
 impl<'a, T, U> FromObjRef<read_fonts::codegen_test::generic_group::MyLookup<'a, U>> for MyLookup<T>
 where
-    U: FontRead<'a, Args = ()> + Sanitize<'a> + Default,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
     fn from_obj_ref(
@@ -67,7 +67,7 @@ where
 impl<'a, T, U> FromTableRef<read_fonts::codegen_test::generic_group::MyLookup<'a, U>>
     for MyLookup<T>
 where
-    U: FontRead<'a, Args = ()> + Sanitize<'a> + Default,
+    U: Sanitize<'a, Args = ()> + Default,
     T: FromTableRef<U> + Default + 'static,
 {
 }

--- a/write-fonts/src/codegen_test.rs
+++ b/write-fonts/src/codegen_test.rs
@@ -162,7 +162,7 @@ mod generic_group {
     fn construct_lookup_group() {
         let lookup: MyLookup<MySubtableFormat1> = MyLookup {
             lookup_type: 2,
-            single_subtable: OffsetMarker::new(MySubtableFormat1 { value: 404 }),
+            single_subtable: OffsetMarker::new(MySubtableFormat1 { value: 42 }),
             subtables: vec![OffsetMarker::new(MySubtableFormat1 { value: 99 })],
         };
         let group = MyLookupGroup::from(lookup);

--- a/write-fonts/src/from_obj.rs
+++ b/write-fonts/src/from_obj.rs
@@ -3,8 +3,8 @@
 use std::collections::BTreeSet;
 
 use read_fonts::{
-    ArrayOfNullableOffsets, ArrayOfOffsets, FontData, FontRead, Offset, ReadArgs, ReadError,
-    Sanitize, SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets,
+    ArrayOfOffsets, FontData, FontRead, Offset, ReadArgs, ReadError, Sanitize,
+    SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets,
 };
 use types::{BigEndian, Scalar};
 
@@ -183,34 +183,9 @@ where
     }
 }
 
-impl<'a, T, U, O, const N: usize> FromObjRef<ArrayOfNullableOffsets<'a, U, O>>
-    for Vec<NullableOffsetMarker<T, N>>
-where
-    T: FromObjRef<U> + Default,
-    U: FontRead<'a>,
-    U::Args: 'static,
-    O: Scalar + Offset,
-{
-    fn from_obj_ref(from: &ArrayOfNullableOffsets<'a, U, O>, data: FontData) -> Self {
-        from.iter()
-            .map(|x| NullableOffsetMarker::from_obj_ref(&x, data))
-            .collect()
-    }
-}
-
 impl<'a, T, U, O, const N: usize> FromTableRef<ArrayOfOffsets<'a, U, O>> for Vec<OffsetMarker<T, N>>
 where
     T: FromTableRef<U> + Default,
-    U: FontRead<'a>,
-    U::Args: 'static,
-    O: Scalar + Offset,
-{
-}
-
-impl<'a, T, U, O, const N: usize> FromTableRef<ArrayOfNullableOffsets<'a, U, O>>
-    for Vec<NullableOffsetMarker<T, N>>
-where
-    T: FromObjRef<U> + Default,
     U: FontRead<'a>,
     U::Args: 'static,
     O: Scalar + Offset,

--- a/write-fonts/src/from_obj.rs
+++ b/write-fonts/src/from_obj.rs
@@ -2,9 +2,10 @@
 
 use std::collections::BTreeSet;
 
-use read_fonts::{ArrayOfNullableOffsets, ArrayOfOffsets, FontData, FontRead, Offset, ReadError};
-#[cfg(test)]
-use read_fonts::{Sanitize, SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets};
+use read_fonts::{
+    ArrayOfNullableOffsets, ArrayOfOffsets, FontData, FontRead, Offset, ReadArgs, ReadError,
+    Sanitize, SanitizedArrayOfNullableOffsets, SanitizedArrayOfOffsets,
+};
 use types::{BigEndian, Scalar};
 
 use crate::{NullableOffsetMarker, OffsetMarker};
@@ -215,12 +216,14 @@ where
     O: Scalar + Offset,
 {
 }
-#[cfg(test)]
+
+// impls for converting sanitized arrays:
 impl<'a, T, U, O, const N: usize> FromObjRef<SanitizedArrayOfOffsets<'a, U, O>>
     for Vec<OffsetMarker<T, N>>
 where
     T: FromObjRef<U> + Default,
-    U: FontRead<'a, Args = ()> + Sanitize<'a, Args = ()> + Default,
+    U: ReadArgs + Sanitize<'a> + Default,
+    U::Args: Copy + 'static,
     O: Scalar + Offset,
 {
     fn from_obj_ref(from: &SanitizedArrayOfOffsets<'a, U, O>, data: FontData) -> Self {
@@ -230,13 +233,12 @@ where
     }
 }
 
-#[cfg(test)]
 impl<'a, T, U, O, const N: usize> FromObjRef<SanitizedArrayOfNullableOffsets<'a, U, O>>
     for Vec<NullableOffsetMarker<T, N>>
 where
     T: FromObjRef<U> + Default,
-    U: FontRead<'a, Args = ()> + Sanitize<'a, Args = ()> + Default,
-    U::Args: 'static,
+    U: ReadArgs + Sanitize<'a> + Default,
+    U::Args: Copy + 'static,
     O: Scalar + Offset,
 {
     fn from_obj_ref(from: &SanitizedArrayOfNullableOffsets<'a, U, O>, data: FontData) -> Self {
@@ -246,23 +248,22 @@ where
     }
 }
 
-#[cfg(test)]
 impl<'a, T, U, O, const N: usize> FromTableRef<SanitizedArrayOfOffsets<'a, U, O>>
     for Vec<OffsetMarker<T, N>>
 where
-    T: FromObjRef<U> + Default,
-    U: FontRead<'a, Args = ()> + Sanitize<'a, Args = ()> + Default,
+    T: FromTableRef<U> + Default,
+    U: ReadArgs + Sanitize<'a> + Default,
+    U::Args: Copy + 'static,
     O: Scalar + Offset,
 {
 }
 
-#[cfg(test)]
 impl<'a, T, U, O, const N: usize> FromTableRef<SanitizedArrayOfNullableOffsets<'a, U, O>>
     for Vec<NullableOffsetMarker<T, N>>
 where
     T: FromObjRef<U> + Default,
-    U: FontRead<'a, Args = ()> + Sanitize<'a, Args = ()> + Default,
-    U::Args: 'static,
+    U: ReadArgs + Sanitize<'a> + Default,
+    U::Args: Copy + 'static,
     O: Scalar + Offset,
 {
 }

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -12,10 +12,7 @@
 use std::collections::HashMap;
 
 use font_types::GlyphId16;
-use read_fonts::tables::{
-    gpos::{self as rgpos},
-    layout as rlayout,
-};
+use read_fonts::tables::layout as rlayout;
 
 use super::Graph;
 use crate::{
@@ -40,10 +37,10 @@ fn split_subtables(
     split_fn: fn(&mut Graph, ObjectId) -> Option<Vec<ObjectId>>,
 ) {
     let data = graph.objects.remove(&lookup).unwrap();
-    debug_assert!(
-        data.reparse::<rgpos::PositionLookup>().is_ok(),
-        "table splitting is only relevant for GPOS?"
-    );
+    //debug_assert!(
+    //data.reparse::<rgpos::PositionLookup>().is_ok(),
+    //"table splitting is only relevant for GPOS?"
+    //);
     log::debug!("trying to split subtables in '{}'", data.type_);
 
     let mut new_subtables = HashMap::new();
@@ -70,7 +67,7 @@ fn split_subtables(
 
     let n_total_subtables: u16 = (data.offsets.len() + n_new_subtables).try_into().unwrap();
     // we just want the lookup type/flag/etc, but we need a generic FontRead type
-    let generic_lookup: rlayout::Lookup<()> = data.reparse().unwrap();
+    let generic_lookup: rlayout::Lookup<()> = data.reparse();
     let mut new_data = TableData::new(data.type_);
     new_data.write(generic_lookup.lookup_type());
     new_data.write(generic_lookup.lookup_flag());

--- a/write-fonts/src/graph/splitting/mark2base.rs
+++ b/write-fonts/src/graph/splitting/mark2base.rs
@@ -22,7 +22,6 @@ fn split_mark_to_base_subtable(graph: &mut Graph, subtable: ObjectId) -> Option<
     let data = &graph.objects[&subtable];
     let base_coverage_id = data.offsets[1].object;
     let base_coverage_size = graph.objects[&base_coverage_id].bytes.len();
-    debug_assert!(data.reparse::<rgpos::MarkBasePosFormat1>().is_ok());
 
     let min_subtable_size = BASE_SIZE + base_coverage_size;
     let class_info = get_class_info(graph, subtable);
@@ -93,7 +92,7 @@ fn split_off_mark_pos(
 ) -> TableData {
     let mark_coverage_id = graph.objects[&subtable].offsets.first().unwrap().object;
     let mark_coverage = &graph.objects[&mark_coverage_id];
-    let mark_coverage = mark_coverage.reparse::<rlayout::CoverageTable>().unwrap();
+    let mark_coverage = mark_coverage.reparse::<rlayout::CoverageTable>();
     let data = &graph.objects[&subtable];
     let base_coverage_id = data.offsets[1].object;
     let mark_array_id = data.offsets[2].object;
@@ -135,7 +134,7 @@ fn split_off_mark_array(
     first_class: u16,
     mark_glyph_coverage_ids: &HashSet<usize>,
 ) -> TableData {
-    let mark_array = old_mark_array.reparse::<rgpos::MarkArray>().unwrap();
+    let mark_array = old_mark_array.reparse::<rgpos::MarkArray>();
     let mark_count = mark_glyph_coverage_ids.len() as u16;
 
     let mut new_mark_array = TableData::new(old_mark_array.type_);
@@ -169,9 +168,8 @@ fn split_off_base_array(
     // for each base, we want to prune the marks to only include those
     // in the range (start..end).
 
-    let base_array: rgpos::BaseArray = old_base_array
-        .reparse_with_args(old_mark_class_count as u16)
-        .unwrap();
+    let base_array: rgpos::BaseArray =
+        old_base_array.reparse_with_args(old_mark_class_count as u16);
 
     let mut next_offset_idx = 0;
     // because offsets may be null, and there is no pattern, we visit each one
@@ -251,7 +249,7 @@ fn get_class_info(graph: &Graph, subtable: ObjectId) -> Vec<Mark2BaseClassInfo> 
     let mark_array_off = &data.offsets[2];
     assert_eq!(mark_array_off.pos, 8);
     let mark_array_data = &graph.objects[&mark_array_off.object];
-    let mark_array = mark_array_data.reparse::<rgpos::MarkArray>().unwrap();
+    let mark_array = mark_array_data.reparse::<rgpos::MarkArray>();
     // okay so:
     // - there is one mark record for each mark glyph
     // - there may be multiple mark glyphs with the same class
@@ -613,7 +611,7 @@ mod tests {
             GLYPHS_PER_CLASS as usize * SPLIT_CLASS_RANGE.len()
         );
 
-        let reparsed = result.reparse::<rgpos::MarkArray>().unwrap();
+        let reparsed = result.reparse::<rgpos::MarkArray>();
         // ensure classes are correct
         for (i, rec) in reparsed.mark_records().iter().enumerate() {
             let exp_class = i as u16 / GLYPHS_PER_CLASS;
@@ -626,7 +624,7 @@ mod tests {
             let gid = i as u16 + gid_delta;
             let anchor_val = u16_to_i16(gid);
             let anchor_table = &graph.objects[&offset.object];
-            let anchor_table = anchor_table.reparse::<rgpos::AnchorFormat1>().unwrap();
+            let anchor_table = anchor_table.reparse::<rgpos::AnchorFormat1>();
             assert_eq!(anchor_table.x_coordinate(), anchor_val);
         }
     }
@@ -657,7 +655,7 @@ mod tests {
                     // anchor table is non-null
                     let anchor_id = result.offsets[idx].object;
                     let anchor = &graph.objects[&anchor_id];
-                    let anchor = anchor.reparse::<rgpos::AnchorFormat1>().unwrap();
+                    let anchor = anchor.reparse::<rgpos::AnchorFormat1>();
 
                     let exp_val = u16_to_i16((base * N_CLASSES) + original_mark_class);
                     assert_eq!(

--- a/write-fonts/src/graph/splitting/pairpos.rs
+++ b/write-fonts/src/graph/splitting/pairpos.rs
@@ -35,7 +35,6 @@ fn split_pair_pos_format_1(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<
 
     let data = &graph.objects[&subtable];
 
-    debug_assert!(data.reparse::<rgpos::PairPosFormat1>().is_ok());
     let coverage_id = data.offsets.first().unwrap();
     assert_eq!(coverage_id.pos, 2, "offset records are always sorted");
     let coverage_size = graph.objects[&coverage_id.object].bytes.len();
@@ -108,13 +107,13 @@ fn split_pair_pos_format_1(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<
 fn split_off_ppf1(graph: &mut Graph, subtable: ObjectId, start: usize, end: usize) -> TableData {
     let coverage = graph.objects[&subtable].offsets.first().unwrap().object;
     let coverage = graph.objects.get(&coverage).unwrap();
-    let coverage = coverage.reparse::<rlayout::CoverageTable>().unwrap();
+    let coverage = coverage.reparse::<rlayout::CoverageTable>();
     let n_pair_sets = end - start;
     let new_coverage = super::split_coverage(&coverage, start as u16, end as u16);
     let new_cov_id = graph.add_object(new_coverage);
 
     let data = &graph.objects[&subtable];
-    let table = data.reparse::<rgpos::PairPosFormat1>().unwrap();
+    let table = data.reparse::<rgpos::PairPosFormat1>();
 
     let mut new_ppf1 = TableData::new(data.type_);
 
@@ -136,7 +135,7 @@ fn split_pair_pos_format_2(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<
     const BASE_SIZE: usize = 8 * u16::RAW_BYTE_LEN;
     let data = &graph.objects[&subtable];
 
-    let pp2 = data.reparse::<rgpos::PairPosFormat2>().unwrap();
+    let pp2 = data.reparse::<rgpos::PairPosFormat2>();
     let cur_len = data.bytes.len();
     log::info!(
         "PairPos f.2 subtable has {} class1 and {} class2, current size {cur_len} ",
@@ -150,10 +149,10 @@ fn split_pair_pos_format_2(graph: &mut Graph, subtable: ObjectId) -> Option<Vec<
     let class_def2_id = data.offsets[2].object;
     let class_def2_size = graph.objects[&class_def2_id].bytes.len();
     let coverage = &graph.objects[&coverage_id];
-    let coverage = coverage.reparse::<rlayout::CoverageTable>().unwrap();
+    let coverage = coverage.reparse::<rlayout::CoverageTable>();
 
     let class_def1 = &graph.objects[&class_def1_id];
-    let class_def1 = class_def1.reparse::<rlayout::ClassDef>().unwrap();
+    let class_def1 = class_def1.reparse::<rlayout::ClassDef>();
     let estimator = ClassDefSizeEstimator::new(coverage, class_def1);
 
     let class2_count = pp2.class2_count();
@@ -246,10 +245,10 @@ fn split_off_ppf2(
     // we have to do this bit manually (instead of via reparsing) because of borrowk
     let coverage = graph.objects[&subtable].offsets.first().unwrap().object;
     let coverage = graph.objects.get(&coverage).unwrap();
-    let coverage = coverage.reparse::<rlayout::CoverageTable>().unwrap();
+    let coverage = coverage.reparse::<rlayout::CoverageTable>();
     let class_def_1 = graph.objects[&subtable].offsets[1].object;
     let class_def_1 = graph.objects.get(&class_def_1).unwrap();
-    let class_def_1 = class_def_1.reparse::<rlayout::ClassDef>().unwrap();
+    let class_def_1 = class_def_1.reparse::<rlayout::ClassDef>();
 
     let class1_count = end - start;
     log::trace!("splitting off {class1_count} class1records ({start}..={end})");
@@ -281,7 +280,7 @@ fn split_off_ppf2(
     let class_def_2_id = graph.objects[&subtable].offsets[2].object;
 
     let data = &graph.objects[&subtable];
-    let table = data.reparse::<rgpos::PairPosFormat2>().unwrap();
+    let table = data.reparse::<rgpos::PairPosFormat2>();
     let value_format1 = table.value_format1();
     let value_format2 = table.value_format2();
 
@@ -881,7 +880,7 @@ mod tests {
         assert!(graph.pack_objects());
         let root_id = graph.root;
         let ppf2_data = &graph.objects[&root_id];
-        let ppf2 = ppf2_data.reparse::<rgpos::PairPosFormat2>().unwrap();
+        let ppf2 = ppf2_data.reparse::<rgpos::PairPosFormat2>();
         assert_eq!(ppf2.class1_records().len(), 1);
         let c1rec = ppf2.class1_records().get(0).unwrap();
         let mut visited = HashSet::new();

--- a/write-fonts/src/lib.rs
+++ b/write-fonts/src/lib.rs
@@ -202,9 +202,9 @@ pub(crate) mod codegen_prelude {
     pub use std::collections::BTreeSet;
     pub use types::*;
 
-    #[cfg(test)]
-    pub use read_fonts::Sanitize;
-    pub use read_fonts::{FontData, FontRead, ReadArgs, ReadError, ResolveOffset, TopLevelTable};
+    pub use read_fonts::{
+        FontData, FontRead, ReadArgs, ReadError, ResolveOffset, Sanitize, TopLevelTable,
+    };
 
     /// checked conversion to u16
     pub fn array_len<T: super::collections::HasLen>(s: &T) -> usize {

--- a/write-fonts/src/tables/layout/spec_tests.rs
+++ b/write-fonts/src/tables/layout/spec_tests.rs
@@ -2,16 +2,16 @@ use super::*;
 use crate::assert_hex_eq;
 use font_test_data::layout as test_data;
 
-#[test]
-fn example_1_scripts() {
-    // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#example-1-scriptlist-table-and-scriptrecords
+// this test data is only a header and no subtables, so we can't do much with it.
+//#[test]
+//fn example_1_scripts() {
+// // https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#example-1-scriptlist-table-and-scriptrecords
 
-    let table = ScriptList::read(test_data::SCRIPTS.into()).unwrap();
-    // validation fails because of of missing subtables
-    let _dumped = crate::dump_table(&table);
-    //NOTE: we can't roundtrip this because the data doesn't include subtables.
-    //assert_hex_eq!(&bytes, &dumped);
-}
+//let table = ScriptList::read(test_data::SCRIPTS.into()).unwrap();
+// // validation fails because of of missing subtables
+//let _dumped = crate::dump_table(&table);
+// //assert_hex_eq!(&bytes, &dumped);
+//}
 
 #[test]
 fn example_2_scripts_and_langs() {

--- a/write-fonts/src/write.rs
+++ b/write-fonts/src/write.rs
@@ -12,7 +12,7 @@ use crate::validate::Validate;
 #[cfg(feature = "tables")]
 use font_types::{FixedSize, Scalar};
 #[cfg(feature = "tables")]
-use read_fonts::{FontData, FontRead, ReadError};
+use read_fonts::{FontData, Sanitize};
 
 /// A type that that can be written out as part of a font file.
 ///
@@ -253,19 +253,15 @@ impl TableData {
     /// Used internally when modifying the graph after initial compilation,
     /// such as during table splitting.
     #[cfg(feature = "tables")]
-    pub(crate) fn reparse<'a, T: FontRead<'a, Args = ()>>(&'a self) -> Result<T, ReadError> {
-        let data = FontData::new(&self.bytes);
-        T::read(data)
+    pub(crate) fn reparse<'a, T: read_fonts::Sanitize<'a, Args = ()>>(&'a self) -> T {
+        self.reparse_with_args(())
     }
 
     // see above
     #[cfg(feature = "tables")]
-    pub(crate) fn reparse_with_args<'a, A, T: FontRead<'a, Args = A>>(
-        &'a self,
-        args: A,
-    ) -> Result<T, ReadError> {
+    pub(crate) fn reparse_with_args<'a, A, T: Sanitize<'a, Args = A>>(&'a self, args: A) -> T {
         let data = FontData::new(&self.bytes);
-        T::read_with_args(data, args)
+        T::read_fast(data, args)
     }
 
     /// A helper function to read a value out of this data.


### PR DESCRIPTION
I thought we could put this off until colrv1, but it turns out to also be relevant for Condition tables, and there's a test in varc that explicitly builds a highly nested graph and tries to read it, which overflows.

Interestingly this is okay on harfbuzz, because in harfbuzz the calls to sanitize child offsets of this table are tail calls, and so at standard optimization levels it doesn't end up growing the stack; because we call ctx.finish() after we finish with the offsets, this isn't available to us.