### PR TITLE
Release types 0.12.4, read 0.43.2, skrifa 0.46.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ serde_json = "1.0"
 # default-features enabled by `skrifa`. Other crates using `read-fonts`
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
-font-types = { version = "0.12.3", path = "font-types" }
-read-fonts = { version = "0.43.1", path = "read-fonts", default-features = false }
+font-types = { version = "0.12.4", path = "font-types" }
+read-fonts = { version = "0.43.2", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
-skrifa = { version = "0.46.1", path = "skrifa", default-features = false, features = ["std"] }
+skrifa = { version = "0.46.2", path = "skrifa", default-features = false, features = ["std"] }
 write-fonts = { version = "0.52.0", path = "write-fonts", default-features = false }
 shared-brotli-patch-decoder = { version = "0.1.5", path = "shared-brotli-patch-decoder", default-features = false }
 incremental-font-transfer = { version = "0.7.0", path = "incremental-font-transfer" }

--- a/font-types/Cargo.toml
+++ b/font-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-types"
-version = "0.12.3"
+version = "0.12.4"
 description = "Scalar types used in fonts."
 readme = "README.md"
 categories = ["text-processing"]

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.43.1"
+version = "0.43.2"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]

--- a/skrifa/Cargo.toml
+++ b/skrifa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrifa"
-version = "0.46.1"
+version = "0.46.2"
 description = "Metadata reader and glyph scaler for OpenType fonts."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for font-types from font-types-v0.12.3 to 0.12.4
             fa2749c [font-types] derive bytemuck::NoUninit for glyph ids (#2066)