### PR TITLE
[read-fonts] Remove use of peekable iterators in int_set

### DIFF
--- a/read-fonts/src/collections/int_set/bitset.rs
+++ b/read-fonts/src/collections/int_set/bitset.rs
@@ -289,31 +289,37 @@ impl U32Set {
         if self.len() > other.len() {
             return false;
         }
-        let mut it_b = other.page_map.iter().peekable();
+        let mut a_index = 0;
+        let mut b_index = 0;
 
-        for a_info in self.page_map.iter() {
+        while a_index < self.page_map.len() {
+            let a_info = &self.page_map[a_index];
             let page_a = &self.pages[a_info.index as usize];
             if page_a.is_empty() {
+                a_index += 1;
                 continue;
             }
 
-            while let Some(b_info) = it_b.peek() {
-                if b_info.major_value < a_info.major_value {
-                    it_b.next();
+            while b_index < other.page_map.len() {
+                if other.page_map[b_index].major_value < a_info.major_value {
+                    b_index += 1;
                 } else {
                     break;
                 }
             }
 
-            match it_b.peek() {
-                Some(b_info) if b_info.major_value == a_info.major_value => {
-                    let page_b = &other.pages[b_info.index as usize];
-                    if !page_a.is_subset(page_b) {
-                        return false;
-                    }
-                    it_b.next();
+            let Some(b_info) = &other.page_map.get(b_index) else {
+                return false;
+            };
+            if b_info.major_value == a_info.major_value {
+                let page_b = &other.pages[b_info.index as usize];
+                if !page_a.is_subset(page_b) {
+                    return false;
                 }
-                _ => return false,
+                a_index += 1;
+                b_index += 1;
+            } else {
+                return false;
             }
         }
 
@@ -322,24 +328,26 @@ impl U32Set {
 
     /// Returns the number of members present in both `self` and `other`.
     pub fn intersection_len(&self, other: &U32Set) -> u64 {
-        let mut it_a = self.page_map.iter().peekable();
-        let mut it_b = other.page_map.iter().peekable();
+        let mut a_index = 0;
+        let mut b_index = 0;
         let mut count = 0u64;
 
-        while let (Some(a), Some(b)) = (it_a.peek(), it_b.peek()) {
+        while a_index < self.page_map.len() && b_index < other.page_map.len() {
+            let a = &self.page_map[a_index];
+            let b = &other.page_map[b_index];
             match a.major_value.cmp(&b.major_value) {
                 Ordering::Equal => {
                     count += self.pages[a.index as usize]
                         .intersection_len(&other.pages[b.index as usize])
                         as u64;
-                    it_a.next();
-                    it_b.next();
+                    a_index += 1;
+                    b_index += 1;
                 }
                 Ordering::Less => {
-                    it_a.next();
+                    a_index += 1;
                 }
                 Ordering::Greater => {
-                    it_b.next();
+                    b_index += 1;
                 }
             }
         }

--- a/read-fonts/src/collections/int_set/mod.rs
+++ b/read-fonts/src/collections/int_set/mod.rs
@@ -172,27 +172,29 @@ impl<T: Domain> IntSet<T> {
 
     /// Returns an iterator over members of this set that are in `range`.
     pub fn range<R: RangeBounds<T>>(&self, range: R) -> impl Iterator<Item = T> + '_ {
-        let mut it = match range.start_bound() {
-            Bound::Included(start) | Bound::Excluded(start) => {
-                self.iter_from_u32(*start).peekable()
+        let (first, it) = match range.start_bound() {
+            Bound::Included(start) => (None, self.iter_from_u32(*start)),
+            Bound::Excluded(start) => {
+                let mut it = self.iter_from_u32(*start);
+                let first = it.next().filter(|v| v != &start.to_u32());
+                (first, it)
             }
             Bound::Unbounded => {
                 let min = T::from_u32(InDomain(T::ordered_values().next().unwrap()));
-                self.iter_from_u32(min).peekable()
+                (None, self.iter_from_u32(min))
             }
         };
 
-        if let Bound::Excluded(start) = range.start_bound() {
-            it.next_if_eq(&start.to_u32());
-        }
-
         let range_end = range.end_bound().cloned();
-        it.take_while(move |v| match range_end {
-            Bound::Included(end) => *v <= end.to_u32(),
-            Bound::Excluded(end) => *v < end.to_u32(),
-            Bound::Unbounded => true,
-        })
-        .map(move |v| T::from_u32(InDomain(v)))
+        first
+            .into_iter()
+            .chain(it)
+            .take_while(move |v| match range_end {
+                Bound::Included(end) => *v <= end.to_u32(),
+                Bound::Excluded(end) => *v < end.to_u32(),
+                Bound::Unbounded => true,
+            })
+            .map(move |v| T::from_u32(InDomain(v)))
     }
 
     /// Returns an iterator over all disjoint ranges of values within the set in sorted ascending order.
@@ -656,13 +658,14 @@ where
     T: Domain + Display,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut ranges = self.iter_ranges().peekable();
         write!(f, "{{ ")?;
-        while let Some(range) = ranges.next() {
-            write!(f, "{}..={}", range.start(), range.end())?;
-            if ranges.peek().is_some() {
+        let mut first = true;
+        for range in self.iter_ranges() {
+            if !first {
                 write!(f, ", ")?;
             }
+            first = false;
+            write!(f, "{}..={}", range.start(), range.end())?;
         }
         write!(f, "}}")
     }


### PR DESCRIPTION
Inspired by https://github.com/googlefonts/fontations/pull/2108, and I do see intersects_range() shows up in one profile. Asked Gemini to make changes

Eliminate Peekable iterators across src/collections/int_set:
    - In bitset.rs, use direct index-based two-pointer traversal in U32Set::is_subset and U32Set::intersection_len, matching the pattern used in U32Set::intersects_set.
    - In mod.rs, avoid wrapping the iterator in Peekable in IntSet::range by consuming the first element for Bound::Excluded and prepending via chain only if not excluded, eliminating per-item branching and state-checking overhead during iteration.
    - In mod.rs, replace ranges.peek() in the Display implementation for IntSet with a boolean flag to format comma separators.
