### PR TITLE
[int_set] Streamline the insert path

### DIFF
--- a/read-fonts/src/collections/int_set/bitpage.rs
+++ b/read-fonts/src/collections/int_set/bitpage.rs
@@ -124,6 +124,7 @@ impl BitPage {
     }
 
     /// Marks `(val % page width)` a member of this set and returns `true` if it is newly added.
+    #[inline(always)]
     pub(crate) fn insert(&mut self, val: u32) -> bool {
         let el_mut = self.element_mut(val);
         let mask = elem_index_bit_mask(val);

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -83,6 +83,7 @@ impl U32Set {
     /// Add val as a member of this set.
     ///
     /// If the set did not previously contain this value, returns `true`.
+    #[inline]
     pub fn insert(&mut self, val: u32) -> bool {
         let page = self.ensure_page_for_mut(val);
         let ret = page.insert(val);
@@ -119,15 +120,27 @@ impl U32Set {
     /// iterator of values.
     ///
     /// [`extend()`]: Self::extend
+    #[inline]
     pub fn extend_unsorted<U: IntoIterator<Item = u32>>(&mut self, iter: U) {
-        self.length += iter
-            .into_iter()
-            .map(|val| {
-                let major_value = Self::get_major_value(val);
-                let page = self.ensure_page_for_major_mut(major_value);
-                page.insert(val) as u64
-            })
-            .sum::<u64>();
+        // Unsorted values from real workloads (e.g. the glyph ids of a
+        // shaping buffer) still tend to arrive in runs that stay within a
+        // single page. Memoizing the page index of the last value in loop
+        // locals skips the page_map search for all but the first value of
+        // each run.
+        let mut last_major_value = u32::MAX;
+        let mut last_page_index = usize::MAX;
+        let mut added = 0u64;
+        for val in iter {
+            let major_value = Self::get_major_value(val);
+            if major_value != last_major_value {
+                last_page_index = self.ensure_page_index_for_major(major_value);
+                last_major_value = major_value;
+            }
+            if let Some(page) = self.pages.get_mut(last_page_index) {
+                added += page.insert(val) as u64;
+            }
+        }
+        self.length += added;
     }
 
     /// Remove val from this set.
@@ -690,24 +703,31 @@ impl U32Set {
 
     /// Returns the index in `self.pages` for the page with the same major as `major_value`. Will create
     /// the page if it does not yet exist.
-    #[inline]
+    #[inline(always)]
     fn ensure_page_index_for_major(&mut self, major_value: u32) -> usize {
         match self
             .page_map
             .binary_search_by(|probe| probe.major_value.cmp(&major_value))
         {
             Ok(map_index) => self.page_map[map_index].index as usize,
-            Err(map_index_to_insert) => {
-                let page_index = self.pages.len();
-                self.pages.push(BitPage::new_zeroes());
-                let new_info = PageInfo {
-                    index: page_index as u32,
-                    major_value,
-                };
-                self.page_map.insert(map_index_to_insert, new_info);
-                page_index
-            }
+            Err(map_index_to_insert) => self.insert_page_for_major(map_index_to_insert, major_value),
         }
+    }
+
+    /// The miss path of [`ensure_page_index_for_major`]: allocate and
+    /// link a new page. Kept out of line so the hit path stays small
+    /// enough to inline into the per-value insert loops.
+    #[cold]
+    #[inline(never)]
+    fn insert_page_for_major(&mut self, map_index_to_insert: usize, major_value: u32) -> usize {
+        let page_index = self.pages.len();
+        self.pages.push(BitPage::new_zeroes());
+        let new_info = PageInfo {
+            index: page_index as u32,
+            major_value,
+        };
+        self.page_map.insert(map_index_to_insert, new_info);
+        page_index
     }
 
     /// Return a mutable reference to the page that `value` resides in.
@@ -727,12 +747,14 @@ impl U32Set {
     /// Return a mutable reference to the page that `value` resides in.
     ///
     /// Insert a new page if it doesn't exist.
+    #[inline(always)]
     fn ensure_page_for_mut(&mut self, value: u32) -> &mut BitPage {
         self.ensure_page_for_major_mut(Self::get_major_value(value))
     }
 
     /// Return a mutable reference to the page with major value equal to `major_value`.
     /// Inserts a new page if it doesn't exist.
+    #[inline(always)]
     fn ensure_page_for_major_mut(&mut self, major_value: u32) -> &mut BitPage {
         let page_index = self.ensure_page_index_for_major(major_value);
         self.pages.get_mut(page_index).unwrap()

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -710,7 +710,9 @@ impl U32Set {
             .binary_search_by(|probe| probe.major_value.cmp(&major_value))
         {
             Ok(map_index) => self.page_map[map_index].index as usize,
-            Err(map_index_to_insert) => self.insert_page_for_major(map_index_to_insert, major_value),
+            Err(map_index_to_insert) => {
+                self.insert_page_for_major(map_index_to_insert, major_value)
+            }
         }
     }
 

--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -716,7 +716,7 @@ impl U32Set {
         }
     }
 
-    /// The miss path of [`ensure_page_index_for_major`]: allocate and
+    /// The miss path of `ensure_page_index_for_major`: allocate and
     /// link a new page. Kept out of line so the hit path stays small
     /// enough to inline into the per-value insert loops.
     #[cold]


### PR DESCRIPTION
Two changes to the hot insert chain, found while profiling HarfRust's AAT shaping (the buffer glyph set is rebuilt per line — ~74K unsorted inserts per benchmark run, ~95 instructions each before this):

1. **Inline hints + hot/cold split**: hints along the insert chain, and the page-allocation miss path of `ensure_page_index_for_major` split into a `#[cold]` `#[inline(never)]` helper so the search hit path inlines into per-value loops.
2. **Loop-local memo in `extend_unsorted`**: glyph sequences are unsorted but cluster within a few pages, so remembering the last (major, page index) in the loop skips the page-map search on most iterations. The memo lives in the loop, not the set — per-insert cost is unchanged for non-clustered input (a miss adds one compare), unlike the set-resident cache of #2065 which regressed.

Microbench (extend_unsorted, 300 values / 4 pages, clear() between rounds, fat-LTO release): **51.9 → 29.7 instructions, 22.4 → 8.2 cycles per insert** clustered; non-regressing on random and single-page input. End-to-end HarfRust shaping (clang release rig): instructions −4.4% GeezaPro, −3.9% Menlo, −2.7% Lucida Grande, −0.8% Devanagari Sangam; shaping outputs byte-identical. `cargo test -p read-fonts` passes (637).