### PR TITLE
[read-fonts] Decode glyph coordinates through a slice iterator

### DIFF
--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -260,11 +260,12 @@ impl<'a> SimpleGlyph<'a> {
                 break;
             }
         }
-        // Both coordinate passes walk one iterator over the bytes the flags
-        // did not use. A cursor would bounds check, build a `Result` and
-        // advance a saturating offset for each of the up to four bytes a point
-        // takes; `next` is a pointer comparison, and the y pass simply carries
-        // on from where the x pass stopped.
+        // This used to use a `Cursor` but that implies saturating
+        // arithmetic, bounds checking and `Result` building for each byte
+        // read.
+        //
+        // A byte slice iterator is just a pointer comparison and is
+        // significantly faster.
         let coords = self
             .glyph_data()
             .get(read_flags_bytes..)

--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -260,19 +260,29 @@ impl<'a> SimpleGlyph<'a> {
                 break;
             }
         }
-        let mut cursor = FontData::new(self.glyph_data()).cursor();
-        cursor.advance_by(read_flags_bytes);
+        // Both coordinate passes walk one iterator over the bytes the flags
+        // did not use. A cursor would bounds check, build a `Result` and
+        // advance a saturating offset for each of the up to four bytes a point
+        // takes; `next` is a pointer comparison, and the y pass simply carries
+        // on from where the x pass stopped.
+        let coords = self
+            .glyph_data()
+            .get(read_flags_bytes..)
+            .ok_or(ReadError::OutOfBounds)?;
+        let mut bytes = coords.iter();
         let mut x = 0i32;
         for (&point_flags, point) in flags.iter().zip(points.as_mut()) {
             let mut delta = 0i32;
             let flag = SimpleGlyphFlags::from_bits_truncate(point_flags.0);
             if flag.contains(SimpleGlyphFlags::X_SHORT_VECTOR) {
-                delta = cursor.read::<u8>()? as i32;
+                delta = *bytes.next().ok_or(ReadError::OutOfBounds)? as i32;
                 if !flag.contains(SimpleGlyphFlags::X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR) {
                     delta = -delta;
                 }
             } else if !flag.contains(SimpleGlyphFlags::X_IS_SAME_OR_POSITIVE_X_SHORT_VECTOR) {
-                delta = cursor.read::<i16>()? as i32;
+                let hi = *bytes.next().ok_or(ReadError::OutOfBounds)?;
+                let lo = *bytes.next().ok_or(ReadError::OutOfBounds)?;
+                delta = i16::from_be_bytes([hi, lo]) as i32;
             }
             x = x.wrapping_add(delta);
             point.x = C::from_i32(x);
@@ -282,12 +292,14 @@ impl<'a> SimpleGlyph<'a> {
             let mut delta = 0i32;
             let flag = SimpleGlyphFlags::from_bits_truncate(point_flags.0);
             if flag.contains(SimpleGlyphFlags::Y_SHORT_VECTOR) {
-                delta = cursor.read::<u8>()? as i32;
+                delta = *bytes.next().ok_or(ReadError::OutOfBounds)? as i32;
                 if !flag.contains(SimpleGlyphFlags::Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR) {
                     delta = -delta;
                 }
             } else if !flag.contains(SimpleGlyphFlags::Y_IS_SAME_OR_POSITIVE_Y_SHORT_VECTOR) {
-                delta = cursor.read::<i16>()? as i32;
+                let hi = *bytes.next().ok_or(ReadError::OutOfBounds)?;
+                let lo = *bytes.next().ok_or(ReadError::OutOfBounds)?;
+                delta = i16::from_be_bytes([hi, lo]) as i32;
             }
             y = y.wrapping_add(delta);
             point.y = C::from_i32(y);


### PR DESCRIPTION
Profiling a glyph draw puts read_points_fast at 58% of loading, which is more than everything else in the loader put together.

Its two coordinate passes read through a cursor, so each of the up to four bytes a point takes costs a bounds check, a Result and a saturating add of the offset. Both passes now walk one iterator over the bytes the flags did not use: next is a pointer comparison, and the y pass carries on from where the x pass stopped rather than tracking an offset of its own.

Point decoding, and loading a whole glyph, both measured interleaved over three rounds at 16ppem:

                decode          load
    arial      -13.1%          -5.6%
    times      -11.8%          -8.4%
    calibri    -11.2%          -7.7%
    segoeui     -9.8%          -5.0%
    consola    -15.7%

Two other shapes were tried and were worse. Counting each axis's byte length during the flags pass, to size the coordinate slices exactly and bounds check once, costs more in the flags pass than it saves: 20% to 25% slower than the cursor it replaced. Reading whole i16s rather than byte pairs makes no difference either way.

Decoding is unchanged. Every glyph of 145 fonts draws to the same path as before, and skrifa's own tests pass untouched.