### PR TITLE
[read-fonts] experimental Font API: add GlobalMetrics

### DIFF
--- a/read-fonts/src/model.rs
+++ b/read-fonts/src/model.rs
@@ -1,5 +1,6 @@
 //! Higher level interface for accessing font data.
 
+pub mod metrics;
 pub mod pen;
 
 #[cfg(feature = "experimental_font_api")]

--- a/read-fonts/src/model/font.rs
+++ b/read-fonts/src/model/font.rs
@@ -19,6 +19,7 @@ pub use tables::{FontTableFunction, FontTables};
 #[rust_analyzer::completions(hidden_from_completion)]
 pub mod interop;
 
+use super::metrics::GlobalMetrics;
 use super::once::Once;
 use crate::{
     ps::{cff::CffFontRef, type1::Type1Font},
@@ -42,10 +43,12 @@ impl Font {
     pub fn new(source: impl Into<FontSource>, index: u32) -> Result<Self, ReadError> {
         let source = source.into();
         let kind = if let Ok(tables) = FontTables::new(source.clone(), index) {
-            Some(FontKindRepr::Sfnt(tables, index))
+            Some(FontKindRepr::Sfnt(Arc::new(tables), index))
         } else if let FontSource::Blob(blob) = &source {
             match FontFormat::new(blob) {
-                Some(FontFormat::Type1) => Type1Font::new(blob).ok().map(FontKindRepr::Type1),
+                Some(FontFormat::Type1) => Type1Font::new(blob)
+                    .ok()
+                    .map(|font| FontKindRepr::Type1(Box::new(font))),
                 // TODO: pure CFF fonts
                 _ => None,
             }
@@ -57,6 +60,7 @@ impl Font {
             source,
             kind,
             shaping_data: Once::new(),
+            global_metrics: Once::new(),
         };
         Ok(Self(Arc::new(repr)))
     }
@@ -72,6 +76,38 @@ impl Font {
             FontKindRepr::Sfnt(tables, index) => FontKind::Sfnt(tables, *index),
             FontKindRepr::Type1(font) => FontKind::Type1(font),
         }
+    }
+
+    /// Returns the metrics describing the font as a whole, at its default
+    /// location.
+    #[inline]
+    pub fn global_metrics(&self) -> &GlobalMetrics {
+        self.0.global_metrics.get_or_init(|| match self.kind() {
+            FontKind::Type1(font) => GlobalMetrics::from_type1(font),
+            _ => GlobalMetrics::from_sfnt(&self.tables(), &[]),
+        })
+    }
+
+    /// Returns the number of glyphs in the font.
+    ///
+    /// Fixed for the font: no location varies it.
+    #[inline]
+    pub fn num_glyphs(&self) -> u32 {
+        self.global_metrics().num_glyphs
+    }
+
+    /// Returns the size of the em square, in design units.
+    ///
+    /// Fixed for the font: no location varies it.
+    #[inline]
+    pub fn units_per_em(&self) -> u16 {
+        self.global_metrics().units_per_em
+    }
+
+    /// Returns this font as an instance at its default location.
+    #[inline]
+    pub fn default_instance(&self) -> FontInstance {
+        FontInstance::from(self)
     }
 
     /// Returns an object that provides access to individual font tables.
@@ -91,6 +127,10 @@ struct FontRepr {
     kind: FontKindRepr,
     // Storage cell for lazily loaded HarfRust shaping data.
     shaping_data: Once<Box<dyn Any + Send + Sync>>,
+    // Metrics that describe the font as a whole, at the default location,
+    // read once rather than per query. Kept apart from `shaping_data`, which
+    // holds one thing for one owner.
+    global_metrics: Once<GlobalMetrics>,
 }
 
 /// The underlying type of a font.
@@ -105,8 +145,9 @@ pub enum FontKind<'a> {
 }
 
 /// The underlying type of a font.
-#[expect(clippy::large_enum_variant)]
 enum FontKindRepr {
-    Sfnt(FontTables, u32),
-    Type1(Type1Font),
+    Sfnt(Arc<FontTables>, u32),
+    // Boxed: a `Type1Font` is an order of magnitude larger than the sfnt
+    // variant, and inline it would be paid by every font that is not one.
+    Type1(Box<Type1Font>),
 }

--- a/read-fonts/src/model/font/instance.rs
+++ b/read-fonts/src/model/font/instance.rs
@@ -1,6 +1,7 @@
 //! Font instance representation.
 
 use super::Font;
+use crate::model::{metrics::GlobalMetrics, once::Once};
 use crate::{
     tables::{
         avar::Avar,
@@ -9,55 +10,124 @@ use crate::{
     },
     TableProvider,
 };
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 use core::{
     str::FromStr,
     sync::atomic::{self, AtomicU32},
 };
 use types::{Fixed, Tag};
 
-/// A specific instance of a font, with a size and variation settings.
-pub struct FontInstance {
+/// A font at one location in its design space.
+///
+/// Cloning is cheap: clones share one instance rather than copying it.
+#[derive(Clone)]
+pub struct FontInstance(Repr);
+
+#[derive(Clone)]
+enum Repr {
+    Default(Font),
+    Varied(Arc<VariedInstance>),
+}
+
+/// What a location away from the default carries.
+struct VariedInstance {
     font: Font,
-    size: Option<f32>,
+    /// Never empty: an all-default location is [`Repr::Default`].
     coords: CoordStorage,
     feature_vars: FeatureVarsStorage,
+    global_metrics: Once<GlobalMetrics>,
 }
 
 impl FontInstance {
     /// Returns a builder for configuring a font instance from the given font.
     pub fn builder(font: &Font) -> FontInstanceBuilder {
         FontInstanceBuilder {
-            instance: Self {
+            instance: VariedInstance {
                 font: font.clone(),
-                size: None,
                 coords: CoordStorage::default(),
                 feature_vars: FeatureVarsStorage::new(),
+                global_metrics: Once::new(),
             },
         }
     }
 
     /// Returns the font for this instance.
     pub fn font(&self) -> &Font {
-        &self.font
-    }
-
-    /// Returns the size of the font instance, in pixels per em.
-    pub fn size(&self) -> Option<f32> {
-        self.size
+        match &self.0 {
+            Repr::Default(font) => font,
+            Repr::Varied(varied) => &varied.font,
+        }
     }
 
     /// Returns the normalized variation coordinates for this font instance.
     pub fn normalized_coords(&self) -> &[NormalizedCoord] {
-        self.coords.as_slice()
+        match &self.0 {
+            Repr::Default(_) => &[],
+            Repr::Varied(varied) => varied.coords.as_slice(),
+        }
     }
 
-    /// Returns the selected feature variations for this font instance.
+    /// Returns the feature variations this instance selects.
+    ///
+    /// The default location selects none. A variable font is meant to keep
+    /// working for a client that knows nothing of variations, and such a
+    /// client reaches the default instance without ever consulting this
+    /// table. Selecting here would render that font one way for it and
+    /// another for everyone else.
     pub fn feature_variations(&self) -> FontFeatureVariations {
-        self.feature_vars.load(&self.font, self.coords.as_slice())
+        match &self.0 {
+            Repr::Default(_) => FontFeatureVariations::default(),
+            Repr::Varied(varied) => varied
+                .feature_vars
+                .load(&varied.font, varied.coords.as_slice()),
+        }
+    }
+
+    /// Returns the metrics describing the font as a whole, at this
+    /// instance's location.
+    pub fn global_metrics(&self) -> &GlobalMetrics {
+        match &self.0 {
+            // Nothing varies there, so the font already holds the answer.
+            Repr::Default(font) => font.global_metrics(),
+            Repr::Varied(varied) => varied.global_metrics.get_or_init(|| {
+                debug_assert!(!varied.coords.as_slice().is_empty());
+                GlobalMetrics::from_sfnt(&varied.font.tables(), varied.coords.as_slice())
+            }),
+        }
     }
 }
 
+impl From<Font> for FontInstance {
+    /// A font is an instance of itself, at the default location.
+    fn from(font: Font) -> Self {
+        Self(Repr::Default(font))
+    }
+}
+
+impl From<&Font> for FontInstance {
+    /// A font is an instance of itself, at the default location.
+    fn from(font: &Font) -> Self {
+        Self(Repr::Default(font.clone()))
+    }
+}
+
+#[cfg(test)]
+impl FontInstance {
+    /// The storage behind a varied instance, for the cache tests.
+    fn feature_vars(&self) -> &FeatureVarsStorage {
+        match &self.0 {
+            Repr::Varied(varied) => &varied.feature_vars,
+            Repr::Default(_) => panic!("the default instance keeps no storage of its own"),
+        }
+    }
+}
+
+/// An instance answers for its font wherever a location makes no difference,
+/// so everything a [`Font`] offers is reachable through one.
+///
+/// Where a location does make a difference the inherent method wins:
+/// [`global_metrics`](FontInstance::global_metrics) reports this instance,
+/// while the font's own stays reachable through [`font`](FontInstance::font).
 impl core::ops::Deref for FontInstance {
     type Target = Font;
     fn deref(&self) -> &Font {
@@ -67,18 +137,10 @@ impl core::ops::Deref for FontInstance {
 
 /// Builder for configuring a font instance.
 pub struct FontInstanceBuilder {
-    instance: FontInstance,
+    instance: VariedInstance,
 }
 
 impl FontInstanceBuilder {
-    /// Sets the size for the font instance, in pixels per em.
-    ///
-    /// Setting this to `None` disables scaling.
-    pub fn size(mut self, size: Option<f32>) -> Self {
-        self.instance.size = size;
-        self
-    }
-
     /// Sets the variations for the font instance from an unordered sequence of
     /// variations in user space.
     ///
@@ -138,7 +200,13 @@ impl FontInstanceBuilder {
 
     /// Builds the font instance.
     pub fn build(self) -> FontInstance {
-        self.instance
+        // An all-default location is just the font, so nothing needs owning.
+        // This is what keeps `VariedInstance::coords` non-empty.
+        if self.instance.coords.as_slice().is_empty() {
+            FontInstance(Repr::Default(self.instance.font))
+        } else {
+            FontInstance(Repr::Varied(Arc::new(self.instance)))
+        }
     }
 }
 
@@ -413,7 +481,7 @@ impl FontFeatureVariations {
 /// Lazy atomic storage for feature variation selections.
 ///
 /// We don't want to load the GSUB and GPOS tables unless explicitly requested.
-struct FeatureVarsStorage {
+pub(crate) struct FeatureVarsStorage {
     status: AtomicU32,
     gsub: AtomicU32,
     gpos: AtomicU32,
@@ -438,7 +506,7 @@ impl FeatureVarsStorage {
     /// low 16 bits.
     const GPOS_SHIFT: u32 = 16;
 
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             status: AtomicU32::new(Self::UNCHECKED),
             gsub: AtomicU32::new(0),
@@ -446,7 +514,7 @@ impl FeatureVarsStorage {
         }
     }
 
-    fn load(&self, font: &Font, coords: &[NormalizedCoord]) -> FontFeatureVariations {
+    pub(crate) fn load(&self, font: &Font, coords: &[NormalizedCoord]) -> FontFeatureVariations {
         let mut status = self.status.load(atomic::Ordering::Acquire);
         if status == Self::UNCHECKED {
             let tables = font.tables();
@@ -638,13 +706,13 @@ mod tests {
         let instance = FontInstance::builder(&font)
             .variations([("FILL", 0.5)])
             .build();
-        assert_eq!(instance.feature_vars.status.load(Ordering::Acquire), 0);
+        assert_eq!(instance.feature_vars().status.load(Ordering::Acquire), 0);
         assert_eq!(
             instance.feature_variations(),
             FontFeatureVariations::default()
         );
         assert_eq!(
-            instance.feature_vars.status.load(Ordering::Acquire),
+            instance.feature_vars().status.load(Ordering::Acquire),
             FeatureVarsStorage::BOTH_ABSENT
         );
     }
@@ -671,13 +739,13 @@ mod tests {
                 });
             }
         });
-        let status = instance.feature_vars.status.load(Ordering::Acquire);
+        let status = instance.feature_vars().status.load(Ordering::Acquire);
         assert_eq!(status & 0xFFFF, FeatureVarsStorage::PRESENT);
         assert_eq!(
             (status >> FeatureVarsStorage::GPOS_SHIFT) & 0xFFFF,
             FeatureVarsStorage::ABSENT
         );
-        assert_eq!(instance.feature_vars.gsub.load(Ordering::Acquire), 0);
+        assert_eq!(instance.feature_vars().gsub.load(Ordering::Acquire), 0);
     }
 
     #[test]
@@ -740,5 +808,132 @@ mod tests {
         assert!(coords[copied..]
             .iter()
             .all(|&coord| coord == NormalizedCoord::ZERO));
+    }
+
+    /// Twelve axes, and an `MVAR` that varies its heights.
+    const MVAR_FONT: &[u8] = font_test_data::AMSTELVAR_AVAR2_A;
+
+    #[test]
+    fn an_instance_varies_its_global_metrics() {
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        let far = FontInstance::builder(&font)
+            .normalized_coords([NormalizedCoord::from_f32(1.0); 12])
+            .build();
+        assert!(!far.normalized_coords().is_empty());
+        assert_ne!(far.global_metrics(), font.global_metrics());
+    }
+
+    #[test]
+    fn an_instance_at_the_default_location_shares_the_font_metrics() {
+        // Nothing varies there, so there is no second copy to compute.
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        let default = FontInstance::builder(&font).build();
+        assert!(core::ptr::eq(
+            default.global_metrics(),
+            font.global_metrics()
+        ));
+    }
+
+    #[test]
+    fn clones_of_an_instance_share_one_set_of_metrics() {
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        let far = FontInstance::builder(&font)
+            .normalized_coords([NormalizedCoord::from_f32(1.0); 12])
+            .build();
+        let shared = far.clone();
+        // The location is resolved once, not once per holder.
+        assert!(core::ptr::eq(far.global_metrics(), shared.global_metrics()));
+    }
+
+    #[test]
+    fn the_fixed_numbers_do_not_resolve_a_location() {
+        // Both are properties of the font, so reaching them through an
+        // instance must not read `MVAR` the way its whole-font metrics do.
+        let asked = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let logged = asked.clone();
+        let source: Arc<dyn Fn(Tag) -> Option<crate::model::FontBlob> + Send + Sync> =
+            Arc::new(move |tag: Tag| {
+                logged.lock().unwrap().push(tag);
+                let font = crate::FontRef::new(MVAR_FONT).ok()?;
+                Some(crate::model::FontBlob::from(
+                    font.table_data(tag)?.as_bytes().to_vec(),
+                ))
+            });
+        let font = Font::new(source, 0).unwrap();
+        let far = FontInstance::builder(&font)
+            .normalized_coords([NormalizedCoord::from_f32(1.0); 12])
+            .build();
+        asked.lock().unwrap().clear();
+
+        assert_eq!(far.num_glyphs(), font.num_glyphs());
+        assert_eq!(far.units_per_em(), font.units_per_em());
+        assert!(
+            !asked.lock().unwrap().contains(&Tag::new(b"MVAR")),
+            "reading a fixed number resolved the location"
+        );
+
+        // And the varied metrics still do.
+        let _ = far.global_metrics();
+        assert!(asked.lock().unwrap().contains(&Tag::new(b"MVAR")));
+    }
+
+    #[test]
+    fn a_font_converts_into_an_instance_of_itself() {
+        // By value where the caller is done with the font, by reference
+        // where it is not.
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        let borrowed = FontInstance::from(&font);
+        let owned = FontInstance::from(font.clone());
+        for instance in [borrowed, owned, font.default_instance()] {
+            assert!(matches!(instance.0, Repr::Default(_)));
+            assert!(core::ptr::eq(
+                instance.global_metrics(),
+                font.global_metrics()
+            ));
+        }
+    }
+
+    #[test]
+    fn a_default_instance_is_only_its_font() {
+        // Nothing about the default location needs owning, so building one
+        // shares the font rather than allocating beside it.
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        for instance in [
+            font.default_instance(),
+            FontInstance::builder(&font).build(),
+            // An all-default location collapses to no coordinates, so this
+            // reaches the same place.
+            FontInstance::builder(&font)
+                .normalized_coords([NormalizedCoord::from_f32(0.0); 12])
+                .build(),
+        ] {
+            assert!(matches!(instance.0, Repr::Default(_)));
+            assert!(instance.normalized_coords().is_empty());
+            assert!(core::ptr::eq(
+                instance.global_metrics(),
+                font.global_metrics()
+            ));
+        }
+    }
+
+    #[test]
+    fn a_location_away_from_the_default_is_owned() {
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        let far = FontInstance::builder(&font)
+            .normalized_coords([NormalizedCoord::from_f32(1.0); 12])
+            .build();
+        assert!(matches!(far.0, Repr::Varied(_)));
+        assert_eq!(far.normalized_coords().len(), 12);
+    }
+
+    #[test]
+    fn a_default_instance_reports_the_font_it_came_from() {
+        let font = Font::new(MVAR_FONT, 0).unwrap();
+        let instance = font.default_instance();
+        assert_eq!(instance.num_glyphs(), font.num_glyphs());
+        assert_eq!(
+            instance.feature_variations(),
+            FontFeatureVariations::default()
+        );
     }
 }

--- a/read-fonts/src/model/metrics.rs
+++ b/read-fonts/src/model/metrics.rs
@@ -1,0 +1,5 @@
+//! Metrics for a font and its glyphs.
+
+mod global;
+
+pub use global::{GlobalMetrics, LineBox};

--- a/read-fonts/src/model/metrics/global.rs
+++ b/read-fonts/src/model/metrics/global.rs
@@ -1,0 +1,350 @@
+//! Font-wide metrics.
+
+use crate::{
+    ps::type1::Type1Font,
+    tables::{
+        mvar::{tags, MvarInstance},
+        os2::SelectionFlags,
+    },
+    TableProvider,
+};
+use types::{BoundingBox, F2Dot14, F48Dot16, Tag};
+
+/// Returns `value` in design units with the location's delta applied.
+fn metric(value: i32, deltas: Option<&MvarInstance>, tag: Tag) -> F48Dot16 {
+    F48Dot16::from_i32(value)
+        + deltas
+            .and_then(|deltas| deltas.get(tag))
+            .unwrap_or_default()
+}
+
+/// Ascender, descender and line gap, as one table states them.
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
+pub struct LineBox {
+    /// Distance from the baseline to the top of the line.
+    pub ascender: F48Dot16,
+    /// Distance from the baseline to the bottom of the line. Usually negative.
+    pub descender: F48Dot16,
+    /// Extra space between the bottom of one line and the top of the next.
+    pub line_gap: F48Dot16,
+}
+
+/// Metrics that describe a font rather than any glyph in it.
+///
+/// Read from `head`, `maxp`, `hhea`, `vhea` and `OS/2`, which together are a
+/// few hundred bytes.
+///
+/// A font states its line metrics three times and the three disagree.
+/// [`hhea_line`](Self::hhea_line) is what macOS reads,
+/// [`win_ascent`](Self::win_ascent) and [`win_descent`](Self::win_descent)
+/// are what Windows reads, and [`typo_line`](Self::typo_line) is what the
+/// font asks for when [`use_typo_metrics`](Self::use_typo_metrics) is set.
+/// Choosing between them is left to the caller.
+///
+/// A field the font does not state is `None`, which is distinct from a stated
+/// zero.
+///
+/// `MVAR` varies most of these, so a set belongs to the location it was read
+/// at. The units per em, the counts, the bounding box, the widest and tallest
+/// advance and the average width cannot vary.
+///
+/// # Units
+///
+/// Measurements are unscaled design units. They are [`F48Dot16`] because a
+/// location can move them off a whole unit, and rounding here would decide
+/// for every caller how that fraction is spent.
+///
+/// The two axes do not scale alike: [`vhea_line`](Self::vhea_line) is
+/// measured across the vertical baseline rather than along it, so it scales
+/// on x where the horizontal sets scale on y.
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug)]
+pub struct GlobalMetrics {
+    /// Design units per em.
+    pub units_per_em: u16,
+    /// Number of glyphs in the font.
+    pub num_glyphs: u32,
+    /// Box enclosing every glyph in the font.
+    pub bounds: BoundingBox<F48Dot16>,
+    /// Line metrics from `hhea`.
+    pub hhea_line: Option<LineBox>,
+    /// Widest advance of any glyph.
+    pub max_advance_width: Option<F48Dot16>,
+    /// Line metrics from `vhea`, measured across the vertical baseline.
+    pub vhea_line: Option<LineBox>,
+    /// Tallest advance of any glyph.
+    pub max_advance_height: Option<F48Dot16>,
+    /// Typographic line metrics, from `OS/2`.
+    pub typo_line: Option<LineBox>,
+    /// Whether the font asks for [`typo_line`](Self::typo_line) to be used
+    /// in preference to [`hhea_line`](Self::hhea_line).
+    pub use_typo_metrics: bool,
+    /// Height above the baseline to leave clear, as a positive number.
+    pub win_ascent: Option<F48Dot16>,
+    /// Depth below the baseline to leave clear, as a positive number.
+    pub win_descent: Option<F48Dot16>,
+    /// Height of a lowercase x.
+    pub x_height: Option<F48Dot16>,
+    /// Height of a capital letter.
+    pub cap_height: Option<F48Dot16>,
+    /// Average glyph width, as the font reports it.
+    pub average_char_width: Option<F48Dot16>,
+}
+
+impl GlobalMetrics {
+    /// Reads the metrics from `tables` at the given location.
+    ///
+    /// A missing or unreadable table leaves the metrics that come from it
+    /// unset rather than failing.
+    ///
+    /// Pass an empty location for the font's defaults. At any other location
+    /// `MVAR` is read and its deltas applied.
+    pub fn from_sfnt<'a>(tables: &impl TableProvider<'a>, coords: &[F2Dot14]) -> Self {
+        // Only at a location, so that the common case does not reach for a
+        // table it has nothing to ask.
+        let mvar = (!coords.is_empty()).then(|| tables.mvar().ok()).flatten();
+        let deltas = mvar.as_ref().and_then(|mvar| mvar.at(coords));
+        let deltas = deltas.as_ref();
+        let mut metrics = Self::default();
+        if let Ok(head) = tables.head() {
+            metrics.units_per_em = head.units_per_em();
+            metrics.bounds = BoundingBox {
+                x_min: F48Dot16::from_i32(head.x_min() as i32),
+                y_min: F48Dot16::from_i32(head.y_min() as i32),
+                x_max: F48Dot16::from_i32(head.x_max() as i32),
+                y_max: F48Dot16::from_i32(head.y_max() as i32),
+            };
+        }
+        if let Ok(maxp) = tables.maxp() {
+            metrics.num_glyphs = maxp.num_glyphs() as u32;
+        }
+        if let Ok(hhea) = tables.hhea() {
+            // `MVAR` names one horizontal ascender, descender and line gap
+            // between them, so the same delta applies to whichever of these
+            // two sets a caller goes on to believe.
+            metrics.hhea_line = Some(LineBox {
+                ascender: metric(hhea.ascender().to_i16() as i32, deltas, tags::HASC),
+                descender: metric(hhea.descender().to_i16() as i32, deltas, tags::HDSC),
+                line_gap: metric(hhea.line_gap().to_i16() as i32, deltas, tags::HLGP),
+            });
+            metrics.max_advance_width =
+                Some(F48Dot16::from_i32(hhea.advance_width_max().to_u16() as i32));
+        }
+        if let Ok(vhea) = tables.vhea() {
+            metrics.vhea_line = Some(LineBox {
+                ascender: metric(vhea.ascender().to_i16() as i32, deltas, tags::VASC),
+                descender: metric(vhea.descender().to_i16() as i32, deltas, tags::VDSC),
+                line_gap: metric(vhea.line_gap().to_i16() as i32, deltas, tags::VLGP),
+            });
+            metrics.max_advance_height =
+                Some(F48Dot16::from_i32(vhea.advance_height_max().to_u16() as i32));
+        }
+        if let Ok(os2) = tables.os2() {
+            metrics.typo_line = Some(LineBox {
+                ascender: metric(os2.s_typo_ascender() as i32, deltas, tags::HASC),
+                descender: metric(os2.s_typo_descender() as i32, deltas, tags::HDSC),
+                line_gap: metric(os2.s_typo_line_gap() as i32, deltas, tags::HLGP),
+            });
+            metrics.win_ascent = Some(metric(os2.us_win_ascent() as i32, deltas, tags::HCLA));
+            metrics.win_descent = Some(metric(os2.us_win_descent() as i32, deltas, tags::HCLD));
+            metrics.use_typo_metrics = os2
+                .fs_selection()
+                .contains(SelectionFlags::USE_TYPO_METRICS);
+            metrics.x_height = os2
+                .sx_height()
+                .map(|value| metric(value as i32, deltas, tags::XHGT));
+            metrics.cap_height = os2
+                .s_cap_height()
+                .map(|value| metric(value as i32, deltas, tags::CPHT));
+            metrics.average_char_width = Some(F48Dot16::from_i32(os2.x_avg_char_width() as i32));
+        }
+        metrics
+    }
+
+    /// Reads the metrics a Type1 font states.
+    ///
+    /// Such a font has only a bounding box, a glyph count and a matrix. The
+    /// ascender and descender are the top and bottom of that box, as FreeType
+    /// takes them, since the font states none of its own. Everything else is
+    /// unset.
+    pub fn from_type1(font: &Type1Font) -> Self {
+        let bbox = font.bbox();
+        let bounds = BoundingBox {
+            x_min: bbox.x_min.to_f48dot16(),
+            y_min: bbox.y_min.to_f48dot16(),
+            x_max: bbox.x_max.to_f48dot16(),
+            y_max: bbox.y_max.to_f48dot16(),
+        };
+        Self {
+            units_per_em: font.upem().clamp(0, u16::MAX as i32) as u16,
+            num_glyphs: font.num_glyphs(),
+            bounds,
+            hhea_line: Some(LineBox {
+                ascender: bounds.y_max,
+                descender: bounds.y_min,
+                line_gap: F48Dot16::ZERO,
+            }),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FontRef;
+
+    /// A horizontal font with `OS/2` and `post`, but no `vhea`.
+    fn horizontal() -> FontRef<'static> {
+        FontRef::new(font_test_data::TINOS_SUBSET).unwrap()
+    }
+
+    /// A font set vertically as well, so it has `vhea`.
+    fn vertical() -> FontRef<'static> {
+        FontRef::new(font_test_data::VORG).unwrap()
+    }
+
+    /// A variable font whose `MVAR` varies its line metrics, among others.
+    fn variable() -> FontRef<'static> {
+        FontRef::new(font_test_data::AMSTELVAR_AVAR2_A).unwrap()
+    }
+
+    /// The far end of every one of that font's twelve axes.
+    fn far() -> [F2Dot14; 12] {
+        [F2Dot14::from_f32(1.0); 12]
+    }
+
+    #[test]
+    fn the_three_sets_of_line_metrics_are_kept_apart() {
+        let metrics = GlobalMetrics::from_sfnt(&horizontal(), &[]);
+        assert_eq!(metrics.units_per_em, 2048);
+        let hhea = metrics.hhea_line.unwrap();
+        assert!(hhea.ascender > F48Dot16::ZERO);
+        assert!(hhea.descender < F48Dot16::ZERO);
+        // The typographic set descends the same way `hhea` does.
+        let typo = metrics.typo_line.unwrap();
+        assert!(typo.ascender > F48Dot16::ZERO);
+        assert!(typo.descender < F48Dot16::ZERO);
+        // The Windows pair does not: both are stated as positive extents.
+        assert!(metrics.win_ascent.unwrap() > F48Dot16::ZERO);
+        assert!(metrics.win_descent.unwrap() > F48Dot16::ZERO);
+    }
+
+    #[test]
+    fn a_font_without_a_table_leaves_its_measurements_unset() {
+        // A font with no `vhea`, which most horizontal fonts are.
+        let metrics = GlobalMetrics::from_sfnt(&horizontal(), &[]);
+        assert!(metrics.vhea_line.is_none());
+        assert!(metrics.max_advance_height.is_none());
+        // And one that has it.
+        let metrics = GlobalMetrics::from_sfnt(&vertical(), &[]);
+        assert!(metrics.vhea_line.is_some());
+        assert!(metrics.max_advance_height.unwrap() > F48Dot16::ZERO);
+    }
+
+    #[test]
+    fn a_font_with_nothing_to_read_gives_up_rather_than_failing() {
+        let metrics =
+            GlobalMetrics::from_sfnt(&FontRef::new(font_test_data::NAMES_ONLY).unwrap(), &[]);
+        assert_eq!(metrics, GlobalMetrics::default());
+    }
+
+    #[test]
+    fn a_default_location_leaves_every_measurement_on_a_whole_unit() {
+        // Nothing has moved them off one, so each is exactly what its table
+        // states.
+        let metrics = GlobalMetrics::from_sfnt(&horizontal(), &[]);
+        let ascender = metrics.hhea_line.unwrap().ascender;
+        assert_eq!(ascender, F48Dot16::from_i32(ascender.to_i32()));
+    }
+
+    #[test]
+    fn a_location_moves_what_mvar_varies() {
+        let font = variable();
+        let default = GlobalMetrics::from_sfnt(&font, &[]);
+        let far = GlobalMetrics::from_sfnt(&font, &far());
+        assert_ne!(default, far);
+        // This font varies its clipping extents and both of its heights.
+        assert_ne!(default.win_ascent, far.win_ascent);
+        assert_ne!(default.win_descent, far.win_descent);
+        assert_ne!(default.x_height, far.x_height);
+        assert_ne!(default.cap_height, far.cap_height);
+    }
+
+    #[test]
+    fn the_two_horizontal_line_sets_move_together() {
+        // `MVAR` names one horizontal ascender between `hhea` and the
+        // typographic set, so a location moves both by the same amount.
+        let font = variable();
+        let default = GlobalMetrics::from_sfnt(&font, &[]);
+        let far = GlobalMetrics::from_sfnt(&font, &far());
+        let shift = far.hhea_line.unwrap().ascender - default.hhea_line.unwrap().ascender;
+        assert_ne!(shift, F48Dot16::ZERO);
+        assert_eq!(
+            far.typo_line.unwrap().ascender - default.typo_line.unwrap().ascender,
+            shift
+        );
+    }
+
+    #[test]
+    fn a_delta_keeps_the_fraction_the_variation_store_computed() {
+        // The whole reason these are not integers: some of this font's
+        // metrics land off a whole design unit, and rounding them here would
+        // decide for every caller how that fraction is spent.
+        // Part way along the axes, where the region scalars are fractions;
+        // at the far end of every one they are exactly one and the deltas
+        // land on whole units by luck rather than by design.
+        let far = GlobalMetrics::from_sfnt(&variable(), &[F2Dot14::from_f32(0.4); 12]);
+        let moved = [
+            far.hhea_line.unwrap().ascender,
+            far.hhea_line.unwrap().descender,
+            far.win_ascent.unwrap(),
+            far.win_descent.unwrap(),
+            far.x_height.unwrap(),
+            far.cap_height.unwrap(),
+        ];
+        assert!(moved
+            .iter()
+            .any(|value| *value != F48Dot16::from_i32(value.to_i32())));
+    }
+
+    #[test]
+    fn what_mvar_cannot_say_does_not_move() {
+        let font = variable();
+        let default = GlobalMetrics::from_sfnt(&font, &[]);
+        let far = GlobalMetrics::from_sfnt(&font, &far());
+        assert_eq!(default.units_per_em, far.units_per_em);
+        assert_eq!(default.num_glyphs, far.num_glyphs);
+        assert_eq!(default.bounds, far.bounds);
+        assert_eq!(default.max_advance_width, far.max_advance_width);
+        assert_eq!(default.average_char_width, far.average_char_width);
+    }
+
+    #[test]
+    fn a_type1_font_states_what_little_it_can() {
+        let font =
+            crate::ps::type1::Type1Font::new(font_test_data::type1::NOTO_SERIF_REGULAR_SUBSET_PFA)
+                .unwrap();
+        let metrics = GlobalMetrics::from_type1(&font);
+        assert_eq!(metrics.units_per_em, 1000);
+        assert!(metrics.num_glyphs > 0);
+        assert!(metrics.bounds.y_max > F48Dot16::ZERO);
+        // No table states these, so the bounding box stands in for them.
+        assert_eq!(metrics.hhea_line.unwrap().ascender, metrics.bounds.y_max);
+        assert_eq!(metrics.hhea_line.unwrap().descender, metrics.bounds.y_min);
+        // And what such a font cannot express stays unset.
+        assert!(metrics.vhea_line.is_none());
+        assert!(metrics.typo_line.is_none());
+        assert!(metrics.win_ascent.is_none());
+        assert!(metrics.cap_height.is_none());
+    }
+
+    #[test]
+    fn a_static_font_reads_the_same_at_every_location() {
+        // Coordinates a font has no way to use change nothing about it.
+        let font = horizontal();
+        assert_eq!(
+            GlobalMetrics::from_sfnt(&font, &[]),
+            GlobalMetrics::from_sfnt(&font, &far())
+        );
+    }
+}


### PR DESCRIPTION
Adds font-wide metrics to `Font` and `FontInstance`. The list of metrics is slightly different here than in `skrifa::metrics::Metrics` because this slices the set to the values that don't require the `post` table (those will follow later in `StyleMetrics`). The reasoning is that none of those are required for shaping so we don't want to pull large `post` 2.0 tables unnecessarily.

Also removes any notion of size from `FontInstance` (that will come later as some `Scaler` type), so `FontInstance` becomes internally `Arc`'d and we can now create an instance at the default location for free.

Requires #2110