### PR TITLE
[read-fonts] ps: clean up pass on error reporting

### DIFF
--- a/incremental-font-transfer/src/glyph_keyed.rs
+++ b/incremental-font-transfer/src/glyph_keyed.rs
@@ -1006,8 +1006,8 @@ impl GlyphDataOffsetArray for CFFAndCharStrings<'_> {
     fn offset_for(&self, gid: GlyphId) -> Result<u32, PatchingError> {
         self.charstrings
             .get_offset(gid.to_u32() as usize)
-            .map_err(|_| PatchingError::FontParsingFailed(ReadError::OutOfBounds))
             .map(|offset| offset as u32)
+            .ok_or(PatchingError::FontParsingFailed(ReadError::OutOfBounds))
     }
 
     fn all_offsets_are_ascending(&self) -> bool {

--- a/read-fonts/src/ps/cff/blend.rs
+++ b/read-fonts/src/ps/cff/blend.rs
@@ -95,7 +95,7 @@ impl<'a> BlendState<'a> {
         let variation_data = store.item_variation_data();
         let data = variation_data
             .get(self.store_index as usize)
-            .ok_or(Error::InvalidVariationStoreIndex(self.store_index))??;
+            .ok_or(Error::InvalidVariationStoreIndex)??;
         let region_indices = data.region_indexes();
         let regions = self.store.variation_region_list()?.variation_regions();
         // Precompute scalars for all regions up to MAX_PRECOMPUTED_SCALARS
@@ -120,7 +120,7 @@ impl<'a> BlendState<'a> {
             .variation_region_list()?
             .variation_regions()
             .get(index as usize)
-            .map_err(Error::Read)?
+            .map_err(|_| Error::Malformed)?
             .compute_scalar(self.coords))
     }
 }

--- a/read-fonts/src/ps/cff/charset.rs
+++ b/read-fonts/src/ps/cff/charset.rs
@@ -1,7 +1,7 @@
 //! CFF charset support.
 
 use crate::ps::string::Sid;
-use crate::{FontData, FontRead, GlyphId, ReadError};
+use crate::{FontData, FontRead, GlyphId};
 
 #[doc(inline)]
 pub use super::v1::{
@@ -19,23 +19,17 @@ pub struct Charset<'a> {
 }
 
 impl<'a> Charset<'a> {
-    pub fn new(
-        cff_data: FontData<'a>,
-        charset_offset: usize,
-        num_glyphs: u32,
-    ) -> Result<Self, ReadError> {
+    pub fn new(cff_data: FontData<'a>, charset_offset: usize, num_glyphs: u32) -> Option<Self> {
         let kind = match charset_offset {
             0 => CharsetKind::IsoAdobe,
             1 => CharsetKind::Expert,
             2 => CharsetKind::ExpertSubset,
             _ => {
-                let data = cff_data
-                    .split_off(charset_offset)
-                    .ok_or(ReadError::OutOfBounds)?;
-                CharsetKind::Custom(CustomCharset::read(data)?)
+                let data = cff_data.split_off(charset_offset)?;
+                CharsetKind::Custom(CustomCharset::read(data).ok()?)
             }
         };
-        Ok(Self { kind, num_glyphs })
+        Some(Self { kind, num_glyphs })
     }
 
     pub fn kind(&self) -> &CharsetKind<'a> {
@@ -47,10 +41,10 @@ impl<'a> Charset<'a> {
     }
 
     /// Returns the string identifier for the given glyph identifier.
-    pub fn string_id(&self, glyph_id: GlyphId) -> Result<Sid, ReadError> {
+    pub fn string_id(&self, glyph_id: GlyphId) -> Option<Sid> {
         let gid = glyph_id.to_u32();
         if gid >= self.num_glyphs {
-            return Err(ReadError::OutOfBounds);
+            return None;
         }
         match &self.kind {
             CharsetKind::IsoAdobe => {
@@ -58,20 +52,15 @@ impl<'a> Charset<'a> {
                 // to 228 entries
                 // <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=45>
                 if gid <= 228 {
-                    Ok(Sid::new(gid as u16))
+                    Some(Sid::new(gid as u16))
                 } else {
-                    Err(ReadError::OutOfBounds)
+                    None
                 }
             }
-            CharsetKind::Expert => EXPERT_CHARSET
-                .get(gid as usize)
-                .copied()
-                .ok_or(ReadError::OutOfBounds)
-                .map(Sid::new),
+            CharsetKind::Expert => EXPERT_CHARSET.get(gid as usize).copied().map(Sid::new),
             CharsetKind::ExpertSubset => EXPERT_SUBSET_CHARSET
                 .get(gid as usize)
                 .copied()
-                .ok_or(ReadError::OutOfBounds)
                 .map(Sid::new),
             CharsetKind::Custom(custom) => match custom {
                 CustomCharset::Format0(fmt) => fmt.string_id(glyph_id),
@@ -82,7 +71,7 @@ impl<'a> Charset<'a> {
     }
 
     /// Returns the glyph identifier for the given string identifier.
-    pub fn glyph_id(&self, string_id: Sid) -> Result<GlyphId, ReadError> {
+    pub fn glyph_id(&self, string_id: Sid) -> Option<GlyphId> {
         let sid = string_id.to_u16();
         match &self.kind {
             CharsetKind::IsoAdobe => {
@@ -90,21 +79,19 @@ impl<'a> Charset<'a> {
                 // to 228 entries
                 // <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=45>
                 if sid <= 228 {
-                    Ok(GlyphId::from(sid))
+                    Some(GlyphId::from(sid))
                 } else {
-                    Err(ReadError::OutOfBounds)
+                    None
                 }
             }
             CharsetKind::Expert => EXPERT_CHARSET
                 .iter()
                 .position(|n| *n == sid)
-                .map(|pos| GlyphId::new(pos as u32))
-                .ok_or(ReadError::OutOfBounds),
+                .map(|pos| GlyphId::new(pos as u32)),
             CharsetKind::ExpertSubset => EXPERT_SUBSET_CHARSET
                 .iter()
                 .position(|n| *n == sid)
-                .map(|pos| GlyphId::new(pos as u32))
-                .ok_or(ReadError::OutOfBounds),
+                .map(|pos| GlyphId::new(pos as u32)),
             CharsetKind::Custom(custom) => match custom {
                 CustomCharset::Format0(fmt) => fmt.glyph_id(string_id),
                 CustomCharset::Format1(fmt) => fmt.glyph_id(string_id),
@@ -143,59 +130,52 @@ pub enum CharsetKind<'a> {
 }
 
 impl Format0<'_> {
-    fn string_id(&self, glyph_id: GlyphId) -> Result<Sid, ReadError> {
+    fn string_id(&self, glyph_id: GlyphId) -> Option<Sid> {
         let gid = glyph_id.to_u32() as usize;
         if gid == 0 {
-            Ok(Sid::new(0))
+            Some(Sid::new(0))
         } else {
-            self.glyph()
-                .get(gid - 1)
-                .map(|id| Sid::new(id.get()))
-                .ok_or(ReadError::OutOfBounds)
+            self.glyph().get(gid - 1).map(|id| Sid::new(id.get()))
         }
     }
 
-    fn glyph_id(&self, string_id: Sid) -> Result<GlyphId, ReadError> {
+    fn glyph_id(&self, string_id: Sid) -> Option<GlyphId> {
         if string_id.to_u16() == 0 {
-            return Ok(GlyphId::NOTDEF);
+            return Some(GlyphId::NOTDEF);
         }
         self.glyph()
             .iter()
             .position(|n| n.get() == string_id.to_u16())
             .map(|n| GlyphId::from((n as u16).saturating_add(1)))
-            .ok_or(ReadError::OutOfBounds)
     }
 }
 
 impl Format1<'_> {
-    fn string_id(&self, glyph_id: GlyphId) -> Result<Sid, ReadError> {
+    fn string_id(&self, glyph_id: GlyphId) -> Option<Sid> {
         string_id_from_ranges(self.ranges(), glyph_id)
     }
 
-    fn glyph_id(&self, string_id: Sid) -> Result<GlyphId, ReadError> {
+    fn glyph_id(&self, string_id: Sid) -> Option<GlyphId> {
         glyph_id_from_ranges(self.ranges(), string_id)
     }
 }
 
 impl Format2<'_> {
-    fn string_id(&self, glyph_id: GlyphId) -> Result<Sid, ReadError> {
+    fn string_id(&self, glyph_id: GlyphId) -> Option<Sid> {
         string_id_from_ranges(self.ranges(), glyph_id)
     }
 
-    fn glyph_id(&self, string_id: Sid) -> Result<GlyphId, ReadError> {
+    fn glyph_id(&self, string_id: Sid) -> Option<GlyphId> {
         glyph_id_from_ranges(self.ranges(), string_id)
     }
 }
 
-fn string_id_from_ranges<T: CharsetRange>(
-    ranges: &[T],
-    glyph_id: GlyphId,
-) -> Result<Sid, ReadError> {
+fn string_id_from_ranges<T: CharsetRange>(ranges: &[T], glyph_id: GlyphId) -> Option<Sid> {
     let mut gid = glyph_id.to_u32();
     // The notdef glyph isn't explicitly mapped so we need to special case
     // it and add -1 and +1 at a few places when processing ranges
     if gid == 0 {
-        return Ok(Sid::new(0));
+        return Some(Sid::new(0));
     }
     gid -= 1;
     let mut end = 0u32;
@@ -207,44 +187,38 @@ fn string_id_from_ranges<T: CharsetRange>(
         let next_end = range
             .n_left()
             .checked_add(1)
-            .and_then(|span| end.checked_add(span))
-            .ok_or(ReadError::OutOfBounds)?;
+            .and_then(|span| end.checked_add(span))?;
         if gid < next_end {
             return (gid - end)
                 .checked_add(range.first())
                 .and_then(|sid| sid.try_into().ok())
-                .ok_or(ReadError::OutOfBounds)
                 .map(Sid::new);
         }
         end = next_end;
     }
-    Err(ReadError::OutOfBounds)
+    None
 }
 
-fn glyph_id_from_ranges<T: CharsetRange>(
-    ranges: &[T],
-    string_id: Sid,
-) -> Result<GlyphId, ReadError> {
+fn glyph_id_from_ranges<T: CharsetRange>(ranges: &[T], string_id: Sid) -> Option<GlyphId> {
     let sid = string_id.to_u16() as u32;
     // notdef glyph is not explicitly mapped
     if sid == 0 {
-        return Ok(GlyphId::NOTDEF);
+        return Some(GlyphId::NOTDEF);
     }
     let mut gid = 1u32;
     for range in ranges {
         let first = range.first();
         let n_left = range.n_left();
-        let last = first.checked_add(n_left).ok_or(ReadError::OutOfBounds)?;
+        let last = first.checked_add(n_left)?;
         if first <= sid && sid <= last {
-            gid = gid.checked_add(sid - first).ok_or(ReadError::OutOfBounds)?;
-            return Ok(GlyphId::new(gid));
+            gid = gid.checked_add(sid - first)?;
+            return Some(GlyphId::new(gid));
         }
         gid = n_left
             .checked_add(1)
-            .and_then(|span| gid.checked_add(span))
-            .ok_or(ReadError::OutOfBounds)?;
+            .and_then(|span| gid.checked_add(span))?;
     }
-    Err(ReadError::OutOfBounds)
+    None
 }
 
 /// Trait that unifies ranges for formats 1 and 2 so that we can implement
@@ -285,7 +259,7 @@ impl Iterator for Iter<'_> {
         match &mut self.0 {
             IterKind::Simple(charset, cur) => {
                 let gid = GlyphId::new(*cur);
-                let sid = charset.string_id(gid).ok()?;
+                let sid = charset.string_id(gid)?;
                 *cur = cur.checked_add(1)?;
                 Some((gid, sid))
             }
@@ -472,7 +446,7 @@ mod tests {
         }
         // Don't map glyphs beyond num_glyphs
         for gid in num_glyphs..u16::MAX as u32 {
-            assert_eq!(charset.string_id(GlyphId::new(gid)).ok(), None);
+            assert_eq!(charset.string_id(GlyphId::new(gid)), None);
         }
     }
 
@@ -501,7 +475,7 @@ mod tests {
         assert_eq!(charset.iter().count() as u32, num_glyphs);
         // Test out of bounds glyphs
         for gid in num_glyphs..u16::MAX as u32 {
-            assert_eq!(charset.string_id(GlyphId::new(gid)).ok(), None);
+            assert_eq!(charset.string_id(GlyphId::new(gid)), None);
         }
     }
 
@@ -558,13 +532,13 @@ mod tests {
         assert_eq!(charset.iter().count() as u32, num_glyphs);
         // Test out of bounds glyphs
         for gid in num_glyphs..u16::MAX as u32 {
-            assert_eq!(charset.string_id(GlyphId::new(gid)).ok(), None);
+            assert_eq!(charset.string_id(GlyphId::new(gid)), None);
         }
         // Test reverse mapping
         for (gid, sid) in expected_sids.iter().enumerate() {
             assert_eq!(
                 charset.glyph_id(Sid::new(*sid as u16)),
-                Ok(GlyphId::new(gid as u32))
+                Some(GlyphId::new(gid as u32))
             );
         }
     }
@@ -576,10 +550,7 @@ mod tests {
             first: 42,
             n_left: u32::MAX,
         }];
-        assert_eq!(
-            string_id_from_ranges(&ranges, GlyphId::new(1)),
-            Err(ReadError::OutOfBounds)
-        );
+        assert_eq!(string_id_from_ranges(&ranges, GlyphId::new(1)), None);
     }
 
     #[test]
@@ -595,10 +566,7 @@ mod tests {
                 n_left: u32::MAX - 2,
             },
         ];
-        assert_eq!(
-            glyph_id_from_ranges(&ranges, Sid::new(1)),
-            Err(ReadError::OutOfBounds)
-        );
+        assert_eq!(glyph_id_from_ranges(&ranges, Sid::new(1)), None);
     }
 
     #[test]

--- a/read-fonts/src/ps/cff/dict.rs
+++ b/read-fonts/src/ps/cff/dict.rs
@@ -13,7 +13,7 @@ use crate::{
         transform::ScaledFontMatrix,
     },
     types::Fixed,
-    Cursor, ReadError,
+    Cursor,
 };
 use std::ops::Range;
 
@@ -161,6 +161,19 @@ impl Operator {
 pub enum Token {
     /// An operator parsed from a DICT.
     Operator(Operator),
+    /// An opcode that is not a known operator.
+    ///
+    /// Reported rather than refused: a DICT containing one is still a DICT,
+    /// and what to do about it is the caller's decision. FreeType ignores
+    /// unknown operators and clears the stack, which is what
+    /// [`entries`] does; refusing here would leave a caller no way to do the
+    /// same through the raw view.
+    InvalidOperator(u8),
+    /// As [`InvalidOperator`][Self::InvalidOperator], for the two-byte form.
+    ///
+    /// Carries the extended opcode only; the byte before it is always the
+    /// escape.
+    InvalidTwoByteOperator(u8),
     /// A number parsed from a DICT. If the source was in
     /// binary coded decimal format, then the second field
     /// contains the parsed components.
@@ -204,7 +217,10 @@ fn parse_token(cursor: &mut Cursor) -> Result<Token, Error> {
     let b0 = cursor.read::<u8>()?;
     Ok(if b0 == ESCAPE {
         let b1 = cursor.read::<u8>()?;
-        Token::Operator(Operator::from_extended_opcode(b1).ok_or(Error::InvalidDictOperator(b1))?)
+        match Operator::from_extended_opcode(b1) {
+            Some(op) => Token::Operator(op),
+            None => Token::InvalidTwoByteOperator(b1),
+        }
     } else {
         // See <https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#table-3-operand-encoding>
         match b0 {
@@ -213,7 +229,10 @@ fn parse_token(cursor: &mut Cursor) -> Result<Token, Error> {
                 let components = BcdComponents::parse(cursor)?;
                 Token::Operand(components.value(false).into(), Some(components))
             }
-            _ => Token::Operator(Operator::from_opcode(b0).ok_or(Error::InvalidDictOperator(b0))?),
+            _ => match Operator::from_opcode(b0) {
+                Some(op) => Token::Operator(op),
+                None => Token::InvalidOperator(b0),
+            },
         }
     })
 }
@@ -429,7 +448,7 @@ fn parse_entry(op: Operator, stack: &mut Stack) -> Result<Entry, Error> {
         PrivateDictRange => {
             let len = stack.get_i32(0)? as usize;
             let start = stack.get_i32(1)? as usize;
-            let end = start.checked_add(len).ok_or(ReadError::OutOfBounds)?;
+            let end = start.checked_add(len).ok_or(Error::Malformed)?;
             Entry::PrivateDictRange(start..end)
         }
         VariationStoreOffset => Entry::VariationStoreOffset(stack.pop_i32()? as usize),
@@ -513,6 +532,31 @@ mod tests {
         TableProvider,
     };
     use font_test_data::bebuffer::BeBuffer;
+
+    /// An unknown operator is a token, not the end of the iteration.
+    ///
+    /// This is the whole point of reporting it that way: `entries` skips
+    /// unknown operators and clears the stack, as FreeType does, and a caller
+    /// working from the raw view has to be able to do the same. Refusing here
+    /// would end the walk at the first buggy font.
+    #[test]
+    fn unknown_operators_are_tokens() {
+        // a single byte operand encodes `b0 - 139`; 25 is not a one byte
+        // operator and 12/77 is not a two byte one
+        let dict = [139u8, 25, 139, 12, 77, 139, 17];
+        let tokens: Vec<_> = tokens(&dict).map(|tok| tok.unwrap()).collect();
+        assert_eq!(
+            &tokens,
+            &[
+                0.into(),
+                Token::InvalidOperator(25),
+                0.into(),
+                Token::InvalidTwoByteOperator(77),
+                0.into(),
+                Operator::CharstringsOffset.into(),
+            ]
+        );
+    }
 
     #[test]
     fn example_top_dict_tokens() {

--- a/read-fonts/src/ps/cff/encoding.rs
+++ b/read-fonts/src/ps/cff/encoding.rs
@@ -8,7 +8,7 @@
 use super::charset::Charset;
 use crate::{
     ps::{encoding::PredefinedEncoding, string::Sid},
-    FontData, GlyphId, ReadError,
+    FontData, GlyphId,
 };
 
 #[doc(inline)]
@@ -28,19 +28,18 @@ impl<'a> Encoding<'a> {
     ///
     /// Special offsets 0 and 1 are parsed as the predefined standard and
     /// expert encodings, respectively.
-    pub fn new(data: &'a [u8], offset: usize) -> Result<Self, ReadError> {
+    pub fn new(data: &'a [u8], offset: usize) -> Option<Self> {
         match offset {
-            0 => Ok(Self::Predefined(PredefinedEncoding::Standard)),
-            1 => Ok(Self::Predefined(PredefinedEncoding::Expert)),
-            _ => CustomEncoding::new(data.get(offset..).ok_or(ReadError::OutOfBounds)?)
-                .map(Self::Custom),
+            0 => Some(Self::Predefined(PredefinedEncoding::Standard)),
+            1 => Some(Self::Predefined(PredefinedEncoding::Expert)),
+            _ => CustomEncoding::new(data.get(offset..)?).map(Self::Custom),
         }
     }
 
     /// Maps a character code to a glyph identifier.
     pub fn map(&self, charset: &Charset, code: u8) -> Option<GlyphId> {
         match self {
-            Self::Predefined(predefined) => charset.glyph_id(predefined.sid(code)?).ok(),
+            Self::Predefined(predefined) => charset.glyph_id(predefined.sid(code)?),
             Self::Custom(custom) => custom.map(charset, code),
         }
     }
@@ -58,16 +57,16 @@ pub enum CustomEncoding<'a> {
 
 impl<'a> CustomEncoding<'a> {
     /// Parses a custom encoding from the given data.
-    pub fn new(data: &'a [u8]) -> Result<Self, ReadError> {
+    pub fn new(data: &'a [u8]) -> Option<Self> {
         let mut cursor = FontData::new(data).cursor();
-        let header = cursor.read::<u8>()?;
+        let header = cursor.read::<u8>().ok()?;
         let has_supplement = header & 0x80 != 0;
         // Macro because a closure cannot borrow cursor mutably
         macro_rules! read_supplement {
             () => {
                 if has_supplement {
-                    let count = cursor.read::<u8>()?;
-                    cursor.read_array::<Supplement>(count as usize)?
+                    let count = cursor.read::<u8>().ok()?;
+                    cursor.read_array::<Supplement>(count as usize).ok()?
                 } else {
                     &[]
                 }
@@ -76,18 +75,19 @@ impl<'a> CustomEncoding<'a> {
         let format = header & 0x7F;
         match format {
             0 => {
-                let n_codes = cursor.read::<u8>()?;
-                let codes = cursor.read_array(n_codes as usize)?;
+                let n_codes = cursor.read::<u8>().ok()?;
+                let codes = cursor.read_array(n_codes as usize).ok()?;
                 let supp = read_supplement!();
-                Ok(Self::Format0(codes, supp))
+                Some(Self::Format0(codes, supp))
             }
             1 => {
-                let n_ranges = cursor.read::<u8>()?;
-                let ranges = cursor.read_array(n_ranges as usize)?;
+                let n_ranges = cursor.read::<u8>().ok()?;
+                let ranges = cursor.read_array(n_ranges as usize).ok()?;
                 let supp = read_supplement!();
-                Ok(Self::Format1(ranges, supp))
+                Some(Self::Format1(ranges, supp))
             }
-            _ => Err(ReadError::InvalidFormat(format as _)),
+            // the spec allows only 0 and 1
+            _ => None,
         }
     }
 
@@ -96,7 +96,7 @@ impl<'a> CustomEncoding<'a> {
         let read_sup = |sup: &[Supplement]| {
             sup.iter()
                 .find(|s| s.code == code)
-                .and_then(|s| charset.glyph_id(Sid::new(s.glyph.get())).ok())
+                .and_then(|s| charset.glyph_id(Sid::new(s.glyph.get())))
         };
         match self {
             Self::Format0(codes, sup) => read_sup(sup).or_else(|| {

--- a/read-fonts/src/ps/cff/font.rs
+++ b/read-fonts/src/ps/cff/font.rs
@@ -15,7 +15,7 @@ use crate::{
         transform::{self, ScaledFontMatrix, Transform},
     },
     tables::{cff, cff2, variations::ItemVariationStore},
-    FontData, FontRead, ReadError,
+    FontData, FontRead,
 };
 use core::ops::Range;
 use types::{BoundingBox, F2Dot14, Fixed, GlyphId};
@@ -47,7 +47,8 @@ impl<'a> CffFontRef<'a> {
         match version {
             1 => Self::new_cff(data, top_dict_index, upem),
             2 => Self::new_cff2(data, upem),
-            _ => Err(Error::InvalidFontFormat),
+            // the first byte says neither 1 nor 2
+            _ => Err(Error::Malformed),
         }
     }
 
@@ -57,10 +58,11 @@ impl<'a> CffFontRef<'a> {
     /// from the `head` table. Otherwise, 1000 will be assumed.
     pub fn new_cff(data: &'a [u8], top_dict_index: u32, upem: Option<i32>) -> Result<Self, Error> {
         let cff = cff::Cff::read(data.into())?;
-        let top_dict_data = cff.top_dicts().get(top_dict_index as usize)?;
-        let top_dict_index: u16 = top_dict_index
-            .try_into()
-            .map_err(|_| ReadError::OutOfBounds)?;
+        let top_dict_data = cff
+            .top_dicts()
+            .get(top_dict_index as usize)
+            .ok_or(Error::Malformed)?;
+        let top_dict_index: u16 = top_dict_index.try_into().map_err(|_| Error::Malformed)?;
         Self::new_impl(
             data,
             false,
@@ -161,7 +163,7 @@ impl<'a> CffFontRef<'a> {
     pub fn string(&self, sid: Sid) -> Option<&'a [u8]> {
         match sid.resolve_standard() {
             Ok(s) => Some(s),
-            Err(idx) => self.strings()?.get(idx).ok(),
+            Err(idx) => self.strings()?.get(idx),
         }
     }
 
@@ -175,13 +177,12 @@ impl<'a> CffFontRef<'a> {
             self.top_dict.charset_offset.get()?,
             self.top_dict.charstrings.count(),
         )
-        .ok()
     }
 
     /// Returns the mapping from character codes to glyph identifiers.
     pub fn encoding(&self) -> Option<Encoding<'a>> {
         let charset = self.charset()?;
-        let encoding = RawEncoding::new(self.data, self.top_dict.encoding_offset.get()?).ok()?;
+        let encoding = RawEncoding::new(self.data, self.top_dict.encoding_offset.get()?)?;
         Some(Encoding { encoding, charset })
     }
 
@@ -234,7 +235,8 @@ impl<'a> CffFontRef<'a> {
                 None,
             ),
             CffFontKind::Cid { fd_array, .. } | CffFontKind::Cff2 { fd_array, .. } => {
-                let font_dict = FontDict::new(fd_array.get(index as usize)?)?;
+                let font_dict =
+                    FontDict::new(fd_array.get(index as usize).ok_or(Error::Malformed)?)?;
                 Subfont::new(
                     self.data,
                     font_dict.private_dict_range,
@@ -261,7 +263,8 @@ impl<'a> CffFontRef<'a> {
                 None,
             ),
             CffFontKind::Cid { fd_array, .. } | CffFontKind::Cff2 { fd_array, .. } => {
-                let font_dict = FontDict::new(fd_array.get(index as usize)?)?;
+                let font_dict =
+                    FontDict::new(fd_array.get(index as usize).ok_or(Error::Malformed)?)?;
                 Subfont::new_hinted(
                     self.data,
                     font_dict.private_dict_range,
@@ -351,12 +354,14 @@ impl<'a> CffFontRef<'a> {
             let data = self
                 .data
                 .get(subfont.subrs_offset as usize..)
-                .ok_or(ReadError::OutOfBounds)?;
+                .ok_or(Error::Malformed)?;
             Index::new(data, self.is_cff2)?
         } else {
             Index::Empty
         };
-        let charstring_data = charstrings.get(gid.to_u32() as usize)?;
+        let charstring_data = charstrings
+            .get(gid.to_u32() as usize)
+            .ok_or(Error::Malformed)?;
         let ctx = (self.data, &charstrings, &self.global_subrs, &subrs);
         if let Some(width) = cs::evaluate(&ctx, blend, charstring_data, sink)? {
             Ok(Some(width + subfont.nominal_width))
@@ -480,15 +485,12 @@ impl Subfont {
             matrix,
             ..Default::default()
         };
-        let data = data.get(range.clone()).ok_or(ReadError::OutOfBounds)?;
+        let data = data.get(range.clone()).ok_or(Error::Malformed)?;
         for entry in dict::entries(data, blend).filter_map(|e| e.ok()) {
             match entry {
                 dict::Entry::SubrsOffset(offset) => {
-                    subfont.subrs_offset = range
-                        .start
-                        .checked_add(offset)
-                        .ok_or(ReadError::OutOfBounds)?
-                        as u32;
+                    subfont.subrs_offset =
+                        range.start.checked_add(offset).ok_or(Error::Malformed)? as u32;
                 }
                 dict::Entry::VariationStoreIndex(index) => subfont.vs_index = index,
                 // FreeType truncates the width values to int on read
@@ -511,15 +513,12 @@ impl Subfont {
             ..Default::default()
         };
         let mut params = HintingParams::default();
-        let data = data.get(range.clone()).ok_or(ReadError::OutOfBounds)?;
+        let data = data.get(range.clone()).ok_or(Error::Malformed)?;
         for entry in dict::entries(data, blend).filter_map(|e| e.ok()) {
             match entry {
                 dict::Entry::SubrsOffset(offset) => {
-                    subfont.subrs_offset = range
-                        .start
-                        .checked_add(offset)
-                        .ok_or(ReadError::OutOfBounds)?
-                        as u32;
+                    subfont.subrs_offset =
+                        range.start.checked_add(offset).ok_or(Error::Malformed)? as u32;
                 }
                 dict::Entry::VariationStoreIndex(index) => subfont.vs_index = index,
                 // FreeType truncates the width values to int on read
@@ -642,7 +641,7 @@ impl<'a> TopDict<'a> {
                 }
                 dict::Entry::PrivateDictRange(range) => {
                     // Fail early if our private dictionary is out of bounds
-                    let _ = cff_data.get(range.clone()).ok_or(ReadError::OutOfBounds)?;
+                    let _ = cff_data.get(range.clone()).ok_or(Error::Malformed)?;
                     private_dict_range = range;
                 }
                 dict::Entry::FontMatrix(font_matrix) => {
@@ -654,7 +653,7 @@ impl<'a> TopDict<'a> {
                     // IVS is preceded by a 2 byte length, but ensure that
                     // we don't overflow
                     // See <https://github.com/googlefonts/fontations/issues/1223>
-                    let offset = offset.checked_add(2).ok_or(ReadError::OutOfBounds)?;
+                    let offset = offset.checked_add(2).ok_or(Error::Malformed)?;
                     var_store = Some(ItemVariationStore::read(
                         cff_data.get(offset..).unwrap_or_default().into(),
                     )?);
@@ -748,11 +747,11 @@ impl<'a> Metadata<'a> {
         let get_str = |sid: Sid| {
             let bytes = match sid.resolve_standard() {
                 Ok(bytes) => bytes,
-                Err(idx) => strings.get(idx).ok()?,
+                Err(idx) => strings.get(idx)?,
             };
             core::str::from_utf8(bytes).ok()
         };
-        let top_dict_data = cff.top_dicts().get(top_dict_index as usize).ok()?;
+        let top_dict_data = cff.top_dicts().get(top_dict_index as usize)?;
         let name = cff
             .name(top_dict_index as usize)
             .and_then(|bytes| core::str::from_utf8(bytes).ok());

--- a/read-fonts/src/ps/cff/index.rs
+++ b/read-fonts/src/ps/cff/index.rs
@@ -60,27 +60,27 @@ impl<'a> Index<'a> {
     }
 
     /// Returns the total size in bytes of the index table.
-    pub fn size_in_bytes(&self) -> Result<usize, ReadError> {
+    pub fn size_in_bytes(&self) -> Option<usize> {
         match self {
-            Self::Empty => Ok(0),
+            Self::Empty => Some(0),
             Self::Format1(ix) => ix.size_in_bytes(),
             Self::Format2(ix) => ix.size_in_bytes(),
         }
     }
 
     /// Returns the offset at the given index.
-    pub fn get_offset(&self, index: usize) -> Result<usize, Error> {
+    pub fn get_offset(&self, index: usize) -> Option<usize> {
         match self {
-            Self::Empty => Err(ReadError::OutOfBounds.into()),
+            Self::Empty => None,
             Self::Format1(ix) => ix.get_offset(index),
             Self::Format2(ix) => ix.get_offset(index),
         }
     }
 
     /// Returns the data for the object at the given index.
-    pub fn get(&self, index: usize) -> Result<&'a [u8], Error> {
+    pub fn get(&self, index: usize) -> Option<&'a [u8]> {
         match self {
-            Self::Empty => Err(ReadError::OutOfBounds.into()),
+            Self::Empty => None,
             Self::Format1(ix) => ix.get(index),
             Self::Format2(ix) => ix.get(index),
         }
@@ -115,24 +115,20 @@ impl Default for Index<'_> {
 
 impl<'a> Index1<'a> {
     /// Returns the total size in bytes of the index table.
-    pub fn size_in_bytes(&self) -> Result<usize, ReadError> {
+    pub fn size_in_bytes(&self) -> Option<usize> {
         // 2 byte count + 1 byte off_size
         const HEADER_SIZE: usize = 3;
         // An empty CFF index contains only a 2 byte count field
         const EMPTY_SIZE: usize = 2;
         let count = self.count() as usize;
-        Ok(match count {
+        Some(match count {
             0 => EMPTY_SIZE,
-            _ => {
-                HEADER_SIZE
-                    + self.offsets().len()
-                    + self.get_offset(count).map_err(|_| ReadError::OutOfBounds)?
-            }
+            _ => HEADER_SIZE + self.offsets().len() + self.get_offset(count)?,
         })
     }
 
     /// Returns the offset of the object at the given index.
-    pub fn get_offset(&self, index: usize) -> Result<usize, Error> {
+    pub fn get_offset(&self, index: usize) -> Option<usize> {
         read_offset(
             index,
             self.count() as usize,
@@ -142,33 +138,28 @@ impl<'a> Index1<'a> {
     }
 
     /// Returns the data for the object at the given index.
-    pub fn get(&self, index: usize) -> Result<&'a [u8], Error> {
+    pub fn get(&self, index: usize) -> Option<&'a [u8]> {
         self.data()
             .get(self.get_offset(index)?..self.get_offset(index + 1)?)
-            .ok_or(ReadError::OutOfBounds.into())
     }
 }
 
 impl<'a> Index2<'a> {
     /// Returns the total size in bytes of the index table.
-    pub fn size_in_bytes(&self) -> Result<usize, ReadError> {
+    pub fn size_in_bytes(&self) -> Option<usize> {
         // 4 byte count + 1 byte off_size
         const HEADER_SIZE: usize = 5;
         // An empty CFF2 index contains only a 4 byte count field
         const EMPTY_SIZE: usize = 4;
         let count = self.count() as usize;
-        Ok(match count {
+        Some(match count {
             0 => EMPTY_SIZE,
-            _ => {
-                HEADER_SIZE
-                    + self.offsets().len()
-                    + self.get_offset(count).map_err(|_| ReadError::OutOfBounds)?
-            }
+            _ => HEADER_SIZE + self.offsets().len() + self.get_offset(count)?,
         })
     }
 
     /// Returns the offset of the object at the given index.
-    pub fn get_offset(&self, index: usize) -> Result<usize, Error> {
+    pub fn get_offset(&self, index: usize) -> Option<usize> {
         read_offset(
             index,
             self.count() as usize,
@@ -178,20 +169,14 @@ impl<'a> Index2<'a> {
     }
 
     /// Returns the data for the object at the given index.
-    pub fn get(&self, index: usize) -> Result<&'a [u8], Error> {
+    pub fn get(&self, index: usize) -> Option<&'a [u8]> {
         self.data()
             .get(self.get_offset(index)?..self.get_offset(index + 1)?)
-            .ok_or(ReadError::OutOfBounds.into())
     }
 }
 
 /// Reads an offset which is encoded as a variable sized integer.
-fn read_offset(
-    index: usize,
-    count: usize,
-    offset_size: u8,
-    offset_data: &[u8],
-) -> Result<usize, Error> {
+fn read_offset(index: usize, count: usize, offset_size: u8, offset_data: &[u8]) -> Option<usize> {
     // There are actually count + 1 entries in the offset array.
     //
     // "Offsets in the offset array are relative to the byte that precedes
@@ -202,20 +187,21 @@ fn read_offset(
     //
     // See <https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#table-7-index-format>
     if index > count {
-        Err(ReadError::OutOfBounds)?;
+        return None;
     }
     let data_offset = index * offset_size as usize;
     let offset_data = FontData::new(offset_data);
     match offset_size {
-        1 => offset_data.read_at::<u8>(data_offset)? as usize,
-        2 => offset_data.read_at::<u16>(data_offset)? as usize,
-        3 => offset_data.read_at::<Uint24>(data_offset)?.to_u32() as usize,
-        4 => offset_data.read_at::<u32>(data_offset)? as usize,
-        _ => return Err(Error::InvalidIndexOffsetSize(offset_size)),
+        1 => offset_data.read_at::<u8>(data_offset).ok()? as usize,
+        2 => offset_data.read_at::<u16>(data_offset).ok()? as usize,
+        3 => offset_data.read_at::<Uint24>(data_offset).ok()?.to_u32() as usize,
+        4 => offset_data.read_at::<u32>(data_offset).ok()? as usize,
+        // the spec allows only 1 through 4
+        _ => return None,
     }
-    // As above, subtract one to get the actual offset.
+    // As above, subtract one to get the actual offset. A zero is malformed:
+    // the spec says the first entry is always 1.
     .checked_sub(1)
-    .ok_or(Error::ZeroOffsetInIndex)
 }
 
 #[cfg(test)]

--- a/read-fonts/src/ps/cff/stack.rs
+++ b/read-fonts/src/ps/cff/stack.rs
@@ -141,7 +141,7 @@ impl Stack {
         if self.value_is_fixed[index] {
             // FreeType returns an error here rather than converting
             // <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/psaux/psstack.c#L145>
-            Err(Error::ExpectedI32StackEntry(index))
+            Err(Error::ExpectedInt)
         } else {
             Ok(value)
         }

--- a/read-fonts/src/ps/cff/v1.rs
+++ b/read-fonts/src/ps/cff/v1.rs
@@ -4,7 +4,6 @@ include!("../../../generated/generated_cff.rs");
 
 use crate::ps::{
     cff::{charset::Charset, dict},
-    error::Error,
     string::Sid,
 };
 
@@ -39,7 +38,7 @@ impl<'a> Cff<'a> {
     /// Returns the PostScript name for the font in the font set at the
     /// given index.
     pub fn name(&self, index: usize) -> Option<&'a [u8]> {
-        self.names.get(index).ok()
+        self.names.get(index)
     }
 
     /// Returns the top dict index.
@@ -70,7 +69,7 @@ impl<'a> Cff<'a> {
     pub fn string(&self, id: Sid) -> Option<&'a [u8]> {
         match id.resolve_standard() {
             Ok(name) => Some(name),
-            Err(ix) => self.strings.get(ix).ok(),
+            Err(ix) => self.strings.get(ix),
         }
     }
 
@@ -88,7 +87,7 @@ impl<'a> Cff<'a> {
     /// index.
     ///
     /// See "Charsets" at <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=21>
-    pub fn charset(&self, top_dict_index: usize) -> Result<Option<Charset<'a>>, Error> {
+    pub fn charset(&self, top_dict_index: usize) -> Option<Charset<'a>> {
         let top_dict = self.top_dicts().get(top_dict_index)?;
         let offset_data = self.offset_data();
         let mut charset_offset: Option<usize> = None;
@@ -99,30 +98,21 @@ impl<'a> Cff<'a> {
                     charset_offset = Some(offset);
                 }
                 Ok(dict::Entry::CharstringsOffset(offset)) => {
-                    num_glyphs = Some(
-                        Index::read(
-                            offset_data
-                                .split_off(offset)
-                                .ok_or(ReadError::OutOfBounds)?,
-                        )?
-                        .count() as u32,
-                    );
+                    num_glyphs =
+                        Some(Index::read(offset_data.split_off(offset)?).ok()?.count() as u32);
                 }
                 // The ROS operator signifies a CID-keyed font and the charset
                 // maps to CIDs rather than SIDs which we don't parse for
                 // glyph names.
                 // <https://adobe-type-tools.github.io/font-tech-notes/pdfs/5176.CFF.pdf#page=28>
                 Ok(dict::Entry::Ros { .. }) => {
-                    return Ok(None);
+                    return None;
                 }
                 _ => {}
             }
         }
-        if let Some((charset_offset, num_glyphs)) = charset_offset.zip(num_glyphs) {
-            Ok(Some(Charset::new(offset_data, charset_offset, num_glyphs)?))
-        } else {
-            Ok(None)
-        }
+        let (offset, num_glyphs) = charset_offset.zip(num_glyphs)?;
+        Charset::new(offset_data, offset, num_glyphs)
     }
 }
 
@@ -140,15 +130,15 @@ impl<'a> FontRead<'a> for Cff<'a> {
         let mut data = FontData::new(header.trailing_data());
         let names = Index::read(data)?;
         data = data
-            .split_off(names.size_in_bytes()?)
+            .split_off(names.size_in_bytes().ok_or(ReadError::OutOfBounds)?)
             .ok_or(ReadError::OutOfBounds)?;
         let top_dicts = Index::read(data)?;
         data = data
-            .split_off(top_dicts.size_in_bytes()?)
+            .split_off(top_dicts.size_in_bytes().ok_or(ReadError::OutOfBounds)?)
             .ok_or(ReadError::OutOfBounds)?;
         let strings = Index::read(data)?;
         data = data
-            .split_off(strings.size_in_bytes()?)
+            .split_off(strings.size_in_bytes().ok_or(ReadError::OutOfBounds)?)
             .ok_or(ReadError::OutOfBounds)?;
         let global_subrs = Index::read(data)?;
         Ok(Self {
@@ -215,7 +205,7 @@ mod tests {
     fn test_glyph_names(font_data: &[u8], expected_names: &[&str]) {
         let font = FontRef::new(font_data).unwrap();
         let cff = font.cff().unwrap();
-        let charset = cff.charset(0).unwrap().unwrap();
+        let charset = cff.charset(0).unwrap();
         let sid_to_string = |sid| std::str::from_utf8(cff.string(sid).unwrap()).unwrap();
         let names_by_lookup = (0..charset.num_glyphs())
             .map(|gid| sid_to_string(charset.string_id(GlyphId::new(gid)).unwrap()))

--- a/read-fonts/src/ps/cs.rs
+++ b/read-fonts/src/ps/cs.rs
@@ -79,27 +79,37 @@ impl<'a> CharstringContext for (&'a [u8], &'a Index<'a>, &'a Index<'a>, &'a Inde
     fn seac_components(&self, base_code: i32, accent_code: i32) -> Result<[&[u8]; 2], Error> {
         let cff = Cff::read(FontData::new(self.0))?;
         let charset = cff
-            .charset(0)?
-            .or_else(|| Charset::new(FontData::default(), 0, self.1.count()).ok())
+            .charset(0)
+            .or_else(|| Charset::new(FontData::default(), 0, self.1.count()))
             .ok_or(Error::MissingCharset)?;
         let seac_to_gid = |code: i32| {
             let code: u8 = code.try_into().ok()?;
             let sid = *super::encoding::STANDARD_ENCODING.get(code as usize)?;
-            charset.glyph_id(Sid::new(sid as u16)).ok()
+            charset.glyph_id(Sid::new(sid as u16))
         };
         let accent_gid = seac_to_gid(accent_code).ok_or(Error::InvalidSeacCode(accent_code))?;
         let base_gid = seac_to_gid(base_code).ok_or(Error::InvalidSeacCode(base_code))?;
-        let accent_charstring = self.1.get(accent_gid.to_u32() as usize)?;
-        let base_charstring = self.1.get(base_gid.to_u32() as usize)?;
+        let accent_charstring = self
+            .1
+            .get(accent_gid.to_u32() as usize)
+            .ok_or(Error::Malformed)?;
+        let base_charstring = self
+            .1
+            .get(base_gid.to_u32() as usize)
+            .ok_or(Error::Malformed)?;
         Ok([base_charstring, accent_charstring])
     }
 
     fn global_subr(&self, index: i32) -> Result<&[u8], Error> {
-        self.2.get((index + self.2.subr_bias()) as usize)
+        self.2
+            .get((index + self.2.subr_bias()) as usize)
+            .ok_or(Error::Malformed)
     }
 
     fn subr(&self, index: i32) -> Result<&[u8], Error> {
-        self.3.get((index + self.3.subr_bias()) as usize)
+        self.3
+            .get((index + self.3.subr_bias()) as usize)
+            .ok_or(Error::Malformed)
     }
 }
 
@@ -284,7 +294,7 @@ where
                     // FreeType ignores reserved (unknown) operators.
                     // See <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/psaux/psintrp.c#L703>
                     // and fontations issue <https://github.com/googlefonts/fontations/issues/1680>
-                    if let Ok(operator) = Operator::read(&mut cursor, b0) {
+                    if let Some(operator) = Operator::read(&mut cursor, b0) {
                         seen_endchar |= operator == Operator::EndChar;
                         if !self.evaluate_operator(operator, &mut cursor, nesting_depth)? {
                             break;
@@ -905,9 +915,7 @@ where
         let weight_vector = self.context.weight_vector();
         let num_points = (subr_idx - 13) as usize + (subr_idx == 18) as usize;
         if num_args != num_points * weight_vector.len() {
-            return Err(Error::Read(crate::ReadError::MalformedData(
-                "incorrect number of multiple masters arguments",
-            )));
+            return Err(Error::Malformed);
         }
         // The stack is setup to contain `num_points` values followed
         // by `num_points * (num_weights - 1)` deltas for each point.
@@ -1102,16 +1110,14 @@ enum Operator {
 }
 
 impl Operator {
-    fn read(cursor: &mut Cursor, b0: u8) -> Result<Self, Error> {
+    fn read(cursor: &mut Cursor, b0: u8) -> Option<Self> {
         // Escape opcode for accessing two byte operators
         const ESCAPE: u8 = 12;
-        let (opcode, operator) = if b0 == ESCAPE {
-            let b1 = cursor.read::<u8>()?;
-            (b1, Self::from_two_byte_opcode(b1))
+        if b0 == ESCAPE {
+            Self::from_two_byte_opcode(cursor.read::<u8>().ok()?)
         } else {
-            (b0, Self::from_opcode(b0))
-        };
-        operator.ok_or(Error::InvalidCharstringOperator(opcode))
+            Self::from_opcode(b0)
+        }
     }
 
     /// Creates an operator from the given opcode.

--- a/read-fonts/src/ps/error.rs
+++ b/read-fonts/src/ps/error.rs
@@ -6,17 +6,11 @@ use core::fmt;
 /// Errors that are specific to PostScript processing.
 #[derive(Clone, Debug)]
 pub enum Error {
-    InvalidFontFormat,
-    InvalidIndexOffsetSize(u8),
-    ZeroOffsetInIndex,
-    InvalidVariationStoreIndex(u16),
+    InvalidVariationStoreIndex,
     StackOverflow,
     StackUnderflow,
-    InvalidStackAccess(usize),
-    ExpectedI32StackEntry(usize),
+    ExpectedInt,
     InvalidNumber,
-    InvalidDictOperator(u8),
-    InvalidCharstringOperator(u8),
     CharstringNestingDepthLimitExceeded,
     MissingSubroutines,
     MissingBlendState,
@@ -25,32 +19,28 @@ pub enum Error {
     MissingCharstrings,
     MissingCharset,
     InvalidSeacCode(i32),
-    Read(ReadError),
+    /// The data does not make sense: absent where it was required, too short,
+    /// or self-inconsistent.
+    ///
+    /// Carries nothing. This module answers a malformed read with `None`
+    /// wherever it can; this is what it says where a `Result` is required.
+    Malformed,
 }
 
+/// Kept so the `?` inside this module still reads well. It is `read-fonts`
+/// converting one of its own error types into another, which is why it can
+/// stay: nothing outside the crate has to name `ReadError` to use `Error`.
 impl From<ReadError> for Error {
-    fn from(value: ReadError) -> Self {
-        Self::Read(value)
+    fn from(_: ReadError) -> Self {
+        Self::Malformed
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidFontFormat => {
-                write!(f, "invalid font format")
-            }
-            Self::InvalidIndexOffsetSize(size) => {
-                write!(f, "invalid offset size of {size} for INDEX (expected 1-4)")
-            }
-            Self::ZeroOffsetInIndex => {
-                write!(f, "invalid offset of 0 in INDEX (must be >= 1)")
-            }
-            Self::InvalidVariationStoreIndex(index) => {
-                write!(
-                    f,
-                    "variation store index {index} referenced an invalid variation region"
-                )
+            Self::InvalidVariationStoreIndex => {
+                write!(f, "variation store index referenced an invalid region")
             }
             Self::StackOverflow => {
                 write!(f, "attempted to push a value to a full stack")
@@ -58,20 +48,14 @@ impl fmt::Display for Error {
             Self::StackUnderflow => {
                 write!(f, "attempted to pop a value from an empty stack")
             }
-            Self::InvalidStackAccess(index) => {
-                write!(f, "invalid stack access for index {index}")
-            }
-            Self::ExpectedI32StackEntry(index) => {
-                write!(f, "attempted to read an integer at stack index {index}, but found a fixed point value")
+            Self::ExpectedInt => {
+                write!(
+                    f,
+                    "expected an integer on the stack, found a fixed point value"
+                )
             }
             Self::InvalidNumber => {
                 write!(f, "number is in an invalid format")
-            }
-            Self::InvalidDictOperator(operator) => {
-                write!(f, "dictionary operator {operator} is invalid")
-            }
-            Self::InvalidCharstringOperator(operator) => {
-                write!(f, "charstring operator {operator} is invalid")
             }
             Self::CharstringNestingDepthLimitExceeded => {
                 write!(
@@ -107,16 +91,9 @@ impl fmt::Display for Error {
             Self::InvalidSeacCode(code) => {
                 write!(f, "seac code {code} is not valid")
             }
-            Self::Read(err) => write!(f, "{err}"),
+            Self::Malformed => write!(f, "font data was absent or malformed"),
         }
     }
 }
 
-impl core::error::Error for Error {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::Read(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl core::error::Error for Error {}

--- a/read-fonts/src/ps/type1.rs
+++ b/read-fonts/src/ps/type1.rs
@@ -10,7 +10,6 @@ use super::{
 use crate::{
     model::pen::OutlinePen,
     types::{BoundingBox, Fixed, GlyphId},
-    ReadError,
 };
 use alloc::{string::String, vec::Vec};
 use core::ops::Range;
@@ -37,9 +36,8 @@ pub struct Type1Font {
 impl Type1Font {
     /// Creates a new Type1 font from the given data.
     pub fn new(data: &[u8]) -> Result<Self, Error> {
-        // Any failure to parse is simply represented by an invalid font format
-        // error
-        Self::new_impl(data).ok_or(Error::InvalidFontFormat)
+        // any failure to parse is simply malformed data
+        Self::new_impl(data).ok_or(Error::Malformed)
     }
 
     fn new_impl(data: &[u8]) -> Option<Self> {
@@ -294,10 +292,7 @@ impl Type1Font {
         gid: GlyphId,
         sink: &mut impl CommandSink,
     ) -> Result<Option<Fixed>, Error> {
-        let charstring_data = self
-            .charstrings
-            .get(gid.to_u32())
-            .ok_or(ReadError::OutOfBounds)?;
+        let charstring_data = self.charstrings.get(gid.to_u32()).ok_or(Error::Malformed)?;
         cs::evaluate(self, None, charstring_data, sink)
     }
 
@@ -339,7 +334,7 @@ impl CharstringContext for Type1Font {
     }
 
     fn subr(&self, index: i32) -> Result<&[u8], Error> {
-        Ok(self.subrs.get(index as u32).ok_or(ReadError::OutOfBounds)?)
+        self.subrs.get(index as u32).ok_or(Error::Malformed)
     }
 
     fn global_subr(&self, _index: i32) -> Result<&[u8], Error> {

--- a/read-fonts/src/tables/varc.rs
+++ b/read-fonts/src/tables/varc.rs
@@ -20,7 +20,7 @@ impl<'a> Get<'a> for Option<Result<Index2<'a>, ReadError>> {
     fn get(self, nth: usize) -> Result<&'a [u8], ReadError> {
         self.transpose()?
             .ok_or(ReadError::NullOffset)
-            .and_then(|index| index.get(nth).map_err(|_| ReadError::OutOfBounds))
+            .and_then(|index| index.get(nth).ok_or(ReadError::OutOfBounds))
     }
 }
 
@@ -451,7 +451,7 @@ impl<'a> MultiItemVariationData<'a> {
     /// Equivalent to calling [Self::delta_sets], fetching item i, and parsing as [PackedDeltas]
     pub fn delta_set(&self, i: usize) -> Result<PackedDeltas<'a>, ReadError> {
         let index = self.delta_sets()?;
-        let raw_deltas = index.get(i).map_err(|_| ReadError::OutOfBounds)?;
+        let raw_deltas = index.get(i).ok_or(ReadError::OutOfBounds)?;
         Ok(PackedDeltas::consume_all(raw_deltas.into()))
     }
 }

--- a/skrifa/src/glyph_name.rs
+++ b/skrifa/src/glyph_name.rs
@@ -55,7 +55,7 @@ impl<'a> GlyphNames<'a> {
         if let Some((cff, charset)) = font
             .cff()
             .ok()
-            .and_then(|cff| Some((cff.clone(), cff.charset(0).ok()??)))
+            .and_then(|cff| Some((cff.clone(), cff.charset(0)?)))
         {
             return Self {
                 inner: Inner::Cff(cff, charset),
@@ -92,7 +92,6 @@ impl<'a> GlyphNames<'a> {
             Inner::Post(post, _) => GlyphName::from_post(post, glyph_id),
             Inner::Cff(cff, charset) => charset
                 .string_id(glyph_id)
-                .ok()
                 .and_then(|sid| GlyphName::from_cff_sid(cff, sid)),
             _ => None,
         };

--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -63,7 +63,7 @@ impl<'a> Outlines<'a> {
         // So we always pass 0 for Top DICT index when reading from an
         // OpenType font.
         // <https://learn.microsoft.com/en-us/typography/opentype/spec/cff>
-        let top_dict_data = cff1.top_dicts().get(0).ok()?;
+        let top_dict_data = cff1.top_dicts().get(0)?;
         let top_dict = TopDict::new(cff1.offset_data().as_bytes(), top_dict_data, false).ok()?;
         Some(Self {
             font: font.clone(),
@@ -253,7 +253,9 @@ impl<'a> Outlines<'a> {
     ) -> Result<Option<f32>, Error> {
         let cff_data = self.offset_data.as_bytes();
         let charstrings = self.top_dict.charstrings.clone();
-        let charstring_data = charstrings.get(glyph_id.to_u32() as usize)?;
+        let charstring_data = charstrings
+            .get(glyph_id.to_u32() as usize)
+            .ok_or(Error::Malformed)?;
         let subrs = subfont.subrs(self)?;
         let blend_state = subfont.blend_state(self, coords)?;
         let cs_eval = CharstringEvaluator {
@@ -332,7 +334,11 @@ impl<'a> Outlines<'a> {
         if self.top_dict.font_dicts.count() != 0 {
             // If we have a font dict array, extract the private dict range
             // from the font dict at the given index.
-            let font_dict_data = self.top_dict.font_dicts.get(subfont_index as usize)?;
+            let font_dict_data = self
+                .top_dict
+                .font_dicts
+                .get(subfont_index as usize)
+                .ok_or(Error::Malformed)?;
             FontDict::new(font_dict_data)
         } else {
             // Use the private dict range from the top dict.


### PR DESCRIPTION
tl;dr Remove `Result`s and `Error` variants that provide no signal. 

----

The PostScript module returned `Result` in a lot of places where the only thing that could go wrong was that the data did not make sense, and the callers said so: `charset.string_id(gid).ok()?` inside `charset.rs` itself, `RawEncoding::new(..).ok()?` in `font.rs`, `.ok()` in skrifa's glyph names.

**Lookups return `Option`.** `charset.rs` constructed nineteen errors and every one was `ReadError::OutOfBounds`. `index.rs`'s `size_in_bytes` was the same, and reached it by `map_err`ing a richer error away. A glyph maps to a string id or it does not; there is nothing for a caller to act on.

Converting deletes code rather than adding it -- the bodies were already `Option` chains with `.ok_or(ReadError::OutOfBounds)` bolted on the end.

**`Index::get_offset` and `get` too, and their variants go with them.** `ZeroOffsetInIndex` and `InvalidIndexOffsetSize` looked like real signal, but they say "this INDEX is malformed" -- an offset of zero where the spec requires one or more, an offset size outside 1..=4 -- which is what every other failure in this module now answers with `None`.

**The encodings, for the same reason.** `CustomEncoding::new` reported `InvalidFormat` for a format byte that is not 0 or 1, and no caller read it.

**`Operator::read` as well.** It reported `InvalidCharstringOperator` with the offending opcode, and its one caller discards the error and clears the stack -- deliberately, because FreeType ignores reserved operators.

**An unknown DICT operator becomes a token, not an error.** `entries` already skips one and clears the stack, as FreeType does; `tokens` -- the raw view -- ended the walk instead, so a caller could not do the same thing from it. That made it useless as a general DICT parser at the first buggy font. `Token` gains `InvalidOperator(u8)` and `InvalidTwoByteOperator(u8)` (the first byte is always escape), the decision moves to the caller, and `InvalidDictOperator` goes.

**`Cff::charset` flattens.** It returned `Result<Option<Charset>, Error>`, where the `Ok(None)` arms were a CID-keyed font and a font with no charset, and the `Err` arms were all malformed data. One `Option` says both.

**`Error::Read` becomes `Error::Malformed`, and loses its payload.** It was the only variant named for an operation rather than a condition, which was defensible while it wrapped a `ReadError` and is not now that it also covers eleven direct constructions meaning "these bytes do not make sense".

Those eleven built a `ReadError::OutOfBounds` only for `From` to discard it a line later, so they say `Error::Malformed` directly. What still names `ReadError` here is the two `FontRead` impls, whose signature the trait fixes, and the `From` impl -- which stays: removing it turns 28 `?` on the existing API's reads into `.map_err(..)`, for no information.

**Six variants go, and two payloads.** `InvalidStackAccess` has not been constructed since #1686 relaxed the stack checks. `InvalidFontFormat` named two things that are simply malformed data. `ExpectedI32StackEntry(usize)` becomes `ExpectedInt`: a stack position is not something a caller can act on. `InvalidVariationStoreIndex` drops an index its caller passed in.

The one payload left, `InvalidSeacCode(i32)`, names a value read out of the font rather than one the caller supplied or a position in our own state. Every one of the fourteen variants is constructed.

`ReadError` references in `ps` go from 71 to 13, the module has 25 fewer `Result`-returning signatures, and `Error` goes from 20 variants to 14.