### PR TITLE
[read-fonts] reduce avar application complexity

### DIFF
--- a/read-fonts/src/tables/fvar.rs
+++ b/read-fonts/src/tables/fvar.rs
@@ -60,14 +60,11 @@ fn apply_avar_mappings<T>(
     to_fixed: impl Fn(&T) -> Fixed,
     from_fixed: impl Fn(Fixed) -> T,
 ) {
-    let avar_mappings = avar.map(|avar| avar.axis_segment_maps());
-    for (i, coord) in coords.iter_mut().enumerate() {
-        if let Some(mapping) = avar_mappings
-            .as_ref()
-            .and_then(|mappings| mappings.get(i).transpose().ok())
-            .flatten()
-        {
-            *coord = from_fixed(mapping.apply(to_fixed(coord)));
+    if let Some(maps) = avar.map(|avar| avar.axis_segment_maps()) {
+        for (coord, map) in coords.iter_mut().zip(maps.iter()) {
+            if let Ok(map) = map {
+                *coord = from_fixed(map.apply(to_fixed(coord)));
+            }
         }
     }
 }


### PR DESCRIPTION
This was O(n^2) because we looked up the map for each coord by index in a `VarLenArray`, forcing a sequential scan for each one. Replaced with a zipped iterator making this O(n).

internal bug ref: b/538462421