### PR TITLE
Fix IFT brotli decoding failing to detect trailing data.

### DIFF
--- a/incremental-font-transfer/src/table_keyed.rs
+++ b/incremental-font-transfer/src/table_keyed.rs
@@ -442,4 +442,40 @@ mod tests {
             apply_table_keyed_patch(&patch, &font, &BuiltInBrotliDecoder)
         );
     }
+
+    #[test]
+    fn table_keyed_patch_unconsumed_brotli_data() {
+        let patch_data = table_keyed_patch();
+        let off1 = patch_data.offset_for("patch[1]");
+        let off2 = patch_data.offset_for("patch[2]");
+        let off3 = patch_data.offset_for("end") + 4;
+
+        let patch_off1 = patch_data.offset_for("patch_off[1]");
+        let patch_off2 = patch_data.offset_for("patch_off[2]");
+        let patch_off3 = patch_data.offset_for("patch_off[3]");
+
+        let junk = [0xde, 0xad, 0xbe, 0xef];
+        let mut data = patch_data.as_slice().to_vec();
+        // Insert junk right before patch[1], which is at the end of patch[0]'s brotli stream.
+        data.splice(off1..off1, junk);
+
+        // Update patch_off[1], patch_off[2], and patch_off[3] to account for the inserted junk bytes.
+        data[patch_off1..patch_off1 + 4]
+            .copy_from_slice(&((off1 + junk.len()) as u32).to_be_bytes());
+        data[patch_off2..patch_off2 + 4]
+            .copy_from_slice(&((off2 + junk.len()) as u32).to_be_bytes());
+        data[patch_off3..patch_off3 + 4]
+            .copy_from_slice(&((off3 + junk.len()) as u32).to_be_bytes());
+
+        let patch = TableKeyedPatch::read(FontData::new(&data)).unwrap();
+        let font = test_font();
+        let font = FontRef::new(font.as_slice()).unwrap();
+
+        assert_eq!(
+            Err(PatchingError::InvalidPatch(
+                "Input brotli stream has excess bytes."
+            )),
+            apply_table_keyed_patch(&patch, &font, &BuiltInBrotliDecoder)
+        );
+    }
 }

--- a/shared-brotli-patch-decoder/src/lib.rs
+++ b/shared-brotli-patch-decoder/src/lib.rs
@@ -70,7 +70,11 @@ impl SharedBrotliDecoder for BuiltInBrotliDecoder {
                     max_uncompressed_length,
                 );
             } else if #[cfg(feature = "rust-brotli")] {
-                return rust_brotli::shared_brotli_decode_rust(encoded, shared_dictionary, max_uncompressed_length);
+                rust_brotli::shared_brotli_decode_rust(
+                    encoded,
+                    shared_dictionary,
+                    max_uncompressed_length,
+                )
             } else {
                 compile_error!("At least one of 'c-brotli' or 'rust-brotli' must be enabled.");
             }
@@ -202,11 +206,6 @@ mod tests {
         );
     }
 
-    // TODO(garretrieger): there doesn't seem to be an easy way to detect this condition with
-    // the rust brotli implementation. So disable for now. However, we need to make this behaviour
-    // consistent between the two possible implementations. Either don't check for this in the c
-    // version, or figure out how to have a similar check in rust.
-    #[cfg(feature = "c-brotli")]
     #[test]
     fn brotli_decode_too_much_input() {
         let mut patch: Vec<u8> = NO_DICT_PATCH.to_vec();

--- a/shared-brotli-patch-decoder/src/rust_brotli.rs
+++ b/shared-brotli-patch-decoder/src/rust_brotli.rs
@@ -1,7 +1,5 @@
-use std::io::{self, Cursor, Write};
-
 use crate::decode_error::DecodeError;
-use brotli_decompressor::BrotliDecompressCustomDict;
+use brotli_decompressor::{BrotliDecompressStream, BrotliResult, BrotliState, StandardAlloc};
 
 #[allow(dead_code)]
 pub fn shared_brotli_decode_rust(
@@ -9,51 +7,65 @@ pub fn shared_brotli_decode_rust(
     shared_dictionary: Option<&[u8]>,
     max_uncompressed_length: usize,
 ) -> Result<Vec<u8>, DecodeError> {
-    let mut input_buffer: [u8; 4096] = [0; 4096];
-    let mut output_buffer: [u8; 4096] = [0; 4096];
-
-    let mut cursor = Cursor::new(encoded);
-    let mut output = BoundedOutput(Default::default(), max_uncompressed_length);
-
-    let mut dict: Vec<u8> = Default::default();
-    if let Some(dict_data) = shared_dictionary {
-        dict.extend_from_slice(dict_data);
+    if let Some(dict) = shared_dictionary {
+        if dict.is_empty() {
+            return Err(DecodeError::InvalidDictionary);
+        }
     }
 
-    BrotliDecompressCustomDict(
-        &mut cursor,
-        &mut output,
-        &mut input_buffer,
-        &mut output_buffer,
-        dict,
-    )
-    .map_err(DecodeError::from_io_error)?;
+    let alloc_u8 = StandardAlloc::default();
+    let alloc_u32 = StandardAlloc::default();
+    let alloc_hc = StandardAlloc::default();
 
-    if cursor.get_ref().len() as u64 > cursor.position() {
+    let mut state = if let Some(dict) = shared_dictionary {
+        let custom_dict = dict.to_vec().into();
+        BrotliState::new_with_custom_dictionary(alloc_u8, alloc_u32, alloc_hc, custom_dict)
+    } else {
+        BrotliState::new(alloc_u8, alloc_u32, alloc_hc)
+    };
+
+    let mut sink = vec![0u8; max_uncompressed_length];
+    let mut available_in = encoded.len();
+    let mut input_offset = 0;
+    let mut available_out = sink.len();
+    let mut output_offset = 0;
+    let mut total_out = 0;
+
+    loop {
+        let result = BrotliDecompressStream(
+            &mut available_in,
+            &mut input_offset,
+            encoded,
+            &mut available_out,
+            &mut output_offset,
+            &mut sink,
+            &mut total_out,
+            &mut state,
+        );
+
+        match result {
+            BrotliResult::ResultSuccess => break,
+            BrotliResult::ResultFailure => {
+                return Err(DecodeError::InvalidStream);
+            }
+            BrotliResult::NeedsMoreInput if available_in == 0 => {
+                return Err(DecodeError::InvalidStream);
+            }
+            BrotliResult::NeedsMoreOutput if available_out == 0 => {
+                return Err(DecodeError::MaxSizeExceeded);
+            }
+            _ => continue,
+        }
+    }
+
+    if available_in > 0 {
         return Err(DecodeError::ExcessInputData);
     }
 
-    Ok(output.0)
-}
-
-#[allow(dead_code)]
-struct BoundedOutput(Vec<u8>, usize);
-
-#[allow(dead_code)]
-impl Write for BoundedOutput {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if self.1 < buf.len() {
-            // hit the write bound, return an error.
-            return Err(io::Error::new(
-                io::ErrorKind::OutOfMemory,
-                "Max output size reached.",
-            ));
-        }
-        self.1 -= buf.len();
-        self.0.write(buf)
+    if total_out > sink.len() {
+        return Err(DecodeError::MaxSizeExceeded);
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
-    }
+    sink.resize(total_out, 0);
+    Ok(sink)
 }


### PR DESCRIPTION
Re-implement using BrotliDecompressStream (matching how c_brotli.rs is implemented) so this condition can be detected when utilizing the rust_brotli implementation.

Fixes issue found in https://github.com/w3c/ift-client-tests/pull/56