### PR TITLE
Remove vestigial traces of traversal

### DIFF
--- a/font-codegen/README.md
+++ b/font-codegen/README.md
@@ -224,10 +224,6 @@ The following annotations are supported on top-level objects:
 - `#[validate(arg)]`: arg is either the literal 'skip' or the name of a method.
   If the name of a method, that method will be called during validation, and can
   implement custom validation logic.
-- `#[traverse_with(method name)]`: uncommon/hacky: provides a method name that
-  will be called in traversal code to get the `FieldType` for this field.
-  To skip traversing this field, you can use the 'skip' keyword
-  (`#[traverse_with(skip)]`).
 - `#[to_owned(expr)]`: uncommon/hacky: provide an expression that will be used
   in `FromObjRef` to convert the parse type to the compile type.
 

--- a/font-codegen/src/parsing/attrs.rs
+++ b/font-codegen/src/parsing/attrs.rs
@@ -87,9 +87,6 @@ pub(crate) struct FieldAttrs {
     pub(crate) compile_type: Option<Attr<syn::Type>>,
     pub(crate) read_with_args: Option<Attr<FieldReadArgs>>,
     pub(crate) read_offset_args: Option<Attr<FieldReadArgs>>,
-    /// If present, a custom method that returns a FieldType for this field,
-    /// during traversal.
-    pub(crate) traverse_with: Option<Attr<syn::Ident>>,
     pub(crate) to_owned: Option<Attr<InlineExpr>>,
     /// Custom validation behaviour
     pub(crate) validate: Option<Attr<FieldValidation>>,
@@ -273,7 +270,6 @@ static COMPILE_TYPE: &str = "compile_type";
 static DEFAULT: &str = "default";
 static READ_WITH: &str = "read_with";
 static READ_OFFSET_WITH: &str = "read_offset_with";
-static TRAVERSE_WITH: &str = "traverse_with";
 static TO_OWNED: &str = "to_owned";
 static VALIDATE: &str = "validate";
 static DISCRIMINANT: &str = "discriminant";
@@ -341,8 +337,6 @@ impl Parse for FieldAttrs {
                 this.read_with_args = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == READ_OFFSET_WITH {
                 this.read_offset_args = Some(Attr::new(ident.clone(), attr.parse_args()?));
-            } else if ident == TRAVERSE_WITH {
-                this.traverse_with = Some(Attr::new(ident.clone(), attr.parse_args()?));
             } else if ident == FORMAT {
                 this.format = Some(Attr::new(ident.clone(), parse_attr_eq_value(&attr)?))
             } else if ident == DISCRIMINANT {

--- a/resources/codegen_inputs/cvar.rs
+++ b/resources/codegen_inputs/cvar.rs
@@ -16,15 +16,12 @@ table Cvar {
     /// number of tuple variation tables can be any number between 1
     /// and 4095.
     #[compile(skip)]
-    #[traverse_with(skip)]
     tuple_variation_count: TupleVariationCount,
     /// Offset from the start of the 'cvar' table to the serialized data.
-    #[traverse_with(skip)]
     #[compile(skip)]
     data_offset: Offset16<FontData>,
     /// Array of tuple variation headers.
     #[count(..)]
     #[compile_type(CvarVariationData)]
-    #[traverse_with(skip)]
     tuple_variation_headers: VarLenArray<TupleVariationHeader<'_>>,
 }

--- a/resources/codegen_inputs/gvar.rs
+++ b/resources/codegen_inputs/gvar.rs
@@ -41,7 +41,6 @@ table Gvar {
     /// GlyphVariationData table.
     #[count(add($glyph_count, 1))]
     #[read_with($flags)]
-    #[traverse_with(skip)]
     #[compile_with(compile_variation_data)]
     #[compile_type(Vec<GlyphVariationData>)]
     glyph_variation_data_offsets: ComputedArray<U16Or32>,
@@ -69,16 +68,13 @@ table GlyphVariationDataHeader {
     /// are the number of tuple variation tables for this glyph. The
     /// number of tuple variation tables can be any number between 1
     /// and 4095.
-    #[traverse_with(skip)]
     tuple_variation_count: TupleVariationCount,
     /// Offset from the start of the GlyphVariationData table to the
     /// serialized data
-    #[traverse_with(skip)]
     #[compile(skip)]
     serialized_data_offset: Offset16<FontData>,
     /// Array of tuple variation headers.
     #[count(..)]
-    #[traverse_with(skip)]
     tuple_variation_headers: VarLenArray<TupleVariationHeader<'_>>,
 }
 

--- a/resources/codegen_inputs/ift.rs
+++ b/resources/codegen_inputs/ift.rs
@@ -28,7 +28,6 @@ table IftPatchMap {
   field_flags: PatchMapFieldPresenceFlags,
 
   /// Unique ID that identifies compatible patches.
-  #[traverse_with(skip)]
   compatibility_id: CompatibilityId,
 
   /// Patch format number for patches referenced by this mapping.
@@ -78,7 +77,6 @@ table EntryData {
 
   // CHILD_INDICES
   #[if_flag($format_flags, EntryFormatFlags::CHILD_INDICES)]
-  #[traverse_with(skip)]
   #[compile(skip)] // TODO remove this once write fonts side is implemented.]
   match_mode_and_count: MatchModeAndCount,
   #[if_flag($format_flags, EntryFormatFlags::CHILD_INDICES)]
@@ -143,7 +141,6 @@ table TableKeyedPatch {
   _reserved: u32,
 
   /// Unique ID that identifies compatible patches.
-  #[traverse_with(skip)]
   compatibility_id: CompatibilityId,
 
   patches_count: u16,
@@ -173,7 +170,6 @@ table GlyphKeyedPatch {
   #[compile(0)]
   _reserved: u32,
   flags: GlyphKeyedFlags,
-  #[traverse_with(skip)]
   compatibility_id: CompatibilityId,
   max_uncompressed_length: u32,
   #[count(..)]
@@ -193,7 +189,6 @@ table GlyphPatches {
 
   #[count($glyph_count)]
   #[read_with($flags)]
-  #[traverse_with(skip)]
   #[compile(skip)] // TODO remove this once write fonts side is implemented.
   glyph_ids: ComputedArray<U16Or24>,
 

--- a/resources/codegen_inputs/layout.rs
+++ b/resources/codegen_inputs/layout.rs
@@ -119,7 +119,6 @@ table Lookup {
     #[discriminant]
     lookup_type: u16,
     /// Lookup qualifiers
-    #[traverse_with(traverse_lookup_flag)]
     lookup_flag: LookupFlag,
     /// Number of subtables for this lookup
     #[compile(array_len($subtable_offsets))]

--- a/resources/codegen_inputs/meta.rs
+++ b/resources/codegen_inputs/meta.rs
@@ -28,7 +28,6 @@ record DataMapRecord {
     tag: Tag,
     /// Offset in bytes from the beginning of the metadata table to the data for this tag.
     #[read_offset_with($tag, $data_length)]
-    #[traverse_with(skip)]
     #[validate(validate_data_type)]
     data_offset: Offset32<Metadata>,
     /// Length of the data, in bytes. The data is not required to be padded to any byte boundary.

--- a/resources/codegen_inputs/name.rs
+++ b/resources/codegen_inputs/name.rs
@@ -39,7 +39,6 @@ record LangTagRecord {
     /// Language-tag string offset from start of storage area (in
     /// bytes).
     #[offset_getter(lang_tag)]
-    #[traverse_with(traverse_lang_tag)]
     #[compile_type(OffsetMarker<String>)]
     #[compile_with(compile_name_string)]
     #[validate(skip)]
@@ -60,7 +59,6 @@ record NameRecord {
     #[compile(skip)]
     length: u16,
     /// String offset from start of storage area (in bytes).
-    #[traverse_with(traverse_string)]
     #[offset_getter(string)]
     #[compile_type(OffsetMarker<String>)]
     #[compile_with(compile_name_string)]

--- a/resources/codegen_inputs/post.rs
+++ b/resources/codegen_inputs/post.rs
@@ -53,6 +53,5 @@ table Post {
     #[count(..)]
     #[validate(skip)]
     #[since_version(2.0)]
-    #[traverse_with(traverse_string_data)]
     string_data: VarLenArray<PString<'a>>,
 }

--- a/resources/codegen_inputs/test_offsets_arrays.rs
+++ b/resources/codegen_inputs/test_offsets_arrays.rs
@@ -95,7 +95,6 @@ table KindsOfArrays {
 table VarLenHaver {
     count: u16,
     #[count($count)]
-    #[traverse_with(skip)]
     var_len: VarLenArray<VarSizeDummy<'_>>,
     other_field: u32,
 }

--- a/resources/codegen_inputs/variations.rs
+++ b/resources/codegen_inputs/variations.rs
@@ -11,7 +11,6 @@ table TupleVariationHeader {
     variation_data_size: u16,
     /// A packed field. The high 4 bits are flags (see below). The low
     /// 12 bits are an index into a shared tuple records array.
-    #[traverse_with(traverse_tuple_index)]
     tuple_index: TupleIndex,
     /// Peak tuple record for this tuple variation table — optional,
     /// determined by flags in the tupleIndex value.  Note that this

--- a/resources/scripts/println_ignore.txt
+++ b/resources/scripts/println_ignore.txt
@@ -1,8 +1,6 @@
 font-codegen/src/bin/preprocessor.rs
 incremental-font-transfer/src/bin/ift_extend.rs
 incremental-font-transfer/src/bin/ift_graph.rs
-otexplorer/src/main.rs
-otexplorer/src/query.rs
 read-fonts/build.rs
 shared-brotli-patch-decoder/build.rs
 skera/src/main.rs


### PR DESCRIPTION
The otexplorer println checks, the traverse_with codegen attribute and the parsing functionality for it.