### PR TITLE
[chore] tidy for release

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features libm,serde,std
-features = ["libm", "serde", "std"]
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features agl,libm,serde,std
+features = ["agl", "libm", "serde", "std"]
 
 [features]
 std = ["font-types/std"]

--- a/read-fonts/src/collections.rs
+++ b/read-fonts/src/collections.rs
@@ -8,6 +8,6 @@ mod range_set;
 pub use range_set::RangeSet;
 
 #[cfg(feature = "std")]
-pub mod fnv;
+pub(crate) mod fnv;
 #[cfg(feature = "std")]
-pub use fnv::FnvHashMap;
+pub(crate) use fnv::FnvHashMap;


### PR DESCRIPTION
Just tying up some loose ends before release:

1. Add `agl` feature to docs.rs metadata
2. Reduce visibility of new `read_fonts::collections::fnv` module to `pub(crate)` so we don't have to support it in the public API