### PR TITLE
Speed up full-font subsetting in Skera

### DIFF
--- a/skera/src/cblc.rs
+++ b/skera/src/cblc.rs
@@ -76,6 +76,73 @@ impl Subset for Cblc<'_> {
     }
 }
 
+/// Returns true when subsetting would copy the bitmap tables without changing them.
+///
+/// Keep this deliberately conservative. In particular, multiple subtables or empty bitmap
+/// ranges may require repacking even when the glyph-id map itself is the identity map.
+pub(crate) fn can_passthrough_bitmap_tables(cblc: &Cblc, cbdt: &Cbdt, plan: &Plan) -> bool {
+    if !plan.has_identity_glyph_map() {
+        return false;
+    }
+
+    let [bitmap_size] = cblc.bitmap_sizes() else {
+        return false;
+    };
+    if bitmap_size.number_of_index_subtables() != 1
+        || bitmap_size.index_subtable_list_offset() as usize != cblc.bitmap_sizes_byte_range().end
+        || bitmap_size.index_subtable_list_offset() as usize
+            + bitmap_size.index_subtable_list_size() as usize
+            != cblc.offset_data().len()
+    {
+        return false;
+    }
+
+    let Ok(index_subtable_list) = bitmap_size.index_subtable_list(cblc.offset_data()) else {
+        return false;
+    };
+    let [record] = index_subtable_list.index_subtable_records() else {
+        return false;
+    };
+    if bitmap_size.start_glyph_index() != record.first_glyph_index()
+        || bitmap_size.end_glyph_index() != record.last_glyph_index()
+    {
+        return false;
+    }
+
+    let Ok(subtable) = record.index_subtable(index_subtable_list.offset_data()) else {
+        return false;
+    };
+    if IndexSubtableRecord::RAW_BYTE_LEN + subtable.min_table_bytes().len()
+        != bitmap_size.index_subtable_list_size() as usize
+    {
+        return false;
+    }
+
+    let cbdt_header_len = cbdt.min_table_bytes().len();
+    let cbdt_len = cbdt.offset_data().len();
+    match subtable {
+        IndexSubtable::Format1(subtable) => {
+            let offsets = subtable.sbit_offsets();
+            subtable.image_data_offset() as usize == cbdt_header_len
+                && offsets.first().is_some_and(|offset| offset.get() == 0)
+                && offsets.windows(2).all(|pair| pair[0].get() < pair[1].get())
+                && offsets.last().is_some_and(|offset| {
+                    subtable.image_data_offset() as usize + offset.get() as usize == cbdt_len
+                })
+        }
+        IndexSubtable::Format3(subtable) => {
+            let offsets = subtable.sbit_offsets();
+            subtable.image_data_offset() as usize == cbdt_header_len
+                && offsets.first().is_some_and(|offset| offset.get() == 0)
+                && offsets.windows(2).all(|pair| pair[0].get() < pair[1].get())
+                && offsets.last().is_some_and(|offset| {
+                    subtable.image_data_offset() as usize + offset.get() as usize == cbdt_len
+                })
+        }
+        _ => false,
+    }
+}
+
 impl<'a> SubsetTable<'a> for BitmapSize {
     // (Cblc table, CBDT table, src_bitmapsize_bytes, cbdt_out)
     type ArgsForSubset = (&'a Cblc<'a>, &'a Cbdt<'a>, &'a [u8], &'a mut Vec<u8>);
@@ -499,6 +566,78 @@ impl<'a> SubsetTable<'a> for IndexSubtable3<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn single_subtable_bitmap_font() -> Vec<u8> {
+        let mut cblc = Vec::from([
+            0x00, 0x03, 0x00, 0x00, // version 3.0
+            0x00, 0x00, 0x00, 0x01, // one bitmap-size record
+            0x00, 0x00, 0x00, 0x38, // index-subtable list offset
+            0x00, 0x00, 0x00, 0x1C, // index-subtable list size
+            0x00, 0x00, 0x00, 0x01, // one index subtable
+            0x00, 0x00, 0x00, 0x00, // color ref
+        ]);
+        cblc.extend_from_slice(&[0; 24]); // horizontal and vertical line metrics
+        cblc.extend_from_slice(&[
+            0x00, 0x01, 0x00, 0x02, // glyph range 1..=2
+            0x10, 0x10, 0x20, 0x01, // ppem, bit depth, and flags
+            0x00, 0x01, 0x00, 0x02, // index-subtable record glyph range
+            0x00, 0x00, 0x00, 0x08, // subtable follows the record
+            0x00, 0x01, 0x00, 0x11, // index format 1, image format 17
+            0x00, 0x00, 0x00, 0x04, // image data follows the CBDT header
+            0x00, 0x00, 0x00, 0x00, // first bitmap offset
+            0x00, 0x00, 0x00, 0x02, // second bitmap offset
+            0x00, 0x00, 0x00, 0x05, // end of bitmap data
+        ]);
+
+        let mut builder = FontBuilder::new();
+        builder.add_raw(Cblc::TAG, cblc);
+        builder.add_raw(
+            Cbdt::TAG,
+            [0x00, 0x03, 0x00, 0x00, 10, 11, 12, 13, 14].as_slice(),
+        );
+        builder.build()
+    }
+
+    #[test]
+    fn detects_unchanged_bitmap_tables() {
+        let font_data = single_subtable_bitmap_font();
+        let font = FontRef::new(&font_data).unwrap();
+        let cblc = font.cblc().unwrap();
+        let cbdt = font.cbdt().unwrap();
+
+        let mut plan = Plan {
+            font_num_glyphs: 3,
+            num_output_glyphs: 3,
+            ..Default::default()
+        };
+        plan.glyphset
+            .insert_range(GlyphId::NOTDEF..=GlyphId::from(2_u32));
+        plan.new_to_old_gid_list.extend((0_u32..3).map(|gid| {
+            let gid = GlyphId::from(gid);
+            (gid, gid)
+        }));
+
+        assert!(can_passthrough_bitmap_tables(&cblc, &cbdt, &plan));
+
+        // Verify that the existing subsetter really does reproduce both tables byte-for-byte
+        // under the conditions accepted by the fast path.
+        let mut output_builder = FontBuilder::new();
+        let mut s = Serializer::new(1024);
+        s.start_serialize().unwrap();
+        cblc.subset(&plan, &font, &mut s, &mut output_builder)
+            .unwrap();
+        s.end_serialize();
+        output_builder.add_raw(Cblc::TAG, s.copy_bytes());
+        let output_data = output_builder.build();
+        let output = FontRef::new(&output_data).unwrap();
+        for tag in [Cblc::TAG, Cbdt::TAG] {
+            assert_eq!(
+                font.data_for_tag(tag).unwrap().as_bytes(),
+                output.data_for_tag(tag).unwrap().as_bytes()
+            );
+        }
+    }
+
     #[test]
     fn test_subset_cbdt_noop() {
         let font = FontRef::new(include_bytes!(

--- a/skera/src/glyf_loca.rs
+++ b/skera/src/glyf_loca.rs
@@ -49,15 +49,15 @@ impl Subset for Glyf<'_> {
                             .subset_flags
                             .contains(SubsetFlags::SUBSET_FLAGS_NOTDEF_OUTLINE)
                     {
-                        subset_glyphs.push(Vec::new());
+                        subset_glyphs.push(SubsetGlyph::Empty);
                         continue;
                     }
 
                     let Some(glyph) = g.into_glyph() else {
-                        subset_glyphs.push(Vec::new());
+                        subset_glyphs.push(SubsetGlyph::Empty);
                         continue;
                     };
-                    let subset_glyph = subset_glyph(&glyph, plan);
+                    let subset_glyph = SubsetGlyph::new(&glyph, plan);
                     let trimmed_len = subset_glyph.len();
                     max_offset += padded_size(trimmed_len) as u32;
                     subset_glyphs.push(subset_glyph);
@@ -90,7 +90,7 @@ fn write_glyf_loca(
     plan: &Plan,
     s: &mut Serializer,
     loca_format: u8,
-    subset_glyphs: &[Vec<u8>],
+    subset_glyphs: &[SubsetGlyph<'_>],
 ) -> Result<Vec<u8>, SubsetError> {
     let loca_cap = estimate_subset_table_size(font, Loca::TAG, plan);
     let mut loca_out: Vec<u8> = Vec::with_capacity(loca_cap);
@@ -118,8 +118,7 @@ fn write_glyf_loca(
             offset += padded_len as u32;
             value = ((offset >> 1) as u16).to_be_bytes();
             loca_out.extend_from_slice(&value);
-            s.embed_bytes(g)
-                .map_err(|_| SubsetError::SubsetTableError(Glyf::TAG))?;
+            g.write(s)?;
             if padded_len > g.len() {
                 s.embed_bytes(&[0])
                     .map_err(|_| SubsetError::SubsetTableError(Glyf::TAG))?;
@@ -147,8 +146,7 @@ fn write_glyf_loca(
             value = offset.to_be_bytes();
             loca_out.extend_from_slice(&value);
 
-            s.embed_bytes(g)
-                .map_err(|_| SubsetError::SubsetTableError(Glyf::TAG))?;
+            g.write(s)?;
 
             last += 1;
         }
@@ -170,6 +168,109 @@ fn write_glyf_loca(
     Ok(loca_out)
 }
 
+enum SubsetGlyph<'a> {
+    Empty,
+    Simple(SimpleSubsetGlyph<'a>),
+    Composite(Vec<u8>),
+}
+
+impl<'a> SubsetGlyph<'a> {
+    fn new(glyph: &Glyph<'a>, plan: &Plan) -> Self {
+        match glyph {
+            Simple(glyph) => SimpleSubsetGlyph::new(glyph, plan)
+                .map(Self::Simple)
+                .unwrap_or(Self::Empty),
+            Composite(glyph) => Self::Composite(subset_composite_glyph(glyph, plan)),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::Simple(glyph) => glyph.len(),
+            Self::Composite(bytes) => bytes.len(),
+        }
+    }
+
+    fn write(&self, s: &mut Serializer) -> Result<(), SubsetError> {
+        match self {
+            Self::Empty => Ok(()),
+            Self::Simple(glyph) => glyph.write(s),
+            Self::Composite(bytes) => s
+                .embed_bytes(bytes)
+                .map(|_| ())
+                .map_err(|_| SubsetTableError(Glyf::TAG)),
+        }
+    }
+}
+
+struct SimpleSubsetGlyph<'a> {
+    header: &'a [u8],
+    instructions: &'a [u8],
+    glyph_data: &'a [u8],
+    drop_hinting: bool,
+    set_overlaps_flag: bool,
+}
+
+impl<'a> SimpleSubsetGlyph<'a> {
+    fn new(g: &SimpleGlyph<'a>, plan: &Plan) -> Option<Self> {
+        let num_coords = g.end_pts_of_contours().last()?.get() + 1;
+        let glyph_data = g.glyph_data();
+        let glyph_data = glyph_data.get(..trim_simple_glyph_padding(glyph_data, num_coords))?;
+        if glyph_data.is_empty() {
+            return None;
+        }
+
+        let glyph_bytes = g.offset_data().as_bytes();
+        let header_len = 10 + 2 * g.end_pts_of_contours().len() + 2;
+        let header = glyph_bytes.get(..header_len)?;
+        let drop_hinting = plan
+            .subset_flags
+            .contains(SubsetFlags::SUBSET_FLAGS_NO_HINTING);
+        let instructions = if drop_hinting {
+            &[]
+        } else {
+            glyph_bytes.get(header_len..header_len + g.instruction_length() as usize)?
+        };
+
+        Some(Self {
+            header,
+            instructions,
+            glyph_data,
+            drop_hinting,
+            set_overlaps_flag: plan
+                .subset_flags
+                .contains(SubsetFlags::SUBSET_FLAGS_SET_OVERLAPS_FLAG),
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.header.len() + self.instructions.len() + self.glyph_data.len()
+    }
+
+    fn write(&self, s: &mut Serializer) -> Result<(), SubsetError> {
+        let map_err = |_| SubsetTableError(Glyf::TAG);
+        if self.drop_hinting {
+            s.embed_bytes(&self.header[..self.header.len() - 2])
+                .map_err(map_err)?;
+            s.embed(0_u16).map_err(map_err)?;
+        } else {
+            s.embed_bytes(self.header).map_err(map_err)?;
+            s.embed_bytes(self.instructions).map_err(map_err)?;
+        }
+
+        if self.set_overlaps_flag {
+            s.embed(self.glyph_data[0] | SimpleGlyphFlags::OVERLAP_SIMPLE.bits())
+                .map_err(map_err)?;
+            s.embed_bytes(&self.glyph_data[1..]).map_err(map_err)?;
+        } else {
+            s.embed_bytes(self.glyph_data).map_err(map_err)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
 fn subset_glyph(glyph: &Glyph, plan: &Plan) -> Vec<u8> {
     //TODO: support set_overlaps_flag and drop_hints
     match glyph {
@@ -179,6 +280,7 @@ fn subset_glyph(glyph: &Glyph, plan: &Plan) -> Vec<u8> {
 }
 
 // TODO: drop_hints and set_overlaps_flag
+#[cfg(test)]
 fn subset_simple_glyph(g: &SimpleGlyph, plan: &Plan) -> Vec<u8> {
     let mut out = Vec::with_capacity(g.offset_data().len());
 

--- a/skera/src/lib.rs
+++ b/skera/src/lib.rs
@@ -334,7 +334,6 @@ pub struct Plan {
     num_output_glyphs: usize,
     font_num_glyphs: usize,
     unicode_to_new_gid_list: Vec<(u32, GlyphId)>,
-    codepoint_to_glyph: FnvHashMap<u32, GlyphId>,
 
     subset_flags: SubsetFlags,
     no_subset_tables: IntSet<Tag>,
@@ -455,13 +454,11 @@ impl Plan {
         if input_gids.is_empty() && unicodes.len() < (self.font_num_glyphs as u64) {
             let cap: usize = unicodes.len().try_into().unwrap_or(usize::MAX);
             self.unicode_to_new_gid_list.reserve(cap);
-            self.codepoint_to_glyph.reserve(cap);
             //TODO: add support for subset accelerator?
 
             for cp in unicodes.iter() {
                 match charmap.map(cp) {
                     Some(gid) => {
-                        self.codepoint_to_glyph.insert(cp, gid);
                         self.unicode_to_new_gid_list.push((cp, gid));
                     }
                     None => {
@@ -471,31 +468,17 @@ impl Plan {
             }
         } else {
             //TODO: add support for subset accelerator?
-            let cmap_unicodes = charmap.mappings().map(|t| t.0).collect::<IntSet<u32>>();
-            let unicode_gid_map = charmap.mappings().collect::<FnvHashMap<u32, GlyphId>>();
-
             let vec_cap: u64 = input_gids.len() + unicodes.len();
             let vec_cap: usize = vec_cap
-                .min(cmap_unicodes.len())
+                .min(self.font_num_glyphs as u64)
                 .try_into()
                 .unwrap_or(usize::MAX);
-            self.codepoint_to_glyph.reserve(vec_cap);
             self.unicode_to_new_gid_list.reserve(vec_cap);
-            for range in cmap_unicodes.iter_ranges() {
-                for cp in range {
-                    match unicode_gid_map.get(&cp) {
-                        Some(gid) => {
-                            if !input_gids.contains(*gid) && !unicodes.contains(cp) {
-                                continue;
-                            }
-                            self.codepoint_to_glyph.insert(cp, *gid);
-                            self.unicode_to_new_gid_list.push((cp, *gid));
-                        }
-                        None => {
-                            continue;
-                        }
-                    }
+            for (cp, gid) in charmap.mappings() {
+                if !input_gids.contains(gid) && !unicodes.contains(cp) {
+                    continue;
                 }
+                self.unicode_to_new_gid_list.push((cp, gid));
             }
 
             /* Add gids which where requested, but not mapped in cmap */
@@ -1462,16 +1445,6 @@ mod test {
         assert_eq!(plan.unicode_to_new_gid_list.len(), 2);
         assert_eq!(plan.unicode_to_new_gid_list[0], (0x2c_u32, GlyphId::new(2)));
         assert_eq!(plan.unicode_to_new_gid_list[1], (0x31_u32, GlyphId::new(4)));
-
-        assert_eq!(plan.codepoint_to_glyph.len(), 2);
-        assert_eq!(
-            plan.codepoint_to_glyph.get(&0x2c_u32),
-            Some(GlyphId::new(2)).as_ref()
-        );
-        assert_eq!(
-            plan.codepoint_to_glyph.get(&0x31_u32),
-            Some(GlyphId::new(4)).as_ref()
-        );
     }
 
     #[test]
@@ -1497,16 +1470,6 @@ mod test {
         assert_eq!(plan.unicode_to_new_gid_list.len(), 2);
         assert_eq!(plan.unicode_to_new_gid_list[0], (0x2c_u32, GlyphId::new(2)));
         assert_eq!(plan.unicode_to_new_gid_list[1], (0x31_u32, GlyphId::new(4)));
-
-        assert_eq!(plan.codepoint_to_glyph.len(), 2);
-        assert_eq!(
-            plan.codepoint_to_glyph.get(&0x2c_u32),
-            Some(GlyphId::new(2)).as_ref()
-        );
-        assert_eq!(
-            plan.codepoint_to_glyph.get(&0x31_u32),
-            Some(GlyphId::new(4)).as_ref()
-        );
     }
 
     #[test]

--- a/skera/src/lib.rs
+++ b/skera/src/lib.rs
@@ -393,6 +393,18 @@ struct Os2Info {
 }
 
 impl Plan {
+    fn has_identity_glyph_map(&self) -> bool {
+        self.num_output_glyphs == self.font_num_glyphs
+            && self.new_to_old_gid_list.len() == self.font_num_glyphs
+            && self
+                .new_to_old_gid_list
+                .iter()
+                .enumerate()
+                .all(|(gid, &(new_gid, old_gid))| {
+                    new_gid.to_u32() as usize == gid && old_gid == new_gid
+                })
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_gids: &IntSet<GlyphId>,
@@ -1118,8 +1130,8 @@ trait Serialize<'a> {
     fn serialize(s: &mut Serializer, args: Self::Args) -> Result<(), SerializeErrorFlags>;
 }
 
-pub fn subset_font(font: &FontRef, plan: &Plan) -> Result<Vec<u8>, SubsetError> {
-    let mut builder = FontBuilder::default();
+pub fn subset_font<'a>(font: &FontRef<'a>, plan: &Plan) -> Result<Vec<u8>, SubsetError> {
+    let mut builder = FontBuilder::<'a>::default();
 
     let mut state = SubsetState::default();
     let mut tags_with_dependencies = Vec::with_capacity(5);
@@ -1127,6 +1139,42 @@ pub fn subset_font(font: &FontRef, plan: &Plan) -> Result<Vec<u8>, SubsetError> 
         let tag = record.tag();
         if should_drop_table(tag, plan) {
             continue;
+        }
+
+        // CBDT is handled together with CBLC. Avoid allocating a serializer sized for the
+        // (typically much larger) bitmap-data table when there is nothing to do here.
+        if tag == Cbdt::TAG {
+            continue;
+        }
+
+        // When glyph ids are unchanged, the bitmap location and data tables need no rewriting.
+        // Borrow them directly until FontBuilder assembles the final font instead of copying the
+        // bitmap data into an intermediate buffer first.
+        if tag == Cblc::TAG {
+            if let (Ok(cblc), Ok(cbdt)) = (font.cblc(), font.cbdt()) {
+                if cblc::can_passthrough_bitmap_tables(&cblc, &cbdt, plan) {
+                    builder.add_raw_with_checksum(
+                        Cblc::TAG,
+                        cblc.offset_data().as_bytes(),
+                        record.checksum(),
+                    );
+                    if let Some(cbdt_record) = font
+                        .table_directory()
+                        .table_records()
+                        .iter()
+                        .find(|record| record.tag() == Cbdt::TAG)
+                    {
+                        builder.add_raw_with_checksum(
+                            Cbdt::TAG,
+                            cbdt.offset_data().as_bytes(),
+                            cbdt_record.checksum(),
+                        );
+                    } else {
+                        builder.add_raw(Cbdt::TAG, cbdt.offset_data().as_bytes());
+                    }
+                    continue;
+                }
+            }
         }
 
         // TODO: add more tags with dependencies for instancing

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -182,10 +182,10 @@ impl<'a> FontBuilder<'a> {
         let table_order = self.ordered_tags();
 
         let mut position = header_len as u32;
-        let mut checksums = Vec::new();
+        let mut checksums = Vec::with_capacity(self.tables.len() + 1);
         let head_tag = Tag::new(b"head");
 
-        let mut table_records = Vec::new();
+        let mut table_records = Vec::with_capacity(self.tables.len());
         for tag in table_order.iter() {
             // safe to unwrap as ordered_tags() guarantees that all keys exist
             let data = self.tables.get_mut(tag).unwrap();
@@ -212,6 +212,8 @@ impl<'a> FontBuilder<'a> {
         let mut writer = TableWriter::default();
         directory.write_into(&mut writer);
         let mut data = writer.into_data().bytes;
+        data.reserve_exact((position as usize).saturating_sub(data.len()));
+        let expected_data_len = data.capacity();
         checksums.push(read_fonts::tables::compute_checksum(&data));
 
         // Summing all the individual table checksums, including the table directory's,
@@ -234,6 +236,12 @@ impl<'a> FontBuilder<'a> {
             let rem = round4(table.len()) - table.len();
             let padding = [0u8; 4];
             data.extend_from_slice(&padding[..rem]);
+        }
+        if expected_data_len != data.len() {
+            log::warn!(
+                "suboptimal: allocated {expected_data_len} bytes but needed {actual_len}",
+                actual_len = data.len()
+            );
         }
         data
     }

--- a/write-fonts/src/font_builder.rs
+++ b/write-fonts/src/font_builder.rs
@@ -20,6 +20,7 @@ const CFF2: Tag = Tag::new(b"CFF2");
 #[derive(Debug, Clone, Default)]
 pub struct FontBuilder<'a> {
     tables: BTreeMap<Tag, Cow<'a, [u8]>>,
+    checksums: BTreeMap<Tag, u32>,
 }
 
 impl TableDirectory {
@@ -105,6 +106,22 @@ impl<'a> FontBuilder<'a> {
     /// A builder method to add raw data for the provided tag
     pub fn add_raw(&mut self, tag: Tag, data: impl Into<Cow<'a, [u8]>>) -> &mut Self {
         self.tables.insert(tag, data.into());
+        self.checksums.remove(&tag);
+        self
+    }
+
+    /// Add raw table data with its precomputed OpenType checksum.
+    ///
+    /// The checksum must include the table's implicit zero padding to a multiple of four bytes.
+    /// Supplying it avoids rescanning table data that was copied unchanged from another font.
+    pub fn add_raw_with_checksum(
+        &mut self,
+        tag: Tag,
+        data: impl Into<Cow<'a, [u8]>>,
+        checksum: u32,
+    ) -> &mut Self {
+        self.tables.insert(tag, data.into());
+        self.checksums.insert(tag, checksum);
         self
     }
 
@@ -200,9 +217,18 @@ impl<'a> FontBuilder<'a> {
                 let head = data.to_mut();
                 head[HEAD_CHECKSUM_START..HEAD_CHECKSUM_END].copy_from_slice(&[0, 0, 0, 0]);
             }
-            let (checksum, padding) = checksum_and_padding(data);
+            // The head table is mutated above, so any supplied checksum for it is stale.
+            let padding = round4(data.len()) - data.len();
+            let checksum = if *tag == head_tag {
+                read_fonts::tables::compute_checksum(data)
+            } else {
+                self.checksums
+                    .get(tag)
+                    .copied()
+                    .unwrap_or_else(|| read_fonts::tables::compute_checksum(data))
+            };
             checksums.push(checksum);
-            position += padding;
+            position += padding as u32;
             table_records.push(TableRecord::new(*tag, checksum, offset, length));
         }
         table_records.sort_unstable_by_key(|record| record.tag);
@@ -225,6 +251,7 @@ impl<'a> FontBuilder<'a> {
 
         for tag in table_order {
             let table = self.tables.remove(&tag).unwrap();
+            self.checksums.remove(&tag);
             if tag == head_tag && table.len() >= HEAD_CHECKSUM_END {
                 // store the checksum_adjustment in the head table
                 data.extend_from_slice(&table[..HEAD_CHECKSUM_START]);
@@ -252,6 +279,7 @@ fn round4(sz: usize) -> usize {
     (sz + 3) & !3
 }
 
+#[cfg(test)]
 fn checksum_and_padding(table: &[u8]) -> (u32, u32) {
     let checksum = read_fonts::tables::compute_checksum(table);
     let padding = round4(table.len()) - table.len();
@@ -304,6 +332,34 @@ mod tests {
             assert!(pad < 4);
             assert!((i + pad as usize) % 4 == 0, "pad {i} +{pad} bytes");
         }
+    }
+
+    #[test]
+    fn uses_and_invalidates_precomputed_checksums() {
+        let tag = Tag::new(b"TEST");
+        let mut builder = FontBuilder::default();
+        builder.add_raw_with_checksum(tag, [1, 2, 3].as_slice(), 0xDEAD_BEEF);
+        let bytes = builder.build();
+        let font = FontRef::new(&bytes).unwrap();
+        let record = font
+            .table_directory()
+            .table_records()
+            .iter()
+            .find(|record| record.tag() == tag)
+            .unwrap();
+        assert_eq!(record.checksum(), 0xDEAD_BEEF);
+
+        builder.add_raw_with_checksum(tag, [0; 4].as_slice(), 0xDEAD_BEEF);
+        builder.add_raw(tag, [1, 2, 3].as_slice());
+        let bytes = builder.build();
+        let font = FontRef::new(&bytes).unwrap();
+        let record = font
+            .table_directory()
+            .table_records()
+            .iter()
+            .find(|record| record.tag() == tag)
+            .unwrap();
+        assert_eq!(record.checksum(), 0x0102_0300);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #2125.

## Summary

- iterate cmap mappings directly instead of materializing intermediate `IntSet` and `HashMap` collections
- remove the unused codepoint-to-glyph map from `Plan`
- serialize simple glyphs directly from borrowed slices instead of allocating and copying one `Vec<u8>` per glyph
- let `FontBuilder` accept a trusted precomputed checksum for unchanged raw tables
- pass canonical, identity-mapped `CBLC`/`CBDT` tables through unchanged, avoiding a large temporary allocation, an intermediate bitmap-data copy, and a redundant checksum scan

## Performance

Release builds, five interleaved runs of 50,000 full-font subsets using `FruityGirl-Regular.ttf`:

| Implementation | Median |
| --- | ---: |
| Skera on `wm-opt` | 4.14 s |
| First two commits in this PR | 3.99 s |
| This PR | 1.31 s |
| HarfBuzz `hb-subset` | 1.63 s |

The bitmap fast path makes Skera approximately 68% faster than the base branch and approximately 20% faster than HarfBuzz for this font. The resulting Skera file is byte-for-byte identical before and after the bitmap optimization. Skera and HarfBuzz both produce a 711,664-byte font with 96 glyphs and the same table set and table sizes.

The earlier benchmark font contained `glyf`, so the simple-glyph change helped there. FruityGirl is bitmap-only: its 710,072-byte `CBDT` table accounts for almost the whole font. Profiling showed Skera allocating a serializer for `CBDT` despite handling it through `CBLC`, copying all bitmap bytes through an intermediate buffer, and then spending most of the remaining time checksumming those unchanged bytes. The new conservative fast path removes all three costs when the glyph mapping and bitmap layout prove the tables will be emitted unchanged.

Benchmark arguments:

```sh
--unicodes="*" --num-iterations=50000
```

## Validation

- `cargo test -p write-fonts -p skera --all-features`
- `cargo +stable clippy -p write-fonts --lib --all-features --no-deps -- -D warnings` (with allowances for two pre-existing lints from the newer local stable toolchain)
- `cargo +stable clippy -p skera --all-targets --all-features --no-deps -- -D warnings` (with allowances for pre-existing lints from the newer local stable toolchain)
- `cargo fmt --all -- --check`
- `git diff --check`
