### PR TITLE
Rework some skrifa errors

### DIFF
--- a/fauntlet/src/font/skrifa.rs
+++ b/fauntlet/src/font/skrifa.rs
@@ -6,7 +6,7 @@ use skrifa::{
     raw::{
         ps::{cff::CffFontRef, type1::Type1Font},
         types::F2Dot14,
-        FontRef, ReadError, TableProvider,
+        FontRef, TableProvider,
     },
     GlyphId, MetadataProvider, OutlineGlyphCollection,
 };
@@ -214,7 +214,7 @@ impl<'a> SkrifaCffInstance<'a> {
         let subfont = self.font.subfont(
             self.font
                 .subfont_index(glyph_id)
-                .ok_or(ReadError::OutOfBounds)?,
+                .ok_or(DrawError::Malformed)?,
             &[],
         )?;
         Ok(self.font.draw(&subfont, glyph_id, &[], self.ppem, pen)?)

--- a/read-fonts/src/tables/colr.rs
+++ b/read-fonts/src/tables/colr.rs
@@ -16,92 +16,77 @@ impl<'a> Colr<'a> {
     /// The return value is a range of layer indices that can be passed to
     /// [`v0_layer`](Self::v0_layer) to retrieve the layer glyph identifiers
     /// and palette color indices.
-    pub fn v0_base_glyph(&self, glyph_id: GlyphId) -> Result<Option<Range<usize>>, ReadError> {
-        let records = self.base_glyph_records().ok_or(ReadError::NullOffset)??;
-        let Ok(glyph_id) = glyph_id.try_into() else {
-            return Ok(None);
-        };
-        let record = match records.binary_search_by(|rec| rec.glyph_id().cmp(&glyph_id)) {
-            Ok(ix) => &records[ix],
-            _ => return Ok(None),
-        };
+    pub fn v0_base_glyph(&self, glyph_id: GlyphId) -> Option<Range<usize>> {
+        let records = self.base_glyph_records()?.ok()?;
+        let glyph_id = glyph_id.try_into().ok()?;
+        let ix = records
+            .binary_search_by(|rec| rec.glyph_id().cmp(&glyph_id))
+            .ok()?;
+        let record = records.get(ix)?;
         let start = record.first_layer_index() as usize;
-        let end = start + record.num_layers() as usize;
-        Ok(Some(start..end))
+        Some(start..start.checked_add(record.num_layers() as usize)?)
     }
 
     /// Returns the COLRv0 layer at the given index.
     ///
     /// The layer is represented by a tuple containing the glyph identifier of
     /// the associated outline and the palette color index.
-    pub fn v0_layer(&self, index: usize) -> Result<(GlyphId16, u16), ReadError> {
-        let layers = self.layer_records().ok_or(ReadError::NullOffset)??;
-        let layer = layers.get(index).ok_or(ReadError::OutOfBounds)?;
-        Ok((layer.glyph_id(), layer.palette_index()))
+    pub fn v0_layer(&self, index: usize) -> Option<(GlyphId16, u16)> {
+        let layer = self.layer_records()?.ok()?.get(index)?;
+        Some((layer.glyph_id(), layer.palette_index()))
     }
 
     /// Returns the COLRv1 base glyph for the given glyph identifier.
     ///
     /// The second value in the tuple is a unique identifier for the paint that
     /// may be used to detect recursion in the paint graph.
-    pub fn v1_base_glyph(
-        &self,
-        glyph_id: GlyphId,
-    ) -> Result<Option<(Paint<'a>, PaintId)>, ReadError> {
-        let Ok(glyph_id) = glyph_id.try_into() else {
-            return Ok(None);
-        };
-        let list = self.base_glyph_list().ok_or(ReadError::NullOffset)??;
+    pub fn v1_base_glyph(&self, glyph_id: GlyphId) -> Option<(Paint<'a>, PaintId)> {
+        let glyph_id = glyph_id.try_into().ok()?;
+        let list = self.base_glyph_list()?.ok()?;
         let records = list.base_glyph_paint_records();
-        let record = match records.binary_search_by(|rec| rec.glyph_id().cmp(&glyph_id)) {
-            Ok(ix) => &records[ix],
-            _ => return Ok(None),
-        };
+        let ix = records
+            .binary_search_by(|rec| rec.glyph_id().cmp(&glyph_id))
+            .ok()?;
+        let record = records.get(ix)?;
         let offset_data = list.offset_data();
         // Use the address of the paint as an identifier for the recursion
         // blacklist.
         let id = record.paint_offset().to_u32() as usize + offset_data.as_ref().as_ptr() as usize;
-        Ok(Some((record.paint(offset_data)?, id)))
+        Some((record.paint(offset_data).ok()?, id))
     }
 
     /// Returns the COLRv1 layer at the given index.
     ///
     /// The second value in the tuple is a unique identifier for the paint that
     /// may be used to detect recursion in the paint graph.
-    pub fn v1_layer(&self, index: usize) -> Result<(Paint<'a>, PaintId), ReadError> {
-        let list = self.layer_list().ok_or(ReadError::NullOffset)??;
-        let offset = list
-            .paint_offsets()
-            .get(index)
-            .ok_or(ReadError::OutOfBounds)?
-            .get();
+    pub fn v1_layer(&self, index: usize) -> Option<(Paint<'a>, PaintId)> {
+        let list = self.layer_list()?.ok()?;
+        let offset = list.paint_offsets().get(index)?.get();
         let offset_data = list.offset_data();
         // Use the address of the paint as an identifier for the recursion
         // blacklist.
         let id = offset.to_u32() as usize + offset_data.as_ref().as_ptr() as usize;
-        Ok((offset.resolve(offset_data)?, id))
+        Some((offset.resolve(offset_data).ok()?, id))
     }
 
     /// Returns the COLRv1 clip box for the given glyph identifier.
-    pub fn v1_clip_box(&self, glyph_id: GlyphId) -> Result<Option<ClipBox<'a>>, ReadError> {
+    pub fn v1_clip_box(&self, glyph_id: GlyphId) -> Option<ClipBox<'a>> {
         use core::cmp::Ordering;
-        let Ok(glyph_id): Result<GlyphId16, _> = glyph_id.try_into() else {
-            return Ok(None);
-        };
-        let list = self.clip_list().ok_or(ReadError::NullOffset)??;
+        let glyph_id: GlyphId16 = glyph_id.try_into().ok()?;
+        let list = self.clip_list()?.ok()?;
         let clips = list.clips();
-        let clip = match clips.binary_search_by(|clip| {
-            if glyph_id < clip.start_glyph_id() {
-                Ordering::Greater
-            } else if glyph_id > clip.end_glyph_id() {
-                Ordering::Less
-            } else {
-                Ordering::Equal
-            }
-        }) {
-            Ok(ix) => &clips[ix],
-            _ => return Ok(None),
-        };
-        Ok(Some(clip.clip_box(list.offset_data())?))
+        let ix = clips
+            .binary_search_by(|clip| {
+                if glyph_id < clip.start_glyph_id() {
+                    Ordering::Greater
+                } else if glyph_id > clip.end_glyph_id() {
+                    Ordering::Less
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .ok()?;
+        let clip = clips.get(ix)?;
+        clip.clip_box(list.offset_data()).ok()
     }
 }

--- a/skrifa/src/color/instance.rs
+++ b/skrifa/src/color/instance.rs
@@ -14,7 +14,6 @@ use read_fonts::{
         },
     },
     types::{BoundingBox, F2Dot14, GlyphId16, Point},
-    ReadError,
 };
 
 /// Unique paint identifier used for detecting cycles in the paint graph.
@@ -714,7 +713,7 @@ fn make_sorted_resolved_stops(
 pub fn resolve_paint<'a>(
     instance: &ColrInstance<'a>,
     paint: &Paint<'a>,
-) -> Result<ResolvedPaint<'a>, ReadError> {
+) -> Result<ResolvedPaint<'a>, PaintError> {
     Ok(match paint {
         Paint::ColrLayers(layers) => {
             let start = layers.first_layer_index() as usize;
@@ -734,7 +733,7 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::LinearGradient(gradient) => {
-            let color_line = gradient.color_line()?;
+            let color_line = gradient.color_line().map_err(|_| PaintError::Malformed)?;
             let extend = color_line.extend();
             ResolvedPaint::LinearGradient {
                 x0: gradient.x0().to_i16() as f32,
@@ -748,7 +747,7 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::VarLinearGradient(gradient) => {
-            let color_line = gradient.color_line()?;
+            let color_line = gradient.color_line().map_err(|_| PaintError::Malformed)?;
             let extend = color_line.extend();
             let deltas = instance.var_deltas::<6>(gradient.var_index_base());
             ResolvedPaint::LinearGradient {
@@ -763,7 +762,7 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::RadialGradient(gradient) => {
-            let color_line = gradient.color_line()?;
+            let color_line = gradient.color_line().map_err(|_| PaintError::Malformed)?;
             let extend = color_line.extend();
             ResolvedPaint::RadialGradient {
                 x0: gradient.x0().to_i16() as f32,
@@ -777,7 +776,7 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::VarRadialGradient(gradient) => {
-            let color_line = gradient.color_line()?;
+            let color_line = gradient.color_line().map_err(|_| PaintError::Malformed)?;
             let extend = color_line.extend();
             let deltas = instance.var_deltas::<6>(gradient.var_index_base());
             ResolvedPaint::RadialGradient {
@@ -792,7 +791,7 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::SweepGradient(gradient) => {
-            let color_line = gradient.color_line()?;
+            let color_line = gradient.color_line().map_err(|_| PaintError::Malformed)?;
             let extend = color_line.extend();
             ResolvedPaint::SweepGradient {
                 center_x: gradient.center_x().to_i16() as f32,
@@ -804,7 +803,7 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::VarSweepGradient(gradient) => {
-            let color_line = gradient.color_line()?;
+            let color_line = gradient.color_line().map_err(|_| PaintError::Malformed)?;
             let extend = color_line.extend();
             let deltas = instance.var_deltas::<4>(gradient.var_index_base());
             ResolvedPaint::SweepGradient {
@@ -818,14 +817,14 @@ pub fn resolve_paint<'a>(
         }
         Paint::Glyph(glyph) => ResolvedPaint::Glyph {
             glyph_id: glyph.glyph_id(),
-            paint: glyph.paint()?,
+            paint: glyph.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::ColrGlyph(glyph) => ResolvedPaint::ColrGlyph {
             glyph_id: glyph.glyph_id(),
         },
         Paint::Transform(transform) => {
-            let affine = transform.transform()?;
-            let paint = transform.paint()?;
+            let affine = transform.transform().map_err(|_| PaintError::Malformed)?;
+            let paint = transform.paint().map_err(|_| PaintError::Malformed)?;
             ResolvedPaint::Transform {
                 xx: affine.xx().to_f32(),
                 yx: affine.yx().to_f32(),
@@ -837,8 +836,8 @@ pub fn resolve_paint<'a>(
             }
         }
         Paint::VarTransform(transform) => {
-            let affine = transform.transform()?;
-            let paint = transform.paint()?;
+            let affine = transform.transform().map_err(|_| PaintError::Malformed)?;
+            let paint = transform.paint().map_err(|_| PaintError::Malformed)?;
             let deltas = instance.var_deltas::<6>(affine.var_index_base());
             ResolvedPaint::Transform {
                 xx: affine.xx().apply_float_delta(deltas[0]),
@@ -853,21 +852,21 @@ pub fn resolve_paint<'a>(
         Paint::Translate(transform) => ResolvedPaint::Translate {
             dx: transform.dx().to_i16() as f32,
             dy: transform.dy().to_i16() as f32,
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarTranslate(transform) => {
             let deltas = instance.var_deltas::<2>(transform.var_index_base());
             ResolvedPaint::Translate {
                 dx: transform.dx().apply_float_delta(deltas[0]),
                 dy: transform.dy().apply_float_delta(deltas[1]),
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::Scale(transform) => ResolvedPaint::Scale {
             scale_x: transform.scale_x().to_f32(),
             scale_y: transform.scale_y().to_f32(),
             around_center: None,
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarScale(transform) => {
             let deltas = instance.var_deltas::<2>(transform.var_index_base());
@@ -875,7 +874,7 @@ pub fn resolve_paint<'a>(
                 scale_x: transform.scale_x().apply_float_delta(deltas[0]),
                 scale_y: transform.scale_y().apply_float_delta(deltas[1]),
                 around_center: None,
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::ScaleAroundCenter(transform) => ResolvedPaint::Scale {
@@ -885,7 +884,7 @@ pub fn resolve_paint<'a>(
                 transform.center_x().to_i16() as f32,
                 transform.center_y().to_i16() as f32,
             )),
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarScaleAroundCenter(transform) => {
             let deltas = instance.var_deltas::<4>(transform.var_index_base());
@@ -896,7 +895,7 @@ pub fn resolve_paint<'a>(
                     transform.center_x().apply_float_delta(deltas[2]),
                     transform.center_y().apply_float_delta(deltas[3]),
                 )),
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::ScaleUniform(transform) => {
@@ -905,7 +904,7 @@ pub fn resolve_paint<'a>(
                 scale_x: scale,
                 scale_y: scale,
                 around_center: None,
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::VarScaleUniform(transform) => {
@@ -915,7 +914,7 @@ pub fn resolve_paint<'a>(
                 scale_x: scale,
                 scale_y: scale,
                 around_center: None,
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::ScaleUniformAroundCenter(transform) => {
@@ -927,7 +926,7 @@ pub fn resolve_paint<'a>(
                     transform.center_x().to_i16() as f32,
                     transform.center_y().to_i16() as f32,
                 )),
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::VarScaleUniformAroundCenter(transform) => {
@@ -940,20 +939,20 @@ pub fn resolve_paint<'a>(
                     transform.center_x().apply_float_delta(deltas[1]),
                     transform.center_y().apply_float_delta(deltas[2]),
                 )),
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::Rotate(transform) => ResolvedPaint::Rotate {
             angle: transform.angle().to_f32(),
             around_center: None,
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarRotate(transform) => {
             let deltas = instance.var_deltas::<1>(transform.var_index_base());
             ResolvedPaint::Rotate {
                 angle: transform.angle().apply_float_delta(deltas[0]),
                 around_center: None,
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::RotateAroundCenter(transform) => ResolvedPaint::Rotate {
@@ -962,7 +961,7 @@ pub fn resolve_paint<'a>(
                 transform.center_x().to_i16() as f32,
                 transform.center_y().to_i16() as f32,
             )),
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarRotateAroundCenter(transform) => {
             let deltas = instance.var_deltas::<3>(transform.var_index_base());
@@ -972,14 +971,14 @@ pub fn resolve_paint<'a>(
                     transform.center_x().apply_float_delta(deltas[1]),
                     transform.center_y().apply_float_delta(deltas[2]),
                 )),
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::Skew(transform) => ResolvedPaint::Skew {
             x_skew_angle: transform.x_skew_angle().to_f32(),
             y_skew_angle: transform.y_skew_angle().to_f32(),
             around_center: None,
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarSkew(transform) => {
             let deltas = instance.var_deltas::<2>(transform.var_index_base());
@@ -987,7 +986,7 @@ pub fn resolve_paint<'a>(
                 x_skew_angle: transform.x_skew_angle().apply_float_delta(deltas[0]),
                 y_skew_angle: transform.y_skew_angle().apply_float_delta(deltas[1]),
                 around_center: None,
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::SkewAroundCenter(transform) => ResolvedPaint::Skew {
@@ -997,7 +996,7 @@ pub fn resolve_paint<'a>(
                 transform.center_x().to_i16() as f32,
                 transform.center_y().to_i16() as f32,
             )),
-            paint: transform.paint()?,
+            paint: transform.paint().map_err(|_| PaintError::Malformed)?,
         },
         Paint::VarSkewAroundCenter(transform) => {
             let deltas = instance.var_deltas::<4>(transform.var_index_base());
@@ -1008,13 +1007,17 @@ pub fn resolve_paint<'a>(
                     transform.center_x().apply_float_delta(deltas[2]),
                     transform.center_y().apply_float_delta(deltas[3]),
                 )),
-                paint: transform.paint()?,
+                paint: transform.paint().map_err(|_| PaintError::Malformed)?,
             }
         }
         Paint::Composite(composite) => ResolvedPaint::Composite {
-            source_paint: composite.source_paint()?,
+            source_paint: composite
+                .source_paint()
+                .map_err(|_| PaintError::Malformed)?,
             mode: composite.composite_mode(),
-            backdrop_paint: composite.backdrop_paint()?,
+            backdrop_paint: composite
+                .backdrop_paint()
+                .map_err(|_| PaintError::Malformed)?,
         },
     })
 }

--- a/skrifa/src/color/mod.rs
+++ b/skrifa/src/color/mod.rs
@@ -53,7 +53,7 @@ pub use read_fonts::tables::colr::{CompositeMode, Extend};
 
 use read_fonts::{
     types::{BoundingBox, GlyphId, Point},
-    ReadError, TableProvider,
+    TableProvider,
 };
 
 #[doc(inline)]
@@ -82,7 +82,12 @@ pub type Transform = read_fonts::types::Matrix<f32>;
 /// parse errors from read-fonts.
 #[derive(Debug, Clone)]
 pub enum PaintError {
-    ParseError(ReadError),
+    /// The font data does not make sense: absent where it was required, too
+    /// short, or self-inconsistent.
+    ///
+    /// Carries nothing, for the reason given on
+    /// [`DrawError::Malformed`][crate::outline::DrawError::Malformed].
+    Malformed,
     GlyphNotFound(GlyphId),
     PaintCycleDetected,
     DepthLimitExceeded,
@@ -91,9 +96,7 @@ pub enum PaintError {
 impl std::fmt::Display for PaintError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            PaintError::ParseError(read_error) => {
-                write!(f, "Error parsing font data: {read_error}")
-            }
+            PaintError::Malformed => write!(f, "font data was absent or malformed"),
             PaintError::GlyphNotFound(glyph_id) => {
                 write!(f, "No COLRv1 glyph found for glyph id: {glyph_id}")
             }
@@ -105,16 +108,7 @@ impl std::fmt::Display for PaintError {
 
 impl core::error::Error for PaintError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            PaintError::ParseError(read_error) => Some(read_error),
-            _ => None,
-        }
-    }
-}
-
-impl From<ReadError> for PaintError {
-    fn from(value: ReadError) -> Self {
-        PaintError::ParseError(value)
+        None
     }
 }
 
@@ -318,7 +312,7 @@ pub struct ColorGlyph<'a> {
 #[derive(Clone)]
 enum ColorGlyphRoot<'a> {
     V0Range(Range<usize>),
-    V1Paint(colr::Paint<'a>, PaintId, GlyphId, Result<u16, ReadError>),
+    V1Paint(colr::Paint<'a>, PaintId, GlyphId, Option<u16>),
 }
 
 impl<'a> ColorGlyph<'a> {
@@ -354,7 +348,7 @@ impl<'a> ColorGlyph<'a> {
                     instance::ColrInstance::new(self.colr.clone(), location.into().coords());
                 let resolved_bounding_box = get_clipbox_font_units(&instance, *glyph_id);
                 resolved_bounding_box.map(|bounding_box| {
-                    let scale_factor = size.linear_scale((*upem).clone().unwrap_or(0));
+                    let scale_factor = size.linear_scale(upem.unwrap_or(0));
                     bounding_box.scale(scale_factor)
                 })
             }
@@ -418,14 +412,14 @@ impl<'a> ColorGlyph<'a> {
 #[derive(Clone)]
 pub struct ColorGlyphCollection<'a> {
     colr: Option<colr::Colr<'a>>,
-    upem: Result<u16, ReadError>,
+    upem: Option<u16>,
 }
 
 impl<'a> ColorGlyphCollection<'a> {
     /// Creates a new collection of paintable color glyphs for the given font.
     pub fn new(font: &FontRef<'a>) -> Self {
         let colr = font.colr().ok();
-        let upem = font.head().map(|h| h.units_per_em());
+        let upem = font.head().map(|h| h.units_per_em()).ok();
 
         Self { colr, upem }
     }
@@ -441,12 +435,12 @@ impl<'a> ColorGlyphCollection<'a> {
 
         let root_paint_ref = match glyph_format {
             ColorGlyphFormat::ColrV0 => {
-                let layer_range = colr.v0_base_glyph(glyph_id).ok()??;
+                let layer_range = colr.v0_base_glyph(glyph_id)?;
                 ColorGlyphRoot::V0Range(layer_range)
             }
             ColorGlyphFormat::ColrV1 => {
-                let (paint, paint_id) = colr.v1_base_glyph(glyph_id).ok()??;
-                ColorGlyphRoot::V1Paint(paint, paint_id, glyph_id, self.upem.clone())
+                let (paint, paint_id) = colr.v1_base_glyph(glyph_id)?;
+                ColorGlyphRoot::V1Paint(paint, paint_id, glyph_id, self.upem)
             }
         };
         Some(ColorGlyph {

--- a/skrifa/src/color/traversal.rs
+++ b/skrifa/src/color/traversal.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use raw::{tables::colr::Paint, ReadError};
+use raw::tables::colr::Paint;
 use read_fonts::{
     tables::colr::CompositeMode,
     types::{BoundingBox, GlyphId},
@@ -63,7 +63,7 @@ pub(crate) fn get_clipbox_font_units(
     colr_instance: &ColrInstance,
     glyph_id: GlyphId,
 ) -> Option<BoundingBox<f32>> {
-    let maybe_clipbox = (*colr_instance).v1_clip_box(glyph_id).ok().flatten()?;
+    let maybe_clipbox = (*colr_instance).v1_clip_box(glyph_id)?;
     Some(resolve_clip_box(colr_instance, &maybe_clipbox))
 }
 
@@ -102,7 +102,7 @@ impl<'a, P: ColorPainter> TraversalState<'a, P> {
             .nodes_left
             .checked_sub(1)
             .ok_or(PaintError::DepthLimitExceeded)?;
-        Ok(super::instance::resolve_paint(&self.instance, paint)?)
+        super::instance::resolve_paint(&self.instance, paint)
     }
 }
 
@@ -119,7 +119,10 @@ pub(crate) fn traverse_with_callbacks<'a, P: ColorPainter>(
         ResolvedPaint::ColrLayers { range } => {
             for layer_index in range.clone() {
                 // Perform cycle detection with paint id here, second part of the tuple.
-                let (layer_paint, paint_id) = state.instance.v1_layer(layer_index)?;
+                let (layer_paint, paint_id) = state
+                    .instance
+                    .v1_layer(layer_index)
+                    .ok_or(PaintError::Malformed)?;
                 let mut cycle_guard = decycler.enter(paint_id)?;
                 traverse_with_callbacks(
                     &state.resolve_paint(&layer_paint)?,
@@ -187,7 +190,7 @@ pub(crate) fn traverse_with_callbacks<'a, P: ColorPainter>(
         }
         ResolvedPaint::ColrGlyph { glyph_id } => {
             let glyph_id = (*glyph_id).into();
-            match state.instance.v1_base_glyph(glyph_id)? {
+            match state.instance.v1_base_glyph(glyph_id) {
                 Some((base_glyph, base_glyph_paint_id)) => {
                     let mut cycle_guard = decycler.enter(base_glyph_paint_id)?;
                     let draw_result = state.painter.paint_cached_color_glyph(glyph_id)?;
@@ -230,12 +233,9 @@ pub(crate) fn traverse_with_callbacks<'a, P: ColorPainter>(
         | ResolvedPaint::Skew {
             paint: next_paint, ..
         } => {
-            state.painter.push_transform(
-                paint
-                    .as_transform()
-                    .ok_or(ReadError::MalformedData("expected a transform paint"))?
-                    .0,
-            );
+            state
+                .painter
+                .push_transform(paint.as_transform().ok_or(PaintError::Malformed)?.0);
             let result = traverse_unresolved_paint(next_paint, state, decycler, recurse_depth + 1);
             state.painter.pop_transform();
             result
@@ -277,7 +277,9 @@ pub(crate) fn traverse_v0_range(
     painter: &mut impl ColorPainter,
 ) -> Result<(), PaintError> {
     for layer_index in range.clone() {
-        let (layer_glyph, palette_index) = (*instance).v0_layer(layer_index)?;
+        let (layer_glyph, palette_index) = (*instance)
+            .v0_layer(layer_index)
+            .ok_or(PaintError::Malformed)?;
         painter.fill_glyph(
             layer_glyph.into(),
             None,
@@ -447,7 +449,7 @@ mod tests {
         let glyph_id = font.charmap().map(CLIPBOX[0]).unwrap();
         let mut painter = StackTrackingPainter::default();
         let instance = ColrInstance::new(font.colr().unwrap(), &[]);
-        let inner_paint = instance.v1_base_glyph(glyph_id).unwrap().unwrap().0;
+        let inner_paint = instance.v1_base_glyph(glyph_id).unwrap().0;
         let mut state = TraversalState::new(instance, &mut painter);
         let mut decycler = PaintDecycler::new();
         state.nodes_left = 0;
@@ -473,7 +475,7 @@ mod tests {
         let glyph_id = font.charmap().map(CLIPBOX[0]).unwrap();
         let mut painter = StackTrackingPainter::default();
         let instance = ColrInstance::new(font.colr().unwrap(), &[]);
-        let inner_paint = instance.v1_base_glyph(glyph_id).unwrap().unwrap().0;
+        let inner_paint = instance.v1_base_glyph(glyph_id).unwrap().0;
         let mut state = TraversalState::new(instance, &mut painter);
         let mut decycler = PaintDecycler::new();
         state.nodes_left = 0;
@@ -555,7 +557,7 @@ mod tests {
             let mut decycler = PaintDecycler::new();
             state.nodes_left = limit;
             let paint = state
-                .resolve_paint(&state.instance.v1_base_glyph(gid).unwrap().unwrap().0)
+                .resolve_paint(&state.instance.v1_base_glyph(gid).unwrap().0)
                 .unwrap();
             traverse_with_callbacks(&paint, &mut state, &mut decycler, 0)
                 .map(|_| limit - state.nodes_left)

--- a/skrifa/src/outline/autohint/shape.rs
+++ b/skrifa/src/outline/autohint/shape.rs
@@ -13,7 +13,7 @@ use raw::{
         varc::CoverageTable,
     },
     types::Tag,
-    ReadError, TableProvider,
+    TableProvider,
 };
 
 // To prevent infinite recursion in contextual lookups. Matches HB
@@ -479,7 +479,7 @@ impl<'a, 'b> GsubHandler<'a, 'b> {
                             // required and if we're not under a contextual
                             // lookup
                             if self.need_blue_substs && self.lookup_depth == 1 {
-                                self.check_blue_coverage(Ok(coverage));
+                                self.check_blue_coverage(Some(coverage));
                             }
                         }
                         SingleSubst::Format2(table) => {
@@ -488,7 +488,7 @@ impl<'a, 'b> GsubHandler<'a, 'b> {
                             }
                             // See above
                             if self.need_blue_substs && self.lookup_depth == 1 {
-                                self.check_blue_coverage(table.coverage());
+                                self.check_blue_coverage(table.coverage().ok());
                             }
                         }
                     }
@@ -503,7 +503,7 @@ impl<'a, 'b> GsubHandler<'a, 'b> {
                     }
                     // See above
                     if self.need_blue_substs && self.lookup_depth == 1 {
-                        self.check_blue_coverage(table.coverage());
+                        self.check_blue_coverage(table.coverage().ok());
                     }
                 }
             }
@@ -643,8 +643,8 @@ impl<'a, 'b> GsubHandler<'a, 'b> {
 
     /// Checks the given coverage table for any characters in the blue
     /// strings associated with our current style.
-    fn check_blue_coverage(&mut self, coverage: Result<CoverageTable<'a>, ReadError>) {
-        let Ok(coverage) = coverage else {
+    fn check_blue_coverage(&mut self, coverage: Option<CoverageTable<'a>>) {
+        let Some(coverage) = coverage else {
             return;
         };
         for (blue_str, _) in self.style.script.blues {

--- a/skrifa/src/outline/cff/mod.rs
+++ b/skrifa/src/outline/cff/mod.rs
@@ -13,7 +13,7 @@ use read_fonts::{
     },
     tables::variations::ItemVariationStore,
     types::{F2Dot14, Fixed, GlyphId},
-    FontData, FontRead, FontRef, ReadError, TableProvider,
+    FontData, FontRead, FontRef, TableProvider,
 };
 use std::ops::Range;
 
@@ -463,12 +463,8 @@ impl PrivateDict {
                 LanguageGroup(group) => dict.hint_params.language_group = group,
                 // Subrs offset is relative to the private DICT
                 SubrsOffset(offset) => {
-                    dict.subrs_offset = Some(
-                        range
-                            .start
-                            .checked_add(offset)
-                            .ok_or(ReadError::OutOfBounds)?,
-                    )
+                    dict.subrs_offset =
+                        Some(range.start.checked_add(offset).ok_or(Error::Malformed)?)
                 }
                 VariationStoreIndex(index) => dict.store_index = index,
                 _ => {}
@@ -549,7 +545,7 @@ impl<'a> TopDict<'a> {
                     // IVS is preceded by a 2 byte length, but ensure that
                     // we don't overflow
                     // See <https://github.com/googlefonts/fontations/issues/1223>
-                    let offset = offset.checked_add(2).ok_or(ReadError::OutOfBounds)?;
+                    let offset = offset.checked_add(2).ok_or(Error::Malformed)?;
                     items.var_store = Some(ItemVariationStore::read(FontData::new(
                         table_data.get(offset..).unwrap_or_default(),
                     ))?);

--- a/skrifa/src/outline/error.rs
+++ b/skrifa/src/outline/error.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 use read_fonts::types::GlyphId;
 
-pub use read_fonts::{ps::error::Error as CffError, ReadError};
+pub use read_fonts::ps::error::Error as CffError;
 
 pub use super::glyf::HintError;
 pub use super::path::ToPathError;
@@ -29,8 +29,13 @@ pub enum DrawError {
     PostScript(CffError),
     /// Conversion from outline to path failed.
     ToPath(ToPathError),
-    /// Error occurred when reading font data.
-    Read(ReadError),
+    /// The font data does not make sense: absent where it was required, too
+    /// short, or self-inconsistent.
+    ///
+    /// Carries nothing. A table that is missing, one that is truncated and one
+    /// whose offsets do not resolve are the same answer to "can this glyph be
+    /// drawn", and there is nothing a caller can do differently between them.
+    Malformed,
     /// HarfBuzz style drawing with hints is not supported
     // Error rather than silently returning unhinted per f2f discussion.
     HarfBuzzHintingUnsupported,
@@ -45,12 +50,6 @@ impl From<HintError> for DrawError {
 impl From<ToPathError> for DrawError {
     fn from(e: ToPathError) -> Self {
         Self::ToPath(e)
-    }
-}
-
-impl From<ReadError> for DrawError {
-    fn from(e: ReadError) -> Self {
-        Self::Read(e)
     }
 }
 
@@ -79,7 +78,7 @@ impl fmt::Display for DrawError {
             ),
             Self::PostScript(e) => write!(f, "{e}"),
             Self::ToPath(e) => write!(f, "{e}"),
-            Self::Read(e) => write!(f, "{e}"),
+            Self::Malformed => write!(f, "font data was absent or malformed"),
             Self::HarfBuzzHintingUnsupported => write!(
                 f,
                 "HarfBuzz style paths with hinting is not (yet?) supported"

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -14,7 +14,7 @@ pub use outline::{Outline, ScaledOutline};
 use super::{DrawError, GlyphHMetrics, Hinting};
 use crate::{GLYF_COMPOSITE_RECURSION_LIMIT, MAX_GLYF_POINTS, MAX_GRAPH_EDGES};
 use memory::{FreeTypeOutlineMemory, HarfBuzzOutlineMemory};
-use raw::{FontRef, ReadError};
+use raw::FontRef;
 use read_fonts::{
     tables::{
         glyf::{
@@ -153,7 +153,10 @@ impl<'a> Outlines<'a> {
             has_variations: self.gvar.is_some(),
             ..Default::default()
         };
-        let glyph = self.loca.get_glyf(glyph_id, &self.glyf)?;
+        let glyph = self
+            .loca
+            .get_glyf(glyph_id, &self.glyf)
+            .map_err(|_| DrawError::Malformed)?;
         if let Some(glyph) = glyph.as_ref() {
             self.outline_rec(glyph, &mut outline, 0, 0, &mut 0)?;
         }
@@ -216,7 +219,10 @@ impl Outlines<'_> {
                 let point_base = outline.points;
                 for (component, flags) in composite.component_glyphs_and_flags() {
                     outline.has_overlaps |= flags.contains(CompositeGlyphFlags::OVERLAP_COMPOUND);
-                    let component_glyph = self.loca.get_glyf(component.into(), &self.glyf)?;
+                    let component_glyph = self
+                        .loca
+                        .get_glyf(component.into(), &self.glyf)
+                        .map_err(|_| DrawError::Malformed)?;
                     let Some(component_glyph) = component_glyph else {
                         continue;
                     };
@@ -618,7 +624,9 @@ impl Scaler for FreeTypeScaler<'_> {
             .ok_or(InsufficientMemory)?;
         // Read our unscaled points and flags (up to point_count which does not
         // include phantom points).
-        glyph.read_points_fast(&mut unscaled[..point_count], &mut flags[..point_count])?;
+        glyph
+            .read_points_fast(&mut unscaled[..point_count], &mut flags[..point_count])
+            .map_err(|_| DrawError::Malformed)?;
         // Compute the range for our contour end point buffer and slice it.
         let contours_start = self.contour_count;
         let contour_end_pts = glyph.end_pts_of_contours();
@@ -635,10 +643,9 @@ impl Scaler for FreeTypeScaler<'_> {
         for (end_pt, contour) in contour_end_pts.iter().zip(contours.iter_mut()) {
             let end_pt = end_pt.get();
             if end_pt < last_end_pt {
-                return Err(ReadError::MalformedData(
-                    "unordered contour end points in TrueType glyph",
-                )
-                .into());
+                // unordered contour end points: malformed, like every other
+                // way the data can fail to make sense
+                return Err(DrawError::Malformed);
             }
             last_end_pt = end_pt;
             *contour = end_pt;
@@ -856,7 +863,8 @@ impl Scaler for FreeTypeScaler<'_> {
             let component_glyph = self
                 .outlines
                 .loca
-                .get_glyf(component.glyph.into(), &self.outlines.glyf)?;
+                .get_glyf(component.glyph.into(), &self.outlines.glyf)
+                .map_err(|_| DrawError::Malformed)?;
             self.load(&component_glyph, component.glyph.into(), recurse_depth + 1)?;
             let end_point = self.point_count;
             if !component
@@ -1141,7 +1149,9 @@ impl Scaler for HarfBuzzScaler<'_> {
             .flags
             .get_mut(point_range)
             .ok_or(InsufficientMemory)?;
-        glyph.read_points_fast(&mut points[..point_count], &mut flags[..point_count])?;
+        glyph
+            .read_points_fast(&mut points[..point_count], &mut flags[..point_count])
+            .map_err(|_| DrawError::Malformed)?;
         // Compute the range for our contour end point buffer and slice it.
         let contours_start = self.contour_count;
         let contour_end_pts = glyph.end_pts_of_contours();
@@ -1263,7 +1273,8 @@ impl Scaler for HarfBuzzScaler<'_> {
             let component_glyph = self
                 .outlines
                 .loca
-                .get_glyf(component.glyph.into(), &self.outlines.glyf)?;
+                .get_glyf(component.glyph.into(), &self.outlines.glyf)
+                .map_err(|_| DrawError::Malformed)?;
             self.load(&component_glyph, component.glyph.into(), recurse_depth + 1)?;
             let end_point = self.point_count;
             if !component

--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -10,7 +10,7 @@ use read_fonts::{
         variations::NO_VARIATION_INDEX,
     },
     types::{F2Dot14, GlyphId, Matrix},
-    FontRef, ReadError, TableProvider,
+    FontRef, TableProvider,
 };
 
 use crate::{
@@ -196,7 +196,7 @@ impl<'a> Outlines<'a> {
         self.base.base_outline_kind(glyph_id)
     }
 
-    pub fn outline(&self, glyph_id: GlyphId) -> Result<Option<Outline>, ReadError> {
+    pub fn outline(&self, glyph_id: GlyphId) -> Result<Option<Outline>, DrawError> {
         let Some(coverage_index) = self.coverage.get(glyph_id) else {
             return Ok(None);
         };
@@ -209,7 +209,7 @@ impl<'a> Outlines<'a> {
     }
 
     /// Lightweight coverage lookup without computing max_component_memory.
-    fn coverage_index(&self, glyph_id: GlyphId) -> Result<Option<u16>, ReadError> {
+    fn coverage_index(&self, glyph_id: GlyphId) -> Result<Option<u16>, DrawError> {
         Ok(self.coverage.get(glyph_id))
     }
 
@@ -217,7 +217,7 @@ impl<'a> Outlines<'a> {
         &self,
         glyph_id: GlyphId,
         coverage_index: u16,
-    ) -> Result<usize, ReadError> {
+    ) -> Result<usize, DrawError> {
         let mut stack = GlyphStack::new();
         let mut edges_left = MAX_GRAPH_EDGES;
         self.max_component_memory_for_glyph(glyph_id, coverage_index, &mut stack, &mut edges_left)
@@ -229,7 +229,7 @@ impl<'a> Outlines<'a> {
         coverage_index: u16,
         stack: &mut GlyphStack,
         edges_left: &mut usize,
-    ) -> Result<usize, ReadError> {
+    ) -> Result<usize, DrawError> {
         if stack.contains(&glyph_id) {
             return Ok(0);
         }
@@ -244,9 +244,12 @@ impl<'a> Outlines<'a> {
         *edges_left -= 1;
         stack.push(glyph_id);
         let mut max_memory = 0usize;
-        let glyph = self.varc.glyph(coverage_index as usize)?;
+        let glyph = self
+            .varc
+            .glyph(coverage_index as usize)
+            .map_err(|_| DrawError::Malformed)?;
         for component in glyph.components() {
-            let component = component?;
+            let component = component.map_err(|_| DrawError::Malformed)?;
             let component_gid = component.gid();
             let component_memory = if component_gid == glyph_id {
                 self.base.base_outline_memory(component_gid)
@@ -336,14 +339,17 @@ impl<'a> Outlines<'a> {
             return Err(DrawError::RecursionLimitExceeded(glyph_id));
         }
         scratch.edges_left -= 1;
-        let glyph = self.varc.glyph(coverage_index as usize)?;
+        let glyph = self
+            .varc
+            .glyph(coverage_index as usize)
+            .map_err(|_| DrawError::Malformed)?;
         stack.push(glyph_id);
         let coverage = ctx.coverage;
         let store_regions = ctx.store_regions;
         let mut component_coords_buffer = CoordVec::new();
         let mut child_scalar_cache: Option<ScalarCache> = None;
         for component in glyph.components() {
-            let component = component?;
+            let component = component.map_err(|_| DrawError::Malformed)?;
             if !self.component_condition_met(
                 &component,
                 current_coords,
@@ -482,14 +488,12 @@ impl<'a> Outlines<'a> {
             return Ok(());
         }
 
-        let axis_indices_index = component
-            .axis_indices_index()
-            .ok_or(ReadError::MalformedData("Missing axisIndicesIndex"))?;
+        let axis_indices_index = component.axis_indices_index().ok_or(DrawError::Malformed)?;
         let num_axes = self.axis_indices(axis_indices_index as usize, &mut scratch.axis_indices)?;
 
         self.axis_values(component, num_axes, &mut scratch.axis_values)?;
         if let Some(var_idx) = component.axis_values_var_index() {
-            let (store, regions) = store_regions.ok_or(ReadError::NullOffset)?;
+            let (store, regions) = store_regions.ok_or(DrawError::Malformed)?;
             compute_tuple_deltas(
                 store,
                 regions,
@@ -510,7 +514,7 @@ impl<'a> Outlines<'a> {
             .zip(scratch.axis_values.iter().copied())
         {
             let Some(slot) = coords.get_mut(*axis_index as usize) else {
-                return Err(DrawError::Read(ReadError::OutOfBounds));
+                return Err(DrawError::Malformed);
             };
             let raw = value.round().clamp(i16::MIN as f32, i16::MAX as f32) as i16;
             *slot = F2Dot14::from_bits(raw);
@@ -519,7 +523,10 @@ impl<'a> Outlines<'a> {
     }
 
     fn axis_indices(&self, nth: usize, out: &mut AxisIndexVec) -> Result<usize, DrawError> {
-        let packed = self.varc.axis_indices(nth)?;
+        let packed = self
+            .varc
+            .axis_indices(nth)
+            .map_err(|_| DrawError::Malformed)?;
         out.clear();
         for value in packed.iter() {
             out.push(value as u16);
@@ -576,7 +583,7 @@ impl<'a> Outlines<'a> {
             return Ok(());
         }
 
-        let (store, regions) = store_regions.ok_or(ReadError::NullOffset)?;
+        let (store, regions) = store_regions.ok_or(DrawError::Malformed)?;
         compute_tuple_deltas(
             store,
             regions,
@@ -653,11 +660,14 @@ impl<'a> Outlines<'a> {
             return Ok(true);
         };
         let Some(condition_list) = self.varc.condition_list() else {
-            return Err(DrawError::Read(ReadError::NullOffset));
+            return Err(DrawError::Malformed);
         };
-        let condition_list = condition_list?;
-        let condition = condition_list.conditions().get(condition_index as usize)?;
-        let (store, regions) = store_regions.ok_or(ReadError::NullOffset)?;
+        let condition_list = condition_list.map_err(|_| DrawError::Malformed)?;
+        let condition = condition_list
+            .conditions()
+            .get(condition_index as usize)
+            .map_err(|_| DrawError::Malformed)?;
+        let (store, regions) = store_regions.ok_or(DrawError::Malformed)?;
         Self::eval_condition(&condition, coords, store, regions, scalar_cache, scratch, 0)
     }
 
@@ -701,7 +711,7 @@ impl<'a> Outlines<'a> {
             }
             Condition::Format3And(condition) => {
                 for nested in condition.conditions().iter() {
-                    let nested = nested?;
+                    let nested = nested.map_err(|_| DrawError::Malformed)?;
                     if !Self::eval_condition(
                         &nested,
                         coords,
@@ -718,7 +728,7 @@ impl<'a> Outlines<'a> {
             }
             Condition::Format4Or(condition) => {
                 for nested in condition.conditions().iter() {
-                    let nested = nested?;
+                    let nested = nested.map_err(|_| DrawError::Malformed)?;
                     if Self::eval_condition(
                         &nested,
                         coords,
@@ -734,7 +744,7 @@ impl<'a> Outlines<'a> {
                 Ok(false)
             }
             Condition::Format5Negate(condition) => {
-                let nested = condition.condition()?;
+                let nested = condition.condition().map_err(|_| DrawError::Malformed)?;
                 Ok(!Self::eval_condition(
                     &nested,
                     coords,
@@ -755,10 +765,13 @@ impl<'a> Outlines<'a> {
         // The VARC `multiVarStore` offset is nullable, so a valid font may omit the
         // store entirely. In that case there are no variation regions and an empty
         // cache is correct: any component that references variation data will fail
-        // gracefully with `ReadError::NullOffset` when it resolves the missing store,
-        // rather than us panicking here.
+        // gracefully when it resolves the missing store, rather than us
+        // panicking here.
         let region_count = match store {
-            Some(store) => store.region_list()?.region_count() as usize,
+            Some(store) => store
+                .region_list()
+                .map_err(|_| DrawError::Malformed)?
+                .region_count() as usize,
             None => 0,
         };
         Ok(ScalarCache::new(region_count))
@@ -804,7 +817,7 @@ fn compute_tuple_deltas(
     tuple_len: usize,
     cache: &mut ScalarCache,
     out: &mut DeltaVec,
-) -> Result<(), ReadError> {
+) -> Result<(), DrawError> {
     out.resize_and_fill(tuple_len, 0.0);
     if tuple_len == 0 || var_idx == NO_VARIATION_INDEX {
         return Ok(());
@@ -814,9 +827,12 @@ fn compute_tuple_deltas(
     let data = store
         .variation_data()
         .get(outer)
-        .map_err(|_| ReadError::InvalidCollectionIndex(outer as _))?;
+        .map_err(|_| DrawError::Malformed)?;
     let region_indices = data.region_indices();
-    let mut deltas = data.delta_set(inner)?.fetcher();
+    let mut deltas = data
+        .delta_set(inner)
+        .map_err(|_| DrawError::Malformed)?
+        .fetcher();
     let regions = regions.regions();
     let out_slice = out.as_mut_slice();
 
@@ -825,7 +841,10 @@ fn compute_tuple_deltas(
         let region_idx = region_index.get() as usize;
         let mut scalar = cache.get(region_idx);
         if scalar >= 2.0 {
-            scalar = regions.get(region_idx)?.compute_scalar_f32(coords);
+            scalar = regions
+                .get(region_idx)
+                .map_err(|_| DrawError::Malformed)?
+                .compute_scalar_f32(coords);
             cache.set(region_idx, scalar);
         }
         // We skip lazily. Reduces work at the tail end.
@@ -833,10 +852,12 @@ fn compute_tuple_deltas(
             skip += out_slice.len();
         } else {
             if skip != 0 {
-                deltas.skip(skip)?;
+                deltas.skip(skip).map_err(|_| DrawError::Malformed)?;
                 skip = 0;
             }
-            deltas.add_to_f32_scaled(out_slice, scalar)?;
+            deltas
+                .add_to_f32_scaled(out_slice, scalar)
+                .map_err(|_| DrawError::Malformed)?;
         }
     }
 
@@ -1006,7 +1027,9 @@ mod tests {
 
         let err = compute_tuple_deltas(&store, &regions, 0xFFFF_0000, &[], 1, &mut cache, &mut out)
             .unwrap_err();
-        assert!(matches!(err, ReadError::InvalidCollectionIndex(_)));
+        // an outer index past the end of the variation data is refused,
+        // rather than silently contributing zero deltas
+        assert!(matches!(err, DrawError::Malformed));
     }
 
     #[test]
@@ -1114,8 +1137,8 @@ mod tests {
             return Ok(());
         }
 
-        let store = var_store.ok_or(ReadError::NullOffset)?;
-        let regions = regions.ok_or(ReadError::NullOffset)?;
+        let store = var_store.ok_or(DrawError::Malformed)?;
+        let regions = regions.ok_or(DrawError::Malformed)?;
         compute_tuple_deltas(
             store,
             regions,


### PR DESCRIPTION
The first commit swaps out `Result` for `Option` in the hand-written `COLR` table accessors in read-fonts. Nothing in our must-maintain-compat set touches them directly.

The second is a skrifa patch that replaces error variants that hold `ReadError` with a payload free `Malformed` variant, like was done for the postscript work. No functional changes, all just mechanical swapping of error types. Final result is that skrifa contains no reference to `ReadError` at all.