### PR TITLE
[read-fonts] Read a charstring's width without drawing it

### DIFF
--- a/read-fonts/src/ps/cff/font.rs
+++ b/read-fonts/src/ps/cff/font.rs
@@ -336,11 +336,73 @@ impl<'a> CffFontRef<'a> {
         }
     }
 
+    /// Evaluates the charstring for the requested glyph far enough to read
+    /// its advance width, without drawing it.
+    ///
+    /// A Type 2 charstring states its width, where it states one at all, as
+    /// an optional extra argument on the first operator that clears the
+    /// stack, so evaluation stops there. Where the charstring states none,
+    /// the subfont's default width applies.
+    ///
+    /// The font matrix is applied and no size is, so the width is exact and
+    /// in the units the rest of the font is measured in.
+    /// [`advance`](Self::advance) applies a size as well and reports what
+    /// [`draw`](Self::draw) does.
+    ///
+    /// Unlike [`evaluate_charstring`], the matrix is applied here rather than
+    /// left to a caller. That one withholds it so a hinter can be slotted in
+    /// ahead of it; nothing hints a width.
+    ///
+    /// [`evaluate_charstring`]: Self::evaluate_charstring
+    pub fn evaluate_width(
+        &self,
+        subfont: &Subfont,
+        gid: GlyphId,
+        coords: &[F2Dot14],
+    ) -> Result<Option<Fixed>, Error> {
+        let transform = self.transform(subfont, None);
+        Ok(self
+            .charstring_width(subfont, gid, coords)?
+            .map(|width| transform.transform_h_metric(width)))
+    }
+
+    /// The width the charstring itself gives, before any transform.
+    ///
+    /// Where it gives none the subfont's default applies, as it does when the
+    /// glyph is drawn.
+    fn charstring_width(
+        &self,
+        subfont: &Subfont,
+        gid: GlyphId,
+        coords: &[F2Dot14],
+    ) -> Result<Option<Fixed>, Error> {
+        let charstrings = self.top_dict.charstrings.clone();
+        let blend = self.blend_state(subfont.vs_index, coords);
+        let subrs = if subfont.subrs_offset != 0 {
+            let data = self
+                .data
+                .get(subfont.subrs_offset as usize..)
+                .ok_or(Error::Malformed)?;
+            Index::new(data, self.is_cff2)?
+        } else {
+            Index::Empty
+        };
+        let charstring_data = charstrings
+            .get(gid.to_u32() as usize)
+            .ok_or(Error::Malformed)?;
+        let ctx = (self.data, &charstrings, &self.global_subrs, &subrs);
+        Ok(match cs::evaluate_width(&ctx, blend, charstring_data)? {
+            Some(width) => Some(width + subfont.nominal_width),
+            None => subfont.default_width,
+        })
+    }
+
     /// Evaluates the charstring for the requested glyph and sends the results
     /// to the given sink.
     ///
-    /// Returns the advance with of the glyph in font units if the charstring
-    /// provides one.
+    /// Returns the width the charstring states, in the charstring's own
+    /// space: neither the font matrix nor a size is applied, to the width or
+    /// to the commands. [`draw`](Self::draw) applies both.
     pub fn evaluate_charstring(
         &self,
         subfont: &Subfont,
@@ -368,6 +430,24 @@ impl<'a> CffFontRef<'a> {
         } else {
             Ok(subfont.default_width)
         }
+    }
+
+    /// Returns the advance width of the glyph with an optional size in
+    /// ppem, without drawing it.
+    ///
+    /// This is the width [`draw`](Self::draw) reports, arrived at without
+    /// the drawing.
+    pub fn advance(
+        &self,
+        subfont: &Subfont,
+        gid: GlyphId,
+        coords: &[F2Dot14],
+        ppem: Option<f32>,
+    ) -> Result<Option<f32>, Error> {
+        let transform = self.transform(subfont, ppem);
+        Ok(self
+            .charstring_width(subfont, gid, coords)?
+            .map(|width| transform.transform_h_metric(width).to_f32().max(0.0)))
     }
 
     /// Draws the glyph with an optional size in ppem to the given pen.
@@ -1234,5 +1314,80 @@ mod tests {
         let font = FontRef::new(font_test_data::CANTARELL_VF_TRIMMED).unwrap();
         let cff = CffFontRef::new(font.cff2().unwrap().offset_data().as_bytes(), 0, None).unwrap();
         assert!(cff.encoding().is_none());
+    }
+}
+
+#[cfg(test)]
+mod width_only_tests {
+    use super::*;
+    use crate::{model::pen::NullPen, FontRef, TableProvider};
+
+    const FONTS: [&[u8]; 3] = [
+        font_test_data::NOTO_SERIF_DISPLAY_TRIMMED,
+        font_test_data::ift::CFF_FONT,
+        // A nested matrix, so the charstring's space and the font's differ
+        // and the two widths are not the same number.
+        font_test_data::MATERIAL_ICONS_SUBSET_MATRIX,
+    ];
+
+    /// Calls `check` for every glyph, with the subfont that glyph belongs to.
+    fn for_each_glyph(data: &[u8], mut check: impl FnMut(&CffFontRef, &Subfont, GlyphId)) {
+        let font = FontRef::new(data).unwrap();
+        let cff =
+            CffFontRef::new_cff(font.cff().unwrap().offset_data().as_bytes(), 0, None).unwrap();
+        let num_glyphs = font.maxp().unwrap().num_glyphs() as u32;
+        assert!(num_glyphs > 1);
+        for gid in (0..num_glyphs).map(GlyphId::new) {
+            let index = cff.subfont_index(gid).unwrap_or(0);
+            let subfont = cff.subfont(index, &[]).unwrap();
+            check(&cff, &subfont, gid);
+        }
+    }
+
+    #[test]
+    fn the_quick_width_is_what_a_full_run_reports() {
+        let mut mapped = 0;
+        for data in FONTS {
+            let mut stated = 0;
+            for_each_glyph(data, |cff, subfont, gid| {
+                // `evaluate_charstring` answers in the charstring's own space
+                // and `evaluate_width` in design units, so the matrix goes on
+                // the full run before the two can be compared.
+                let transform = cff.transform(subfont, None);
+                let full = cff
+                    .evaluate_charstring(subfont, gid, &[], &mut cs::NullSink)
+                    .unwrap();
+                let quick = cff.evaluate_width(subfont, gid, &[]).unwrap();
+                assert_eq!(
+                    full.map(|width| transform.transform_h_metric(width)),
+                    quick,
+                    "glyph {gid}"
+                );
+                stated += full.is_some() as u32;
+                if let (Some(full), Some(quick)) = (full, quick) {
+                    mapped += (full != quick) as u32;
+                }
+            });
+            // The comparison is worthless if nothing reported a width at all.
+            assert!(stated > 0, "no glyph reported a width");
+        }
+        // And worthless again if the matrix never moved one, since then the
+        // two spaces coincide and the comparison spans nothing.
+        assert!(mapped > 0, "no width was moved by a matrix");
+    }
+
+    #[test]
+    fn the_quick_advance_is_what_drawing_reports() {
+        // Drawing scales the width by the font matrix, and by ppem where one
+        // is given, so this is what catches an advance that skipped either.
+        for data in FONTS {
+            for ppem in [None, Some(16.0), Some(72.0)] {
+                for_each_glyph(data, |cff, subfont, gid| {
+                    let drawn = cff.draw(subfont, gid, &[], ppem, &mut NullPen).unwrap();
+                    let quick = cff.advance(subfont, gid, &[], ppem).unwrap();
+                    assert_eq!(drawn, quick, "glyph {gid} at {ppem:?}");
+                });
+            }
+        }
     }
 }

--- a/read-fonts/src/ps/cs.rs
+++ b/read-fonts/src/ps/cs.rs
@@ -146,6 +146,25 @@ pub trait CommandSink {
     fn finish(&mut self) {}
 }
 
+/// Sink that drops all drawing output into the ether.
+pub struct NullSink;
+
+impl CommandSink for NullSink {
+    fn move_to(&mut self, _x: Fixed, _y: Fixed) {}
+    fn line_to(&mut self, _x: Fixed, _y: Fixed) {}
+    fn curve_to(
+        &mut self,
+        _cx0: Fixed,
+        _cy0: Fixed,
+        _cx1: Fixed,
+        _cy1: Fixed,
+        _x: Fixed,
+        _y: Fixed,
+    ) {
+    }
+    fn close(&mut self) {}
+}
+
 /// Evaluates the given charstring and emits the resulting commands to the
 /// specified sink.
 ///
@@ -169,6 +188,31 @@ pub fn evaluate<'a>(
     let width = evaluator.have_read_width.then_some(evaluator.wx);
     sink.finish();
     Ok(width)
+}
+
+/// Returns the advance width the charstring states, without drawing it.
+///
+/// A charstring states its width before it draws anything: Type 1 in the
+/// `hsbw` or `sbw` that must open it, Type 2 as an optional extra argument
+/// on the first operator that clears the stack. Evaluation therefore stops
+/// as soon as that operator has been seen, which for most glyphs is a
+/// handful of bytes out of hundreds.
+///
+/// `None` where the charstring states no width of its own. For Type 2 that
+/// is the common case and means the font's default width applies; the
+/// caller supplies it, since the charstring does not know it.
+pub fn evaluate_width<'a>(
+    context: &'a impl CharstringContext,
+    blend_state: Option<BlendState<'a>>,
+    charstring_data: &[u8],
+) -> Result<Option<Fixed>, Error> {
+    let mut sink = NullSink;
+    let mut evaluator = Evaluator::new(context, blend_state, &mut sink);
+    evaluator.width_only = true;
+    // A charstring that ends before saying anything is not an error; it
+    // simply states no width.
+    evaluator.evaluate(charstring_data)?;
+    Ok(evaluator.have_read_width.then_some(evaluator.wx))
 }
 
 /// Specifies how the seac operation was invoked.
@@ -195,6 +239,8 @@ struct Evaluator<'a, S> {
     is_flexing: bool,
     /// True if we've seen a command that might read width
     seen_width_command: bool,
+    /// Stop as soon as the width is settled, rather than drawing the glyph.
+    width_only: bool,
     /// True if we've actually read a width
     have_read_width: bool,
     stem_count: usize,
@@ -229,6 +275,7 @@ where
             is_open: false,
             is_flexing: false,
             seen_width_command: false,
+            width_only: false,
             have_read_width: false,
             stem_count: 0,
             stack: Stack::new(),
@@ -297,6 +344,12 @@ where
                     if let Some(operator) = Operator::read(&mut cursor, b0) {
                         seen_endchar |= operator == Operator::EndChar;
                         if !self.evaluate_operator(operator, &mut cursor, nesting_depth)? {
+                            break;
+                        }
+                        // The first stack-clearing operator settles the
+                        // width, whether or not it carried one, so there is
+                        // nothing further to learn from the rest.
+                        if self.width_only && self.seen_width_command {
                             break;
                         }
                     } else {
@@ -380,7 +433,7 @@ where
                     self.read_width()?;
                 }
                 self.seen_width_command = true;
-                if stack_len > 1 {
+                if stack_len > 1 && !self.width_only {
                     self.handle_seac(SeacMode::Implicit, nesting_depth)?;
                 }
                 return Ok(false);
@@ -662,7 +715,9 @@ where
             // Spec: <https://adobe-type-tools.github.io/font-tech-notes/pdfs/T1_SPEC.pdf#page=56>
             // FT: <https://gitlab.freedesktop.org/freetype/freetype/-/blob/80a507a6b8e3d2906ad2c8ba69329bd2fb2a85ef/src/psaux/psintrp.c#L1294>
             Seac => {
-                self.handle_seac(SeacMode::Explicit, nesting_depth)?;
+                if !self.width_only {
+                    self.handle_seac(SeacMode::Explicit, nesting_depth)?;
+                }
             }
             // Sets the left sidebearing point to (sbx, sby) and the character
             // width vector to (wx, wy) in character space. Also sets current

--- a/read-fonts/src/ps/type1.rs
+++ b/read-fonts/src/ps/type1.rs
@@ -282,11 +282,35 @@ impl Type1Font {
         }
     }
 
+    /// Evaluates the charstring for the requested glyph far enough to read
+    /// its advance width, without drawing it.
+    ///
+    /// A Type 1 charstring states its width in the `hsbw` or `sbw` that must
+    /// open it, so evaluation stops there.
+    ///
+    /// The font matrix is applied and no size is, so the width is exact and
+    /// in the units the rest of the font is measured in.
+    /// [`advance`](Self::advance) applies a size as well and reports what
+    /// [`draw`](Self::draw) does.
+    ///
+    /// Unlike [`evaluate_charstring`], the matrix is applied here rather than
+    /// left to a caller. That one withholds it so a hinter can be slotted in
+    /// ahead of it; nothing hints a width.
+    ///
+    /// [`evaluate_charstring`]: Self::evaluate_charstring
+    pub fn evaluate_width(&self, gid: GlyphId) -> Result<Option<Fixed>, Error> {
+        let charstring_data = self.charstrings.get(gid.to_u32()).ok_or(Error::Malformed)?;
+        let transform = self.transform(None);
+        Ok(cs::evaluate_width(self, None, charstring_data)?
+            .map(|width| transform.transform_h_metric(width)))
+    }
+
     /// Evaluates the charstring for the requested glyph and sends the results
     /// to the given sink.
     ///
-    /// Returns the advance with of the glyph in font units if the charstring
-    /// provides one.
+    /// Returns the width the charstring states, in the charstring's own
+    /// space: neither the font matrix nor a size is applied, to the width or
+    /// to the commands. [`draw`](Self::draw) applies both.
     pub fn evaluate_charstring(
         &self,
         gid: GlyphId,
@@ -294,6 +318,18 @@ impl Type1Font {
     ) -> Result<Option<Fixed>, Error> {
         let charstring_data = self.charstrings.get(gid.to_u32()).ok_or(Error::Malformed)?;
         cs::evaluate(self, None, charstring_data, sink)
+    }
+
+    /// Returns the advance width of the glyph with an optional size in
+    /// ppem, without drawing it.
+    ///
+    /// This is the width [`draw`](Self::draw) reports, arrived at without
+    /// the drawing.
+    pub fn advance(&self, gid: GlyphId, ppem: Option<f32>) -> Result<Option<f32>, Error> {
+        let charstring_data = self.charstrings.get(gid.to_u32()).ok_or(Error::Malformed)?;
+        let transform = self.transform(ppem);
+        Ok(cs::evaluate_width(self, None, charstring_data)?
+            .map(|width| transform.transform_h_metric(width).to_f32().max(0.0)))
     }
 
     /// Draws the glyph with an optional size in ppem to the given pen.
@@ -2279,6 +2315,66 @@ mod tests {
         for (code, gid, name) in expected {
             assert_eq!(encoding.glyph_name(code).unwrap(), name);
             assert_eq!(encoding.map(code).unwrap().to_u32(), gid);
+        }
+    }
+}
+
+#[cfg(test)]
+mod width_only_tests {
+    use super::*;
+    use crate::model::pen::NullPen;
+
+    const FONTS: [&[u8]; 2] = [
+        font_test_data::type1::NOTO_SERIF_REGULAR_SUBSET_PFA,
+        font_test_data::type1::NOTO_SERIF_REGULAR_SUBSET_PFB,
+    ];
+
+    #[test]
+    fn the_quick_width_is_what_a_full_run_reports() {
+        for data in FONTS {
+            let font = Type1Font::new(data).unwrap();
+            assert!(font.num_glyphs() > 1);
+            // `evaluate_charstring` answers in the charstring's own space and
+            // `evaluate_width` in design units, so the matrix goes on the
+            // full run before the two can be compared. It maps one onto the
+            // other unchanged in these fonts, so what this pins is the width
+            // rather than the mapping; the CFF side has a font where the two
+            // spaces differ.
+            let transform = font.transform(None);
+            for gid in (0..font.num_glyphs()).map(GlyphId::new) {
+                let full = font
+                    .evaluate_charstring(gid, &mut cs::NullSink)
+                    .unwrap()
+                    .map(|width| transform.transform_h_metric(width));
+                let quick = font.evaluate_width(gid).unwrap();
+                assert_eq!(full, quick, "glyph {gid}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_quick_advance_is_what_drawing_reports() {
+        // Drawing scales the width by the font matrix, and by ppem where one
+        // is given, so this is what catches an advance that skipped either.
+        for data in FONTS {
+            let font = Type1Font::new(data).unwrap();
+            for ppem in [None, Some(16.0), Some(72.0)] {
+                for gid in (0..font.num_glyphs()).map(GlyphId::new) {
+                    let drawn = font.draw(gid, ppem, &mut NullPen).unwrap();
+                    let quick = font.advance(gid, ppem).unwrap();
+                    assert_eq!(drawn, quick, "glyph {gid} at {ppem:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_glyph_states_a_width() {
+        // A Type 1 charstring must open with hsbw or sbw, so one that
+        // reports nothing is malformed rather than merely silent.
+        let font = Type1Font::new(font_test_data::type1::NOTO_SERIF_REGULAR_SUBSET_PFA).unwrap();
+        for gid in (0..font.num_glyphs()).map(GlyphId::new) {
+            assert!(font.evaluate_width(gid).unwrap().is_some(), "glyph {gid}");
         }
     }
 }


### PR DESCRIPTION
We currently have to evaluate a whole charstring to grab the advance width but those are usually encoded up front so this adds an early out when only the advance is needed. This only matters for type1 and bare cff fonts but those are read by PDFium and we don't want to regress performance there.

    CFF     1.269us -> 223ns per glyph
    Type 1  4.249us -> 166ns per glyph
