### PR TITLE
[read-fonts] avoid panics in classdef intersection 

### DIFF
--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -463,15 +463,18 @@ impl<'a> ClassDefFormat1<'a> {
         }
 
         let start_glyph = self.start_glyph_id().to_u32();
-        let glyph_count = self.glyph_count();
-        let end_glyph = start_glyph + glyph_count as u32 - 1;
+        let class_values = self.class_value_array();
+        if class_values.is_empty() {
+            out.insert(0);
+            return out;
+        }
+        let end_glyph = start_glyph + class_values.len() as u32 - 1;
         if glyphs.first().unwrap().to_u32() < start_glyph
             || glyphs.last().unwrap().to_u32() > end_glyph
         {
             out.insert(0);
         }
 
-        let class_values = self.class_value_array();
         if glyphs.contains(GlyphId::from(start_glyph)) {
             let Some(start_glyph_class) = class_values.first() else {
                 return out;
@@ -613,13 +616,11 @@ impl<'a> ClassDefFormat2<'a> {
             return out;
         }
 
-        if self.class_range_count() == 0 {
+        let range_records = self.class_range_records();
+        let Some(first_record) = range_records.first() else {
             out.insert(0);
             return out;
-        }
-
-        let range_records = self.class_range_records();
-        let first_record = range_records[0];
+        };
 
         if glyphs.first().unwrap() < first_record.start_glyph_id() {
             out.insert(0);
@@ -1034,6 +1035,23 @@ mod tests {
         for (gid, class) in classdef.iter() {
             assert_eq!(classdef.get(gid), class);
         }
+    }
+
+    #[test]
+    fn classdef_format1_short_read_no_panic() {
+        // glyph_count is 5, but only one class value is present.
+        let classdef =
+            ClassDefFormat1::read(FontData::new(&[0, 1, 0, 10, 0, 5, 0, 1])).unwrap();
+        let glyphs: IntSet<GlyphId> = [GlyphId::new(10), GlyphId::new(11), GlyphId::new(14)]
+            .into_iter()
+            .collect();
+
+        assert_eq!(classdef.get(GlyphId::new(10)), 0);
+        assert_eq!(classdef.get(GlyphId::new(11)), 0);
+        assert!(!classdef.intersects_class_glyphs(&glyphs, 2));
+
+        let class_ones = classdef.intersected_class_glyphs(&glyphs, 1);
+        assert!(class_ones.is_empty());
     }
 
     #[test]

--- a/read-fonts/src/tables/layout.rs
+++ b/read-fonts/src/tables/layout.rs
@@ -1040,8 +1040,7 @@ mod tests {
     #[test]
     fn classdef_format1_short_read_no_panic() {
         // glyph_count is 5, but only one class value is present.
-        let classdef =
-            ClassDefFormat1::read(FontData::new(&[0, 1, 0, 10, 0, 5, 0, 1])).unwrap();
+        let classdef = ClassDefFormat1::read(FontData::new(&[0, 1, 0, 10, 0, 5, 0, 1])).unwrap();
         let glyphs: IntSet<GlyphId> = [GlyphId::new(10), GlyphId::new(11), GlyphId::new(14)]
             .into_iter()
             .collect();

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -1131,8 +1131,7 @@ mod tests {
     #[test]
     fn classdef_format1_short_read_no_panic() {
         // glyph_count is 5, but only one class value is present.
-        let classdef =
-            ClassDefFormat1::read(FontData::new(&[0, 1, 0, 10, 0, 5, 0, 1])).unwrap();
+        let classdef = ClassDefFormat1::read(FontData::new(&[0, 1, 0, 10, 0, 5, 0, 1])).unwrap();
         let glyphs: IntSet<GlyphId> = [GlyphId::new(14)].into_iter().collect();
 
         assert!(!classdef.intersects(&glyphs).unwrap());

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -393,16 +393,15 @@ impl Intersect for ClassDef<'_> {
 
 impl Intersect for ClassDefFormat1<'_> {
     fn intersects(&self, glyph_set: &IntSet<GlyphId>) -> Result<bool, ReadError> {
-        let glyph_count = self.glyph_count();
-        if glyph_count == 0 {
+        let class_values = self.class_value_array();
+        if class_values.is_empty() {
             return Ok(false);
         }
 
         let start = self.start_glyph_id().to_u32();
-        let end = start + glyph_count as u32;
+        let end = start + self.glyph_count() as u32;
 
         let mut start_glyph = GlyphId::from(start);
-        let class_values = self.class_value_array();
         if glyph_set.contains(start_glyph) && class_values[0] != 0 {
             return Ok(true);
         }
@@ -1121,5 +1120,21 @@ impl LookupClosure for ChainedSequenceContext<'_> {
             Self::Format2(table) => ContextFormat2::Chain(table.clone()).closure_lookups(c, arg),
             Self::Format3(table) => ContextFormat3::Chain(table.clone()).closure_lookups(c, arg),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FontData;
+
+    #[test]
+    fn classdef_format1_short_read_no_panic() {
+        // glyph_count is 5, but only one class value is present.
+        let classdef =
+            ClassDefFormat1::read(FontData::new(&[0, 1, 0, 10, 0, 5, 0, 1])).unwrap();
+        let glyphs: IntSet<GlyphId> = [GlyphId::new(14)].into_iter().collect();
+
+        assert!(!classdef.intersects(&glyphs).unwrap());
     }
 }


### PR DESCRIPTION
These are mostly minimal validate things where checks were conditional on a count field rather than the length of the available array data.