### PR TITLE
[int-set] Reuse the last-page cache when inserting

### DIFF
--- a/read-fonts/benches/int_set_benchmark.rs
+++ b/read-fonts/benches/int_set_benchmark.rs
@@ -56,6 +56,30 @@ pub fn insert_benchmark(c: &mut Criterion) {
     }
 }
 
+pub fn insert_ordered_benchmark(c: &mut Criterion) {
+    const NUM_INSERTS: u32 = 1000;
+    let inputs = set_parameters();
+
+    for input in inputs {
+        c.bench_with_input(
+            BenchmarkId::new("BM_SetInsertOrdered_1000", &input),
+            &input,
+            |b, p: &SetTest| {
+                let set = random_set(p.set_size, p.max_value());
+                b.iter_batched(
+                    || set.clone(),
+                    |mut s| {
+                        for i in 0..NUM_INSERTS {
+                            s.insert(i % p.max_value());
+                        }
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+}
+
 pub fn ordered_extend_benchmark(c: &mut Criterion) {
     let num_inserts = 1000u32;
     let inputs = set_parameters();
@@ -157,6 +181,7 @@ pub fn iteration_benchmark(c: &mut Criterion) {
 criterion_group!(
     benches,
     insert_benchmark,
+    insert_ordered_benchmark,
     ordered_extend_benchmark,
     lookup_random_benchmark,
     lookup_ordered_benchmark,

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -692,11 +692,22 @@ impl U32Set {
     /// the page if it does not yet exist.
     #[inline]
     fn ensure_page_index_for_major(&mut self, major_value: u32) -> usize {
+        // Check the last-accessed-page cache (also maintained by contains())
+        // before searching; runs of nearby values mostly hit the same page.
+        let cached_map_index = *self.last_page_map_index.get_mut();
+        if let Some(info) = self.page_map.get(cached_map_index) {
+            if info.major_value == major_value {
+                return info.index as usize;
+            }
+        }
         match self
             .page_map
             .binary_search_by(|probe| probe.major_value.cmp(&major_value))
         {
-            Ok(map_index) => self.page_map[map_index].index as usize,
+            Ok(map_index) => {
+                *self.last_page_map_index.get_mut() = map_index;
+                self.page_map[map_index].index as usize
+            }
             Err(map_index_to_insert) => {
                 let page_index = self.pages.len();
                 self.pages.push(BitPage::new_zeroes());
@@ -705,6 +716,7 @@ impl U32Set {
                     major_value,
                 };
                 self.page_map.insert(map_index_to_insert, new_info);
+                *self.last_page_map_index.get_mut() = map_index_to_insert;
                 page_index
             }
         }


### PR DESCRIPTION
`ensure_page_index_for_major` (the path under `insert`, `extend_unsorted`, etc.) goes straight to a binary search of the page map on every call, while `contains` consults the `last_page_map_index` cache first. This checks and maintains the same cache on the insert path — mirroring `hb_bit_set_t`, which caches page lookups on both reads and writes. Staleness is handled the same way `contains` already handles it: verify the major value, fall back to the search on mismatch.

First commit adds an ordered-insert benchmark: the existing `BM_SetInsert_1000` inserts hash-scattered values (the always-miss case), and nothing covered runs of nearby values — the pattern range-ish workloads (closure, cmap collection, buffer glyph sets) actually produce.

Measured (criterion, `--baseline` A/B):
- `BM_SetInsertOrdered_1000`: **−30% to −83%**, larger sets gain more (e.g. 65536/64: 12.0 µs → 2.0 µs).
- `BM_SetInsert_1000` (scattered): **+7–9%** on small/mid sets (~0.5 ns/insert for the extra compare); large-set configs unchanged within noise.

That trade-off matches HarfBuzz's long-standing choice for the same structure. All read-fonts tests pass.