### PR TITLE
[codegen] traversal: don't unwrap versioned fields

### DIFF
--- a/font-codegen/src/fields.rs
+++ b/font-codegen/src/fields.rs
@@ -326,8 +326,8 @@ fn traversal_arm_for_field(
 ) -> TokenStream {
     let name_str = &fld.name.to_string();
     let name = &fld.name;
-    let maybe_unwrap = fld.attrs.conditional.is_some().then(|| quote!(.unwrap()));
-    let maybe_unwrap_getter = maybe_unwrap.as_ref().filter(|_| !fld.is_nullable());
+    let maybe_try = fld.attrs.conditional.is_some().then(|| quote!(?));
+    let maybe_try_getter = maybe_try.as_ref().filter(|_| !fld.is_nullable());
     if let Some(traverse_with) = &fld.attrs.traverse_with {
         let traverse_fn = &traverse_with.attr;
         if traverse_fn == "skip" {
@@ -348,8 +348,8 @@ fn traversal_arm_for_field(
             quote!(Field::new(
                     #name_str,
                     traversal::FieldType::offset_to_array_of_records(
-                        self.#name()#maybe_unwrap,
-                        self.#getter(#pass_data)#maybe_unwrap_getter,
+                        self.#name()#maybe_try,
+                        self.#getter(#pass_data)#maybe_try_getter,
                         stringify!(#typ),
                         #offset_data,
                     )
@@ -361,15 +361,15 @@ fn traversal_arm_for_field(
                 OffsetTarget::Array(_) => quote!(offset_to_array_of_scalars),
             };
             let getter = fld.offset_getter_name();
-            quote!(Field::new(#name_str, FieldType::#constructor_name(self.#name()#maybe_unwrap, self.#getter(#pass_data)#maybe_unwrap_getter)))
+            quote!(Field::new(#name_str, FieldType::#constructor_name(self.#name()#maybe_try, self.#getter(#pass_data)#maybe_try_getter)))
         }
-        FieldType::Scalar { .. } => quote!(Field::new(#name_str, self.#name()#maybe_unwrap)),
+        FieldType::Scalar { .. } => quote!(Field::new(#name_str, self.#name()#maybe_try)),
 
         FieldType::Array { inner_typ } => match inner_typ.as_ref() {
-            FieldType::Scalar { .. } => quote!(Field::new(#name_str, self.#name()#maybe_unwrap)),
+            FieldType::Scalar { .. } => quote!(Field::new(#name_str, self.#name()#maybe_try)),
             //HACK: glyf has fields that are [u8]
             FieldType::Struct { typ } if typ == "u8" => {
-                quote!(Field::new( #name_str, self.#name()#maybe_unwrap))
+                quote!(Field::new( #name_str, self.#name()#maybe_try))
             }
             FieldType::Struct { typ } => {
                 let offset_data = pass_data
@@ -379,7 +379,7 @@ fn traversal_arm_for_field(
                         #name_str,
                         traversal::FieldType::array_of_records(
                             stringify!(#typ),
-                            self.#name()#maybe_unwrap,
+                            self.#name()#maybe_try,
                             #offset_data,
                         )
                 ))
@@ -390,7 +390,7 @@ fn traversal_arm_for_field(
                 ..
             } => {
                 let getter = fld.offset_getter_name().unwrap();
-                quote!(Field::new(#name_str, FieldType::from(self.#getter(#pass_data)#maybe_unwrap)))
+                quote!(Field::new(#name_str, FieldType::from(self.#getter(#pass_data)#maybe_try)))
             }
             FieldType::Offset {
                 target: OffsetTarget::Array(_),
@@ -414,7 +414,7 @@ fn traversal_arm_for_field(
                     #name_str,
                     traversal::FieldType::computed_array(
                         #typ_str,
-                        self.#name()#maybe_clone #maybe_unwrap,
+                        self.#name()#maybe_clone #maybe_try,
                         #data
                     )
             ))
@@ -422,7 +422,7 @@ fn traversal_arm_for_field(
         FieldType::VarLenArray(arr) => {
             let typ_str = arr.raw_inner_type().to_string();
             let data = fld.offset_getter_data_src();
-            quote!(Field::new(#name_str, traversal::FieldType::var_array(#typ_str, self.#name()#maybe_unwrap, #data)))
+            quote!(Field::new(#name_str, traversal::FieldType::var_array(#typ_str, self.#name()#maybe_try, #data)))
         }
         // See if there are better ways to handle these hardcoded types
         // <https://github.com/googlefonts/fontations/issues/659>
@@ -430,7 +430,7 @@ fn traversal_arm_for_field(
             let offset_data = pass_data
                 .cloned()
                 .unwrap_or_else(|| fld.offset_getter_data_src());
-            quote!(Field::new(#name_str, self.#name() #maybe_unwrap .traversal_type(#offset_data)))
+            quote!(Field::new(#name_str, self.#name() #maybe_try .traversal_type(#offset_data)))
         }
         FieldType::Struct { .. } => {
             quote!(compile_error!(concat!("another weird type: ", #name_str)))

--- a/read-fonts/generated/font.rs
+++ b/read-fonts/generated/font.rs
@@ -382,13 +382,13 @@ impl<'a> SomeTable<'a> for TTCHeader<'a> {
                 self.table_directory_offsets(),
             )),
             4usize if self.version().compatible((2u16, 0u16)) => {
-                Some(Field::new("dsig_tag", self.dsig_tag().unwrap()))
+                Some(Field::new("dsig_tag", self.dsig_tag()?))
             }
             5usize if self.version().compatible((2u16, 0u16)) => {
-                Some(Field::new("dsig_length", self.dsig_length().unwrap()))
+                Some(Field::new("dsig_length", self.dsig_length()?))
             }
             6usize if self.version().compatible((2u16, 0u16)) => {
-                Some(Field::new("dsig_offset", self.dsig_offset().unwrap()))
+                Some(Field::new("dsig_offset", self.dsig_offset()?))
             }
             _ => None,
         }

--- a/read-fonts/generated/generated_avar.rs
+++ b/read-fonts/generated/generated_avar.rs
@@ -174,11 +174,11 @@ impl<'a> SomeTable<'a> for Avar<'a> {
             )),
             3usize if self.version().compatible((2u16, 0u16)) => Some(Field::new(
                 "axis_index_map_offset",
-                FieldType::offset(self.axis_index_map_offset().unwrap(), self.axis_index_map()),
+                FieldType::offset(self.axis_index_map_offset()?, self.axis_index_map()),
             )),
             4usize if self.version().compatible((2u16, 0u16)) => Some(Field::new(
                 "var_store_offset",
-                FieldType::offset(self.var_store_offset().unwrap(), self.var_store()),
+                FieldType::offset(self.var_store_offset()?, self.var_store()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_base.rs
+++ b/read-fonts/generated/generated_base.rs
@@ -147,7 +147,7 @@ impl<'a> SomeTable<'a> for Base<'a> {
             )),
             3usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "item_var_store_offset",
-                FieldType::offset(self.item_var_store_offset().unwrap(), self.item_var_store()),
+                FieldType::offset(self.item_var_store_offset()?, self.item_var_store()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_colr.rs
+++ b/read-fonts/generated/generated_colr.rs
@@ -289,27 +289,24 @@ impl<'a> SomeTable<'a> for Colr<'a> {
             4usize => Some(Field::new("num_layer_records", self.num_layer_records())),
             5usize if self.version().compatible(1u16) => Some(Field::new(
                 "base_glyph_list_offset",
-                FieldType::offset(
-                    self.base_glyph_list_offset().unwrap(),
-                    self.base_glyph_list(),
-                ),
+                FieldType::offset(self.base_glyph_list_offset()?, self.base_glyph_list()),
             )),
             6usize if self.version().compatible(1u16) => Some(Field::new(
                 "layer_list_offset",
-                FieldType::offset(self.layer_list_offset().unwrap(), self.layer_list()),
+                FieldType::offset(self.layer_list_offset()?, self.layer_list()),
             )),
             7usize if self.version().compatible(1u16) => Some(Field::new(
                 "clip_list_offset",
-                FieldType::offset(self.clip_list_offset().unwrap(), self.clip_list()),
+                FieldType::offset(self.clip_list_offset()?, self.clip_list()),
             )),
             8usize if self.version().compatible(1u16) => Some(Field::new(
                 "var_index_map_offset",
-                FieldType::offset(self.var_index_map_offset().unwrap(), self.var_index_map()),
+                FieldType::offset(self.var_index_map_offset()?, self.var_index_map()),
             )),
             9usize if self.version().compatible(1u16) => Some(Field::new(
                 "item_variation_store_offset",
                 FieldType::offset(
-                    self.item_variation_store_offset().unwrap(),
+                    self.item_variation_store_offset()?,
                     self.item_variation_store(),
                 ),
             )),

--- a/read-fonts/generated/generated_cpal.rs
+++ b/read-fonts/generated/generated_cpal.rs
@@ -269,21 +269,21 @@ impl<'a> SomeTable<'a> for Cpal<'a> {
             6usize if self.version().compatible(1u16) => Some(Field::new(
                 "palette_types_array_offset",
                 FieldType::offset_to_array_of_scalars(
-                    self.palette_types_array_offset().unwrap(),
+                    self.palette_types_array_offset()?,
                     self.palette_types_array(),
                 ),
             )),
             7usize if self.version().compatible(1u16) => Some(Field::new(
                 "palette_labels_array_offset",
                 FieldType::offset_to_array_of_scalars(
-                    self.palette_labels_array_offset().unwrap(),
+                    self.palette_labels_array_offset()?,
                     self.palette_labels_array(),
                 ),
             )),
             8usize if self.version().compatible(1u16) => Some(Field::new(
                 "palette_entry_labels_array_offset",
                 FieldType::offset_to_array_of_scalars(
-                    self.palette_entry_labels_array_offset().unwrap(),
+                    self.palette_entry_labels_array_offset()?,
                     self.palette_entry_labels_array(),
                 ),
             )),

--- a/read-fonts/generated/generated_gdef.rs
+++ b/read-fonts/generated/generated_gdef.rs
@@ -228,13 +228,13 @@ impl<'a> SomeTable<'a> for Gdef<'a> {
             5usize if self.version().compatible((1u16, 2u16)) => Some(Field::new(
                 "mark_glyph_sets_def_offset",
                 FieldType::offset(
-                    self.mark_glyph_sets_def_offset().unwrap(),
+                    self.mark_glyph_sets_def_offset()?,
                     self.mark_glyph_sets_def(),
                 ),
             )),
             6usize if self.version().compatible((1u16, 3u16)) => Some(Field::new(
                 "item_var_store_offset",
-                FieldType::offset(self.item_var_store_offset().unwrap(), self.item_var_store()),
+                FieldType::offset(self.item_var_store_offset()?, self.item_var_store()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_gpos.rs
+++ b/read-fonts/generated/generated_gpos.rs
@@ -171,10 +171,7 @@ impl<'a> SomeTable<'a> for Gpos<'a> {
             )),
             4usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "feature_variations_offset",
-                FieldType::offset(
-                    self.feature_variations_offset().unwrap(),
-                    self.feature_variations(),
-                ),
+                FieldType::offset(self.feature_variations_offset()?, self.feature_variations()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_gsub.rs
+++ b/read-fonts/generated/generated_gsub.rs
@@ -172,10 +172,7 @@ impl<'a> SomeTable<'a> for Gsub<'a> {
             )),
             4usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "feature_variations_offset",
-                FieldType::offset(
-                    self.feature_variations_offset().unwrap(),
-                    self.feature_variations(),
-                ),
+                FieldType::offset(self.feature_variations_offset()?, self.feature_variations()),
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_ift.rs
+++ b/read-fonts/generated/generated_ift.rs
@@ -581,7 +581,7 @@ impl<'a> SomeTable<'a> for IftPatchMap<'a> {
             {
                 Some(Field::new(
                     "cff_charstrings_offset",
-                    self.cff_charstrings_offset().unwrap(),
+                    self.cff_charstrings_offset()?,
                 ))
             }
             10usize
@@ -591,7 +591,7 @@ impl<'a> SomeTable<'a> for IftPatchMap<'a> {
             {
                 Some(Field::new(
                     "cff2_charstrings_offset",
-                    self.cff2_charstrings_offset().unwrap(),
+                    self.cff2_charstrings_offset()?,
                 ))
             }
             _ => None,
@@ -888,24 +888,21 @@ impl<'a> SomeTable<'a> for EntryData<'a> {
                     .format_flags()
                     .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE) =>
             {
-                Some(Field::new("feature_count", self.feature_count().unwrap()))
+                Some(Field::new("feature_count", self.feature_count()?))
             }
             2usize
                 if self
                     .format_flags()
                     .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE) =>
             {
-                Some(Field::new("feature_tags", self.feature_tags().unwrap()))
+                Some(Field::new("feature_tags", self.feature_tags()?))
             }
             3usize
                 if self
                     .format_flags()
                     .contains(EntryFormatFlags::FEATURES_AND_DESIGN_SPACE) =>
             {
-                Some(Field::new(
-                    "design_space_count",
-                    self.design_space_count().unwrap(),
-                ))
+                Some(Field::new("design_space_count", self.design_space_count()?))
             }
             4usize
                 if self
@@ -916,7 +913,7 @@ impl<'a> SomeTable<'a> for EntryData<'a> {
                     "design_space_segments",
                     traversal::FieldType::array_of_records(
                         stringify!(DesignSpaceSegment),
-                        self.design_space_segments().unwrap(),
+                        self.design_space_segments()?,
                         self.offset_data(),
                     ),
                 ))
@@ -936,7 +933,7 @@ impl<'a> SomeTable<'a> for EntryData<'a> {
                     .format_flags()
                     .contains(EntryFormatFlags::CHILD_INDICES) =>
             {
-                Some(Field::new("child_indices", self.child_indices().unwrap()))
+                Some(Field::new("child_indices", self.child_indices()?))
             }
             _ => None,
         }

--- a/read-fonts/generated/generated_layout.rs
+++ b/read-fonts/generated/generated_layout.rs
@@ -1050,10 +1050,7 @@ impl<'a, T: FontRead<'a, Args = ()> + SomeTable<'a> + 'a> SomeTable<'a> for Look
                     .lookup_flag()
                     .contains(LookupFlag::USE_MARK_FILTERING_SET) =>
             {
-                Some(Field::new(
-                    "mark_filtering_set",
-                    self.mark_filtering_set().unwrap(),
-                ))
+                Some(Field::new("mark_filtering_set", self.mark_filtering_set()?))
             }
             _ => None,
         }

--- a/read-fonts/generated/generated_maxp.rs
+++ b/read-fonts/generated/generated_maxp.rs
@@ -328,52 +328,50 @@ impl<'a> SomeTable<'a> for Maxp<'a> {
             0usize => Some(Field::new("version", self.version())),
             1usize => Some(Field::new("num_glyphs", self.num_glyphs())),
             2usize if self.version().compatible((1u16, 0u16)) => {
-                Some(Field::new("max_points", self.max_points().unwrap()))
+                Some(Field::new("max_points", self.max_points()?))
             }
             3usize if self.version().compatible((1u16, 0u16)) => {
-                Some(Field::new("max_contours", self.max_contours().unwrap()))
+                Some(Field::new("max_contours", self.max_contours()?))
             }
             4usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_composite_points",
-                self.max_composite_points().unwrap(),
+                self.max_composite_points()?,
             )),
             5usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_composite_contours",
-                self.max_composite_contours().unwrap(),
+                self.max_composite_contours()?,
             )),
             6usize if self.version().compatible((1u16, 0u16)) => {
-                Some(Field::new("max_zones", self.max_zones().unwrap()))
+                Some(Field::new("max_zones", self.max_zones()?))
             }
             7usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_twilight_points",
-                self.max_twilight_points().unwrap(),
+                self.max_twilight_points()?,
             )),
             8usize if self.version().compatible((1u16, 0u16)) => {
-                Some(Field::new("max_storage", self.max_storage().unwrap()))
+                Some(Field::new("max_storage", self.max_storage()?))
             }
-            9usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
-                "max_function_defs",
-                self.max_function_defs().unwrap(),
-            )),
+            9usize if self.version().compatible((1u16, 0u16)) => {
+                Some(Field::new("max_function_defs", self.max_function_defs()?))
+            }
             10usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_instruction_defs",
-                self.max_instruction_defs().unwrap(),
+                self.max_instruction_defs()?,
             )),
-            11usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
-                "max_stack_elements",
-                self.max_stack_elements().unwrap(),
-            )),
+            11usize if self.version().compatible((1u16, 0u16)) => {
+                Some(Field::new("max_stack_elements", self.max_stack_elements()?))
+            }
             12usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_size_of_instructions",
-                self.max_size_of_instructions().unwrap(),
+                self.max_size_of_instructions()?,
             )),
             13usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_component_elements",
-                self.max_component_elements().unwrap(),
+                self.max_component_elements()?,
             )),
             14usize if self.version().compatible((1u16, 0u16)) => Some(Field::new(
                 "max_component_depth",
-                self.max_component_depth().unwrap(),
+                self.max_component_depth()?,
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_name.rs
+++ b/read-fonts/generated/generated_name.rs
@@ -162,13 +162,13 @@ impl<'a> SomeTable<'a> for Name<'a> {
                 ),
             )),
             4usize if self.version().compatible(1u16) => {
-                Some(Field::new("lang_tag_count", self.lang_tag_count().unwrap()))
+                Some(Field::new("lang_tag_count", self.lang_tag_count()?))
             }
             5usize if self.version().compatible(1u16) => Some(Field::new(
                 "lang_tag_record",
                 traversal::FieldType::array_of_records(
                     stringify!(LangTagRecord),
-                    self.lang_tag_record().unwrap(),
+                    self.lang_tag_record()?,
                     self.string_data(),
                 ),
             )),

--- a/read-fonts/generated/generated_os2.rs
+++ b/read-fonts/generated/generated_os2.rs
@@ -1063,35 +1063,34 @@ impl<'a> SomeTable<'a> for Os2<'a> {
             29usize => Some(Field::new("us_win_descent", self.us_win_descent())),
             30usize if self.version().compatible(1u16) => Some(Field::new(
                 "ul_code_page_range_1",
-                self.ul_code_page_range_1().unwrap(),
+                self.ul_code_page_range_1()?,
             )),
             31usize if self.version().compatible(1u16) => Some(Field::new(
                 "ul_code_page_range_2",
-                self.ul_code_page_range_2().unwrap(),
+                self.ul_code_page_range_2()?,
             )),
             32usize if self.version().compatible(2u16) => {
-                Some(Field::new("sx_height", self.sx_height().unwrap()))
+                Some(Field::new("sx_height", self.sx_height()?))
             }
             33usize if self.version().compatible(2u16) => {
-                Some(Field::new("s_cap_height", self.s_cap_height().unwrap()))
+                Some(Field::new("s_cap_height", self.s_cap_height()?))
             }
-            34usize if self.version().compatible(2u16) => Some(Field::new(
-                "us_default_char",
-                self.us_default_char().unwrap(),
-            )),
+            34usize if self.version().compatible(2u16) => {
+                Some(Field::new("us_default_char", self.us_default_char()?))
+            }
             35usize if self.version().compatible(2u16) => {
-                Some(Field::new("us_break_char", self.us_break_char().unwrap()))
+                Some(Field::new("us_break_char", self.us_break_char()?))
             }
             36usize if self.version().compatible(2u16) => {
-                Some(Field::new("us_max_context", self.us_max_context().unwrap()))
+                Some(Field::new("us_max_context", self.us_max_context()?))
             }
             37usize if self.version().compatible(5u16) => Some(Field::new(
                 "us_lower_optical_point_size",
-                self.us_lower_optical_point_size().unwrap(),
+                self.us_lower_optical_point_size()?,
             )),
             38usize if self.version().compatible(5u16) => Some(Field::new(
                 "us_upper_optical_point_size",
-                self.us_upper_optical_point_size().unwrap(),
+                self.us_upper_optical_point_size()?,
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_post.rs
+++ b/read-fonts/generated/generated_post.rs
@@ -268,12 +268,11 @@ impl<'a> SomeTable<'a> for Post<'a> {
             7usize => Some(Field::new("min_mem_type1", self.min_mem_type1())),
             8usize => Some(Field::new("max_mem_type1", self.max_mem_type1())),
             9usize if self.version().compatible((2u16, 0u16)) => {
-                Some(Field::new("num_glyphs", self.num_glyphs().unwrap()))
+                Some(Field::new("num_glyphs", self.num_glyphs()?))
             }
-            10usize if self.version().compatible((2u16, 0u16)) => Some(Field::new(
-                "glyph_name_index",
-                self.glyph_name_index().unwrap(),
-            )),
+            10usize if self.version().compatible((2u16, 0u16)) => {
+                Some(Field::new("glyph_name_index", self.glyph_name_index()?))
+            }
             11usize if self.version().compatible((2u16, 0u16)) => {
                 Some(Field::new("string_data", self.traverse_string_data()))
             }

--- a/read-fonts/generated/generated_stat.rs
+++ b/read-fonts/generated/generated_stat.rs
@@ -206,7 +206,7 @@ impl<'a> SomeTable<'a> for Stat<'a> {
             )),
             6usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "elided_fallback_name_id",
-                self.elided_fallback_name_id().unwrap(),
+                self.elided_fallback_name_id()?,
             )),
             _ => None,
         }

--- a/read-fonts/generated/generated_test_conditions.rs
+++ b/read-fonts/generated/generated_test_conditions.rs
@@ -118,10 +118,10 @@ impl<'a> SomeTable<'a> for MajorMinorVersion<'a> {
             0usize => Some(Field::new("version", self.version())),
             1usize => Some(Field::new("always_present", self.always_present())),
             2usize if self.version().compatible((1u16, 1u16)) => {
-                Some(Field::new("if_11", self.if_11().unwrap()))
+                Some(Field::new("if_11", self.if_11()?))
             }
             3usize if self.version().compatible((2u16, 0u16)) => {
-                Some(Field::new("if_20", self.if_20().unwrap()))
+                Some(Field::new("if_20", self.if_20()?))
             }
             _ => None,
         }
@@ -551,12 +551,8 @@ impl<'a> SomeTable<'a> for FlagDay<'a> {
         match idx {
             0usize => Some(Field::new("volume", self.volume())),
             1usize => Some(Field::new("flags", self.flags())),
-            2usize if self.flags().contains(GotFlags::FOO) => {
-                Some(Field::new("foo", self.foo().unwrap()))
-            }
-            3usize if self.flags().contains(GotFlags::BAR) => {
-                Some(Field::new("bar", self.bar().unwrap()))
-            }
+            2usize if self.flags().contains(GotFlags::FOO) => Some(Field::new("foo", self.foo()?)),
+            3usize if self.flags().contains(GotFlags::BAR) => Some(Field::new("bar", self.bar()?)),
             _ => None,
         }
     }

--- a/read-fonts/generated/generated_test_offsets_arrays.rs
+++ b/read-fonts/generated/generated_test_offsets_arrays.rs
@@ -260,7 +260,7 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
             6usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nullable_record_array_offset",
                 traversal::FieldType::offset_to_array_of_records(
-                    self.versioned_nullable_record_array_offset().unwrap(),
+                    self.versioned_nullable_record_array_offset()?,
                     self.versioned_nullable_record_array(),
                     stringify!(Shmecord),
                     self.offset_data(),
@@ -269,16 +269,13 @@ impl<'a> SomeTable<'a> for KindsOfOffsets<'a> {
             7usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nonnullable_offset",
                 FieldType::offset(
-                    self.versioned_nonnullable_offset().unwrap(),
-                    self.versioned_nonnullable().unwrap(),
+                    self.versioned_nonnullable_offset()?,
+                    self.versioned_nonnullable()?,
                 ),
             )),
             8usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nullable_offset",
-                FieldType::offset(
-                    self.versioned_nullable_offset().unwrap(),
-                    self.versioned_nullable(),
-                ),
+                FieldType::offset(self.versioned_nullable_offset()?, self.versioned_nullable()),
             )),
             _ => None,
         }
@@ -475,11 +472,11 @@ impl<'a> SomeTable<'a> for KindsOfArraysOfOffsets<'a> {
             )),
             4usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nonnullable_offsets",
-                FieldType::from(self.versioned_nonnullables().unwrap()),
+                FieldType::from(self.versioned_nonnullables()?),
             )),
             5usize if self.version().compatible((1u16, 1u16)) => Some(Field::new(
                 "versioned_nullable_offsets",
-                FieldType::from(self.versioned_nullables().unwrap()),
+                FieldType::from(self.versioned_nullables()?),
             )),
             _ => None,
         }
@@ -644,15 +641,14 @@ impl<'a> SomeTable<'a> for KindsOfArrays<'a> {
                     self.offset_data(),
                 ),
             )),
-            4usize if self.version().compatible(1u16) => Some(Field::new(
-                "versioned_scalars",
-                self.versioned_scalars().unwrap(),
-            )),
+            4usize if self.version().compatible(1u16) => {
+                Some(Field::new("versioned_scalars", self.versioned_scalars()?))
+            }
             5usize if self.version().compatible(1u16) => Some(Field::new(
                 "versioned_records",
                 traversal::FieldType::array_of_records(
                     stringify!(Shmecord),
-                    self.versioned_records().unwrap(),
+                    self.versioned_records()?,
                     self.offset_data(),
                 ),
             )),


### PR DESCRIPTION
Since minimal validate, we don't check presence of versioned fields but traversal still assumed they exist. Replaces unwrap with `?` for generated traversal code ensuring we don't panic when encountering these.

internal bug ref: b/537782897