### PR TITLE
[read-fonts] add Loca::get that returns Option<LocaGlyph>

### DIFF
--- a/read-fonts/src/tables/glyf.rs
+++ b/read-fonts/src/tables/glyf.rs
@@ -861,7 +861,10 @@ mod tests {
         let font = FontRef::new(font_test_data::COLR_GRADIENT_RECT).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let glyph = loca.get_glyf(GlyphId::new(0), &glyf).unwrap().unwrap();
+        let glyph = loca
+            .get(GlyphId::new(0), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap();
         assert_eq!(glyph.number_of_contours(), 2);
         let simple_glyph = if let Glyph::Simple(simple) = glyph {
             simple
@@ -900,7 +903,10 @@ mod tests {
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
         let glyph_count = font.maxp().unwrap().num_glyphs() as u32;
-        (0..glyph_count).map(move |gid| loca.get_glyf(GlyphId::new(gid), &glyf).unwrap())
+        (0..glyph_count).map(move |gid| {
+            loca.get(GlyphId::new(gid), &glyf)
+                .and_then(|g| g.into_glyph())
+        })
     }
 
     #[test]
@@ -1030,7 +1036,10 @@ mod tests {
         let font = FontRef::new(font_test_data::CUBIC_GLYF).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let glyph = loca.get_glyf(GlyphId::new(2), &glyf).unwrap().unwrap();
+        let glyph = loca
+            .get(GlyphId::new(2), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap();
         assert_eq!(glyph.number_of_contours(), 1);
         let simple_glyph = if let Glyph::Simple(simple) = glyph {
             simple

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -9,7 +9,7 @@ pub use deltas::DeltaBuffers;
 
 use super::{
     glyf::{CompositeGlyphFlags, Glyf, Glyph, PointCoord},
-    loca::Loca,
+    loca::{Loca, LocaGlyph},
     variations::{
         PackedPointNumbers, Tuple, TupleDelta, TupleVariationCount, TupleVariationData,
         TupleVariationHeader,
@@ -253,11 +253,12 @@ fn find_glyph_and_point_count(
             "nesting too deep in composite glyph",
         ));
     }
-    let glyph = loca.get_glyf(glyph_id, glyf)?;
-    let Some(glyph) = glyph else {
+    let glyph = match loca.get(glyph_id, glyf) {
         // Empty glyphs might still contain gvar data that
         // only affects phantom points
-        return Ok((glyph_id, 0));
+        Some(LocaGlyph::Empty) => return Ok((glyph_id, 0)),
+        Some(LocaGlyph::Glyph(glyph)) => glyph,
+        None => return Err(ReadError::OutOfBounds),
     };
     match glyph {
         Glyph::Simple(simple) => {

--- a/read-fonts/src/tables/gvar/deltas.rs
+++ b/read-fonts/src/tables/gvar/deltas.rs
@@ -611,7 +611,8 @@ mod tests {
         fn new(font: &FontRef<'a>, gid: GlyphId) -> Self {
             let glyf: Glyf<'a> = font.glyf().unwrap();
             let loca: Loca<'a> = font.loca(None).unwrap();
-            let Some(Glyph::Simple(simple)) = loca.get_glyf(gid, &glyf).unwrap() else {
+            let Some(Glyph::Simple(simple)) = loca.get(gid, &glyf).and_then(|g| g.into_glyph())
+            else {
                 panic!("expected a simple glyph");
             };
             let n = simple.num_points();
@@ -811,7 +812,9 @@ mod tests {
         let coords = [F2Dot14::from_f32(0.5)];
         for gid in 0..font.maxp().unwrap().num_glyphs() {
             let glyph_id = GlyphId::from(gid);
-            let Some(Glyph::Simple(simple)) = loca.get_glyf(glyph_id, &glyf).unwrap() else {
+            let Some(Glyph::Simple(simple)) =
+                loca.get(glyph_id, &glyf).and_then(|g| g.into_glyph())
+            else {
                 continue;
             };
             let count = simple.num_points() + PHANTOM_POINT_COUNT;

--- a/read-fonts/src/tables/loca.rs
+++ b/read-fonts/src/tables/loca.rs
@@ -3,9 +3,9 @@
 //! [loca]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca
 
 use crate::{
-    read::{FontRead, ReadArgs, ReadError},
+    read::{FontRead, ReadArgs},
     table_provider::TopLevelTable,
-    FontData,
+    FontData, ReadError,
 };
 use types::{BigEndian, GlyphId, Tag};
 
@@ -23,7 +23,7 @@ impl TopLevelTable for Loca<'_> {
 }
 
 impl<'a> Loca<'a> {
-    pub fn read(data: FontData<'a>, is_long: bool) -> Result<Self, crate::ReadError> {
+    pub fn read(data: FontData<'a>, is_long: bool) -> Result<Self, ReadError> {
         Self::read_with_args(data, is_long)
     }
 
@@ -59,24 +59,64 @@ impl<'a> Loca<'a> {
         }
     }
 
+    /// What this table says about a glyph, or `None` if it says nothing
+    /// readable.
+    pub fn get(&self, gid: GlyphId, glyf: &super::glyf::Glyf<'a>) -> Option<LocaGlyph<'a>> {
+        let idx = gid.to_u32() as usize;
+        let start = self.get_raw(idx)?;
+        let end = self.get_raw(idx + 1)?;
+        if start == end {
+            return Some(LocaGlyph::Empty);
+        }
+        let data = glyf.offset_data().slice(start as usize..end as usize)?;
+        super::glyf::Glyph::read(data).ok().map(LocaGlyph::Glyph)
+    }
+
+    /// The outline for a glyph, `Ok(None)` where the glyph is empty, and an
+    /// error where this table says nothing readable about it.
+    ///
+    /// Prefer [`get`][Self::get], which names the empty glyph instead of
+    /// spelling it as an inner `None`. This reports every unreadable glyph as
+    /// [`ReadError::OutOfBounds`], whatever the reason.
+    #[doc(hidden)]
     pub fn get_glyf(
         &self,
         gid: GlyphId,
         glyf: &super::glyf::Glyf<'a>,
     ) -> Result<Option<super::glyf::Glyph<'a>>, ReadError> {
-        let idx = gid.to_u32() as usize;
-        let start = self.get_raw(idx).ok_or(ReadError::OutOfBounds)?;
-        let end = self.get_raw(idx + 1).ok_or(ReadError::OutOfBounds)?;
-        if start == end {
-            return Ok(None);
+        self.get(gid, glyf)
+            .map(LocaGlyph::into_glyph)
+            .ok_or(ReadError::OutOfBounds)
+    }
+}
+
+/// What a glyph's entry in the `loca` table leads to.
+///
+/// A glyph with no contours — a space, say — is described by an empty range,
+/// and finding one is a success. It is separate from the glyph being
+/// unreadable, which [`Loca::get`] reports by answering `None`.
+#[derive(Clone)]
+pub enum LocaGlyph<'a> {
+    /// The glyph has no outline.
+    Empty,
+    /// The glyph's outline.
+    Glyph(super::glyf::Glyph<'a>),
+}
+
+impl<'a> LocaGlyph<'a> {
+    /// The outline, or `None` where the glyph is empty.
+    pub fn glyph(&self) -> Option<&super::glyf::Glyph<'a>> {
+        match self {
+            Self::Empty => None,
+            Self::Glyph(glyph) => Some(glyph),
         }
-        let data = glyf
-            .offset_data()
-            .slice(start as usize..end as usize)
-            .ok_or(ReadError::OutOfBounds)?;
-        match super::glyf::Glyph::read(data) {
-            Ok(glyph) => Ok(Some(glyph)),
-            Err(e) => Err(e),
+    }
+
+    /// The outline by value, or `None` where the glyph is empty.
+    pub fn into_glyph(self) -> Option<super::glyf::Glyph<'a>> {
+        match self {
+            Self::Empty => None,
+            Self::Glyph(glyph) => Some(glyph),
         }
     }
 }
@@ -86,7 +126,7 @@ impl ReadArgs for Loca<'_> {
 }
 
 impl<'a> FontRead<'a> for Loca<'a> {
-    fn read_with_args(data: FontData<'a>, args: Self::Args) -> Result<Self, crate::ReadError> {
+    fn read_with_args(data: FontData<'a>, args: Self::Args) -> Result<Self, ReadError> {
         let is_long = args;
         if is_long {
             data.read_array(0..data.len()).map(Loca::Long)

--- a/skera/src/glyf_loca.rs
+++ b/skera/src/glyf_loca.rs
@@ -41,8 +41,8 @@ impl Subset for Glyf<'_> {
         let mut max_offset: u32 = 0;
 
         for (new_gid, old_gid) in &plan.new_to_old_gid_list {
-            match loca.get_glyf(*old_gid, self) {
-                Ok(g) => {
+            match loca.get(*old_gid, self) {
+                Some(g) => {
                     if *old_gid == GlyphId::NOTDEF
                         && *new_gid == GlyphId::NOTDEF
                         && !plan
@@ -53,7 +53,7 @@ impl Subset for Glyf<'_> {
                         continue;
                     }
 
-                    let Some(glyph) = g else {
+                    let Some(glyph) = g.into_glyph() else {
                         subset_glyphs.push(Vec::new());
                         continue;
                     };
@@ -62,7 +62,7 @@ impl Subset for Glyf<'_> {
                     max_offset += padded_size(trimmed_len) as u32;
                     subset_glyphs.push(subset_glyph);
                 }
-                _ => {
+                None => {
                     return Err(SubsetTableError(Glyf::TAG));
                 }
             }
@@ -376,7 +376,10 @@ mod test {
 
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let glyph = loca.get_glyf(GlyphId::from(1_u16), &glyf).unwrap().unwrap();
+        let glyph = loca
+            .get(GlyphId::from(1_u16), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap();
 
         let subset_output = subset_glyph(&glyph, &plan);
         assert_eq!(subset_output.len(), 23);
@@ -396,7 +399,10 @@ mod test {
 
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let glyph = loca.get_glyf(GlyphId::from(4_u16), &glyf).unwrap().unwrap();
+        let glyph = loca
+            .get(GlyphId::from(4_u16), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap();
         plan.glyph_map
             .insert(GlyphId::from(1_u16), GlyphId::from(2_u16));
 

--- a/skera/src/lib.rs
+++ b/skera/src/lib.rs
@@ -954,7 +954,7 @@ fn glyf_closure_glyphs(
         return operation_count;
     }
 
-    if let Some(Glyph::Composite(glyph)) = loca.get_glyf(gid, glyf).ok().flatten() {
+    if let Some(Glyph::Composite(glyph)) = loca.get(gid, glyf).and_then(|g| g.into_glyph()) {
         for child in glyph.components() {
             operation_count = glyf_closure_glyphs(
                 loca,

--- a/skrifa/src/metrics.rs
+++ b/skrifa/src/metrics.rs
@@ -355,7 +355,7 @@ impl<'a> GlyphMetrics<'a> {
             return self.bounds_from_outline(glyph_id);
         }
         let (loca, glyf) = self.loca_glyf.as_ref()?;
-        Some(match loca.get_glyf(glyph_id, glyf).ok()? {
+        Some(match loca.get(glyph_id, glyf)?.glyph() {
             Some(glyph) => BoundingBox {
                 x_min: self.fixed_scale.apply(glyph.x_min() as i32),
                 y_min: self.fixed_scale.apply(glyph.y_min() as i32),

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -155,9 +155,9 @@ impl<'a> Outlines<'a> {
         };
         let glyph = self
             .loca
-            .get_glyf(glyph_id, &self.glyf)
-            .map_err(|_| DrawError::Malformed)?;
-        if let Some(glyph) = glyph.as_ref() {
+            .get(glyph_id, &self.glyf)
+            .ok_or(DrawError::Malformed)?;
+        if let Some(glyph) = glyph.glyph() {
             self.outline_rec(glyph, &mut outline, 0, 0, &mut 0)?;
         }
         outline.points += PHANTOM_POINT_COUNT;
@@ -165,7 +165,7 @@ impl<'a> Outlines<'a> {
         outline.cvt_count = self.cvt_len as usize;
         outline.storage_count = self.max_storage as usize;
         outline.max_twilight_points = self.max_twilight_points as usize;
-        outline.glyph = glyph;
+        outline.glyph = glyph.into_glyph();
         Ok(outline)
     }
 
@@ -221,9 +221,9 @@ impl Outlines<'_> {
                     outline.has_overlaps |= flags.contains(CompositeGlyphFlags::OVERLAP_COMPOUND);
                     let component_glyph = self
                         .loca
-                        .get_glyf(component.into(), &self.glyf)
-                        .map_err(|_| DrawError::Malformed)?;
-                    let Some(component_glyph) = component_glyph else {
+                        .get(component.into(), &self.glyf)
+                        .ok_or(DrawError::Malformed)?;
+                    let Some(component_glyph) = component_glyph.glyph() else {
                         continue;
                     };
                     *total_components += 1;
@@ -231,7 +231,7 @@ impl Outlines<'_> {
                         return Err(DrawError::RecursionLimitExceeded(outline.glyph_id));
                     }
                     self.outline_rec(
-                        &component_glyph,
+                        component_glyph,
                         outline,
                         component_depth + count,
                         recurse_depth + 1,
@@ -863,8 +863,9 @@ impl Scaler for FreeTypeScaler<'_> {
             let component_glyph = self
                 .outlines
                 .loca
-                .get_glyf(component.glyph.into(), &self.outlines.glyf)
-                .map_err(|_| DrawError::Malformed)?;
+                .get(component.glyph.into(), &self.outlines.glyf)
+                .ok_or(DrawError::Malformed)?
+                .into_glyph();
             self.load(&component_glyph, component.glyph.into(), recurse_depth + 1)?;
             let end_point = self.point_count;
             if !component
@@ -1273,8 +1274,9 @@ impl Scaler for HarfBuzzScaler<'_> {
             let component_glyph = self
                 .outlines
                 .loca
-                .get_glyf(component.glyph.into(), &self.outlines.glyf)
-                .map_err(|_| DrawError::Malformed)?;
+                .get(component.glyph.into(), &self.outlines.glyf)
+                .ok_or(DrawError::Malformed)?
+                .into_glyph();
             self.load(&component_glyph, component.glyph.into(), recurse_depth + 1)?;
             let end_point = self.point_count;
             if !component

--- a/write-fonts/src/tables/glyf/composite.rs
+++ b/write-fonts/src/tables/glyf/composite.rs
@@ -330,8 +330,10 @@ mod tests {
         let font = FontRef::new(font_test_data::VAZIRMATN_VAR).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let read_glyf::Glyph::Composite(orig) =
-            loca.get_glyf(GlyphId::new(2), &glyf).unwrap().unwrap()
+        let read_glyf::Glyph::Composite(orig) = loca
+            .get(GlyphId::new(2), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap()
         else {
             panic!("not a composite glyph")
         };

--- a/write-fonts/src/tables/glyf/glyf_loca_builder.rs
+++ b/write-fonts/src/tables/glyf/glyf_loca_builder.rs
@@ -168,10 +168,24 @@ mod tests {
         )
         .unwrap();
 
-        let rglyph1 = Glyph::from_table_ref(&rloca.get_glyf(gid1, &rglyf).unwrap().unwrap());
-        let rglyph2 = Glyph::from_table_ref(&rloca.get_glyf(gid2, &rglyf).unwrap().unwrap());
-        let rglyph3 =
-            Glyph::from_table_ref(&rloca.get_glyf(GlyphId::new(3), &rglyf).unwrap().unwrap());
+        let rglyph1 = Glyph::from_table_ref(
+            &rloca
+                .get(gid1, &rglyf)
+                .and_then(|g| g.into_glyph())
+                .unwrap(),
+        );
+        let rglyph2 = Glyph::from_table_ref(
+            &rloca
+                .get(gid2, &rglyf)
+                .and_then(|g| g.into_glyph())
+                .unwrap(),
+        );
+        let rglyph3 = Glyph::from_table_ref(
+            &rloca
+                .get(GlyphId::new(3), &rglyf)
+                .and_then(|g| g.into_glyph())
+                .unwrap(),
+        );
         assert_eq!(rglyph1, glyph1.into());
         assert_eq!(rglyph2, glyph2.into());
         assert_eq!(rglyph3, glyph3.into());

--- a/write-fonts/src/tables/glyf/simple.rs
+++ b/write-fonts/src/tables/glyf/simple.rs
@@ -669,8 +669,10 @@ mod tests {
         let font = FontRef::new(font_test_data::SIMPLE_GLYF).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let read_glyf::Glyph::Simple(orig) =
-            loca.get_glyf(GlyphId::new(0), &glyf).unwrap().unwrap()
+        let read_glyf::Glyph::Simple(orig) = loca
+            .get(GlyphId::new(0), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap()
         else {
             panic!("not a simple glyph")
         };
@@ -693,8 +695,10 @@ mod tests {
         let font = FontRef::new(font_test_data::SIMPLE_GLYF).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let read_glyf::Glyph::Simple(orig) =
-            loca.get_glyf(GlyphId::new(2), &glyf).unwrap().unwrap()
+        let read_glyf::Glyph::Simple(orig) = loca
+            .get(GlyphId::new(2), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap()
         else {
             panic!("not a simple glyph")
         };
@@ -719,8 +723,10 @@ mod tests {
         let font = FontRef::new(font_test_data::VAZIRMATN_VAR).unwrap();
         let loca = font.loca(None).unwrap();
         let glyf = font.glyf().unwrap();
-        let read_glyf::Glyph::Simple(orig) =
-            loca.get_glyf(GlyphId::new(1), &glyf).unwrap().unwrap()
+        let read_glyf::Glyph::Simple(orig) = loca
+            .get(GlyphId::new(1), &glyf)
+            .and_then(|g| g.into_glyph())
+            .unwrap()
         else {
             panic!("not a simple glyph")
         };


### PR DESCRIPTION
Adds a new `LocaGlyph` type so we can represent the empty glyph and then adds `Loca::get` which returns `Option<LocaGlyph>`. The current `get_glyf` method is used by Skia so we'll need to defer removing it but new code should use this one.

I looked at modifying codegen to add an `Empty` variant to `glyf::Glyph` but that required new complexity for one case and would have made the bbox accessors return `Option` which seemed like a bad trade all around.