### PR TITLE
[write-fonts] fix orphaned duplicate when isolating a subgraph root

### DIFF
--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -695,14 +695,13 @@ impl Graph {
             // for the roots, we set the edge count to the number of long
             // incoming offsets; if this differs from the total number of
             // incoming offsets it means we need to dupe the root as well.
-            let inbound_wide_offsets = self.nodes[root]
-                .parents
-                .iter()
-                .filter(|(_, len)| !matches!(len, OffsetLen::Offset16))
-                .inspect(|(parent_id, _)| {
+            let mut inbound_wide_offsets = 0;
+            for (parent_id, len) in &self.nodes[root].parents {
+                if !matches!(len, OffsetLen::Offset16) {
                     wide_parents.insert(*parent_id);
-                })
-                .count();
+                    inbound_wide_offsets += 1;
+                }
+            }
             subgraph.insert(*root, inbound_wide_offsets);
             self.find_subgraph_map_hb(*root, &mut subgraph);
         }

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -1626,6 +1626,59 @@ mod tests {
     }
 
     #[test]
+    fn duplicated_root_is_linked_from_its_wide_parent() {
+        // When a space root is linked from both 16 and 32-bit space it is
+        // duplicated, and the 32-bit links must be moved to the duplicate.
+        // Here the two roots (2, 3) share a child (4) that is also reachable
+        // from 16-bit space, so 4 is duplicated as well. If the wide link from
+        // 0 is not moved to 2', then 2' is orphaned while still linking to 4',
+        // and sort_shortest_distance panics because 4' has a parent that is
+        // never visited.
+        //
+        //  before           after
+        //      0               0
+        //     /║⑊           ┌─┘║⑊
+        //    1 ║ ⑊          1  ║ ⑊
+        //    │\║  ⑊         │\ 2' 3
+        //    │ 2   3        │ \  \│
+        //    │/    │        │ 2   4'
+        //    4─────┘        │/
+        //                   4
+
+        let _ = env_logger::builder().is_test(true).try_init();
+        let ids = make_ids::<5>();
+        let sizes = [10; 5];
+        let mut graph = TestGraphBuilder::new(ids, sizes)
+            .add_link(ids[0], ids[1], OffsetLen::Offset16)
+            .add_link(ids[0], ids[2], OffsetLen::Offset32)
+            .add_link(ids[0], ids[3], OffsetLen::Offset32)
+            .add_link(ids[1], ids[2], OffsetLen::Offset16)
+            .add_link(ids[1], ids[4], OffsetLen::Offset16)
+            .add_link(ids[2], ids[4], OffsetLen::Offset16)
+            .add_link(ids[3], ids[4], OffsetLen::Offset16)
+            .build();
+
+        graph.assign_spaces_hb();
+        // this used to panic with "cycle or something?"
+        graph.sort_shortest_distance();
+
+        // 2 and 4 are duplicated
+        assert_eq!(graph.nodes.len(), 7);
+        // the wide link from the root now points at the duplicate of 2
+        let wide_targets = graph.objects[&ids[0]]
+            .offsets
+            .iter()
+            .filter(|link| link.len == OffsetLen::Offset32)
+            .map(|link| link.object)
+            .collect::<HashSet<_>>();
+        assert!(!wide_targets.contains(&ids[2]));
+        assert!(wide_targets.contains(&ids[3]));
+        // and nothing was orphaned
+        let reachable = graph.find_descendents(ids[0]);
+        assert_eq!(reachable.len(), graph.nodes.len());
+    }
+
+    #[test]
     fn assign_space_even_without_any_duplication() {
         // the subgraph of the long offset (0->2) is already isolated, and
         // so requires no duplication; but we should still correctly assign a

--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -687,6 +687,9 @@ impl Graph {
 
         // map of object id -> number of incoming edges
         let mut subgraph = BTreeMap::new();
+        // the parents of the roots that link to them via long offsets; if a
+        // root gets duplicated, these links must be moved to the duplicate
+        let mut wide_parents = HashSet::new();
 
         for root in roots.iter() {
             // for the roots, we set the edge count to the number of long
@@ -696,6 +699,9 @@ impl Graph {
                 .parents
                 .iter()
                 .filter(|(_, len)| !matches!(len, OffsetLen::Offset16))
+                .inspect(|(parent_id, _)| {
+                    wide_parents.insert(*parent_id);
+                })
                 .count();
             subgraph.insert(*root, inbound_wide_offsets);
             self.find_subgraph_map_hb(*root, &mut subgraph);
@@ -728,21 +734,17 @@ impl Graph {
             return false;
         }
 
-        // now everything but the links to the roots roots has been remapped;
-        // remap those, if needed
-        for root in roots.iter() {
-            let Some(new_id) = id_map.get(root) else {
-                continue;
-            };
-            self.parents_invalid = true;
-            self.positions_invalid = true;
-            for (parent_id, len) in &self.nodes[new_id].parents {
-                if !matches!(len, OffsetLen::Offset16) {
-                    for link in &mut self.objects.get_mut(parent_id).unwrap().offsets {
-                        if link.object == *root {
-                            link.object = *new_id;
-                        }
-                    }
+        // now everything but the long links into the subgraph has been
+        // remapped; move those to the duplicates, if any
+        for parent_id in &wide_parents {
+            for link in &mut self.objects.get_mut(parent_id).unwrap().offsets {
+                if matches!(link.len, OffsetLen::Offset16) {
+                    continue;
+                }
+                if let Some(new_id) = id_map.get(&link.object) {
+                    link.object = *new_id;
+                    self.parents_invalid = true;
+                    self.positions_invalid = true;
                 }
             }
         }


### PR DESCRIPTION
When a space root is linked from both 16 and 32-bit space, `isolate_subgraph_hb` duplicates it and then has to move the wide links over to the duplicate. It looked for those links among the parents of the *duplicate*, but [`duplicate_subgraph`](https://github.com/googlefonts/fontations/blob/e3cbfdd2769e8b051fc7255ab24992768b132bb3/write-fonts/src/graph.rs#L1091-L1093) creates it with an empty parent list, so nothing was ever remapped: the original kept both its parents and the copy was left orphaned, still linking to its (possibly shared) children. The next `sort_shortest_distance` then panics with ["cycle or something?"](https://github.com/googlefonts/fontations/blob/e3cbfdd2769e8b051fc7255ab24992768b132bb3/write-fonts/src/graph.rs#L490-L495), because the orphan is still in those children's parent lists, so the sort never sees all of their incoming links and mistakes that for a cycle.

I hit this compiling a large GPOS with fontc where extension promotion promoted almost every lookup, so a few subtables deduplicated across a promoted and an unpromoted lookup ended up as space roots with one 32-bit and one 16-bit parent. The existing `duplicate_shared_root_subgraph` test has exactly that shape but only counts nodes, so it passed with the orphan in place (my test also sorts and checks that the wide link moved and that nothing is unreachable).

Here I do what harfbuzz's [isolate_subgraph](https://github.com/harfbuzz/harfbuzz/blob/bc678801ce4be8e83c5b7c013fca805ea71a38e4/src/graph/graph.hh#L998-L1046) does: i.e. collect the wide parents of the roots up front, before anything is duplicated, and afterwards retarget any wide link from those parents whose target was duplicated. This also covers a wide link from one of those parents to a duplicated node other than the root, which the old loop never considered.