### PR TITLE
Validate VariationRegionList axis counts

### DIFF
--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -91,6 +91,7 @@ flags u8 EntryFormat {
 }
 
 /// The [VariationRegionList](https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions) table
+#[validate(validate_axis_count)]
 table VariationRegionList {
     /// The number of variation axes for this font. This must be the
     /// same number as axisCount in the 'fvar' table.
@@ -159,4 +160,3 @@ table ItemVariationData {
     #[count(item_variation_data_len($item_count, $word_delta_count, $region_index_count))]
     delta_sets: [u8],
 }
-

--- a/write-fonts/generated/generated_variations.rs
+++ b/write-fonts/generated/generated_variations.rs
@@ -410,6 +410,7 @@ impl Validate for VariationRegionList {
                 }
                 self.variation_regions.validate_impl(ctx);
             });
+            self.validate_axis_count(ctx);
         })
     }
 }

--- a/write-fonts/src/tables/variations.rs
+++ b/write-fonts/src/tables/variations.rs
@@ -10,6 +10,22 @@ pub mod common_builder;
 pub mod ivs_builder;
 pub mod mivs_builder;
 
+impl VariationRegionList {
+    fn validate_axis_count(&self, ctx: &mut ValidationCtx) {
+        ctx.in_field("variation_regions", |ctx| {
+            ctx.with_array_items(self.variation_regions.iter(), |ctx, region| {
+                if region.region_axes.len() != usize::from(self.axis_count) {
+                    ctx.report(format!(
+                        "region_axes length ({}) does not match axis_count ({})",
+                        region.region_axes.len(),
+                        self.axis_count
+                    ));
+                }
+            });
+        });
+    }
+}
+
 /// The influence of a single axis on a variation region.
 ///
 /// The values here end up serialized in peak/start/end tuples in
@@ -685,6 +701,36 @@ impl<T: std::fmt::Display + std::fmt::Debug> std::error::Error
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn variation_region_list_accepts_matching_axis_counts() {
+        let list = VariationRegionList::new(
+            2,
+            vec![VariationRegion::new(vec![
+                RegionAxisCoordinates::default();
+                2
+            ])],
+        );
+
+        assert!(list.validate().is_ok());
+    }
+
+    #[test]
+    fn variation_region_list_rejects_mismatched_axis_counts() {
+        let list = VariationRegionList::new(
+            2,
+            vec![
+                VariationRegion::new(vec![RegionAxisCoordinates::default()]),
+                VariationRegion::new(vec![RegionAxisCoordinates::default(); 3]),
+            ],
+        );
+
+        let report = list.validate().unwrap_err().to_string();
+        assert!(report.contains("region_axes length (1) does not match axis_count (2)"));
+        assert!(report.contains("VariationRegionList.variation_regions[0]"));
+        assert!(report.contains("region_axes length (3) does not match axis_count (2)"));
+        assert!(report.contains("VariationRegionList.variation_regions[1]"));
+    }
 
     #[test]
     fn point_pack_words() {


### PR DESCRIPTION
## Summary

`VariationRegionList::axis_count` determines how many `RegionAxisCoordinates` every region must contain, but write-fonts did not validate that relationship. A malformed builder value could therefore be serialized even when a region had too few or too many axes.

Fixes #744.

- Add a custom `validate_axis_count` annotation to the codegen input.
- Validate every variation region against `axis_count`, reporting errors at the corresponding `variation_regions[index]` path.
- Regenerate the checked-in write-fonts implementation from the codegen plan.
- Cover both matching and mismatched lists, including multiple bad region indices.

## Verification

- `cargo test -p write-fonts --all-targets --all-features` — 288 passed
- `cargo clippy -p write-fonts --all-features --all-targets -- -D warnings` with the CI-pinned Rust 1.89 toolchain — passed
- `cargo fmt --check` — passed
- Focused validation tests — 2 passed
- `cargo run --bin=codegen resources/codegen_plan.toml` — rerun successfully with no additional generated changes
- `git diff --check` — passed

AI disclosure: I used an AI coding assistant to help inspect the validation/codegen patterns, implement this focused validator and its tests, and run the checks above. I reviewed the behavior, generated diff, and test results before submitting.
