### PR TITLE
[read-fonts] start gathering work limits in a new read_fonts::limits module

### DIFF
--- a/read-fonts/src/lib.rs
+++ b/read-fonts/src/lib.rs
@@ -78,6 +78,7 @@ pub mod array;
 pub mod codegen_test;
 pub mod collections;
 mod font_data;
+pub mod limits;
 pub mod mem;
 pub mod model;
 mod offset;

--- a/read-fonts/src/limits.rs
+++ b/read-fonts/src/limits.rs
@@ -1,0 +1,35 @@
+//! Limits applied when interpreting font data.
+//!
+//! Font files can describe structures that recurse, refer to themselves, or are
+//! simply enormous. Nothing here comes from the OpenType specification: these
+//! are the bounds this crate places on how much work one operation will do
+//! before giving up, so that a malformed or hostile font cannot turn a parse
+//! into a hang.
+
+/// Maximum depth for structures that nest.
+///
+/// Applies to composite glyph trees, nested variation data, layout lookup
+/// nesting, and colour graph traversal.
+///
+/// Matches HarfBuzz's [`HB_MAX_NESTING_LEVEL`].
+///
+/// [`HB_MAX_NESTING_LEVEL`]: https://github.com/harfbuzz/harfbuzz/blob/724ef405f3a0a0b2792c7a575d1f3341b41ca950/src/hb-limits.hh#L53
+pub const MAX_RECURSION_DEPTH: usize = 64;
+
+/// Maximum number of points in a single assembled outline.
+///
+/// A composite glyph accumulates the points of every component in its tree, so
+/// unlike the point count of one simple glyph this is not bounded by the
+/// format. A contour end point is a `u16`, so the last point an outline can
+/// name is `u16::MAX`, and it holds one more than that.
+pub const MAX_OUTLINE_POINTS: usize = u16::MAX as usize + 1;
+
+/// Maximum number of references followed while assembling one composite
+/// glyph, whether a [`glyf`] component tree or a [`VARC`] graph.
+///
+/// Bounds the total work for a graph that fans out at every level, which the
+/// depth limit alone does not.
+///
+/// [`glyf`]: crate::tables::glyf
+/// [`VARC`]: crate::tables::varc
+pub const MAX_COMPOSITE_EDGES: usize = 2048;

--- a/read-fonts/src/tables/gvar.rs
+++ b/read-fonts/src/tables/gvar.rs
@@ -246,9 +246,7 @@ fn find_glyph_and_point_count(
     glyph_id: GlyphId,
     recurse_depth: usize,
 ) -> Result<(GlyphId, usize), ReadError> {
-    // Matches HB's nesting limit
-    const RECURSION_LIMIT: usize = 64;
-    if recurse_depth > RECURSION_LIMIT {
+    if recurse_depth > crate::limits::MAX_RECURSION_DEPTH {
         return Err(ReadError::MalformedData(
             "nesting too deep in composite glyph",
         ));

--- a/read-fonts/src/tables/layout/closure.rs
+++ b/read-fonts/src/tables/layout/closure.rs
@@ -20,7 +20,7 @@ use crate::{
 const MAX_SCRIPTS: u16 = 500;
 const MAX_LANGSYS: u16 = 2000;
 const MAX_FEATURE_INDICES: u16 = 1500;
-pub(crate) const MAX_NESTING_LEVEL: u8 = 64;
+pub(crate) const MAX_NESTING_LEVEL: u8 = crate::limits::MAX_RECURSION_DEPTH as u8;
 pub(crate) const MAX_LOOKUP_VISIT_COUNT: u16 = 35000;
 
 struct CollectFeaturesContext<'a> {

--- a/skrifa/src/color/traversal.rs
+++ b/skrifa/src/color/traversal.rs
@@ -12,12 +12,16 @@ use super::{
 };
 
 use crate::decycler::{Decycler, DecyclerError};
+use read_fonts::limits::MAX_RECURSION_DEPTH;
 
 #[cfg(feature = "libm")]
 #[allow(unused_imports)]
 use core_maths::*;
 
-pub(crate) type PaintDecycler = Decycler<usize, MAX_TRAVERSAL_DEPTH>;
+// Bounds how deep a paint graph is followed, and detects cycles in it.
+// HarfBuzz bounds its own paint context the same way; see
+// <https://github.com/harfbuzz/harfbuzz/blob/724ef405f3a0a0b2792c7a575d1f3341b41ca950/src/OT/Color/COLR/COLR.hh#L74>.
+pub(crate) type PaintDecycler = Decycler<usize, MAX_RECURSION_DEPTH>;
 
 // Avoid heap allocations for any gradient with <= 32 color stops. This number
 // was chosen to keep stack size < 512 bytes.
@@ -40,16 +44,6 @@ impl From<DecyclerError> for PaintError {
         }
     }
 }
-
-/// Depth at which we will stop traversing and return an error.
-///
-/// Used to prevent stack overflows. Also allows us to avoid using a HashSet
-/// in no_std builds.
-///
-/// This limit matches the one used in HarfBuzz:
-/// HB_MAX_NESTING_LEVEL: <https://github.com/harfbuzz/harfbuzz/blob/c2f8f35a6cfce43b88552b3eb5c05062ac7007b2/src/hb-limits.hh#L53>
-/// hb_paint_context_t: <https://github.com/harfbuzz/harfbuzz/blob/c2f8f35a6cfce43b88552b3eb5c05062ac7007b2/src/OT/Color/COLR/COLR.hh#L74>
-const MAX_TRAVERSAL_DEPTH: usize = 64;
 
 /// Maximum number of nodes visited during a single traversal.
 ///
@@ -112,7 +106,7 @@ pub(crate) fn traverse_with_callbacks<'a, P: ColorPainter>(
     decycler: &mut PaintDecycler,
     recurse_depth: usize,
 ) -> Result<(), PaintError> {
-    if recurse_depth >= MAX_TRAVERSAL_DEPTH {
+    if recurse_depth >= MAX_RECURSION_DEPTH {
         return Err(PaintError::DepthLimitExceeded);
     }
     match paint {

--- a/skrifa/src/lib.rs
+++ b/skrifa/src/lib.rs
@@ -69,19 +69,4 @@ pub use read_fonts::{
 #[doc(inline)]
 pub use provider::MetadataProvider;
 
-/// Maximum number of points in a TrueType outline.
-///
-/// TrueType uses a 16 bit integer to store contour end points so
-/// we must keep the total count within this value.
-///
-/// The maxp <https://learn.microsoft.com/en-us/typography/opentype/spec/maxp>
-/// table encodes `maxCompositePoints` as a `uint16` so the spec enforces
-/// this limit.
-const MAX_GLYF_POINTS: usize = u16::MAX as usize;
-
-/// Limit for recursion when loading TrueType composite glyphs.
-const GLYF_COMPOSITE_RECURSION_LIMIT: usize = 32;
-
-/// Maximum number of edges we'll traverse when processing a graph.
-// See <https://github.com/harfbuzz/harfbuzz/blob/cce964cb4f3f29a9addbb079b52c7a712fba93b8/src/hb-limits.hh#L92>
-const MAX_GRAPH_EDGES: usize = 2048;
+use read_fonts::limits::MAX_OUTLINE_POINTS;

--- a/skrifa/src/outline/autohint/outline.rs
+++ b/skrifa/src/outline/autohint/outline.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::collections::SmallVec;
 use core::ops::Range;
 use raw::{
+    limits::MAX_OUTLINE_POINTS,
     tables::glyf::{PointFlags, PointMarker},
     types::Point as Coord,
     types::{F26Dot6, F2Dot14, GlyphId},
@@ -177,10 +178,7 @@ impl Outline {
     }
 
     fn analyze_and_validate(&mut self, gid: GlyphId, quirks: QuirksMode) -> Result<(), DrawError> {
-        // All of our u16 ranges are inclusive so this allows point indices up
-        // to u16::MAX
-        const MAX_LEN: usize = u16::MAX as usize + 1;
-        if self.points.len() > MAX_LEN || self.contours.len() > MAX_LEN {
+        if self.points.len() > MAX_OUTLINE_POINTS || self.contours.len() > MAX_OUTLINE_POINTS {
             return Err(DrawError::TooManyPoints(gid));
         }
         // Heuristic value

--- a/skrifa/src/outline/error.rs
+++ b/skrifa/src/outline/error.rs
@@ -59,7 +59,7 @@ impl fmt::Display for DrawError {
             Self::RecursionLimitExceeded(gid) => write!(
                 f,
                 "Recursion limit ({}) exceeded when loading composite component {gid}",
-                super::GLYF_COMPOSITE_RECURSION_LIMIT,
+                read_fonts::limits::MAX_RECURSION_DEPTH,
             ),
             Self::TooManyPoints(gid) => write!(f, "Glyph {gid} contains more than 64k points"),
             Self::HintingFailed(e) => write!(f, "{e}"),

--- a/skrifa/src/outline/glyf/mod.rs
+++ b/skrifa/src/outline/glyf/mod.rs
@@ -12,9 +12,9 @@ pub use hint::{HintError, HintInstance, HintOutline};
 pub use outline::{Outline, ScaledOutline};
 
 use super::{DrawError, GlyphHMetrics, Hinting};
-use crate::{GLYF_COMPOSITE_RECURSION_LIMIT, MAX_GLYF_POINTS, MAX_GRAPH_EDGES};
 use memory::{FreeTypeOutlineMemory, HarfBuzzOutlineMemory};
 use raw::FontRef;
+use read_fonts::limits::{MAX_COMPOSITE_EDGES, MAX_OUTLINE_POINTS, MAX_RECURSION_DEPTH};
 use read_fonts::{
     tables::{
         glyf::{
@@ -196,7 +196,7 @@ impl Outlines<'_> {
         recurse_depth: usize,
         total_components: &mut usize,
     ) -> Result<(), DrawError> {
-        if recurse_depth > GLYF_COMPOSITE_RECURSION_LIMIT {
+        if recurse_depth > MAX_RECURSION_DEPTH {
             return Err(DrawError::RecursionLimitExceeded(outline.glyph_id));
         }
         match glyph {
@@ -205,7 +205,7 @@ impl Outlines<'_> {
                 let num_points_with_phantom = num_points + PHANTOM_POINT_COUNT;
                 outline.max_simple_points = outline.max_simple_points.max(num_points_with_phantom);
                 outline.points += num_points;
-                if outline.points > MAX_GLYF_POINTS {
+                if outline.points > MAX_OUTLINE_POINTS {
                     return Err(DrawError::TooManyPoints(outline.glyph_id));
                 }
                 outline.contours += simple.end_pts_of_contours().len();
@@ -227,7 +227,7 @@ impl Outlines<'_> {
                         continue;
                     };
                     *total_components += 1;
-                    if *total_components > MAX_GRAPH_EDGES {
+                    if *total_components > MAX_COMPOSITE_EDGES {
                         return Err(DrawError::RecursionLimitExceeded(outline.glyph_id));
                     }
                     self.outline_rec(
@@ -296,7 +296,7 @@ trait Scaler {
         glyph_id: GlyphId,
         recurse_depth: usize,
     ) -> Result<(), DrawError> {
-        if recurse_depth > GLYF_COMPOSITE_RECURSION_LIMIT {
+        if recurse_depth > MAX_RECURSION_DEPTH {
             return Err(DrawError::RecursionLimitExceeded(glyph_id));
         }
         let bounds = match &glyph {
@@ -1474,7 +1474,7 @@ mod tests {
         let gid = GlyphId::new(1);
         // Build a glyph made of more than the allowed number of components,
         // each of which is a valid empty simple glyph.
-        let [glyf_buf, loca_buf] = build_with_n_comps(MAX_GRAPH_EDGES + 1);
+        let [glyf_buf, loca_buf] = build_with_n_comps(MAX_COMPOSITE_EDGES + 1);
         let mut outlines = Outlines::new(&font).unwrap();
         outlines.glyf = Glyf::read(glyf_buf.data().into()).unwrap();
         outlines.loca = Loca::read(loca_buf.data().into(), true).unwrap();
@@ -1482,7 +1482,7 @@ mod tests {
         assert!(matches!(result, Err(DrawError::RecursionLimitExceeded(_))));
         // Check the edge condition; make sure we can load a composite with exactly the
         // limit number of components.
-        let [glyf_buf, loca_buf] = build_with_n_comps(MAX_GRAPH_EDGES);
+        let [glyf_buf, loca_buf] = build_with_n_comps(MAX_COMPOSITE_EDGES);
         let mut outlines = Outlines::new(&font).unwrap();
         outlines.glyf = Glyf::read(glyf_buf.data().into()).unwrap();
         outlines.loca = Loca::read(loca_buf.data().into(), true).unwrap();

--- a/skrifa/src/outline/glyf/outline.rs
+++ b/skrifa/src/outline/glyf/outline.rs
@@ -1,7 +1,7 @@
 //! TrueType outline types.
 
 use super::super::{pen::PathStyle, DrawError, Hinting, OutlinePen};
-use crate::MAX_GLYF_POINTS;
+use crate::MAX_OUTLINE_POINTS;
 use raw::tables::glyf::PointCoord;
 use read_fonts::{
     tables::glyf::{Glyph, PointFlags},
@@ -93,7 +93,7 @@ impl Outline<'_> {
     }
 
     pub(super) fn ensure_point_count_limit(&self) -> Result<(), DrawError> {
-        if self.points > MAX_GLYF_POINTS {
+        if self.points > MAX_OUTLINE_POINTS {
             Err(DrawError::TooManyPoints(self.glyph_id))
         } else {
             Ok(())

--- a/skrifa/src/outline/mod.rs
+++ b/skrifa/src/outline/mod.rs
@@ -103,10 +103,7 @@ use raw::FontRef;
 pub use {error::DrawError, pen::OutlinePen};
 
 use self::glyf::{FreeTypeScaler, HarfBuzzScaler};
-use super::{
-    instance::{LocationRef, NormalizedCoord, Size},
-    GLYF_COMPOSITE_RECURSION_LIMIT,
-};
+use super::instance::{LocationRef, NormalizedCoord, Size};
 use core::fmt::Debug;
 use pen::PathStyle;
 use read_fonts::{types::GlyphId, TableProvider};

--- a/skrifa/src/outline/varc/mod.rs
+++ b/skrifa/src/outline/varc/mod.rs
@@ -18,8 +18,8 @@ use crate::{
     instance::Size,
     outline::{cff, glyf, metrics::GlyphHMetrics, pen::PathStyle, DrawError, OutlinePen},
     provider::MetadataProvider,
-    GLYF_COMPOSITE_RECURSION_LIMIT, MAX_GRAPH_EDGES,
 };
+use read_fonts::limits::{MAX_COMPOSITE_EDGES, MAX_RECURSION_DEPTH};
 
 #[cfg(feature = "libm")]
 #[allow(unused_imports)]
@@ -48,7 +48,7 @@ impl Scratchpad {
             deltas: DeltaVec::new(),
             axis_indices: AxisIndexVec::new(),
             axis_values: AxisValueVec::new(),
-            edges_left: MAX_GRAPH_EDGES,
+            edges_left: MAX_COMPOSITE_EDGES,
         }
     }
 }
@@ -219,7 +219,7 @@ impl<'a> Outlines<'a> {
         coverage_index: u16,
     ) -> Result<usize, DrawError> {
         let mut stack = GlyphStack::new();
-        let mut edges_left = MAX_GRAPH_EDGES;
+        let mut edges_left = MAX_COMPOSITE_EDGES;
         self.max_component_memory_for_glyph(glyph_id, coverage_index, &mut stack, &mut edges_left)
     }
 
@@ -235,7 +235,7 @@ impl<'a> Outlines<'a> {
         }
         // HB returns success for both recursion and edge limits, so we do the same.
         // See <https://github.com/harfbuzz/harfbuzz/blob/0fef675a5ea4973ce49d6dd00c02e70ec409eee3/src/OT/Var/VARC/VARC.cc#L386>
-        if stack.len() >= GLYF_COMPOSITE_RECURSION_LIMIT {
+        if stack.len() >= MAX_RECURSION_DEPTH {
             return Ok(0);
         }
         if *edges_left == 0 {
@@ -332,7 +332,7 @@ impl<'a> Outlines<'a> {
         scalar_cache: &mut ScalarCache,
         scratch: &mut Scratchpad,
     ) -> Result<(), DrawError> {
-        if stack.len() >= GLYF_COMPOSITE_RECURSION_LIMIT {
+        if stack.len() >= MAX_RECURSION_DEPTH {
             return Err(DrawError::RecursionLimitExceeded(glyph_id));
         }
         if scratch.edges_left == 0 {
@@ -684,7 +684,7 @@ impl<'a> Outlines<'a> {
         // is fully attacker-controlled. Bound the recursion so a deeply nested
         // (or degenerate) condition tree returns an error instead of overflowing
         // the stack, mirroring the component-recursion guard in `draw_glyph`.
-        if depth >= GLYF_COMPOSITE_RECURSION_LIMIT {
+        if depth >= MAX_RECURSION_DEPTH {
             return Err(DrawError::RecursionLimitExceeded(GlyphId::NOTDEF));
         }
         match condition {


### PR DESCRIPTION
These were scattered all over the place, defined multiple times, sometimes with different values. This captures limits for recursion, outline points and composite graph fan out in a single place, and updates all references to use them. Will add more as I find them.