### PR TITLE
[read-fonts] Simplify `array::get_pair()`.

### DIFF
--- a/read-fonts/src/array.rs
+++ b/read-fonts/src/array.rs
@@ -215,11 +215,12 @@ impl<'a, T: AnyBitPattern + FixedSize> FontRead<'a> for &'a [T] {
 
 /// Helper to retrieve a pair of items from a slice, returning an error
 /// if the second index overflows or if either index is out of bounds.
-pub(crate) fn get_pair<T>(slice: &[T], idx: usize) -> Result<[&T; 2], ReadError> {
-    let second_idx = idx.checked_add(1).ok_or(ReadError::OutOfBounds)?;
-    let first = slice.get(idx).ok_or(ReadError::OutOfBounds)?;
-    let second = slice.get(second_idx).ok_or(ReadError::OutOfBounds)?;
-    Ok([first, second])
+pub(crate) fn get_pair<T>(slice: &[T], idx: usize) -> Result<&[T; 2], ReadError> {
+    slice
+        .get(idx..)
+        .ok_or(ReadError::OutOfBounds)?
+        .first_chunk()
+        .ok_or(ReadError::OutOfBounds)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I happened to be reading this code and thought that it could be made simpler and clearer. This PR has no significance other than that.

The change has no effect on the optimized machine code (presumably because all uses of `get_pair()` get inlined), but simplifies the Rust code, with only two error paths instead of three and no checked (or unchecked) arithmetic.

