### PR TITLE
[read-fonts] Inline AAT lookup format dispatch

### DIFF
--- a/font-codegen/src/format_group.rs
+++ b/font-codegen/src/format_group.rs
@@ -24,6 +24,7 @@ pub(crate) fn generate(item: &TableFormat, items: &Items) -> syn::Result<TokenSt
         });
 
     let format = &item.format;
+    let read_inline = item.attrs.read_inline.as_ref().map(|_| quote!(#[inline]));
     // if we have any fancy match statement we disable a clippy lint
     let mut has_any_match_stmt = false;
     let match_arms = item
@@ -103,6 +104,7 @@ pub(crate) fn generate(item: &TableFormat, items: &Items) -> syn::Result<TokenSt
         }
 
         impl<'a> FontRead<'a> for #name<'a> {
+            #read_inline
             fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
                 let format: #format = data.read_at(#format_offset)?;
                 #maybe_allow_lint

--- a/font-codegen/src/parsing.rs
+++ b/font-codegen/src/parsing.rs
@@ -831,6 +831,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_format_group_with_read_inline() {
+        let parsed =
+            parse_format_group("#[read_inline]\nformat u16 MyThing { FormatOne(SomeTable), }")
+                .unwrap();
+        assert!(parsed.attrs.read_inline.is_some());
+    }
+
+    #[test]
     #[should_panic(expected = "must be an unsigned")]
     fn parse_format_group_with_negative_format_offset() {
         let s = "format u16@-4 MyThing {

--- a/font-codegen/src/parsing/attrs.rs
+++ b/font-codegen/src/parsing/attrs.rs
@@ -52,6 +52,7 @@ impl<T: ToTokens> ToTokens for Attr<T> {
 #[derive(Debug, Default, Clone)]
 pub(crate) struct TableAttrs {
     pub(crate) docs: Vec<syn::Attribute>,
+    pub(crate) read_inline: Option<syn::Path>,
     pub(crate) skip_font_write: Option<syn::Path>,
     pub(crate) skip_from_obj: Option<syn::Path>,
     pub(crate) skip_constructor: Option<syn::Path>,
@@ -280,6 +281,7 @@ static WRITE_FONTS_ONLY: &str = "write_fonts_only";
 static SKIP_FROM_OBJ: &str = "skip_from_obj";
 static SKIP_FONT_WRITE: &str = "skip_font_write";
 static SKIP_CONSTRUCTOR: &str = "skip_constructor";
+static READ_INLINE: &str = "read_inline";
 static READ_ARGS: &str = "read_args";
 static GENERIC_OFFSET: &str = "generic_offset";
 static TAG: &str = "tag";
@@ -367,6 +369,8 @@ impl Parse for TableAttrs {
             })?;
             if ident == DOC {
                 this.docs.push(attr);
+            } else if ident == READ_INLINE {
+                this.read_inline = Some(attr.path().clone());
             } else if ident == SKIP_FROM_OBJ {
                 this.skip_from_obj = Some(attr.path().clone());
             } else if ident == SKIP_FONT_WRITE {

--- a/read-fonts/generated/generated_aat.rs
+++ b/read-fonts/generated/generated_aat.rs
@@ -54,6 +54,7 @@ impl ReadArgs for Lookup<'_> {
 }
 
 impl<'a> FontRead<'a> for Lookup<'a> {
+    #[inline]
     fn read_with_args(data: FontData<'a>, _: ()) -> Result<Self, ReadError> {
         let format: u16 = data.read_at(0usize)?;
         match format {

--- a/resources/codegen_inputs/aat.rs
+++ b/resources/codegen_inputs/aat.rs
@@ -2,6 +2,7 @@
 
 /// Lookup tables provide a way of looking up information about a glyph index.
 /// The different cmap subtable formats.
+#[read_inline]
 format u16 Lookup {
     Format0(Lookup0),
     Format2(Lookup2),


### PR DESCRIPTION
## Motivation

HarfRust repeatedly reconstructs AAT class-lookup views while applying
`morx` subtables. The generated `Lookup::read_with_args` format switch is
small, but without an inline hint it remains opaque across the
`read-fonts` crate boundary.

Add an opt-in `#[read_inline]` codegen annotation and use it only for the
AAT `Lookup` format group. I tested adding the hint to every format group,
but that caused a measurable regression in an OpenType workload, so this
keeps the change narrowly scoped.

## Performance

With release LTO builds of HarfRust and `benchmark-harf`:

| Workload | Before | After |
| --- | ---: | ---: |
| GeezaPro / `fa-words.txt` | 11.2 ms | 10.7 ms |
| LucidaGrande / `en-thelittleprince.txt` | 4.58 ms | 4.51 ms |
| Menlo / `en-thelittleprince.txt` | 3.35 ms | 3.32 ms |

On Devanagari Sangam / `hi-words.txt`, fixed-iteration hardware counters
dropped from 891,866,354 to 879,745,089 instructions. Cycles are sensitive
to final code layout but were about 1–3% lower in repeated runs.

## Testing

`cargo test --workspace`
