### PR TITLE
[write-fonts] split subtables of Extension lookups when packing

### DIFF
--- a/write-fonts/src/graph.rs
+++ b/write-fonts/src/graph.rs
@@ -838,15 +838,6 @@ impl Graph {
     }
 
     fn actually_promote_subtables(&mut self, to_promote: &[ObjectId]) {
-        fn make_extension(type_: LookupType, subtable_id: ObjectId) -> TableData {
-            const EXT_FORMAT: u16 = 1;
-            let mut data = TableData::new(TableType::Named("ExtensionPosFormat1"));
-            data.write(EXT_FORMAT);
-            data.write(type_.to_raw());
-            data.add_offset(subtable_id, 4, 0);
-            data
-        }
-
         for id in to_promote {
             // 'id' is a lookup table.
             // we need to:
@@ -857,7 +848,7 @@ impl Graph {
             let mut lookup = self.objects.remove(id).unwrap();
             let lookup_type = lookup.type_.to_lookup_type().expect("validated before now");
             for subtable_ref in &mut lookup.offsets {
-                let ext_table = make_extension(lookup_type, subtable_ref.object);
+                let ext_table = Self::make_extension(lookup_type, subtable_ref.object);
                 let ext_id = self.add_object(ext_table);
                 subtable_ref.object = ext_id;
             }
@@ -867,6 +858,19 @@ impl Graph {
         }
         self.parents_invalid = true;
         self.positions_invalid = true;
+    }
+
+    /// Create an Extension subtable pointing at `subtable_id`, a subtable of
+    /// a lookup of type `type_`.
+    ///
+    /// The extension is not added to the graph; use [`add_object`][Self::add_object].
+    pub(super) fn make_extension(type_: LookupType, subtable_id: ObjectId) -> TableData {
+        const EXT_FORMAT: u16 = 1;
+        let mut data = TableData::new(TableType::Named("ExtensionPosFormat1"));
+        data.write(EXT_FORMAT);
+        data.write(type_.to_raw());
+        data.add_offset(subtable_id, 4, 0);
+        data
     }
 
     /// Manually add an object to the graph, after initial compilation.
@@ -1032,8 +1036,18 @@ impl Graph {
 
     fn split_subtables_if_needed(&mut self, lookup: ObjectId) {
         // So You Want to Split Subtables:
-        // - support PairPos and MarkBase.
-        let type_ = self.objects[&lookup].type_;
+        // - support PairPos and MarkBase, either directly or wrapped in an
+        //   Extension lookup (in which case we split the wrapped subtables and
+        //   wrap each of the pieces in a new Extension subtable)
+        let mut type_ = self.objects[&lookup].type_;
+        if type_ == TableType::GposLookup(LookupType::GPOS_EXT_TYPE) {
+            // all subtables of a lookup have the same type, so we only need to
+            // look at the first extension
+            type_ = match self.extension_subtable_type(lookup) {
+                Some(type_) => TableType::GposLookup(type_),
+                None => return,
+            };
+        }
         match type_ {
             TableType::GposLookup(LookupType::PAIR_POS) => splitting::split_pair_pos(self, lookup),
             TableType::GposLookup(LookupType::MARK_TO_BASE) => {
@@ -1041,6 +1055,17 @@ impl Graph {
             }
             _ => (),
         }
+    }
+
+    /// For an Extension lookup, the lookup type of the wrapped subtables.
+    ///
+    /// Returns `None` for an empty lookup.
+    fn extension_subtable_type(&self, lookup: ObjectId) -> Option<u16> {
+        let first_subtable = self.objects[&lookup].offsets.first()?.object;
+        let extension = self.objects[&first_subtable]
+            .reparse::<read_fonts::tables::gpos::ExtensionPosFormat1<()>>()
+            .ok()?;
+        Some(extension.extension_lookup_type())
     }
 
     /// the size only of children of this object, not the whole subgraph

--- a/write-fonts/src/graph/splitting.rs
+++ b/write-fonts/src/graph/splitting.rs
@@ -19,7 +19,8 @@ use read_fonts::tables::{
 
 use super::Graph;
 use crate::{
-    object::ObjectId, tables::layout as wlayout, write::TableData, FontWrite, TableWriter,
+    object::ObjectId, table_type::TableType, tables::layout as wlayout, write::TableData,
+    FontWrite, TableWriter,
 };
 
 mod mark2base;
@@ -34,6 +35,11 @@ const MAX_TABLE_SIZE: usize = u16::MAX as usize;
 ///
 /// This is roughly equivalent to `actuate_subtable_split` in hb-repacker:
 /// <https://github.com/harfbuzz/harfbuzz/blob/d5cb1a315380e9bd78ff377a586b78bc42abafa6/src/graph/split-helpers.hh#L34>
+///
+/// If the lookup is an Extension lookup, `split_fn` is applied to the
+/// subtables wrapped by the extensions, and each new subtable is wrapped in a
+/// new extension, like `split_subtables_if_needed` in hb-repacker:
+/// <https://github.com/harfbuzz/harfbuzz/blob/f5efbbef3841bdcdc6427bde7c2971f62ac8c8f1/src/graph/gsubgpos-graph.hh#L127-L156>
 fn split_subtables(
     graph: &mut Graph,
     lookup: ObjectId,
@@ -45,11 +51,32 @@ fn split_subtables(
         "table splitting is only relevant for GPOS?"
     );
     log::debug!("trying to split subtables in '{}'", data.type_);
+    let is_extension = data.type_ == TableType::GposLookup(wlayout::LookupType::GPOS_EXT_TYPE);
 
     let mut new_subtables = HashMap::new();
     for (i, subtable) in data.offsets.iter().enumerate() {
-        if let Some(split_subtables) = split_fn(graph, subtable.object) {
+        // for an extension lookup, the subtable we split is the one the
+        // extension points to
+        let (target, ext_type) = if is_extension {
+            let ext = &graph.objects[&subtable.object];
+            let ext_type = ext
+                .reparse::<rgpos::ExtensionPosFormat1<()>>()
+                .unwrap()
+                .extension_lookup_type();
+            (
+                ext.offsets[0].object,
+                Some(wlayout::LookupType::Gpos(ext_type)),
+            )
+        } else {
+            (subtable.object, None)
+        };
+        if let Some(mut split_subtables) = split_fn(graph, target) {
             log::trace!("produced {} splits for subtable {i}", split_subtables.len());
+            if let Some(ext_type) = ext_type {
+                for id in split_subtables.iter_mut() {
+                    *id = graph.add_object(Graph::make_extension(ext_type, *id));
+                }
+            }
             new_subtables.insert(subtable.object, split_subtables);
         }
     }

--- a/write-fonts/src/graph/splitting/mark2base.rs
+++ b/write-fonts/src/graph/splitting/mark2base.rs
@@ -508,7 +508,18 @@ mod tests {
     #[test]
     fn full_split_including_variation_index_tables() {
         let _ = env_logger::builder().is_test(true).try_init();
+        full_split_including_variation_index_tables_impl(false)
+    }
 
+    #[test]
+    fn full_split_in_extension_lookup() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // same table, but the lookup is already an extension lookup, so the
+        // packer has to split through the extension subtables
+        full_split_including_variation_index_tables_impl(true)
+    }
+
+    fn full_split_including_variation_index_tables_impl(use_extension: bool) {
         const MARK_CLASS_COUNT: u16 = 120;
         const MARKS_PER_CLASS: u16 = 4;
         const N_BASES: u16 = 500;
@@ -526,28 +537,13 @@ mod tests {
         let base_array = make_base_array(N_BASES, MARK_CLASS_COUNT, true);
 
         let table = MarkBasePosFormat1::new(mark_coverage, base_coverage, mark_array, base_array);
-        let lookup = Lookup::new(LookupFlag::empty(), vec![table]);
-        let lookup_list = LookupList::new(vec![lookup]);
-        let bytes = crate::dump_table(&lookup_list).unwrap();
-        let read_back = rgpos::PositionLookupList::read(bytes.as_slice().into()).unwrap();
-        assert_eq!(read_back.lookup_count(), 1);
-        let lookup = read_back.lookups().get(0).unwrap();
-
-        let subtables: Vec<_> = match lookup.subtables().unwrap() {
-            PositionSubtables::MarkToBase(subs) => subs.iter().map(|sub| sub.unwrap()).collect(),
-            _ => panic!("wrong lookup type"),
-        };
-
-        assert_eq!(subtables.len(), 7);
 
         // now we want to check to see that one of our variation index tables is correct.
         // in the markarray, each mark has a varidx table, with both values equal
         // to that mark's original coverage index.
 
         let mark_cov_idx_to_test = 72;
-        let orig_anchor = &lookup_list.lookups[0].subtables[0].mark_array.mark_records
-            [mark_cov_idx_to_test]
-            .mark_anchor;
+        let orig_anchor = &table.mark_array.mark_records[mark_cov_idx_to_test].mark_anchor;
         // sanity check that our logic makes sense
         match orig_anchor.as_ref() {
             AnchorTable::Format3(anchor) => match anchor.x_device.as_ref() {
@@ -557,6 +553,38 @@ mod tests {
             },
             _ => panic!("very bad assumptions"),
         };
+
+        let lookup = if use_extension {
+            PositionLookup::Extension(Lookup::new(
+                LookupFlag::empty(),
+                vec![ExtensionSubtable::MarkToBase(ExtensionPosFormat1::new(
+                    LookupType::MARK_TO_BASE,
+                    table,
+                ))],
+            ))
+        } else {
+            PositionLookup::MarkToBase(Lookup::new(LookupFlag::empty(), vec![table]))
+        };
+        let lookup_list = LookupList::new(vec![lookup]);
+        let bytes = crate::dump_table(&lookup_list).unwrap();
+        let read_back = rgpos::PositionLookupList::read(bytes.as_slice().into()).unwrap();
+        assert_eq!(read_back.lookup_count(), 1);
+        let lookup = read_back.lookups().get(0).unwrap();
+        if use_extension {
+            assert_eq!(lookup.lookup_type(), LookupType::GPOS_EXT_TYPE);
+        }
+
+        let subtables: Vec<_> = match lookup.subtables().unwrap() {
+            PositionSubtables::MarkToBase(subs) => subs.iter().map(|sub| sub.unwrap()).collect(),
+            _ => panic!("wrong lookup type"),
+        };
+
+        assert_eq!(subtables.len(), 7);
+        let n_marks: u32 = subtables
+            .iter()
+            .map(|sub| sub.mark_coverage().unwrap().iter().count() as u32)
+            .sum();
+        assert_eq!(n_marks, N_MARKS as u32);
 
         let gid = GlyphId16::new(FIRST_MARK_GLYPH + mark_cov_idx_to_test as u16);
         let subtable = subtables
@@ -576,54 +604,6 @@ mod tests {
         assert!(
             matches!(mark_anchor.x_device().transpose().unwrap(), Some(rgpos::DeviceOrVariationIndex::VariationIndex(varidx)) if varidx.delta_set_outer_index() == mark_cov_idx_to_test as u16)
         );
-    }
-
-    #[test]
-    fn full_split_in_extension_lookup() {
-        let _ = env_logger::builder().is_test(true).try_init();
-        // the same table as above, but the lookup is already an extension
-        // lookup, so the packer has to split through the extension subtables
-        const MARK_CLASS_COUNT: u16 = 120;
-        const MARKS_PER_CLASS: u16 = 4;
-        const N_BASES: u16 = 500;
-        const N_MARKS: u16 = MARK_CLASS_COUNT * MARKS_PER_CLASS;
-        const FIRST_BASE_GLYPH: u16 = 2;
-        const FIRST_MARK_GLYPH: u16 = 2000;
-
-        let mark_coverage = (FIRST_MARK_GLYPH..FIRST_MARK_GLYPH + N_MARKS)
-            .map(GlyphId16::new)
-            .collect();
-        let base_coverage = (FIRST_BASE_GLYPH..FIRST_BASE_GLYPH + N_BASES)
-            .map(GlyphId16::new)
-            .collect();
-        let mark_array = make_mark_array(MARK_CLASS_COUNT, MARKS_PER_CLASS, true);
-        let base_array = make_base_array(N_BASES, MARK_CLASS_COUNT, true);
-
-        let table = MarkBasePosFormat1::new(mark_coverage, base_coverage, mark_array, base_array);
-        let lookup = PositionLookup::Extension(Lookup::new(
-            LookupFlag::empty(),
-            vec![ExtensionSubtable::MarkToBase(ExtensionPosFormat1::new(
-                LookupType::MARK_TO_BASE,
-                table,
-            ))],
-        ));
-        let lookup_list = LookupList::new(vec![lookup]);
-        let bytes = crate::dump_table(&lookup_list).unwrap();
-        let read_back = rgpos::PositionLookupList::read(bytes.as_slice().into()).unwrap();
-        let lookup = read_back.lookups().get(0).unwrap();
-        assert_eq!(lookup.lookup_type(), LookupType::GPOS_EXT_TYPE);
-
-        let subtables: Vec<_> = match lookup.subtables().unwrap() {
-            PositionSubtables::MarkToBase(subs) => subs.iter().map(|sub| sub.unwrap()).collect(),
-            _ => panic!("wrong lookup type"),
-        };
-        // same split as the non-extension case
-        assert_eq!(subtables.len(), 7);
-        let n_marks: u32 = subtables
-            .iter()
-            .map(|sub| sub.mark_coverage().unwrap().iter().count() as u32)
-            .sum();
-        assert_eq!(n_marks, N_MARKS as u32);
     }
 
     #[test]

--- a/write-fonts/src/graph/splitting/mark2base.rs
+++ b/write-fonts/src/graph/splitting/mark2base.rs
@@ -296,8 +296,11 @@ mod tests {
 
     use crate::{
         tables::{
-            gpos::{AnchorTable, BaseArray, BaseRecord, MarkArray, MarkBasePosFormat1, MarkRecord},
-            layout::{DeviceOrVariationIndex, Lookup, LookupList, VariationIndex},
+            gpos::{
+                AnchorTable, BaseArray, BaseRecord, ExtensionPosFormat1, ExtensionSubtable,
+                MarkArray, MarkBasePosFormat1, MarkRecord, PositionLookup,
+            },
+            layout::{DeviceOrVariationIndex, Lookup, LookupList, LookupType, VariationIndex},
         },
         TableWriter,
     };
@@ -573,6 +576,54 @@ mod tests {
         assert!(
             matches!(mark_anchor.x_device().transpose().unwrap(), Some(rgpos::DeviceOrVariationIndex::VariationIndex(varidx)) if varidx.delta_set_outer_index() == mark_cov_idx_to_test as u16)
         );
+    }
+
+    #[test]
+    fn full_split_in_extension_lookup() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // the same table as above, but the lookup is already an extension
+        // lookup, so the packer has to split through the extension subtables
+        const MARK_CLASS_COUNT: u16 = 120;
+        const MARKS_PER_CLASS: u16 = 4;
+        const N_BASES: u16 = 500;
+        const N_MARKS: u16 = MARK_CLASS_COUNT * MARKS_PER_CLASS;
+        const FIRST_BASE_GLYPH: u16 = 2;
+        const FIRST_MARK_GLYPH: u16 = 2000;
+
+        let mark_coverage = (FIRST_MARK_GLYPH..FIRST_MARK_GLYPH + N_MARKS)
+            .map(GlyphId16::new)
+            .collect();
+        let base_coverage = (FIRST_BASE_GLYPH..FIRST_BASE_GLYPH + N_BASES)
+            .map(GlyphId16::new)
+            .collect();
+        let mark_array = make_mark_array(MARK_CLASS_COUNT, MARKS_PER_CLASS, true);
+        let base_array = make_base_array(N_BASES, MARK_CLASS_COUNT, true);
+
+        let table = MarkBasePosFormat1::new(mark_coverage, base_coverage, mark_array, base_array);
+        let lookup = PositionLookup::Extension(Lookup::new(
+            LookupFlag::empty(),
+            vec![ExtensionSubtable::MarkToBase(ExtensionPosFormat1::new(
+                LookupType::MARK_TO_BASE,
+                table,
+            ))],
+        ));
+        let lookup_list = LookupList::new(vec![lookup]);
+        let bytes = crate::dump_table(&lookup_list).unwrap();
+        let read_back = rgpos::PositionLookupList::read(bytes.as_slice().into()).unwrap();
+        let lookup = read_back.lookups().get(0).unwrap();
+        assert_eq!(lookup.lookup_type(), LookupType::GPOS_EXT_TYPE);
+
+        let subtables: Vec<_> = match lookup.subtables().unwrap() {
+            PositionSubtables::MarkToBase(subs) => subs.iter().map(|sub| sub.unwrap()).collect(),
+            _ => panic!("wrong lookup type"),
+        };
+        // same split as the non-extension case
+        assert_eq!(subtables.len(), 7);
+        let n_marks: u32 = subtables
+            .iter()
+            .map(|sub| sub.mark_coverage().unwrap().iter().count() as u32)
+            .sum();
+        assert_eq!(n_marks, N_MARKS as u32);
     }
 
     #[test]

--- a/write-fonts/src/graph/splitting/pairpos.rs
+++ b/write-fonts/src/graph/splitting/pairpos.rs
@@ -500,11 +500,12 @@ mod tests {
     use crate::{
         tables::{
             gpos::{
-                Class1Record, Class2Record, PairPos, PairSet, PairValueRecord, PositionLookup,
-                ValueRecord,
+                Class1Record, Class2Record, ExtensionPosFormat1, ExtensionSubtable, PairPos,
+                PairSet, PairValueRecord, PositionLookup, ValueRecord,
             },
             layout::{
-                builders::CoverageTableBuilder, Device, DeviceOrVariationIndex, VariationIndex,
+                builders::CoverageTableBuilder, Device, DeviceOrVariationIndex, LookupType,
+                VariationIndex,
             },
         },
         FontWrite, TableWriter,
@@ -681,6 +682,54 @@ mod tests {
         assert!(crate::dump_table(&lookuplist).is_ok());
     }
 
+    /// Wrap each subtable of a pair lookup in an Extension subtable, like a
+    /// `useExtension` lookup arriving from fea-rs.
+    fn wrap_in_extension(lookup: wlayout::Lookup<PairPos>) -> PositionLookup {
+        let subtables = lookup
+            .subtables
+            .into_iter()
+            .map(|sub| {
+                ExtensionSubtable::Pair(ExtensionPosFormat1::new(
+                    LookupType::PAIR_POS,
+                    sub.into_inner(),
+                ))
+            })
+            .collect();
+        let mut ext = wlayout::Lookup::new(lookup.lookup_flag, subtables);
+        ext.mark_filtering_set = lookup.mark_filtering_set;
+        PositionLookup::Extension(ext)
+    }
+
+    #[test]
+    fn fully_pack_pairpos1_in_extension_lookup() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // same table as above, but the lookup is already an extension lookup,
+        // so the packer cannot promote it and has to split through the extension
+        const G1_COUNT: u16 = 28;
+        const G2_COUNT: u16 = 100;
+
+        let table = make_pairpos_f1_with_device_tables(G1_COUNT, G2_COUNT);
+        let lookup = wrap_in_extension(wlayout::Lookup::new(LookupFlag::empty(), vec![table]));
+        let lookuplist = wlayout::LookupList::new(vec![lookup]);
+        let bytes = crate::dump_table(&lookuplist).unwrap();
+
+        let rlookuplist = rgpos::PositionLookupList::read(FontData::new(&bytes)).unwrap();
+        let rlookup = rlookuplist.lookups().get(0).unwrap();
+        assert_eq!(rlookup.lookup_type(), LookupType::GPOS_EXT_TYPE);
+        let PositionSubtables::Pair(subs) = rlookup.subtables().unwrap() else {
+            panic!("wrong lookup type");
+        };
+        let n_pair_sets: u16 = subs
+            .iter()
+            .map(|sub| match sub.unwrap() {
+                rgpos::PairPos::Format1(sub) => sub.pair_set_count(),
+                rgpos::PairPos::Format2(_) => panic!("wrong subtable format"),
+            })
+            .sum();
+        assert!(subs.len() > 1, "expected the subtable to be split");
+        assert_eq!(n_pair_sets, G1_COUNT);
+    }
+
     #[test]
     fn count_glyph_ranges() {
         fn make_input(glyphs: &[u16]) -> BTreeSet<GlyphId16> {
@@ -787,7 +836,16 @@ mod tests {
     #[test]
     fn ensure_split_pairpos_f2_works() {
         let _ = env_logger::builder().is_test(true).try_init();
+        ensure_split_pairpos_f2_works_impl(false)
+    }
 
+    #[test]
+    fn ensure_split_pairpos_f2_works_in_extension_lookup() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        ensure_split_pairpos_f2_works_impl(true)
+    }
+
+    fn ensure_split_pairpos_f2_works_impl(use_extension: bool) {
         // and sanity check that we have the same number of records:
         let lookup = make_pairpos2();
         let expected_n_c2_recs = match &lookup {
@@ -804,6 +862,10 @@ mod tests {
                 })
                 .sum::<usize>(),
             _ => panic!("wrong lookup type"),
+        };
+        let lookup = match (use_extension, lookup) {
+            (true, PositionLookup::Pair(pairpos)) => wrap_in_extension(pairpos),
+            (_, lookup) => lookup,
         };
         let lookup_list = wlayout::LookupList::new(vec![lookup]);
         let bytes = crate::dump_table(&lookup_list).unwrap();

--- a/write-fonts/src/table_type.rs
+++ b/write-fonts/src/table_type.rs
@@ -54,6 +54,9 @@ impl TableType {
             self,
             TableType::GposLookup(LookupType::PAIR_POS)
                 | TableType::GposLookup(LookupType::MARK_TO_BASE)
+                // an extension lookup is splittable if the wrapped lookup is;
+                // that is checked in Graph::split_subtables_if_needed
+                | TableType::GposLookup(LookupType::GPOS_EXT_TYPE)
         )
     }
 


### PR DESCRIPTION
Fixes #2129

An Extension lookup is now splittable when the lookup type it wraps is: the existing PairPos / MarkToBase splitters run on the subtables the extensions point to, and each new piece gets its own ExtensionPosFormat1, like hb-repacker does. The `make_extension` helper that promotion used is hoisted to a `Graph` method so both paths share it.

The tests fail on main and are a separate first commit.

With this, Source Serif 4, whose kern lookup uses `useExtension`, builds with fontc to a GPOS identical to the one you get when the lookup is left bare and the packer promotes it itself.
