### PR TITLE
[read-fonts] Restore experimental_traverse as an empty feature

### DIFF
--- a/read-fonts/Cargo.toml
+++ b/read-fonts/Cargo.toml
@@ -28,6 +28,11 @@ spec_next = []
 # Enables support for a new font API, as proposed at
 # https://github.com/googlefonts/oxidize/pull/77
 experimental_font_api = []
+# Does nothing. Traversal was removed in #2087, but consumers still ask for
+# this feature -- fontconfig's fc-fontations does, without using any of it --
+# and cargo fails to resolve a feature that does not exist. Keeping it empty
+# lets them upgrade before they edit their manifests.
+experimental_traverse = []
 default = ["std"]
 serde = ["dep:serde", "font-types/serde"]
 libm = ["dep:core_maths"]


### PR DESCRIPTION
Traversal went in #2087, and the feature that gated it went with it. But consumers still name it: fontconfig's `fc-fontations` asks for `read-fonts = { version = "0.37", features = ["experimental_traverse"] }` and uses no traversal at all — no `traverse`, no `SomeTable`, no `FieldType` anywhere in its sources.

Cargo does not resolve a feature that does not exist, so for them the failure is not a deprecation warning or a compile error in code they could fix; it is the dependency refusing to resolve. An empty feature costs nothing and lets a consumer upgrade first and tidy their manifest afterwards, rather than having to do both in the same change.

Found by compiling fc-fontations against this tree.