### PR TITLE
[ci] Read only the archive the packages come from

### DIFF
--- a/.github/workflows/fontconfig-compat.yml
+++ b/.github/workflows/fontconfig-compat.yml
@@ -62,8 +62,17 @@ jobs:
       # meson comes from PyPI rather than apt: fontconfig asks for >= 1.11.0
       # and the runner image ships 1.3.2. pipx because Ubuntu marks its
       # Python externally managed, so a plain pip install is refused.
+      #
+      # The runner image carries third-party apt repositories that nothing
+      # here installs from, and one of them publishing while we read it fails
+      # the whole update: a Release file newer than the Packages.gz it points
+      # at reads as a hash sum mismatch. Dropping them leaves Ubuntu's own
+      # archive, which is where every package below comes from, and which the
+      # image keeps in ubuntu.sources rather than beside these.
       - name: install build dependencies
         run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             ninja-build pkg-config gperf \


### PR DESCRIPTION
The fontconfig job installs six packages, all from Ubuntu's own archive, and was failing on a repository it installs nothing from:

    E: Failed to fetch https://dl.google.com/linux/chrome-stable/... Hash Sum mismatch
       Last modification reported: Wed, 09 Sep 2026 09:41:12 +0000
       Release file created at:    Wed, 09 Sep 2026 17:16:59 +0000

The runner image carries Chrome's apt repository. Those two timestamps are that repository mid-publish, offering a Release file newer than the `Packages.gz` it points at, which apt reports as a hash sum mismatch and which fails the whole update rather than the one source. Retrying does not help while it lasts, and refetching the index makes it likelier by discarding a copy that still agreed with itself.

Dropping the third-party sources leaves the archive every package here comes from. The image keeps Ubuntu's own in `ubuntu.sources` rather than beside them, so removing these by name takes nothing that is needed. Microsoft's is removed alongside Chrome's: it is the other one the image carries and it can publish just as unluckily.