### PR TITLE
Release read-fonts 0.43.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = "1.0"
 # that want default features will have to enable them directly.
 font-test-data = { path = "font-test-data" }
 font-types = { version = "0.12.4", path = "font-types" }
-read-fonts = { version = "0.43.2", path = "read-fonts", default-features = false }
+read-fonts = { version = "0.43.3", path = "read-fonts", default-features = false }
 # Disable default-features so that fauntlet can use skrifa without autohint
 # shaping support
 skrifa = { version = "0.46.2", path = "skrifa", default-features = false, features = ["std"] }

--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "read-fonts"
-version = "0.43.2"
+version = "0.43.3"
 description = "Reading OpenType font files."
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]


### PR DESCRIPTION
     Changes for read-fonts from read-fonts-v0.43.2 to 0.43.3
             a0c08f6 Merge pull request #2078 from googlefonts/state-table-read-compat
             b80d84b [read-fonts] Simplify `array::get_pair()`. (#2072)
             d844510 [read-fonts] Refactor gvar deltas (#2071)
             df7ba9d [read-fonts] Use FontRead for legacy state tables
             5d4fac6 [read-fonts] Add mort table support
             a7b2d9c [read-fonts] Generalize legacy AAT state-table entries
             76f415b [read-fonts] Move gvar delta computation out of skrifa (#2070)
             46204d2 [int_set] Streamline the insert path (#2068)