### PR TITLE
[skera] fix integer underflow panic

### DIFF
--- a/skera/src/cmap.rs
+++ b/skera/src/cmap.rs
@@ -961,7 +961,8 @@ fn copy_default_uvs(
 
             if start == INVALID_UNICODE_CHAR {
                 start = u;
-                end = start - 1;
+                end = u;
+                continue;
             }
 
             if end + 1 != u || end - start == 255 {


### PR DESCRIPTION
When start == INVALID_UNICODE_CHAR, start is set to u and end is set to start - 1. Execution immediately falls through to: if end + 1 != u || end - start == 255 The first condition end + 1 != u evaluates to (start - 1) + 1 != u => u != u => false. Since || short-circuits on true, Rust proceeds to evaluate the second condition: end - start == 255 Here, end is start - 1. Evaluating end - start computes (start - 1) - start, which is -1 as u32. With overflow checks enabled (debug builds, fastbuild, or sanitizers), this causes an immediate panic: attempt to subtract with overflow.