### PR TITLE
Add NotoColorEmoji-Regular.ttf and tests for recursion and traversal …

### DIFF
--- a/font-test-data/src/lib.rs
+++ b/font-test-data/src/lib.rs
@@ -110,6 +110,8 @@ pub static TINOS_SUBSET: &[u8] = include_bytes!("../test_data/ttf/tinos_subset.t
 pub static NOTO_HANDWRITING_SBIX: &[u8] =
     include_bytes!("../test_data/ttf/noto_handwriting-sbix.ttf");
 
+pub static NOTO_COLOR_EMOJI: &[u8] = include_bytes!("../test_data/ttf/NotoColorEmoji-Regular.ttf");
+
 pub static COUSINE_HINT_SUBSET: &[u8] = include_bytes!("../test_data/ttf/cousine_hint_subset.ttf");
 
 pub mod morx {

--- a/skrifa/src/color/traversal.rs
+++ b/skrifa/src/color/traversal.rs
@@ -565,4 +565,32 @@ mod tests {
         let result = traverse_with_limit(node_count - 1);
         assert!(matches!(result, Err(PaintError::DepthLimitExceeded)));
     }
+
+    #[test]
+    fn noto_color_emoji_colrv1_traversal_limits() {
+        let font = FontRef::new(font_test_data::NOTO_COLOR_EMOJI).unwrap();
+        let colr_glyphs = font.color_glyphs();
+
+        // GID 1852 (Flag of Ecuador 🇪🇨) has an extremely complex coat of arms
+        // that exceeds the MAX_NODES (4096) paint graph traversal limit.
+        let gid_ecuador = GlyphId::new(1852);
+        let color_glyph = colr_glyphs.get(gid_ecuador).expect("GID 1852 should exist");
+        let result = color_glyph.paint(LocationRef::default(), &mut NopPainter);
+        assert!(
+            matches!(result, Err(PaintError::DepthLimitExceeded)),
+            "Expected GID 1852 (Flag of Ecuador) to exceed MAX_NODES limit, got: {result:?}"
+        );
+
+        // GID 1986 (Flag of El Salvador 🇸🇻) also has a complex coat of arms
+        // that exceeds the MAX_NODES (4096) limit.
+        let gid_el_salvador = GlyphId::new(1986);
+        let color_glyph = colr_glyphs
+            .get(gid_el_salvador)
+            .expect("GID 1986 should exist");
+        let result = color_glyph.paint(LocationRef::default(), &mut NopPainter);
+        assert!(
+            matches!(result, Err(PaintError::DepthLimitExceeded)),
+            "Expected GID 1986 (Flag of El Salvador) to exceed MAX_NODES limit, got: {result:?}"
+        );
+    }
 }

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -1519,4 +1519,18 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn noto_color_emoji_recursion_limit() {
+        let font = FontRef::new(font_test_data::NOTO_COLOR_EMOJI).unwrap();
+        let outlines = Outlines::new(&font).unwrap();
+        let maxp = font.maxp().unwrap();
+        for gid in 0..maxp.num_glyphs() {
+            let gid = GlyphId::new(gid as u32);
+            let result = outlines.outline(gid);
+            if let Err(DrawError::RecursionLimitExceeded(e)) = result {
+                panic!("Glyph {gid:?} unexpectedly hit recursion limit on component {e:?}");
+            }
+        }
+    }
 }


### PR DESCRIPTION
…limits

Add unit tests validating:
1. TrueType composite recursion limit in glyf outlines across all glyphs in Noto Color Emoji.
2. COLRv1 paint graph MAX_NODES (4096) traversal guard limit for complex emoji (such as Flag of Ecuador 🇪🇨 and Flag of El Salvador 🇸🇻).

TAG=agy
CONV=0ef6491e-4fbd-4e6b-b7d4-502de505d679