### PR TITLE
[ci] Pin dtolnay/rust-toolchain to a commit on its master branch

### DIFF
--- a/.github/workflows/chromium-compat.yml
+++ b/.github/workflows/chromium-compat.yml
@@ -44,7 +44,9 @@ jobs:
           persist-credentials: false
           path: fontations
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       # actions/checkout fetches the whole tree, which for Chromium is not
       # viable. `--filter=tree:0` leaves trees on the server and fetches only

--- a/.github/workflows/fontconfig-compat.yml
+++ b/.github/workflows/fontconfig-compat.yml
@@ -52,7 +52,9 @@ jobs:
           persist-credentials: false
           path: fontations
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       # fontconfig's own build dependencies, plus bindgen, which meson calls
       # through `rust.bindgen()` to generate the two binding crates.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
       - run: rustup component add rustfmt
 
       - name: rustfmt check
@@ -38,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: 1.89
       - run: rustup component add clippy
@@ -71,7 +73,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: 1.85
 
@@ -85,7 +87,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       # test all packages individually to ensure deterministic resolution
       # of dependencies for each package
@@ -153,7 +157,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       - name: run codegen
         run: cargo run --bin=codegen resources/codegen_plan.toml
@@ -170,7 +176,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: 1.89
           # Use a target without `std` to make sure we don't link to `std`
@@ -194,7 +200,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           target: wasm32-unknown-unknown
           toolchain: 1.89
@@ -229,7 +235,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       - name: fauntlet compare
         run: cargo run --release -p fauntlet -- compare-glyphs --print-paths --hinting-engine all --hinting-target all --exit-on-fail fauntlet/test_fonts/*.*tf

--- a/.github/workflows/skia-compat.yml
+++ b/.github/workflows/skia-compat.yml
@@ -56,7 +56,9 @@ jobs:
             src/ports/fontations
             bazel/external/fontations
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       # The ref reaches the shell through the environment rather than through
       # template expansion, which would splice it into the script itself.


### PR DESCRIPTION
zizmor reports the pin as an impostor commit: a commit that resolves on GitHub but belongs to no branch or tag of the repository named. It is not an impostor, and refreshing the pin would not settle it. That action selects a toolchain by the ref it is used at, and each of those refs is one synthetic commit that is force-replaced when the toolchain moves, so `stable` today is a different commit from `stable` last month and the one pinned here is reachable from nothing. Any commit pinned that way eventually reads as an impostor. The `v1` tag sits on the real history and stays reachable.

Moving there is not only a change of hash. The toolchain branches carry an action that defaults the toolchain to their own name; the one on master requires it and fails the step when it is absent:

    inputs.toolchain:  required: false, default: stable   # on `stable`
    inputs.toolchain:  required: true                     # on `v1`

So each use now names its toolchain. Four already did, and keep what they asked for; the seven that were relying on the branch to choose now say `stable` where they meant it. The trailing comment reads `# v1` because that is the ref the hash belongs to, which is also what dependabot needs in order to offer the next one.

fontc reached the same commit in googlefonts/fontc#2131.