### PR TITLE
[release] push only the tags cargo-release just created

### DIFF
--- a/resources/scripts/release.sh
+++ b/resources/scripts/release.sh
@@ -66,7 +66,7 @@ trap - SIGINT  # Remove trap
 echo "Generate tags"
 cargo release tag -x ${crate_specifier}  # this prompts y/N
 echo "Pushing tag to github"
-git push --tags
+cargo release push -x ${crate_specifier}  # this prompts y/N
 
 echo "NEXT STEPS"
 echo "You probably want to create a release on github"


### PR DESCRIPTION
Same as googlefonts/fontc#2141 -- release.sh here ends with the same `git push --tags`, so it gets the same fix.
