### PR TITLE
Convert legacy state offsets without a hardware divide

### DIFF
--- a/read-fonts/src/tables/aat.rs
+++ b/read-fonts/src/tables/aat.rs
@@ -342,6 +342,9 @@ pub struct StateTable<'a> {
     class_array: &'a [u8],
     state_array: &'a [u8],
     entry_table: &'a [u8],
+    /// floor(2^32 / n_classes) + 1: exact reciprocal for dividends < 2^16,
+    /// so the per-transition new-state conversion avoids a hardware divide.
+    n_classes_magic: u64,
 }
 
 impl StateTable<'_> {
@@ -379,10 +382,16 @@ impl StateTable<'_> {
         let mut entry = StateEntry::read(FontData::new(entry_data))?;
         // For legacy state tables, the newState is a byte offset into
         // the state array. Convert this to an index for consistency.
-        let new_state = (entry.new_state as i32)
-            .checked_sub(self.header.state_array_offset().to_u32() as i32)
-            .ok_or(ReadError::OutOfBounds)?
-            / self.n_classes as i32;
+        let offset = self.header.state_array_offset().to_u32() as i32;
+        let diff = entry.new_state as i32 - offset;
+        let new_state = if diff >= 0 {
+            // Multiply by the precomputed reciprocal instead of dividing;
+            // exact for all dividends below 2^16, and this is the per-
+            // transition hot path of legacy state machines.
+            ((diff as u64 * self.n_classes_magic) >> 32) as i32
+        } else {
+            diff / self.n_classes as i32
+        };
         entry.new_state = new_state.try_into().map_err(|_| ReadError::OutOfBounds)?;
         Ok(entry)
     }
@@ -418,6 +427,7 @@ impl<'a> FontRead<'a> for StateTable<'a> {
             class_array,
             state_array,
             entry_table,
+            n_classes_magic: (1u64 << 32) / n_classes as u64 + 1,
         })
     }
 }


### PR DESCRIPTION
Legacy AAT state tables express `newState` as a byte offset that `entry()` converts to an index by dividing by `n_classes` — on every transition, up to three times per glyph with safe-to-break logic. Profiling GeezaPro shaping (via harfrust, which shares this code path) showed the `idiv` taking **39% of `entry()`'s self time**.

This precomputes `floor(2^32 / n_classes) + 1` once at table-read time and converts with a multiply+shift. The reciprocal is exact for all dividends below 2^16 (the standard bound: for divisor d ≤ 2^16 and dividend n < 2^16, `(n·M) >> 32` with `M = ⌊2^32/d⌋+1` equals `⌊n/d⌋` because the error term stays below `1/d · d = 1`), which covers the `u16` `newState` range. Negative differences (malformed fonts) keep the previous signed-division behavior exactly.

All read-fonts tests pass; shaping output verified byte-identical to HarfBuzz across the AAT test corpus (GeezaPro, LucidaGrande, Menlo, Devanagari Sangam MN).
