### PR TITLE
[read-fonts] Add lazily-read GPOS value records

### DIFF
--- a/read-fonts/src/tables/gpos.rs
+++ b/read-fonts/src/tables/gpos.rs
@@ -16,7 +16,7 @@ pub use super::layout::{
     Lookup, ScriptList,
 };
 use super::layout::{ExtensionLookup, LookupFlag, Subtables};
-pub use value_record::{Value, ValueContext, ValueRecord};
+pub use value_record::{Value, ValueContext, ValueRecord, ValueRecordRef};
 
 #[cfg(test)]
 #[path = "../tests/test_gpos.rs"]
@@ -154,6 +154,267 @@ impl<'a> PositionLookup<'a> {
     }
 }
 
+impl<'a> SinglePosFormat1<'a> {
+    /// Returns the value record for this subtable, without reading it.
+    #[inline]
+    pub fn value_record_ref(&self) -> ValueRecordRef<'a> {
+        ValueRecordRef::new(
+            self.offset_data(),
+            self.value_record_byte_range().start,
+            self.value_format(),
+        )
+    }
+}
+
+impl<'a> SinglePosFormat2<'a> {
+    /// Returns the value record at `index`, without reading it.
+    ///
+    /// `index` is a coverage index; returns `None` if it is out of range.
+    #[inline]
+    pub fn value_record_ref(&self, index: usize) -> Option<ValueRecordRef<'a>> {
+        if index >= self.value_count() as usize {
+            return None;
+        }
+        let format = self.value_format();
+        let offset =
+            self.value_records_byte_range().start + index.checked_mul(format.record_byte_len())?;
+        Some(ValueRecordRef::new(self.offset_data(), offset, format))
+    }
+}
+
+/// A [`PairValueRecord`] whose value records are read on demand.
+#[derive(Copy, Clone)]
+pub struct PairValueRecordRef<'a> {
+    /// The offset data of the containing [`PairSet`].
+    data: FontData<'a>,
+    offset: u32,
+    format1: ValueFormat,
+    format2: ValueFormat,
+}
+
+impl<'a> PairValueRecordRef<'a> {
+    /// Glyph ID of the second glyph in the pair.
+    #[inline]
+    pub fn second_glyph(&self) -> GlyphId16 {
+        self.data
+            .read_at(self.offset as usize)
+            .unwrap_or_else(|_| GlyphId16::new(0))
+    }
+
+    /// Positioning for the first glyph in the pair.
+    #[inline]
+    pub fn value_record1(&self) -> ValueRecordRef<'a> {
+        ValueRecordRef::new(
+            self.data,
+            self.offset as usize + GlyphId16::RAW_BYTE_LEN,
+            self.format1,
+        )
+    }
+
+    /// Positioning for the second glyph in the pair.
+    #[inline]
+    pub fn value_record2(&self) -> ValueRecordRef<'a> {
+        ValueRecordRef::new(
+            self.data,
+            self.offset as usize + GlyphId16::RAW_BYTE_LEN + self.format1.record_byte_len(),
+            self.format2,
+        )
+    }
+}
+
+/// The pair value records of a [`PairSet`], located but not read.
+///
+/// Records are addressed by a fixed stride derived from the two value formats,
+/// so locating one costs a multiply and no reads. This makes the array cheap to
+/// scan and cheap to binary search on
+/// [`second_glyph`](PairValueRecordRef::second_glyph).
+#[derive(Copy, Clone)]
+pub struct PairValueRecordRefs<'a> {
+    data: FontData<'a>,
+    start: u32,
+    stride: u32,
+    len: u32,
+    format1: ValueFormat,
+    format2: ValueFormat,
+}
+
+impl<'a> PairValueRecordRefs<'a> {
+    /// The number of records in the array.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns the record at `index`, or `None` if out of range.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<PairValueRecordRef<'a>> {
+        if index >= self.len as usize {
+            return None;
+        }
+        Some(PairValueRecordRef {
+            data: self.data,
+            offset: self.start + self.stride * index as u32,
+            format1: self.format1,
+            format2: self.format2,
+        })
+    }
+
+    /// Returns an iterator over the records.
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = PairValueRecordRef<'a>> + 'a + Clone {
+        let this = *self;
+        (0..self.len as usize).map(move |i| PairValueRecordRef {
+            data: this.data,
+            offset: this.start + this.stride * i as u32,
+            format1: this.format1,
+            format2: this.format2,
+        })
+    }
+
+    /// Returns the record for `second_glyph`, using a binary search.
+    ///
+    /// Pair value records are ordered by second glyph, so this reads only the
+    /// glyph ID of each probed record.
+    pub fn find(&self, second_glyph: GlyphId16) -> Option<PairValueRecordRef<'a>> {
+        let (mut lo, mut hi) = (0usize, self.len as usize);
+        while lo < hi {
+            // deliberately not usize::midpoint, which widens to u128; these
+            // values are bounded by a u16 count
+            #[allow(clippy::manual_midpoint)]
+            let mid = (lo + hi) / 2;
+            let record = self.get(mid)?;
+            match record.second_glyph().cmp(&second_glyph) {
+                core::cmp::Ordering::Less => lo = mid + 1,
+                core::cmp::Ordering::Greater => hi = mid,
+                core::cmp::Ordering::Equal => return Some(record),
+            }
+        }
+        None
+    }
+}
+
+impl<'a> PairSet<'a> {
+    /// Returns the pair value records, located but not read.
+    ///
+    /// Unlike [`pair_value_records`][Self::pair_value_records], reading a
+    /// record's fields is deferred until they are asked for, so scanning or
+    /// searching the array does not build any value records.
+    pub fn pair_value_record_refs(&self) -> PairValueRecordRefs<'a> {
+        let format1 = self.value_format1();
+        let format2 = self.value_format2();
+        let range = self.pair_value_records_byte_range();
+        let stride =
+            GlyphId16::RAW_BYTE_LEN + format1.record_byte_len() + format2.record_byte_len();
+        // matches `pair_value_records`, which yields nothing at all when the
+        // declared array doesn't fit in the available data
+        let len = match (stride, self.data.slice(range.clone())) {
+            (0, _) | (_, None) => 0,
+            (stride, Some(_)) => (range.end - range.start) / stride,
+        };
+        PairValueRecordRefs {
+            data: self.data,
+            start: range.start as u32,
+            stride: stride as u32,
+            len: len as u32,
+            format1,
+            format2,
+        }
+    }
+}
+
+/// The two-dimensional array of value records in a [`PairPosFormat2`], located
+/// but not read.
+///
+/// The class counts, value formats and record stride are read once when this is
+/// built, so addressing a record afterwards is pure arithmetic. Callers walking
+/// many class pairs should build this once and reuse it rather than going
+/// through [`PairPosFormat2::value_record_refs`], which rebuilds it every call.
+#[derive(Copy, Clone)]
+pub struct ClassValueRecords<'a> {
+    data: FontData<'a>,
+    start: u32,
+    record_size: u32,
+    format1_len: u32,
+    class1_count: u16,
+    class2_count: u16,
+    format1: ValueFormat,
+    format2: ValueFormat,
+}
+
+impl<'a> ClassValueRecords<'a> {
+    /// Number of classes in classDef1, including class 0.
+    #[inline]
+    pub fn class1_count(&self) -> u16 {
+        self.class1_count
+    }
+
+    /// Number of classes in classDef2, including class 0.
+    #[inline]
+    pub fn class2_count(&self) -> u16 {
+        self.class2_count
+    }
+
+    /// Returns the pair of value records for the given classes.
+    ///
+    /// Returns `None` if either class is out of range.
+    #[inline]
+    pub fn get(&self, class1: u16, class2: u16) -> Option<[ValueRecordRef<'a>; 2]> {
+        if class1 >= self.class1_count || class2 >= self.class2_count {
+            return None;
+        }
+        // Compute an offset into the 2D array of positioning records. Every
+        // term is bounded by a u16 count times a u16-derived stride, so this
+        // cannot overflow usize on any supported target.
+        let record_offset = self.start as usize
+            + class1 as usize * self.record_size as usize * self.class2_count as usize
+            + class2 as usize * self.record_size as usize;
+        Some([
+            ValueRecordRef::new(self.data, record_offset, self.format1),
+            ValueRecordRef::new(
+                self.data,
+                record_offset + self.format1_len as usize,
+                self.format2,
+            ),
+        ])
+    }
+}
+
+impl<'a> PairPosFormat2<'a> {
+    /// Returns the two-dimensional array of class value records, located but
+    /// not read.
+    pub fn class_value_records(&self) -> ClassValueRecords<'a> {
+        let format1 = self.value_format1();
+        let format2 = self.value_format2();
+        let format1_len = format1.record_byte_len();
+        ClassValueRecords {
+            data: self.offset_data(),
+            start: self.class1_records_byte_range().start as u32,
+            record_size: (format1_len + format2.record_byte_len()) as u32,
+            format1_len: format1_len as u32,
+            class1_count: self.class1_count(),
+            class2_count: self.class2_count(),
+            format1,
+            format2,
+        }
+    }
+
+    /// Returns the pair of value records for the given classes, located but
+    /// not read.
+    ///
+    /// Returns `None` if either class is out of range. When reading more than
+    /// one class pair, prefer [`class_value_records`][Self::class_value_records],
+    /// which reads the table's counts and formats only once.
+    #[inline]
+    pub fn value_record_refs(&self, class1: u16, class2: u16) -> Option<[ValueRecordRef<'a>; 2]> {
+        self.class_value_records().get(class1, class2)
+    }
+}
+
 impl PairPosFormat2<'_> {
     /// Returns the pair of values for the given classes, optionally accounting
     /// for variations.
@@ -207,6 +468,142 @@ mod tests {
                 assert_eq!(value_records, values);
             }
         }
+    }
+
+    /// The lazy accessors must locate exactly the records the generated
+    /// accessors read.
+    fn assert_same_record(lazy: ValueRecordRef, owned: &ValueRecord, data: FontData) {
+        assert_eq!(lazy.format(), owned.format);
+        assert_eq!(lazy.x_placement(), owned.x_placement());
+        assert_eq!(lazy.y_placement(), owned.y_placement());
+        assert_eq!(lazy.x_advance(), owned.x_advance());
+        assert_eq!(lazy.y_advance(), owned.y_advance());
+        // the resolved device tables aren't comparable, but they're determined
+        // by the raw offset and the data they resolve against, so compare those
+        // and check that the lazy record's base actually resolves.
+        for (field, lazy_device, owned_offset, owned_device) in [
+            (
+                ValueFormat::X_PLACEMENT_DEVICE,
+                lazy.x_placement_device(),
+                owned.x_placement_device,
+                owned.x_placement_device(data),
+            ),
+            (
+                ValueFormat::Y_PLACEMENT_DEVICE,
+                lazy.y_placement_device(),
+                owned.y_placement_device,
+                owned.y_placement_device(data),
+            ),
+            (
+                ValueFormat::X_ADVANCE_DEVICE,
+                lazy.x_advance_device(),
+                owned.x_advance_device,
+                owned.x_advance_device(data),
+            ),
+            (
+                ValueFormat::Y_ADVANCE_DEVICE,
+                lazy.y_advance_device(),
+                owned.y_advance_device,
+                owned.y_advance_device(data),
+            ),
+        ] {
+            let expected = lazy.format().contains(field).then_some(owned_offset.get());
+            assert_eq!(lazy.device_offset(field), expected, "{field:?}");
+            assert_eq!(lazy_device.is_some(), owned_device.is_some(), "{field:?}");
+            if let Some(resolved) = lazy_device {
+                assert!(resolved.is_ok(), "{field:?} failed to resolve");
+            }
+        }
+    }
+
+    #[test]
+    fn single_pos1_lazy_matches_generated() {
+        let data = FontData::new(font_test_data::gpos::SINGLEPOSFORMAT1);
+        let table = SinglePosFormat1::read(data).unwrap();
+        assert_same_record(table.value_record_ref(), &table.value_record(), data);
+    }
+
+    /// Exercises a record carrying device tables, whose offsets resolve against
+    /// the containing table rather than the record.
+    #[test]
+    fn single_pos1_lazy_matches_generated_with_devices() {
+        let data = FontData::new(font_test_data::gpos::VALUEFORMATTABLE);
+        let table = SinglePosFormat1::read(data).unwrap();
+        let lazy = table.value_record_ref();
+        assert!(lazy.format().intersects(ValueFormat::ANY_DEVICE_OR_VARIDX));
+        assert!(lazy.x_placement_device().is_some());
+        assert_same_record(lazy, &table.value_record(), data);
+    }
+
+    #[test]
+    fn single_pos2_lazy_matches_generated() {
+        let data = FontData::new(font_test_data::gpos::SINGLEPOSFORMAT2);
+        let table = SinglePosFormat2::read(data).unwrap();
+        let records = table.value_records();
+        assert!(!records.is_empty());
+        for i in 0..records.len() {
+            assert_same_record(
+                table.value_record_ref(i).unwrap(),
+                &records.get(i).unwrap(),
+                data,
+            );
+        }
+        assert!(table.value_record_ref(records.len()).is_none());
+    }
+
+    #[test]
+    fn pair_set_lazy_matches_generated() {
+        let data = FontData::new(font_test_data::gpos::PAIRPOSFORMAT1);
+        let table = PairPosFormat1::read(data).unwrap();
+        let mut seen = 0;
+        for set_offset in table.pair_set_offsets() {
+            let pair_set = set_offset
+                .get()
+                .resolve_with_args::<PairSet>(data, (table.value_format1(), table.value_format2()))
+                .unwrap();
+            let set_data = pair_set.offset_data();
+            let owned = pair_set.pair_value_records();
+            let lazy = pair_set.pair_value_record_refs();
+            assert_eq!(lazy.len(), owned.len());
+            assert!(!lazy.is_empty());
+            for (i, lazy_rec) in lazy.iter().enumerate() {
+                let owned_rec = owned.get(i).unwrap();
+                assert_eq!(lazy_rec.second_glyph(), owned_rec.second_glyph());
+                assert_same_record(lazy_rec.value_record1(), &owned_rec.value_record1, set_data);
+                assert_same_record(lazy_rec.value_record2(), &owned_rec.value_record2, set_data);
+
+                // and the binary search finds the same record
+                let found = lazy.find(owned_rec.second_glyph()).unwrap();
+                assert_eq!(found.second_glyph(), owned_rec.second_glyph());
+                seen += 1;
+            }
+            assert!(lazy.find(GlyphId16::new(0xFFFF)).is_none());
+        }
+        assert!(seen > 0);
+    }
+
+    #[test]
+    fn pair_pos2_lazy_matches_generated() {
+        let data = FontData::new(font_test_data::gpos::PAIRPOSFORMAT2);
+        let table = PairPosFormat2::read(data).unwrap();
+        let class1_count = table.class1_count();
+        let class2_count = table.class2_count();
+        let records = table.class1_records();
+        for class1 in 0..class1_count {
+            let class2_records = records
+                .get(class1 as usize)
+                .unwrap()
+                .class2_records()
+                .clone();
+            for class2 in 0..class2_count {
+                let owned = class2_records.get(class2 as usize).unwrap();
+                let [lazy1, lazy2] = table.value_record_refs(class1, class2).unwrap();
+                assert_same_record(lazy1, &owned.value_record1, data);
+                assert_same_record(lazy2, &owned.value_record2, data);
+            }
+        }
+        assert!(table.value_record_refs(class1_count, 0).is_none());
+        assert!(table.value_record_refs(0, class2_count).is_none());
     }
 
     #[test]

--- a/read-fonts/src/tables/value_record.rs
+++ b/read-fonts/src/tables/value_record.rs
@@ -143,6 +143,195 @@ impl Value {
     }
 }
 
+/// A GPOS ValueRecord, with fields read on demand.
+///
+/// The contents of a value record are described by a [`ValueFormat`] stored in
+/// the parent table, so a record cannot be located or interpreted on its own.
+/// This type stores the position of the record within its parent table's data
+/// alongside that format, and reads individual fields only when they are asked
+/// for; constructing one performs no reads at all.
+#[derive(Copy, Clone)]
+pub struct ValueRecordRef<'a> {
+    /// The offset data of the table *containing* the record.
+    data: FontData<'a>,
+    /// The position of the record within `data`.
+    offset: u32,
+    format: ValueFormat,
+}
+
+impl<'a> ValueRecordRef<'a> {
+    /// Creates a value record positioned at `offset` within `data`.
+    ///
+    /// `data` must be the offset data of the table containing the record, and
+    /// not merely the bytes of the record itself: the device and variation
+    /// index offsets in a value record are resolved relative to that table.
+    #[inline]
+    pub fn new(data: FontData<'a>, offset: usize, format: ValueFormat) -> Self {
+        Self {
+            data,
+            // an offset that doesn't fit is out of bounds by definition, and
+            // saturating here lets every subsequent read fail cleanly
+            offset: u32::try_from(offset).unwrap_or(u32::MAX),
+            format,
+        }
+    }
+
+    /// The format describing which fields this record contains.
+    #[inline]
+    pub fn format(&self) -> ValueFormat {
+        self.format
+    }
+
+    /// The number of bytes occupied by this record.
+    #[inline]
+    pub fn byte_len(&self) -> usize {
+        self.format.record_byte_len()
+    }
+
+    /// Returns `true` if this record contains no fields.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.format.is_empty()
+    }
+
+    /// The offset data of the table containing this record.
+    #[inline]
+    pub fn offset_data(&self) -> FontData<'a> {
+        self.data
+    }
+
+    /// The position of this record within [`offset_data`](Self::offset_data).
+    #[inline]
+    pub fn offset(&self) -> usize {
+        self.offset as usize
+    }
+
+    #[inline]
+    pub fn x_placement(&self) -> Option<i16> {
+        self.read_i16(ValueFormat::X_PLACEMENT)
+    }
+
+    #[inline]
+    pub fn y_placement(&self) -> Option<i16> {
+        self.read_i16(ValueFormat::Y_PLACEMENT)
+    }
+
+    #[inline]
+    pub fn x_advance(&self) -> Option<i16> {
+        self.read_i16(ValueFormat::X_ADVANCE)
+    }
+
+    #[inline]
+    pub fn y_advance(&self) -> Option<i16> {
+        self.read_i16(ValueFormat::Y_ADVANCE)
+    }
+
+    #[inline]
+    pub fn x_placement_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        self.read_device(ValueFormat::X_PLACEMENT_DEVICE)
+    }
+
+    #[inline]
+    pub fn y_placement_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        self.read_device(ValueFormat::Y_PLACEMENT_DEVICE)
+    }
+
+    #[inline]
+    pub fn x_advance_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        self.read_device(ValueFormat::X_ADVANCE_DEVICE)
+    }
+
+    #[inline]
+    pub fn y_advance_device(&self) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        self.read_device(ValueFormat::Y_ADVANCE_DEVICE)
+    }
+
+    /// Returns the raw, unresolved offset for the given device field.
+    ///
+    /// The returned offset is relative to [`offset_data`](Self::offset_data).
+    /// Returns `None` if the field is not present in this record's format, or
+    /// if the record is truncated.
+    #[inline]
+    pub fn device_offset(&self, field: ValueFormat) -> Option<Nullable<Offset16>> {
+        self.data.read_at(self.field_offset(field)?).ok()
+    }
+
+    /// The raw bytes of this record, or `None` if the data is truncated.
+    #[inline]
+    pub fn bytes(&self) -> Option<&'a [u8]> {
+        let start = self.offset as usize;
+        self.data
+            .as_bytes()
+            .get(start..start.checked_add(self.byte_len())?)
+    }
+
+    /// Returns the position of `field` within [`offset_data`](Self::offset_data),
+    /// or `None` if this record's format doesn't include it.
+    ///
+    /// Fields are laid out in the order of their format bits and each occupies
+    /// two bytes, so a field's position is fixed by the number of lower format
+    /// bits that are set.
+    #[inline]
+    fn field_offset(&self, field: ValueFormat) -> Option<usize> {
+        if !self.format.contains(field) {
+            return None;
+        }
+        let preceding = (self.format.bits() & (field.bits() - 1)).count_ones() as usize;
+        Some(self.offset as usize + preceding * u16::RAW_BYTE_LEN)
+    }
+
+    #[inline]
+    fn read_i16(&self, field: ValueFormat) -> Option<i16> {
+        self.data.read_at(self.field_offset(field)?).ok()
+    }
+
+    #[inline]
+    fn read_device(
+        &self,
+        field: ValueFormat,
+    ) -> Option<Result<DeviceOrVariationIndex<'a>, ReadError>> {
+        let pos = self.field_offset(field)?;
+        match self.data.read_at::<Nullable<Offset16>>(pos) {
+            Ok(offset) => offset.resolve(self.data),
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+/// Two records are equal when they describe the same positioning: same format,
+/// and the same bytes for the fields that format selects.
+impl PartialEq for ValueRecordRef<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.format == other.format && self.bytes() == other.bytes()
+    }
+}
+
+impl Eq for ValueRecordRef<'_> {}
+
+impl std::fmt::Debug for ValueRecordRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut f = f.debug_struct("ValueRecordRef");
+        self.x_placement().map(|x| f.field("x_placement", &x));
+        self.y_placement().map(|y| f.field("y_placement", &y));
+        self.x_advance().map(|x| f.field("x_advance", &x));
+        self.y_advance().map(|y| f.field("y_advance", &y));
+        for (name, field) in [
+            ("x_placement_device", ValueFormat::X_PLACEMENT_DEVICE),
+            ("y_placement_device", ValueFormat::Y_PLACEMENT_DEVICE),
+            ("x_advance_device", ValueFormat::X_ADVANCE_DEVICE),
+            ("y_advance_device", ValueFormat::Y_ADVANCE_DEVICE),
+        ] {
+            match self.device_offset(field) {
+                Some(offset) if !offset.is_null() => {
+                    f.field(name, &offset);
+                }
+                _ => (),
+            }
+        }
+        f.finish()
+    }
+}
+
 /// A Positioning ValueRecord.
 ///
 /// NOTE: we create these manually, since parsing is weird and depends on the
@@ -403,5 +592,59 @@ mod tests {
             | ValueFormat::X_PLACEMENT_DEVICE;
         assert_eq!(format, ValueFormat::ANY_DEVICE_OR_VARIDX);
         assert_eq!(format.record_byte_len(), 4 * 2);
+    }
+
+    /// The lazy reader locates fields with a popcount over the format bits;
+    /// the owned reader walks them in order with a cursor. They must agree for
+    /// every combination of format bits.
+    #[test]
+    fn lazy_fields_match_owned_for_every_format() {
+        // give every field slot a distinct, recognizable value
+        let bytes: Vec<u8> = (0..8u16).flat_map(|i| (0x1100 + i).to_be_bytes()).collect();
+        // pad the front so we exercise a non-zero record offset
+        const PAD: usize = 6;
+        let mut padded = vec![0u8; PAD];
+        padded.extend_from_slice(&bytes);
+        let data = FontData::new(&padded);
+
+        for bits in 0..=u8::MAX {
+            let format = ValueFormat { bits: bits as u16 };
+            let owned = ValueRecord::read(FontData::new(&bytes), format).unwrap();
+            let lazy = ValueRecordRef::new(data, PAD, format);
+
+            assert_eq!(lazy.format(), format);
+            assert_eq!(lazy.byte_len(), format.record_byte_len());
+            assert_eq!(lazy.x_placement(), owned.x_placement(), "{format:?}");
+            assert_eq!(lazy.y_placement(), owned.y_placement(), "{format:?}");
+            assert_eq!(lazy.x_advance(), owned.x_advance(), "{format:?}");
+            assert_eq!(lazy.y_advance(), owned.y_advance(), "{format:?}");
+
+            for (field, expected) in [
+                (ValueFormat::X_PLACEMENT_DEVICE, owned.x_placement_device),
+                (ValueFormat::Y_PLACEMENT_DEVICE, owned.y_placement_device),
+                (ValueFormat::X_ADVANCE_DEVICE, owned.x_advance_device),
+                (ValueFormat::Y_ADVANCE_DEVICE, owned.y_advance_device),
+            ] {
+                // the owned reader leaves absent device fields as null
+                let expected = format.contains(field).then_some(expected.get());
+                assert_eq!(lazy.device_offset(field), expected, "{format:?} {field:?}");
+            }
+        }
+    }
+
+    /// Reads past the end of the data must fail cleanly rather than panic or
+    /// read a neighbouring field.
+    #[test]
+    fn lazy_fields_out_of_bounds() {
+        let format = ValueFormat::X_PLACEMENT | ValueFormat::Y_ADVANCE;
+        // only enough room for the first of the two fields
+        let bytes = [0u8, 1, 0, 2];
+        let lazy = ValueRecordRef::new(FontData::new(&bytes), 2, format);
+        assert_eq!(lazy.x_placement(), Some(2));
+        assert_eq!(lazy.y_advance(), None);
+
+        // an offset that can't even be represented
+        let huge = ValueRecordRef::new(FontData::new(&bytes), usize::MAX, format);
+        assert_eq!(huge.x_placement(), None);
     }
 }


### PR DESCRIPTION
`ValueRecord` is an owned struct built eagerly from a cursor, so anything that walks value records pays for fields it never looks at. A subsetter scanning PairPosFormat2 builds two of them per class pair just to OR together a value format, and a PairSet binary search builds a full `PairValueRecord` at every probe to compare one glyph id.

Add `ValueRecordRef`, which stores the containing table's data, the record's offset within it, and its format. Constructing one performs no reads; fields are located by a popcount over the lower format bits, so a single field can be read without touching its neighbours.

The data is the containing table's rather than a slice at the record because the device and variation index offsets in a value record resolve relative to that table, so slicing to the record would lose the base.

Alongside it, add accessors that locate records without reading them: `SinglePosFormat1/2::value_record_ref`, `PairSet::pair_value_record_refs` (strided, with a `find` that binary searches on second glyph), and `PairPosFormat2::class_value_records`, which reads the class counts and formats once so callers walking many class pairs don't repeat that work.

Nothing here is wired into codegen and the existing `ValueRecord` is untouched, so this is additive. That is a deliberately temporary state: a follow-up will replace `ValueRecord` with this and update its users, at which point `Value` and `ValueContext` are expected to go away too. No conversion between the two is offered in the meantime.