### PR TITLE
[read-fonts] Keep StateTable::read working without a payload

### DIFF
--- a/read-fonts/src/tables/aat.rs
+++ b/read-fonts/src/tables/aat.rs
@@ -482,6 +482,21 @@ impl<'a, T> StateTable<'a, T> {
     }
 }
 
+impl<'a> StateTable<'a, NoPayload> {
+    /// Reads a state table whose entries carry no payload.
+    ///
+    /// This exists so that `StateTable::read(data)` still resolves without
+    /// naming the payload type: a type parameter's default does not apply in a
+    /// path expression, only in type position. Without it, adding the payload
+    /// parameter would have broken every existing caller.
+    ///
+    /// Remove this at the next breaking release, so that callers name the
+    /// payload as they do for `ExtendedStateTable`.
+    pub fn read(data: FontData<'a>) -> Result<Self, ReadError> {
+        <Self as FontRead<'a>>::read(data)
+    }
+}
+
 impl<T> ReadArgs for StateTable<'_, T> {
     type Args = ();
 }


### PR DESCRIPTION
Giving `StateTable` a payload parameter broke every caller of `StateTable::read(data)`: a type parameter's default applies in type position but not in a path expression, so the payload has to be named. That is a breaking change in a release that otherwise has none.

Add an inherent `read` on the no-payload instantiation. Inherent methods are preferred during resolution, so `StateTable::read(data)` matches it and pins the payload to `NoPayload`. Naming a payload still goes through `FontRead` as before.

This is a compatibility shim, not the intended shape; the comment says to drop it at the next breaking release, where callers can name the payload the way they already do for `ExtendedStateTable`.