### PR TITLE
[read-fonts] svg, trak, cvar and dsig helpers return Option

### DIFF
--- a/read-fonts/src/tables/cvar.rs
+++ b/read-fonts/src/tables/cvar.rs
@@ -16,9 +16,9 @@ impl<'a> Cvar<'a> {
     ///
     /// This table doesn't contain an axis count field so this must be provided
     /// by the user and can be read from the `fvar` table.
-    pub fn variation_data(&self, axis_count: u16) -> Result<CvtVariationData<'a>, ReadError> {
+    pub fn variation_data(&self, axis_count: u16) -> Option<CvtVariationData<'a>> {
         let count = self.tuple_variation_count();
-        let data = self.data()?;
+        let data = self.data().ok()?;
         let header_data = self.raw_tuple_header_data();
         // if there are shared point numbers, get them now
         let (shared_point_numbers, serialized_data) = if count.shared_point_numbers() {
@@ -27,7 +27,7 @@ impl<'a> Cvar<'a> {
         } else {
             (None, data)
         };
-        Ok(CvtVariationData {
+        Some(CvtVariationData {
             tuple_count: count,
             axis_count,
             shared_tuples: None,
@@ -47,12 +47,7 @@ impl<'a> Cvar<'a> {
     /// The `deltas` slice should have a length greater than or equal
     /// to the number of values in the `cvt` table. The values are
     /// computed in 16.16 format.
-    pub fn deltas(
-        &self,
-        axis_count: u16,
-        coords: &[F2Dot14],
-        deltas: &mut [i32],
-    ) -> Result<(), ReadError> {
+    pub fn deltas(&self, axis_count: u16, coords: &[F2Dot14], deltas: &mut [i32]) -> Option<()> {
         let var_data = self.variation_data(axis_count)?;
         for (tuple, scalar) in var_data.active_tuples_at(coords) {
             for delta in tuple.deltas() {
@@ -62,7 +57,7 @@ impl<'a> Cvar<'a> {
                 }
             }
         }
-        Ok(())
+        Some(())
     }
 
     fn raw_tuple_header_data(&self) -> FontData<'a> {

--- a/read-fonts/src/tables/dsig.rs
+++ b/read-fonts/src/tables/dsig.rs
@@ -9,28 +9,18 @@ impl SignatureRecord {
     /// By calling its `offset_data` method.
     ///
     /// Only format 1 is recognised and read successfully.
-    pub fn signature_block<'a>(
-        &self,
-        data: FontData<'a>,
-    ) -> Result<SignatureBlockFormat1<'a>, ReadError> {
-        match self.format() {
-            1 => {
-                let signature = self
-                    .signature_block_offset()
-                    .resolve::<SignatureBlockFormat1>(data)?;
-
-                // Check that the inner block's size matches our length field.
-                let actual_len =
-                    u32::try_from(signature.compute_len()).map_err(|_| ReadError::OutOfBounds)?;
-
-                if self.length() == actual_len {
-                    Ok(signature)
-                } else {
-                    Err(ReadError::MalformedData("ambiguous DSIG signature length"))
-                }
-            }
-            unknown => Err(ReadError::InvalidFormat(unknown.into())),
+    pub fn signature_block<'a>(&self, data: FontData<'a>) -> Option<SignatureBlockFormat1<'a>> {
+        if self.format() != 1 {
+            return None;
         }
+        let signature = self
+            .signature_block_offset()
+            .resolve::<SignatureBlockFormat1>(data)
+            .ok()?;
+        // The inner block has to agree with the record's own length field.
+        // Where they disagree there is no saying which one to believe, so the
+        // block is not readable.
+        (self.length() == u32::try_from(signature.compute_len()).ok()?).then_some(signature)
     }
 }
 
@@ -47,7 +37,7 @@ mod tests {
     use font_test_data::bebuffer::BeBuffer;
 
     use super::{Dsig, PermissionFlags};
-    use crate::{FontData, FontRead, ReadError};
+    use crate::{FontData, FontRead};
 
     /// An empty, dummy DSIG, as inserted by fonttools.
     /// See <https://github.com/fonttools/fonttools/blob/ec716f11851f8d5a04e3f535b53219d97001482a/Lib/fontTools/fontBuilder.py#L823-L833>.
@@ -123,8 +113,7 @@ mod tests {
         // Assert that it is the unknown format '2', and that it fails to be read.
         assert_eq!(record.format(), 2);
 
-        let block_attempt = record.signature_block(data);
-        assert_eq!(block_attempt.err(), Some(ReadError::InvalidFormat(2)));
+        assert!(record.signature_block(data).is_none());
     }
 
     // A DSIG with a single entry, whose inner block has a different length to
@@ -152,12 +141,8 @@ mod tests {
         assert_eq!(dsig.signature_records().len(), 1);
         let record = dsig.signature_records()[0];
 
-        // Assert that we yield an error, because the inner length requires more
-        // bytes than the outer length prescribes.
-        let block_attempt = record.signature_block(data);
-        assert_eq!(
-            block_attempt.err(),
-            Some(ReadError::MalformedData("ambiguous DSIG signature length"))
-        );
+        // The inner length requires more bytes than the outer length
+        // prescribes, so the block cannot be read.
+        assert!(record.signature_block(data).is_none());
     }
 }

--- a/read-fonts/src/tables/svg.rs
+++ b/read-fonts/src/tables/svg.rs
@@ -6,8 +6,8 @@ include!("../../generated/generated_svg.rs");
 
 impl<'a> Svg<'a> {
     /// Get the raw data of the SVG document. Is not guaranteed to be valid and might be compressed.
-    pub fn glyph_data(&self, glyph_id: GlyphId) -> Result<Option<&'a [u8]>, ReadError> {
-        let document_list = self.svg_document_list()?;
+    pub fn glyph_data(&self, glyph_id: GlyphId) -> Option<&'a [u8]> {
+        let document_list = self.svg_document_list().ok()?;
         let svg_document = document_list
             .document_records()
             .binary_search_by(|r| {
@@ -27,7 +27,7 @@ impl<'a> Svg<'a> {
                 let end = start.checked_add(r.svg_doc_length())?;
                 all_data.get(start as usize..end as usize)
             });
-        Ok(svg_document)
+        svg_document
     }
 }
 
@@ -75,35 +75,17 @@ mod tests {
         let first_document = &[0, 1, 0, 0, 0, 0, 0, 0, 0, 1][..];
         let second_document = &[0, 2, 0, 0, 0, 0][..];
 
-        assert_eq!(table.glyph_data(GlyphId::new(0)).unwrap(), None);
-        assert_eq!(
-            table.glyph_data(GlyphId::new(1)).unwrap(),
-            Some(first_document)
-        );
-        assert_eq!(
-            table.glyph_data(GlyphId::new(2)).unwrap(),
-            Some(first_document)
-        );
-        assert_eq!(
-            table.glyph_data(GlyphId::new(3)).unwrap(),
-            Some(first_document)
-        );
-        assert_eq!(table.glyph_data(GlyphId::new(4)).unwrap(), None);
-        assert_eq!(table.glyph_data(GlyphId::new(5)).unwrap(), None);
-        assert_eq!(
-            table.glyph_data(GlyphId::new(6)).unwrap(),
-            Some(second_document)
-        );
-        assert_eq!(
-            table.glyph_data(GlyphId::new(7)).unwrap(),
-            Some(second_document)
-        );
-        assert_eq!(table.glyph_data(GlyphId::new(8)).unwrap(), None);
-        assert_eq!(
-            table.glyph_data(GlyphId::new(9)).unwrap(),
-            Some(first_document)
-        );
-        assert_eq!(table.glyph_data(GlyphId::new(10)).unwrap(), None);
+        assert_eq!(table.glyph_data(GlyphId::new(0)), None);
+        assert_eq!(table.glyph_data(GlyphId::new(1)), Some(first_document));
+        assert_eq!(table.glyph_data(GlyphId::new(2)), Some(first_document));
+        assert_eq!(table.glyph_data(GlyphId::new(3)), Some(first_document));
+        assert_eq!(table.glyph_data(GlyphId::new(4)), None);
+        assert_eq!(table.glyph_data(GlyphId::new(5)), None);
+        assert_eq!(table.glyph_data(GlyphId::new(6)), Some(second_document));
+        assert_eq!(table.glyph_data(GlyphId::new(7)), Some(second_document));
+        assert_eq!(table.glyph_data(GlyphId::new(8)), None);
+        assert_eq!(table.glyph_data(GlyphId::new(9)), Some(first_document));
+        assert_eq!(table.glyph_data(GlyphId::new(10)), None);
     }
 
     #[test]

--- a/read-fonts/src/tables/trak.rs
+++ b/read-fonts/src/tables/trak.rs
@@ -6,15 +6,11 @@ impl<'a> TrackData<'a> {
     /// Returns the size table for this set of tracking data.
     ///
     /// The `offset_data` parameter comes from the [`Trak`] table.
-    pub fn size_table(
-        &self,
-        offset_data: FontData<'a>,
-    ) -> Result<&'a [BigEndian<Fixed>], ReadError> {
+    pub fn size_table(&self, offset_data: FontData<'a>) -> Option<&'a [BigEndian<Fixed>]> {
         let mut cursor = offset_data
-            .split_off(self.size_table_offset() as usize)
-            .ok_or(ReadError::OutOfBounds)?
+            .split_off(self.size_table_offset() as usize)?
             .cursor();
-        cursor.read_array(self.n_sizes() as usize)
+        cursor.read_array(self.n_sizes() as usize).ok()
     }
 }
 
@@ -27,12 +23,9 @@ impl TrackTableEntry {
         &self,
         offset_data: FontData<'a>,
         n_sizes: u16,
-    ) -> Result<&'a [BigEndian<i16>], ReadError> {
-        let mut cursor = offset_data
-            .split_off(self.offset() as usize)
-            .ok_or(ReadError::OutOfBounds)?
-            .cursor();
-        cursor.read_array(n_sizes as usize)
+    ) -> Option<&'a [BigEndian<i16>]> {
+        let mut cursor = offset_data.split_off(self.offset() as usize)?.cursor();
+        cursor.read_array(n_sizes as usize).ok()
     }
 }
 
@@ -124,7 +117,6 @@ mod tests {
         for (track, expected_values) in track_table.iter().zip(expected_per_size_tracking_values) {
             let values = track
                 .per_size_values(trak.offset_data(), horiz.n_sizes())
-                .ok()
                 .map(|values| values.iter().map(|v| v.get()).collect::<Vec<_>>());
             assert_eq!(
                 values,
@@ -141,10 +133,9 @@ mod tests {
         let trak = Trak::read(FontData::new(&table_data)).unwrap();
         let horiz = trak.horiz().unwrap().unwrap();
         let track_table = horiz.track_table();
-        assert!(matches!(
-            track_table[0].per_size_values(trak.offset_data(), horiz.n_sizes()),
-            Err(ReadError::OutOfBounds)
-        ));
+        assert!(track_table[0]
+            .per_size_values(trak.offset_data(), horiz.n_sizes())
+            .is_none());
     }
 
     /// From <https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html>

--- a/write-fonts/src/from_obj.rs
+++ b/write-fonts/src/from_obj.rs
@@ -130,6 +130,16 @@ impl<T: FromObjRef<U> + Default, U, const N: usize> FromObjRef<Result<U, ReadErr
     }
 }
 
+// as above, for an accessor that answers with Option
+impl<T: FromObjRef<U> + Default, U, const N: usize> FromObjRef<Option<U>> for OffsetMarker<T, N> {
+    fn from_obj_ref(from: &Option<U>, data: FontData) -> Self {
+        match from {
+            None => OffsetMarker::default(),
+            Some(table) => OffsetMarker::new(table.to_owned_obj(data)),
+        }
+    }
+}
+
 impl<T: FromObjRef<U>, U, const N: usize> FromObjRef<Option<Result<U, ReadError>>>
     for NullableOffsetMarker<T, N>
 {
@@ -149,6 +159,18 @@ impl<T: FromTableRef<U> + Default, U, const N: usize> FromTableRef<Result<U, Rea
         match from {
             Err(_) => OffsetMarker::default(),
             Ok(table) => OffsetMarker::new(table.to_owned_table()),
+        }
+    }
+}
+
+// as above, for an accessor that answers with Option
+impl<T: FromTableRef<U> + Default, U, const N: usize> FromTableRef<Option<U>>
+    for OffsetMarker<T, N>
+{
+    fn from_table_ref(from: &Option<U>) -> Self {
+        match from {
+            None => OffsetMarker::default(),
+            Some(table) => OffsetMarker::new(table.to_owned_table()),
         }
     }
 }


### PR DESCRIPTION
Just a batch of changes to hand written accessors to swap the `Result<T, ReadError>` out for `Option<T>`.