### PR TITLE
[skera] use flat vector which outperforms hashmap lookup

### DIFF
--- a/skera/src/gdef.rs
+++ b/skera/src/gdef.rs
@@ -1,7 +1,7 @@
 //! impl subset() for GDEF
 
 use crate::{
-    layout::ClassDefSubsetStruct,
+    layout::{map_gsub_glyph, ClassDefSubsetStruct},
     offset::{SerializeSerialize, SerializeSubset},
     offset_array::{IterNullableHelper, SubsetOffsetArray},
     serialize::{SerializeErrorFlags, SerializeResultEmpty, Serializer},
@@ -265,20 +265,20 @@ impl SubsetTable<'_> for AttachList<'_> {
         let mut count = 0_u16;
         let src_glyph_count = self.glyph_count() as usize;
         let mut retained_glyphs =
-            Vec::with_capacity(plan.glyph_map_gsub.len().min(src_glyph_count));
+            Vec::with_capacity((plan.glyphset_gsub.len() as usize).min(src_glyph_count));
 
         for (idx, glyph) in coverage
             .iter()
             .enumerate()
             .take(plan.font_num_glyphs.min(src_glyph_count))
         {
-            let Some(new_gid) = plan.glyph_map_gsub.get(&GlyphId::from(glyph)) else {
+            let Some(new_gid) = map_gsub_glyph(&plan.glyph_map_gsub, GlyphId::from(glyph)) else {
                 continue;
             };
 
             if !attach_points.subset_offset(idx, s, plan, ()).is_empty()? {
                 count += 1;
-                retained_glyphs.push(*new_gid);
+                retained_glyphs.push(new_gid);
             }
         }
 
@@ -329,20 +329,20 @@ impl SubsetTable<'_> for LigCaretList<'_> {
         let mut count = 0_u16;
         let src_lig_glyph_count = self.lig_glyph_count() as usize;
         let mut retained_glyphs =
-            Vec::with_capacity(plan.glyph_map_gsub.len().min(src_lig_glyph_count));
+            Vec::with_capacity((plan.glyphset_gsub.len() as usize).min(src_lig_glyph_count));
 
         for (idx, glyph) in coverage
             .iter()
             .enumerate()
             .take(plan.font_num_glyphs.min(src_lig_glyph_count))
         {
-            let Some(new_gid) = plan.glyph_map_gsub.get(&GlyphId::from(glyph)) else {
+            let Some(new_gid) = map_gsub_glyph(&plan.glyph_map_gsub, GlyphId::from(glyph)) else {
                 continue;
             };
 
             if !lig_glyphs.subset_offset(idx, s, plan, ()).is_empty()? {
                 count += 1;
-                retained_glyphs.push(*new_gid);
+                retained_glyphs.push(new_gid);
             }
         }
 

--- a/skera/src/gpos/cursive_pos.rs
+++ b/skera/src/gpos/cursive_pos.rs
@@ -145,12 +145,13 @@ mod test {
         let cursivepos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 3099],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1803_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(3098_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[1803] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[3098] = GlyphId::from(4_u32);
         plan.glyphset_gsub.insert(GlyphId::from(1803_u32));
         plan.glyphset_gsub.insert(GlyphId::from(3098_u32));
 

--- a/skera/src/gpos/mark_base_pos.rs
+++ b/skera/src/gpos/mark_base_pos.rs
@@ -281,14 +281,14 @@ mod test {
         let markbasepos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 406],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(37_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(390_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(405_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[37] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[390] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[405] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(37_u32));
         plan.glyphset_gsub.insert(GlyphId::from(390_u32));
@@ -344,16 +344,15 @@ mod test {
         let markbasepos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 410],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(36_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(37_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(404_u32), GlyphId::from(4_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(409_u32), GlyphId::from(5_u32));
+        plan.glyph_map_gsub[36] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[37] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[404] = GlyphId::from(4_u32);
+        plan.glyph_map_gsub[409] = GlyphId::from(5_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(36_u32));
         plan.glyphset_gsub.insert(GlyphId::from(37_u32));

--- a/skera/src/gpos/mark_lig_pos.rs
+++ b/skera/src/gpos/mark_lig_pos.rs
@@ -315,12 +315,13 @@ mod test {
         let markligpos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 69],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(67_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(68_u32), GlyphId::from(2_u32));
+        plan.glyph_map_gsub[67] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[68] = GlyphId::from(2_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(67_u32));
         plan.glyphset_gsub.insert(GlyphId::from(68_u32));
@@ -362,14 +363,14 @@ mod test {
         let markligpos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 988],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(30_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(987_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(216_u32), GlyphId::from(2_u32));
+        plan.glyph_map_gsub[30] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[216] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[987] = GlyphId::from(3_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(30_u32));
         plan.glyphset_gsub.insert(GlyphId::from(216_u32));

--- a/skera/src/gpos/mark_mark_pos.rs
+++ b/skera/src/gpos/mark_mark_pos.rs
@@ -277,16 +277,15 @@ mod test {
         let markmarkpos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 75],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(66_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(67_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(70_u32), GlyphId::from(4_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(74_u32), GlyphId::from(5_u32));
+        plan.glyph_map_gsub[66] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[67] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[70] = GlyphId::from(4_u32);
+        plan.glyph_map_gsub[74] = GlyphId::from(5_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(66_u32));
         plan.glyphset_gsub.insert(GlyphId::from(67_u32));

--- a/skera/src/gpos/pair_pos.rs
+++ b/skera/src/gpos/pair_pos.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     gpos::value_record::compute_effective_format,
-    layout::{intersected_coverage_indices, intersected_glyphs_and_indices, ClassDefSubsetStruct},
+    layout::{
+        intersected_coverage_indices, intersected_glyphs_and_indices, map_gsub_glyph,
+        ClassDefSubsetStruct,
+    },
     offset::{SerializeSerialize, SerializeSubset},
     offset_array::SubsetOffsetArray,
     serialize::{SerializeErrorFlags, SerializeResultEmpty, Serializer},
@@ -101,10 +104,11 @@ impl SubsetTable<'_> for PairSet<'_> {
         for pairvalue_rec in self.pair_value_records().iter() {
             let pairvalue_rec = pairvalue_rec
                 .map_err(|_| s.set_err(SerializeErrorFlags::SERIALIZE_ERROR_READ_ERROR))?;
-            let Some(gid) = glyph_map.get(&GlyphId::from(pairvalue_rec.second_glyph())) else {
+            let Some(gid) = map_gsub_glyph(glyph_map, GlyphId::from(pairvalue_rec.second_glyph()))
+            else {
                 continue;
             };
-            pairvalue_rec.subset(plan, s, (gid, new_format1, new_format2))?;
+            pairvalue_rec.subset(plan, s, (&gid, new_format1, new_format2))?;
             count += 1;
         }
 
@@ -257,8 +261,7 @@ impl<'a> SubsetTable<'a> for PairPosFormat2<'_> {
         let glyphs: Vec<GlyphId> = coverage
             .intersect_set(&plan.glyphset_gsub)
             .iter()
-            .filter_map(|g| plan.glyph_map_gsub.get(&g))
-            .copied()
+            .filter_map(|g| map_gsub_glyph(&plan.glyph_map_gsub, g))
             .collect();
         if glyphs.is_empty() {
             return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
@@ -506,12 +509,13 @@ mod test {
         let pairpos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 6299],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(6292_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(6298_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[6292] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[6298] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(6292_u32));
         plan.glyphset_gsub.insert(GlyphId::from(6298_u32));
@@ -549,17 +553,16 @@ mod test {
         let pairpos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 6737],
+            ..Default::default()
+        };
 
         //test case 1: ValueFormat remains the same
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(40_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(72_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(168_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(6736_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[40] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[72] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[168] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[6736] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(40_u32));
         plan.glyphset_gsub.insert(GlyphId::from(72_u32));
@@ -589,13 +592,10 @@ mod test {
 
         // test case 2: strip hints is enabled
         plan.subset_flags = SubsetFlags::SUBSET_FLAGS_NO_HINTING;
-        plan.glyph_map_gsub.clear();
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(72_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(168_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(6736_u32), GlyphId::from(3_u32));
+        plan.glyph_map_gsub.resize(6737, crate::INVALID_GID);
+        plan.glyph_map_gsub[72] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[168] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[6736] = GlyphId::from(3_u32);
 
         plan.glyphset_gsub.clear();
         plan.glyphset_gsub.insert(GlyphId::from(72_u32));

--- a/skera/src/gpos/single_pos.rs
+++ b/skera/src/gpos/single_pos.rs
@@ -3,7 +3,7 @@
 use crate::fnv::FnvHashMap;
 use crate::{
     gpos::value_record::compute_effective_format,
-    layout::{intersected_coverage_indices, intersected_glyphs_and_indices},
+    layout::{intersected_coverage_indices, intersected_glyphs_and_indices, map_gsub_glyph},
     offset::SerializeSerialize,
     serialize::{SerializeErrorFlags, Serializer},
     CollectVariationIndices, Plan, Serialize, SubsetFlags, SubsetState, SubsetTable,
@@ -56,8 +56,7 @@ impl<'a> SubsetTable<'a> for SinglePosFormat1<'_> {
         let retained_glyphs: Vec<GlyphId> = coverage
             .intersect_set(&plan.glyphset_gsub)
             .iter()
-            .filter_map(|g| plan.glyph_map_gsub.get(&g))
-            .copied()
+            .filter_map(|g| map_gsub_glyph(&plan.glyph_map_gsub, g))
             .collect();
         if retained_glyphs.is_empty() {
             return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
@@ -297,10 +296,12 @@ mod test {
         let singlepos_table = sub_tables.get(0).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 5988],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(5987_u32), GlyphId::from(3_u32));
+        plan.glyph_map_gsub[5987] = GlyphId::from(3_u32);
         plan.glyphset_gsub.insert(GlyphId::from(5987_u32));
 
         let mut s = Serializer::new(1024);
@@ -335,13 +336,14 @@ mod test {
         let singlepos_table = sub_tables.get(4).unwrap();
 
         let subset_state = SubsetState::default();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 2350],
+            ..Default::default()
+        };
 
         // test case 1: subsetted output is still format 2
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(2270_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(2349_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[2270] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[2349] = GlyphId::from(4_u32);
         plan.glyphset_gsub.insert(GlyphId::from(2270_u32));
         plan.glyphset_gsub.insert(GlyphId::from(2349_u32));
 
@@ -363,11 +365,9 @@ mod test {
         assert_eq!(subsetted_data, expected_data);
 
         // test case 2: subsetted output is optimized to format 1
-        plan.glyph_map_gsub.clear();
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(2270_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(6179_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub = vec![crate::INVALID_GID; 6180];
+        plan.glyph_map_gsub[2270] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[6179] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.clear();
         plan.glyphset_gsub.insert(GlyphId::from(2270_u32));

--- a/skera/src/gsub/alternate_subst.rs
+++ b/skera/src/gsub/alternate_subst.rs
@@ -1,7 +1,7 @@
 //! impl subset() for AlternateSubst subtable
 use crate::fnv::FnvHashMap;
 use crate::{
-    layout::intersected_glyphs_and_indices,
+    layout::{intersected_glyphs_and_indices, map_gsub_glyph},
     offset::SerializeSerialize,
     offset_array::SubsetOffsetArray,
     serialize::{SerializeErrorFlags, SerializeResultEmpty, Serializer},
@@ -86,7 +86,7 @@ impl SubsetTable<'_> for AlternateSet<'_> {
         let glyph_map = &plan.glyph_map_gsub;
         let alt_glyphs = self.alternate_glyph_ids();
         for g in alt_glyphs {
-            let Some(new_g) = glyph_map.get(&GlyphId::from(g.get())) else {
+            let Some(new_g) = map_gsub_glyph(glyph_map, GlyphId::from(g.get())) else {
                 continue;
             };
             s.embed(new_g.to_u32() as u16)?;
@@ -122,14 +122,14 @@ mod test {
             panic!("Wrong type of lookup table!");
         };
         let alt_subst_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 19],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(3_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(10_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(18_u32), GlyphId::from(3_u32));
+        plan.glyph_map_gsub[3] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[10] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[18] = GlyphId::from(3_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(3_u32));
         plan.glyphset_gsub.insert(GlyphId::from(10_u32));

--- a/skera/src/gsub/ligature_subst.rs
+++ b/skera/src/gsub/ligature_subst.rs
@@ -1,7 +1,7 @@
 //! impl subset() for LigatureSubst subtable
 use crate::fnv::FnvHashMap;
 use crate::{
-    layout::intersected_glyphs_and_indices,
+    layout::{intersected_glyphs_and_indices, map_gsub_glyph},
     offset::{SerializeSerialize, SerializeSubset},
     offset_array::{IterNullableHelper, SubsetOffsetArray},
     serialize::{ObjIdx, SerializeErrorFlags, SerializeResultEmpty, Serializer},
@@ -147,16 +147,14 @@ impl SubsetTable<'_> for Ligature<'_> {
         coverage_idx: ObjIdx,
     ) -> Result<Self::Output, SerializeErrorFlags> {
         let glyph_map = &plan.glyph_map_gsub;
-        let lig_glyph = glyph_map
-            .get(&GlyphId::from(self.ligature_glyph()))
+        let lig_glyph = map_gsub_glyph(glyph_map, GlyphId::from(self.ligature_glyph()))
             .ok_or(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY)?;
         s.embed(lig_glyph.to_u32() as u16)?;
 
         s.embed(self.component_count())?;
 
         for g in self.component_glyph_ids() {
-            let new_g = glyph_map
-                .get(&GlyphId::from(g.get()))
+            let new_g = map_gsub_glyph(glyph_map, GlyphId::from(g.get()))
                 .ok_or(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY)?;
 
             s.embed(new_g.to_u32() as u16)?;
@@ -201,20 +199,17 @@ mod test {
             panic!("Wrong type of lookup table!");
         };
         let ligsubst_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 1209],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(51_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(169_u32), GlyphId::from(4_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(170_u32), GlyphId::from(5_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(657_u32), GlyphId::from(9_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(659_u32), GlyphId::from(10_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1208_u32), GlyphId::from(13_u32));
+        plan.glyph_map_gsub[51] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[169] = GlyphId::from(4_u32);
+        plan.glyph_map_gsub[170] = GlyphId::from(5_u32);
+        plan.glyph_map_gsub[657] = GlyphId::from(9_u32);
+        plan.glyph_map_gsub[659] = GlyphId::from(10_u32);
+        plan.glyph_map_gsub[1208] = GlyphId::from(13_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(51_u32));
         plan.glyphset_gsub.insert(GlyphId::from(169_u32));

--- a/skera/src/gsub/multiple_subst.rs
+++ b/skera/src/gsub/multiple_subst.rs
@@ -1,7 +1,7 @@
 //! impl subset() for MultipleSubst subtable
 use crate::fnv::FnvHashMap;
 use crate::{
-    layout::intersected_glyphs_and_indices,
+    layout::{intersected_glyphs_and_indices, map_gsub_glyph},
     offset::SerializeSerialize,
     offset_array::SubsetOffsetArray,
     serialize::{SerializeErrorFlags, SerializeResultEmpty, Serializer},
@@ -89,8 +89,7 @@ impl SubsetTable<'_> for Sequence<'_> {
         let glyph_map = &plan.glyph_map_gsub;
         let sub_glyphs = self.substitute_glyph_ids();
         for g in sub_glyphs {
-            let new_g = glyph_map
-                .get(&GlyphId::from(g.get()))
+            let new_g = map_gsub_glyph(glyph_map, GlyphId::from(g.get()))
                 .ok_or(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY)?;
 
             s.copy_assign(pos, new_g.to_u32() as u16);
@@ -121,14 +120,14 @@ mod test {
             panic!("Wrong type of lookup table!");
         };
         let multiplesubst_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 967],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(362_u32), GlyphId::from(5_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(512_u32), GlyphId::from(6_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(966_u32), GlyphId::from(11_u32));
+        plan.glyph_map_gsub[362] = GlyphId::from(5_u32);
+        plan.glyph_map_gsub[512] = GlyphId::from(6_u32);
+        plan.glyph_map_gsub[966] = GlyphId::from(11_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(362_u32));
         plan.glyphset_gsub.insert(GlyphId::from(512_u32));

--- a/skera/src/gsub/reverse_chain_single_subst.rs
+++ b/skera/src/gsub/reverse_chain_single_subst.rs
@@ -1,6 +1,7 @@
 //! impl subset() for ReverseChainSingleSubst subtable
 use crate::fnv::FnvHashMap;
 use crate::{
+    layout::map_gsub_glyph,
     offset::SerializeSerialize,
     serialize::{SerializeErrorFlags, Serializer},
     Plan, SubsetState, SubsetTable,
@@ -48,9 +49,9 @@ impl<'a> SubsetTable<'a> for ReverseChainSingleSubstFormat1<'_> {
             .iter()
             .zip(sub_glyphs)
             .filter_map(|(cov_g, sub_g)| {
-                let new_cov_g = glyph_map.get(&GlyphId::from(cov_g))?;
-                let new_sub_g = glyph_map.get(&GlyphId::from(sub_g.get()))?;
-                Some((*new_cov_g, *new_sub_g))
+                let new_cov_g = map_gsub_glyph(glyph_map, GlyphId::from(cov_g))?;
+                let new_sub_g = map_gsub_glyph(glyph_map, GlyphId::from(sub_g.get()))?;
+                Some((new_cov_g, new_sub_g))
             })
         {
             retained_cov_glyphs.push(cov_g);
@@ -92,22 +93,15 @@ mod test {
             ..Default::default()
         };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(49_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(50_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(51_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(65_u32), GlyphId::from(4_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(67_u32), GlyphId::from(5_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(75_u32), GlyphId::from(6_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(83_u32), GlyphId::from(7_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(98_u32), GlyphId::from(8_u32));
+        plan.glyph_map_gsub = vec![crate::INVALID_GID; 99];
+        plan.glyph_map_gsub[49] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[50] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[51] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[65] = GlyphId::from(4_u32);
+        plan.glyph_map_gsub[67] = GlyphId::from(5_u32);
+        plan.glyph_map_gsub[75] = GlyphId::from(6_u32);
+        plan.glyph_map_gsub[83] = GlyphId::from(7_u32);
+        plan.glyph_map_gsub[98] = GlyphId::from(8_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(49_u32));
         plan.glyphset_gsub.insert(GlyphId::from(50_u32));

--- a/skera/src/gsub/single_subst.rs
+++ b/skera/src/gsub/single_subst.rs
@@ -1,7 +1,7 @@
 //! impl subset() for SingleSubst subtable
 use crate::fnv::FnvHashMap;
 use crate::{
-    layout::intersected_glyphs_and_indices,
+    layout::{intersected_glyphs_and_indices, map_gsub_glyph},
     offset::SerializeSerialize,
     serialize::{SerializeErrorFlags, Serializer},
     Plan, Serialize, SubsetState, SubsetTable,
@@ -64,9 +64,9 @@ impl SubsetTable<'_> for SingleSubstFormat1<'_> {
             .iter()
             .map(|g| (g, GlyphId::from(g.to_u32().wrapping_add_signed(delta))))
             .filter_map(|(g, sub_g)| {
-                let new_g = glyph_map.get(&g)?;
-                let new_sub_g = glyph_map.get(&sub_g)?;
-                Some((*new_g, *new_sub_g))
+                let new_g = map_gsub_glyph(glyph_map, g)?;
+                let new_sub_g = map_gsub_glyph(glyph_map, sub_g)?;
+                Some((new_g, new_sub_g))
             })
         {
             retained_glyphs.push(new_g);
@@ -114,8 +114,8 @@ impl SubsetTable<'_> for SingleSubstFormat2<'_> {
                 .zip(glyph_idxes.iter())
                 .filter_map(|(new_g, idx)| {
                     let sub_g = sub_glyph_ids.get(idx as usize)?;
-                    let new_sub_g = glyph_map.get(&GlyphId::from(sub_g.get()))?;
-                    Some((*new_g, *new_sub_g))
+                    let new_sub_g = map_gsub_glyph(glyph_map, GlyphId::from(sub_g.get()))?;
+                    Some((*new_g, new_sub_g))
                 })
         {
             retained_glyphs.push(new_g);
@@ -213,12 +213,13 @@ mod test {
             panic!("Wrong type of lookup table!");
         };
         let singlesubst_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 780],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(777_u32), GlyphId::from(5_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(779_u32), GlyphId::from(6_u32));
+        plan.glyph_map_gsub[777] = GlyphId::from(5_u32);
+        plan.glyph_map_gsub[779] = GlyphId::from(6_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(777_u32));
         plan.glyphset_gsub.insert(GlyphId::from(779_u32));
@@ -255,17 +256,16 @@ mod test {
         };
 
         let singlesubst_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 1283],
+            ..Default::default()
+        };
 
         // test that output table is format 1
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(777_u32), GlyphId::from(5_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(779_u32), GlyphId::from(6_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(885_u32), GlyphId::from(7_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1282_u32), GlyphId::from(8_u32));
+        plan.glyph_map_gsub[777] = GlyphId::from(5_u32);
+        plan.glyph_map_gsub[779] = GlyphId::from(6_u32);
+        plan.glyph_map_gsub[885] = GlyphId::from(7_u32);
+        plan.glyph_map_gsub[1282] = GlyphId::from(8_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(777_u32));
         plan.glyphset_gsub.insert(GlyphId::from(779_u32));
@@ -290,15 +290,11 @@ mod test {
         assert_eq!(subsetted_data, expected_data);
 
         // test that output table is format 2
-        plan.glyph_map_gsub.clear();
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(73_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(75_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(485_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(552_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub.resize(553, crate::INVALID_GID);
+        plan.glyph_map_gsub[73] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[75] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[485] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[552] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.clear();
         plan.glyphset_gsub.insert(GlyphId::from(73_u32));

--- a/skera/src/gsubgpos.rs
+++ b/skera/src/gsubgpos.rs
@@ -1,7 +1,7 @@
 //! impl subset() for Sequence Context/Chained Sequence Context tables
 use crate::fnv::FnvHashMap;
 use crate::{
-    layout::{intersected_glyphs_and_indices, ClassDefSubsetStruct},
+    layout::{intersected_glyphs_and_indices, map_gsub_glyph, ClassDefSubsetStruct},
     offset::{SerializeSerialize, SerializeSubset},
     offset_array::{IterNullableHelper, SubsetOffsetArray},
     serialize::{SerializeErrorFlags, SerializeResultEmpty, Serializer},
@@ -133,15 +133,13 @@ impl<'a> SubsetTable<'a> for SequenceRuleSet<'_> {
 
 fn serialize_glyph_sequence(
     sequence: &[BigEndian<GlyphId16>],
-    glyph_map: &FnvHashMap<GlyphId, GlyphId>,
+    glyph_map: &[GlyphId],
     s: &mut Serializer,
 ) -> Result<(), SerializeErrorFlags> {
     for g in sequence {
-        if let Some(new_g) = glyph_map.get(&GlyphId::from(g.get())) {
-            s.embed(new_g.to_u32() as u16)?;
-        } else {
-            return Err(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY);
-        }
+        let new_g = map_gsub_glyph(glyph_map, GlyphId::from(g.get()))
+            .ok_or(SerializeErrorFlags::SERIALIZE_ERROR_EMPTY)?;
+        s.embed(new_g.to_u32() as u16)?;
     }
     Ok(())
 }
@@ -882,14 +880,14 @@ mod test {
             panic!("Wrong type of lookup table!");
         };
         let contextsubst_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 560],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(229_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(235_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(559_u32), GlyphId::from(3_u32));
+        plan.glyph_map_gsub[229] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[235] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[559] = GlyphId::from(3_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(229_u32));
         plan.glyphset_gsub.insert(GlyphId::from(235_u32));
@@ -933,16 +931,15 @@ mod test {
             panic!("Wrong type of lookup table!");
         };
         let chainedcontextpos_table = sub_tables.get(0).unwrap();
-        let mut plan = Plan::default();
+        let mut plan = Plan {
+            glyph_map_gsub: vec![crate::INVALID_GID; 52],
+            ..Default::default()
+        };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(48_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(49_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(50_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(51_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[48] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[49] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[50] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[51] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(48_u32));
         plan.glyphset_gsub.insert(GlyphId::from(49_u32));
@@ -989,21 +986,16 @@ mod test {
         let contextpos_table = sub_tables.get(0).unwrap();
         let mut plan = Plan {
             font_num_glyphs: 1398,
+            glyph_map_gsub: vec![crate::INVALID_GID; 973],
             ..Default::default()
         };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(0_u32), GlyphId::from(0_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(559_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(965_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(966_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(970_u32), GlyphId::from(4_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(972_u32), GlyphId::from(5_u32));
+        plan.glyph_map_gsub[0] = GlyphId::from(0_u32);
+        plan.glyph_map_gsub[559] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[965] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[966] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[970] = GlyphId::from(4_u32);
+        plan.glyph_map_gsub[972] = GlyphId::from(5_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(0_u32));
         plan.glyphset_gsub.insert(GlyphId::from(559_u32));
@@ -1055,25 +1047,18 @@ mod test {
         let contextsubst_table = sub_tables.get(0).unwrap();
         let mut plan = Plan {
             font_num_glyphs: 1398,
+            glyph_map_gsub: vec![crate::INVALID_GID; 1120],
             ..Default::default()
         };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(0_u32), GlyphId::from(0_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(163_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(934_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(986_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1000_u32), GlyphId::from(4_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1001_u32), GlyphId::from(5_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1025_u32), GlyphId::from(6_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1119_u32), GlyphId::from(7_u32));
+        plan.glyph_map_gsub[0] = GlyphId::from(0_u32);
+        plan.glyph_map_gsub[163] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[934] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[986] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[1000] = GlyphId::from(4_u32);
+        plan.glyph_map_gsub[1001] = GlyphId::from(5_u32);
+        plan.glyph_map_gsub[1025] = GlyphId::from(6_u32);
+        plan.glyph_map_gsub[1119] = GlyphId::from(7_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(0_u32));
         plan.glyphset_gsub.insert(GlyphId::from(163_u32));
@@ -1130,17 +1115,14 @@ mod test {
         let contextsubst_table = sub_tables.get(1).unwrap();
         let mut plan = Plan {
             font_num_glyphs: 1398,
+            glyph_map_gsub: vec![crate::INVALID_GID; 1384],
             ..Default::default()
         };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(0_u32), GlyphId::from(0_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(277_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(966_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(1383_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[0] = GlyphId::from(0_u32);
+        plan.glyph_map_gsub[277] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[966] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[1383] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(0_u32));
         plan.glyphset_gsub.insert(GlyphId::from(277_u32));
@@ -1187,19 +1169,15 @@ mod test {
         let contextsubst_table = sub_tables.get(1).unwrap();
         let mut plan = Plan {
             font_num_glyphs: 1398,
+            glyph_map_gsub: vec![crate::INVALID_GID; 276],
             ..Default::default()
         };
 
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(0_u32), GlyphId::from(0_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(31_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(38_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(218_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(275_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub[0] = GlyphId::from(0_u32);
+        plan.glyph_map_gsub[31] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[38] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[218] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[275] = GlyphId::from(4_u32);
 
         plan.glyphset_gsub.insert(GlyphId::from(0_u32));
         plan.glyphset_gsub.insert(GlyphId::from(31_u32));

--- a/skera/src/layout.rs
+++ b/skera/src/layout.rs
@@ -7,7 +7,7 @@ use crate::{
     offset::SerializeSubset,
     offset_array::SubsetOffsetArray,
     serialize::{OffsetWhence, SerializeErrorFlags, SerializeResultEmpty, Serializer},
-    CollectVariationIndices, NameIdClosure, Plan, Serialize, SubsetState, SubsetTable,
+    CollectVariationIndices, NameIdClosure, Plan, Serialize, SubsetState, SubsetTable, INVALID_GID,
 };
 use write_fonts::{
     read::{
@@ -191,20 +191,21 @@ impl<'a> SubsetTable<'a> for ClassDefFormat1<'a> {
         args: Self::ArgsForSubset,
     ) -> Result<Self::Output, SerializeErrorFlags> {
         let glyph_map = &plan.glyph_map_gsub;
+        let glyph_set = &plan.glyphset_gsub;
 
         let start = self.start_glyph_id().to_u32();
         let end = start + self.glyph_count() as u32 - 1;
-        let end = plan.glyphset_gsub.last().unwrap().to_u32().min(end);
+        let end = glyph_set.last().unwrap().to_u32().min(end);
 
         let class_values = self.class_value_array();
         let mut retained_classes = IntSet::empty();
 
-        let cap = glyph_map.len().min(self.glyph_count() as usize);
+        let cap = (glyph_set.len() as usize).min(self.glyph_count() as usize);
         let mut new_gid_classes = Vec::with_capacity(cap);
 
         for g in start..=end {
             let gid = GlyphId::from(g);
-            let Some(new_gid) = glyph_map.get(&gid) else {
+            let Some(new_gid) = map_gsub_glyph(glyph_map, gid) else {
                 continue;
             };
 
@@ -229,12 +230,12 @@ impl<'a> SubsetTable<'a> for ClassDefFormat1<'a> {
 
         let use_class_zero = if args.use_class_zero {
             let glyph_count = if let Some(glyph_filter) = args.glyph_filter {
-                glyph_map
-                    .keys()
-                    .filter(|&g| glyph_filter.get(*g).is_some())
+                glyph_set
+                    .iter()
+                    .filter(|&g| glyph_filter.get(g).is_some())
                     .count()
             } else {
-                glyph_map.len()
+                glyph_set.len() as usize
             };
             glyph_count <= new_gid_classes.len()
         } else {
@@ -271,16 +272,13 @@ impl<'a> SubsetTable<'a> for ClassDefFormat2<'a> {
         let mut retained_classes = IntSet::empty();
 
         let population = self.population();
-        let cap = glyph_map.len().min(population);
+        let cap = (glyph_set.len() as usize).min(population);
         let mut new_gid_classes = Vec::with_capacity(cap);
 
         let num_bits = 16 - self.class_range_count().leading_zeros() as u64;
         if population as u64 > glyph_set.len() * num_bits {
             for g in glyph_set.iter() {
-                if g.to_u32() > 0xFFFF_u32 {
-                    break;
-                }
-                let Some(new_gid) = glyph_map.get(&g) else {
+                let Some(new_gid) = map_gsub_glyph(glyph_map, g) else {
                     continue;
                 };
                 if let Some(glyph_filter) = args.glyph_filter {
@@ -311,7 +309,7 @@ impl<'a> SubsetTable<'a> for ClassDefFormat2<'a> {
                     .min(glyph_set.last().unwrap().to_u32());
                 for g in start..=end {
                     let gid = GlyphId::from(g);
-                    let Some(new_gid) = glyph_map.get(&gid) else {
+                    let Some(new_gid) = map_gsub_glyph(glyph_map, gid) else {
                         continue;
                     };
                     if let Some(glyph_filter) = args.glyph_filter {
@@ -329,12 +327,12 @@ impl<'a> SubsetTable<'a> for ClassDefFormat2<'a> {
         new_gid_classes.sort_by(|a, b| a.0.cmp(&b.0));
         let use_class_zero = if args.use_class_zero {
             let glyph_count = if let Some(glyph_filter) = args.glyph_filter {
-                glyph_map
-                    .keys()
-                    .filter(|&g| glyph_filter.get(*g).is_some())
+                glyph_set
+                    .iter()
+                    .filter(|&g| glyph_filter.get(g).is_some())
                     .count()
             } else {
-                glyph_map.len()
+                glyph_set.len() as usize
             };
             glyph_count <= new_gid_classes.len()
         } else {
@@ -570,15 +568,13 @@ impl<'a> SubsetTable<'a> for CoverageFormat1<'a> {
                         glyph_array
                             .binary_search_by(|g| g.get().to_u32().cmp(&old_gid.to_u32()))
                             .ok()
-                            .and_then(|_| plan.glyph_map_gsub.get(&old_gid))
-                            .copied()
+                            .and_then(|_| map_gsub_glyph(&plan.glyph_map_gsub, old_gid))
                     })
                     .collect()
             } else {
                 glyph_array
                     .iter()
-                    .filter_map(|g| plan.glyph_map_gsub.get(&GlyphId::from(g.get())))
-                    .copied()
+                    .filter_map(|g| map_gsub_glyph(&plan.glyph_map_gsub, GlyphId::from(g.get())))
                     .collect()
             };
 
@@ -606,7 +602,7 @@ impl<'a> SubsetTable<'a> for CoverageFormat2<'a> {
         // if/else branches return the same result, it's just an optimization that
         // we pick the faster approach depending on the number of glyphs
         let retained_glyphs: Vec<GlyphId> =
-            if self.population() > plan.glyph_map_gsub.len() * num_bits {
+            if self.population() > (plan.glyphset_gsub.len() as usize) * num_bits {
                 let range_records = self.range_records();
                 plan.glyphset_gsub
                     .iter()
@@ -622,18 +618,16 @@ impl<'a> SubsetTable<'a> for CoverageFormat2<'a> {
                                 }
                             })
                             .ok()
-                            .and_then(|_| plan.glyph_map_gsub.get(&g))
+                            .and_then(|_| map_gsub_glyph(&plan.glyph_map_gsub, g))
                     })
-                    .copied()
                     .collect()
             } else {
                 self.range_records()
                     .iter()
                     .flat_map(|r| {
                         r.iter()
-                            .filter_map(|g| plan.glyph_map_gsub.get(&GlyphId::from(g)))
+                            .filter_map(|g| map_gsub_glyph(&plan.glyph_map_gsub, GlyphId::from(g)))
                     })
-                    .copied()
                     .collect()
             };
 
@@ -736,12 +730,20 @@ impl<'a> Serialize<'a> for CoverageFormat2<'a> {
     }
 }
 
+#[inline]
+pub(crate) fn map_gsub_glyph(glyph_map: &[GlyphId], gid: GlyphId) -> Option<GlyphId> {
+    glyph_map
+        .get(gid.to_u32() as usize)
+        .copied()
+        .filter(|&g| g != INVALID_GID)
+}
+
 /// Return glyphs and their indices in the input Coverage table that intersect with the input glyph set
 /// returned glyphs are mapped into new glyph ids
 pub(crate) fn intersected_glyphs_and_indices(
     coverage: &CoverageTable,
     glyph_set: &IntSet<GlyphId>,
-    glyph_map: &FnvHashMap<GlyphId, GlyphId>,
+    glyph_map: &[GlyphId],
 ) -> (Vec<GlyphId>, IntSet<u16>) {
     let count = match coverage {
         CoverageTable::Format1(t) => t.glyph_count(),
@@ -759,17 +761,15 @@ pub(crate) fn intersected_glyphs_and_indices(
         for (idx, g) in glyph_set
             .iter()
             .filter_map(|g| coverage.get(g).map(|idx| (idx, g)))
-            .filter_map(|(idx, g)| glyph_map.get(&g).map(|new_g| (idx, *new_g)))
+            .filter_map(|(idx, g)| map_gsub_glyph(glyph_map, g).map(|new_g| (idx, new_g)))
         {
             glyphs.push(g);
             indices.insert(idx);
         }
     } else {
-        for (i, g) in coverage
-            .iter()
-            .enumerate()
-            .filter_map(|(i, g)| glyph_map.get(&GlyphId::from(g)).map(|&new_g| (i, new_g)))
-        {
+        for (i, g) in coverage.iter().enumerate().filter_map(|(i, g)| {
+            map_gsub_glyph(glyph_map, GlyphId::from(g)).map(|new_g| (i, new_g))
+        }) {
             glyphs.push(g);
             indices.insert(i as u16);
         }
@@ -1852,11 +1852,10 @@ mod test {
         plan.glyphset_gsub.insert(GlyphId::from(34_u32));
         plan.glyphset_gsub.insert(GlyphId::from(35_u32));
 
-        plan.glyph_map_gsub.insert(GlyphId::NOTDEF, GlyphId::NOTDEF);
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(34_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(35_u32), GlyphId::from(2_u32));
+        plan.glyph_map_gsub = vec![INVALID_GID; 36];
+        plan.glyph_map_gsub[0] = GlyphId::NOTDEF;
+        plan.glyph_map_gsub[34] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[35] = GlyphId::from(2_u32);
 
         let mut s = Serializer::new(1024);
         assert_eq!(s.start_serialize(), Ok(()));
@@ -1926,9 +1925,9 @@ mod test {
         plan.glyphset_gsub.insert(GlyphId::NOTDEF);
         plan.glyphset_gsub.insert(GlyphId::from(68_u32));
 
-        plan.glyph_map_gsub.insert(GlyphId::NOTDEF, GlyphId::NOTDEF);
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(68_u32), GlyphId::from(1_u32));
+        plan.glyph_map_gsub = vec![INVALID_GID; 69];
+        plan.glyph_map_gsub[0] = GlyphId::NOTDEF;
+        plan.glyph_map_gsub[68] = GlyphId::from(1_u32);
 
         let mut s = Serializer::new(1024);
         assert_eq!(s.start_serialize(), Ok(()));
@@ -1971,9 +1970,9 @@ mod test {
         plan.glyphset_gsub.insert(GlyphId::NOTDEF);
         plan.glyphset_gsub.insert(GlyphId::from(68_u32));
 
-        plan.glyph_map_gsub.insert(GlyphId::NOTDEF, GlyphId::NOTDEF);
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(68_u32), GlyphId::from(3_u32));
+        plan.glyph_map_gsub = vec![INVALID_GID; 69];
+        plan.glyph_map_gsub[0] = GlyphId::NOTDEF;
+        plan.glyph_map_gsub[68] = GlyphId::from(3_u32);
 
         let mut s = Serializer::new(1024);
         assert_eq!(s.start_serialize(), Ok(()));
@@ -2013,15 +2012,12 @@ mod test {
         plan.glyphset_gsub.insert(GlyphId::from(36_u32));
         plan.glyphset_gsub.insert(GlyphId::from(56_u32));
 
-        plan.glyph_map_gsub.insert(GlyphId::NOTDEF, GlyphId::NOTDEF);
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(34_u32), GlyphId::from(1_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(35_u32), GlyphId::from(2_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(36_u32), GlyphId::from(3_u32));
-        plan.glyph_map_gsub
-            .insert(GlyphId::from(56_u32), GlyphId::from(4_u32));
+        plan.glyph_map_gsub = vec![INVALID_GID; 57];
+        plan.glyph_map_gsub[0] = GlyphId::NOTDEF;
+        plan.glyph_map_gsub[34] = GlyphId::from(1_u32);
+        plan.glyph_map_gsub[35] = GlyphId::from(2_u32);
+        plan.glyph_map_gsub[36] = GlyphId::from(3_u32);
+        plan.glyph_map_gsub[56] = GlyphId::from(4_u32);
 
         let mut s = Serializer::new(1024);
         assert_eq!(s.start_serialize(), Ok(()));

--- a/skera/src/lib.rs
+++ b/skera/src/lib.rs
@@ -104,6 +104,7 @@ const MAX_NESTING_LEVEL: u8 = 64;
 // this causes tests to fail with 'subtract with overflow error'.
 // See <https://github.com/googlefonts/fontations/issues/997>
 const MAX_GID: GlyphId = GlyphId::new(0xFFFFFFFF);
+pub(crate) const INVALID_GID: GlyphId = GlyphId::new(u32::MAX);
 
 // ref: <https://github.com/harfbuzz/harfbuzz/blob/689383d05b2609a67efa307a9860b85cf40bf8c3/src/hb-subset-input.cc#L82>
 pub static DEFAULT_LAYOUT_FEATURES: &[Tag] = &[
@@ -324,7 +325,7 @@ pub struct Plan {
     /// Old->New glyph id mapping,
     glyph_map: FnvHashMap<GlyphId, GlyphId>,
     // Old->New glyph id (in glyph_set_gsub) mapping
-    glyph_map_gsub: FnvHashMap<GlyphId, GlyphId>,
+    glyph_map_gsub: Vec<GlyphId>,
     /// New->Old glyph id mapping,
     reverse_glyph_map: FnvHashMap<GlyphId, GlyphId>,
 
@@ -646,12 +647,16 @@ impl Plan {
     }
 
     fn create_glyph_map_gsub(&mut self) {
-        let map: FnvHashMap<GlyphId, GlyphId> = self
-            .glyphset_gsub
-            .iter()
-            .filter_map(|g| self.glyph_map.get(&g).map(|new_gid| (g, *new_gid)))
-            .collect();
-        let _ = std::mem::replace(&mut self.glyph_map_gsub, map);
+        let Some(max_gid) = self.glyphset_gsub.last() else {
+            return;
+        };
+        self.glyph_map_gsub
+            .resize(max_gid.to_u32() as usize + 1, INVALID_GID);
+        for g in self.glyphset_gsub.iter() {
+            if let Some(new_gid) = self.glyph_map.get(&g) {
+                self.glyph_map_gsub[g.to_u32() as usize] = *new_gid;
+            }
+        }
     }
 
     fn colr_closure(&mut self, font: &FontRef) {


### PR DESCRIPTION
port from HB: https://github.com/harfbuzz/harfbuzz/pull/6187, but I use this vector for all layout tables, about 5% improvement on NotoNastaliqUrdu.