### PR TITLE
[read-fonts] fix potential bitmap overflows

### DIFF
--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -212,6 +212,15 @@ impl<'a, T: AnyBitPattern + FixedSize> FontRead<'a> for &'a [T] {
     }
 }
 
+/// Helper to retrieve a pair of items from a slice, returning an error
+/// if the second index overflows or if either index is out of bounds.
+pub(crate) fn get_pair<T>(slice: &[T], idx: usize) -> Result<[&T; 2], ReadError> {
+    let second_idx = idx.checked_add(1).ok_or(ReadError::OutOfBounds)?;
+    let first = slice.get(idx).ok_or(ReadError::OutOfBounds)?;
+    let second = slice.get(second_idx).ok_or(ReadError::OutOfBounds)?;
+    Ok([first, second])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/read-fonts/src/offset.rs
+++ b/read-fonts/src/offset.rs
@@ -88,3 +88,37 @@ impl<O: Offset> ResolveOffset for O {
             .and_then(|data| T::read_with_args(data, args))
     }
 }
+
+/// Helper for performing checked sequences of arithmetic operations on
+/// offsets.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[repr(transparent)]
+pub(crate) struct CheckedOffset(Option<usize>);
+
+impl CheckedOffset {
+    pub(crate) fn new(offset: usize) -> Self {
+        Self(Some(offset))
+    }
+
+    #[must_use]
+    pub(crate) fn add(self, x: usize) -> Self {
+        Self(self.0.and_then(|o| o.checked_add(x)))
+    }
+
+    #[must_use]
+    pub(crate) fn mul(self, x: usize) -> Self {
+        Self(self.0.and_then(|o| o.checked_mul(x)))
+    }
+
+    pub(crate) fn get(&self) -> Option<usize> {
+        self.0
+    }
+
+    pub(crate) fn ok_or<E>(&self, err: E) -> Result<usize, E> {
+        self.get().ok_or(err)
+    }
+
+    pub(crate) fn ok_or_oob(&self) -> Result<usize, ReadError> {
+        self.ok_or(ReadError::OutOfBounds)
+    }
+}

--- a/read-fonts/src/tables/bitmap.rs
+++ b/read-fonts/src/tables/bitmap.rs
@@ -1,5 +1,7 @@
 //! Common bitmap (EBLC/EBDT/CBLC/CBDT) types.
 
+use crate::{array, offset::CheckedOffset};
+
 include!("../../generated/generated_bitmap.rs");
 
 impl BitmapSize {
@@ -34,16 +36,11 @@ impl BitmapSize {
             match &subtable {
                 IndexSubtable::Format1(st) => {
                     location.format = st.image_format();
-                    let start = st.image_data_offset() as usize
-                        + st.sbit_offsets()
-                            .get(glyph_ix)
-                            .ok_or(ReadError::OutOfBounds)?
-                            .get() as usize;
-                    let end = st.image_data_offset() as usize
-                        + st.sbit_offsets()
-                            .get(glyph_ix + 1)
-                            .ok_or(ReadError::OutOfBounds)?
-                            .get() as usize;
+                    let [first_offset, second_offset] =
+                        array::get_pair(st.sbit_offsets(), glyph_ix)?.map(|o| o.get() as usize);
+                    let base = CheckedOffset::new(st.image_data_offset() as usize);
+                    let start = base.add(first_offset).ok_or_oob()?;
+                    let end = base.add(second_offset).ok_or_oob()?;
                     location.data_offset = start;
                     if end < start {
                         return Err(ReadError::OutOfBounds);
@@ -54,22 +51,20 @@ impl BitmapSize {
                     location.format = st.image_format();
                     let data_size = st.image_size() as usize;
                     location.data_size = data_size;
-                    location.data_offset = st.image_data_offset() as usize + glyph_ix * data_size;
+                    location.data_offset = CheckedOffset::new(glyph_ix)
+                        .mul(data_size)
+                        .add(st.image_data_offset() as usize)
+                        .ok_or_oob()?;
                     location.metrics =
                         Some(*st.big_metrics().first().ok_or(ReadError::OutOfBounds)?);
                 }
                 IndexSubtable::Format3(st) => {
                     location.format = st.image_format();
-                    let start = st.image_data_offset() as usize
-                        + st.sbit_offsets()
-                            .get(glyph_ix)
-                            .ok_or(ReadError::OutOfBounds)?
-                            .get() as usize;
-                    let end = st.image_data_offset() as usize
-                        + st.sbit_offsets()
-                            .get(glyph_ix + 1)
-                            .ok_or(ReadError::OutOfBounds)?
-                            .get() as usize;
+                    let [first_offset, second_offset] =
+                        array::get_pair(st.sbit_offsets(), glyph_ix)?.map(|o| o.get() as usize);
+                    let base = CheckedOffset::new(st.image_data_offset() as usize);
+                    let start = base.add(first_offset).ok_or_oob()?;
+                    let end = base.add(second_offset).ok_or_oob()?;
                     location.data_offset = start;
                     if end < start {
                         return Err(ReadError::OutOfBounds);
@@ -85,13 +80,11 @@ impl BitmapSize {
                         Ok(ix) => ix,
                         _ => return Err(ReadError::InvalidCollectionIndex(glyph_id.to_u32())),
                     };
-                    let start =
-                        st.image_data_offset() as usize + array[array_ix].sbit_offset() as usize;
-                    let end = st.image_data_offset() as usize
-                        + array
-                            .get(array_ix + 1)
-                            .ok_or(ReadError::OutOfBounds)?
-                            .sbit_offset() as usize;
+                    let [first_offset, second_offset] =
+                        array::get_pair(array, array_ix)?.map(|p| p.sbit_offset() as usize);
+                    let base = CheckedOffset::new(st.image_data_offset() as usize);
+                    let start = base.add(first_offset).ok_or_oob()?;
+                    let end = base.add(second_offset).ok_or_oob()?;
                     location.data_offset = start;
                     if end < start {
                         return Err(ReadError::OutOfBounds);
@@ -109,7 +102,10 @@ impl BitmapSize {
                     };
                     let data_size = st.image_size() as usize;
                     location.data_size = data_size;
-                    location.data_offset = st.image_data_offset() as usize + array_ix * data_size;
+                    location.data_offset = CheckedOffset::new(array_ix)
+                        .mul(data_size)
+                        .add(st.image_data_offset() as usize)
+                        .ok_or_oob()?;
                     location.metrics =
                         Some(*st.big_metrics().first().ok_or(ReadError::OutOfBounds)?);
                 }
@@ -195,8 +191,12 @@ pub(crate) fn bitmap_data<'a>(
     location: &BitmapLocation,
     is_color: bool,
 ) -> Result<BitmapData<'a>, ReadError> {
+    let start = location.data_offset;
+    let end = CheckedOffset::new(start)
+        .add(location.data_size)
+        .ok_or_oob()?;
     let mut image_data = offset_data
-        .slice(location.data_offset..location.data_offset + location.data_size)
+        .slice(start..end)
         .ok_or(ReadError::OutOfBounds)?
         .cursor();
     match location.format {


### PR DESCRIPTION
Standard fare of using checked arithmetic to catch overflows.

However, this patch introduces two new helpers to assist with this in the future without so much boilerplate:

1. `offset::CheckedOffset` allows computing an offset with chained `add` and `mul` calls that internally use checked arithmetic. The final result can be extracted as an option, user specified result or `ReadError::OutOfBounds` (with `ok_or_oob`).
2. `array::get_pair` is a helper to retrieve elements at both `idx` and `idx + 1` handling potential overflow from the addition and checked reads from the slice.

Would have been nice to have these from the start!

internal bug ref: b/537782625